### PR TITLE
⚡️ perf+test: verify the bound — shared backend contract, EXPLAIN plans, measured memory (LR2 §13/§18)

### DIFF
--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -45,6 +45,8 @@ LIGHTRAG_PARSER=*:legacy-F
 
 不需要做数据迁移。启动后的第一轮 sweep 是一次 strict 全量 sweep，因此旧 writer 留在半途的文档——例如卡在 `PARSING`/`ANALYZING`/`PROCESSING` 但背后已没有 worker 的行——会被自动捡起并重新处理。如果确实无法排空（必须放弃一次运行），基于同样的原因，中途停止也是安全的；不安全的是事后又把旧版本启动回来。
 
+**启动后请检查日志里有没有 strict 能力告警。** 五个内置 `doc_status` 后端（JSON、Redis、PostgreSQL、MongoDB、OpenSearch）都具备全部能力。第三方后端可能不具备，而每一项缺失都是**失败关闭**而非静默降级：admission 返回 503、source-conflict 端点返回 501、scan 会一直重复检查陈旧的 `FAILED` stub。启动日志会逐项列出缺失的能力及其代价，已鉴权的 `/health` 在 `capabilities` 下报告同一份信息。设 `PIPELINE_REQUIRE_STRICT_STORAGE_READS=true` 可把这些缺口变成启动失败。有界分页没有对应旋钮：分页与 typed source 解析方法是抽象方法，缺失的后端根本无法构造。
+
 ## 入门指南
 
 ### 安装

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -45,6 +45,8 @@ Recommended sequence:
 
 No data migration is required. The first sweep after startup is a strict full sweep, so a document an old writer left mid-flight — a row stuck in `PARSING`/`ANALYZING`/`PROCESSING` with no worker behind it — is picked up and reprocessed on its own. If a run genuinely cannot be drained, stopping mid-run is still safe for the same reason; what is not safe is starting the old version again afterwards.
 
+**After starting, check the log for a strict-capability warning.** All five built-in `doc_status` backends (JSON, Redis, PostgreSQL, MongoDB, OpenSearch) have every capability. A third-party backend may not, and each gap fails closed rather than degrading quietly: admission answers 503, the source-conflict endpoints answer 501, and a scan keeps re-examining a stale `FAILED` stub. Startup names each missing capability and what it costs, and the authenticated `/health` reports the same under `capabilities`. Set `PIPELINE_REQUIRE_STRICT_STORAGE_READS=true` to turn those gaps into a startup failure instead. There is no equivalent knob for bounded paging: the paging and typed source-resolution methods are abstract, so a backend without them cannot be constructed at all.
+
 ## Getting Started
 
 ### Installation

--- a/env.example
+++ b/env.example
@@ -688,6 +688,12 @@ MAX_PARALLEL_INSERT=3
 ### positive (there is no "disabled" value — the server refuses to start on 0).
 ### Default 100.
 # SCAN_ENQUEUE_BATCH_SIZE=100
+### Refuse to start when the configured doc_status backend is missing a strict
+### capability (active count / source-conflict listing / source-conflict repair /
+### strict point reads). Default false: the gaps are logged loudly at startup and
+### reported by /health under "capabilities", and the affected features fail closed
+### (admission 503, conflicts 501). Set true if you would rather not start at all.
+# PIPELINE_REQUIRE_STRICT_STORAGE_READS=false
 ### Admission capacity: refuse new uploads / text inserts with HTTP 429 once this
 ### many documents are already active (PENDING/PARSING/ANALYZING/PROCESSING) or
 ### reserved by an in-flight request. Manual retries and /documents/scan may

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -35,6 +35,7 @@ from lightrag.constants import (
     DEFAULT_MAX_ASYNC,
     DEFAULT_MAX_PARALLEL_INSERT,
     DEFAULT_PIPELINE_SCHEDULING_PAGE_SIZE,
+    DEFAULT_PIPELINE_REQUIRE_STRICT_STORAGE_READS,
     DEFAULT_MAX_PENDING_DOCUMENTS,
     DEFAULT_MAX_REQUEST_BODY_BYTES,
     DEFAULT_MAX_TEXTS_PER_REQUEST,
@@ -583,6 +584,14 @@ def parse_args() -> argparse.Namespace:
     # Bounded scheduling page size (LR2 Phase 2); 0 disables paging.
     args.pipeline_scheduling_page_size = get_env_value(
         "PIPELINE_SCHEDULING_PAGE_SIZE", DEFAULT_PIPELINE_SCHEDULING_PAGE_SIZE, int
+    )
+
+    # Turn a missing strict doc_status capability into a startup failure instead
+    # of a warning + /health degradation report (LR2 §11).
+    args.pipeline_require_strict_storage_reads = get_env_value(
+        "PIPELINE_REQUIRE_STRICT_STORAGE_READS",
+        DEFAULT_PIPELINE_REQUIRE_STRICT_STORAGE_READS,
+        bool,
     )
 
     # How many newly claimed files one /documents/scan batch holds before

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -2252,6 +2252,7 @@ def create_app(args):
             default_rerank_timeout=args.rerank_timeout,
             max_parallel_insert=args.max_parallel_insert,
             pipeline_scheduling_page_size=args.pipeline_scheduling_page_size,
+            pipeline_require_strict_storage_reads=args.pipeline_require_strict_storage_reads,
             max_pending_documents=args.max_pending_documents,
             max_graph_nodes=args.max_graph_nodes,
             addon_params=addon_params,

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -49,6 +49,7 @@ from lightrag.base import (
 )
 from lightrag.exceptions import (
     PipelineBackpressureError,
+    SourceConflictPrimaryUnusableError,
     SourceConflictRepairCASError,
     StorageCapabilityError,
     StorageControlPlaneError,
@@ -66,8 +67,9 @@ from lightrag.constants import (
     PROCESS_OPTION_CHUNK_VECTOR,
 )
 from lightrag.tools.source_conflict_repair import (
-    verify_repair_outcome,
+    refuse_a_contentless_primary,
     source_conflict_repair_lock,
+    verify_repair_outcome,
 )
 from lightrag.kg.scan_job_store import (
     SAMPLE_BUCKETS,
@@ -1802,8 +1804,8 @@ async def _acquire_destructive_busy(
             ),
             (
                 "pending_enqueues",
-                "Document upload/insert is being enqueued. Wait for in-flight "
-                "work to complete before clearing or deleting.",
+                "An upload/insert or a source-conflict repair is in flight. "
+                "Wait for it to complete before clearing or deleting.",
             ),
         ),
     )
@@ -3979,8 +3981,8 @@ def create_document_routes(
                     ),
                     (
                         "pending_enqueues",
-                        "Document upload/insert is being enqueued. Wait for in-flight "
-                        "work to complete before triggering a scan.",
+                        "An upload/insert or a source-conflict repair is in "
+                        "flight. Wait for it to complete before triggering a scan.",
                     ),
                     (
                         "manual_freeze_requested",
@@ -4357,6 +4359,12 @@ def create_document_routes(
                 async with source_conflict_repair_lock(
                     rag.workspace, payload.canonical_source_key
                 ):
+                    # A stub with no content can never own the source, and a scan
+                    # would delete it out from under the demotions — refuse
+                    # inside the lock, where the answer cannot go stale.
+                    await refuse_a_contentless_primary(
+                        rag.full_docs, payload.primary_doc_id
+                    )
                     result = await rag.doc_status.repair_source_conflict(
                         payload.canonical_source_key,
                         primary_doc_id=payload.primary_doc_id,
@@ -4381,6 +4389,24 @@ def create_document_routes(
                         payload.primary_doc_id,
                         result,
                     )
+        except SourceConflictPrimaryUnusableError as unusable_primary:
+            # A DIFFERENT 409 from the one below: this primary IS a candidate, it
+            # just cannot own the source (no content). Reporting it as "not a
+            # candidate" would send the operator to re-list a conflict that has
+            # not changed. The message names the state and the fix; it is built
+            # here from sanitized request values, like its sibling.
+            logger.warning(
+                f"[source-conflict repair] {action} REFUSED by {actor}: "
+                f"key='{audit_key}' primary={audit_primary}: {unusable_primary}"
+            )
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Document {audit_primary} has no full_docs content, so it "
+                    f"cannot own source '{audit_key}'. Choose a primary that has "
+                    "content."
+                ),
+            )
         except ValueError as not_a_candidate:
             # The named primary is not currently a primary candidate: either a
             # typo or a view that went stale. Same recovery either way — list the

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -67,7 +67,7 @@ from lightrag.constants import (
     PROCESS_OPTION_CHUNK_VECTOR,
 )
 from lightrag.tools.source_conflict_repair import (
-    refuse_a_contentless_primary,
+    refuse_an_unusable_primary,
     source_conflict_repair_lock,
     verify_repair_outcome,
 )
@@ -4359,11 +4359,16 @@ def create_document_routes(
                 async with source_conflict_repair_lock(
                     rag.workspace, payload.canonical_source_key
                 ):
-                    # A stub with no content can never own the source, and a scan
-                    # would delete it out from under the demotions — refuse
-                    # inside the lock, where the answer cannot go stale.
-                    await refuse_a_contentless_primary(
-                        rag.full_docs, payload.primary_doc_id
+                    # Two primaries can never keep the source: a stub with no
+                    # content (a scan would delete it out from under the
+                    # demotions) and one whose content already lives under
+                    # another document (processing will mark it a duplicate).
+                    # Refuse inside the lock, where the answers cannot go stale.
+                    await refuse_an_unusable_primary(
+                        rag.doc_status,
+                        rag.full_docs,
+                        payload.canonical_source_key,
+                        payload.primary_doc_id,
                     )
                     result = await rag.doc_status.repair_source_conflict(
                         payload.canonical_source_key,

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -4308,7 +4308,9 @@ def create_document_routes(
            runs under the canonical-key + enqueue-serialize locks, which is what
            keeps a NEW primary from being inserted between that re-read and the
            demotions (no backend can block that phantom on its own — see
-           ``DocStatusStorage.repair_source_conflict``).
+           ``DocStatusStorage.repair_source_conflict``), and what orders the
+           commit against the processing stage's duplicate marking, which takes
+           the same canonical-key lock.
 
         The commit marks every candidate other than ``primary_doc_id`` with
         ``metadata.is_duplicate=true`` and ``original_doc_id=<primary>``. Content
@@ -4385,9 +4387,13 @@ def create_document_routes(
                     )
                     # Verify the end state inside the locks rather than reporting
                     # a settled key on the strength of "the demotions landed".
-                    # The locks exclude a concurrent enqueue and nothing else, so
-                    # a concurrent delete / duplicate marking can leave the key
-                    # Absent or still conflicting; raises when it did.
+                    # The locks exclude every in-deployment writer of this
+                    # candidate set — enqueue, clear/delete + scan classification
+                    # + manual reset (the reservation), and the processing
+                    # stage's duplicate marking (the keyed source lock it takes
+                    # too) — so this is a backstop for what stays outside them: a
+                    # second deployment writing the same database. It raises when
+                    # the key came out Absent or still conflicting.
                     await verify_repair_outcome(
                         rag.doc_status,
                         payload.canonical_source_key,

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -4396,22 +4396,37 @@ def create_document_routes(
                     )
         except SourceConflictPrimaryUnusableError as unusable_primary:
             # A DIFFERENT 409 from the one below: this primary IS a candidate, it
-            # just cannot own the source (no content). Reporting it as "not a
-            # candidate" would send the operator to re-list a conflict that has
-            # not changed. The message names the state and the fix; it is built
-            # here from sanitized request values, like its sibling.
+            # just cannot own the source. Reporting it as "not a candidate" would
+            # send the operator to re-list a conflict that has not changed. The
+            # detail is built here from sanitized values rather than forwarded
+            # from the exception text — so it must branch on the exception's
+            # REASON, or it states the wrong cause with total confidence (it used
+            # to answer "has no full_docs content" for a document whose content
+            # was fine and simply belonged to another document).
             logger.warning(
                 f"[source-conflict repair] {action} REFUSED by {actor}: "
                 f"key='{audit_key}' primary={audit_primary}: {unusable_primary}"
             )
-            raise HTTPException(
-                status_code=409,
-                detail=(
+            if (
+                unusable_primary.reason
+                == SourceConflictPrimaryUnusableError.REASON_CONTENT_ELSEWHERE
+            ):
+                holder = safe_log_value(unusable_primary.holder_doc_id)
+                detail = (
+                    f"Document {audit_primary} holds the same content as "
+                    f"{holder or 'another document'}, which claims a different "
+                    f"source, so it cannot own '{audit_key}': processing marks a "
+                    "content duplicate FAILED and deletes its content, leaving "
+                    "the source with no primary. Choose another primary, or "
+                    "settle that document first."
+                )
+            else:
+                detail = (
                     f"Document {audit_primary} has no full_docs content, so it "
                     f"cannot own source '{audit_key}'. Choose a primary that has "
                     "content."
-                ),
-            )
+                )
+            raise HTTPException(status_code=409, detail=detail)
         except ValueError as not_a_candidate:
             # The named primary is not currently a primary candidate: either a
             # typo or a view that went stale. Same recovery either way — list the

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -65,7 +65,10 @@ from lightrag.constants import (
     PROCESS_OPTION_CHUNK_RECURSIVE,
     PROCESS_OPTION_CHUNK_VECTOR,
 )
-from lightrag.tools.source_conflict_repair import source_conflict_repair_lock
+from lightrag.tools.source_conflict_repair import (
+    verify_repair_outcome,
+    source_conflict_repair_lock,
+)
 from lightrag.kg.scan_job_store import (
     SAMPLE_BUCKETS,
     SCAN_JOB_LEASE_SECONDS,
@@ -4041,6 +4044,17 @@ def create_document_routes(
                     status_code=429,
                     detail="Too many scan jobs are in flight; retry once one finishes.",
                 )
+            if create_result.outcome is ScanJobCreateOutcome.INVALID_IDENTIFIER:
+                # Unreachable from here (both identifiers are generated), but the
+                # store validates server-side on principle, so map its refusal
+                # instead of treating it as success.
+                logger.error(
+                    f"Scan job record refused: {create_result.message or 'invalid identifier'}"
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail="internal_server_error",
+                )
             if create_result.outcome is ScanJobCreateOutcome.ALREADY_EXISTS:
                 # Unreachable for a freshly minted track id; a future caller
                 # reusing one must be refused rather than silently adopting (and
@@ -4355,6 +4369,17 @@ def create_document_routes(
                             payload.expected_candidate_fingerprint or ""
                         ),
                         dry_run=False,
+                    )
+                    # Verify the end state inside the locks rather than reporting
+                    # a settled key on the strength of "the demotions landed".
+                    # The locks exclude a concurrent enqueue and nothing else, so
+                    # a concurrent delete / duplicate marking can leave the key
+                    # Absent or still conflicting; raises when it did.
+                    await verify_repair_outcome(
+                        rag.doc_status,
+                        payload.canonical_source_key,
+                        payload.primary_doc_id,
+                        result,
                     )
         except ValueError as not_a_candidate:
             # The named primary is not currently a primary candidate: either a

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -1538,7 +1538,9 @@ class DocStatusStorage(BaseKVStorage, ABC):
         Serializing repair against enqueue is therefore the CALLER's job:
         ``lightrag.tools.source_conflict_repair.source_conflict_repair_lock``
         holds a ``get_storage_keyed_lock`` on the canonical source key (so
-        concurrent repairs of one key serialize) plus the workspace's
+        concurrent repairs of one key serialize, and so does the processing
+        stage's duplicate marking, which takes that same lock) plus the
+        workspace's
         ``ENQUEUE_SERIALIZE_LOCK_NAMESPACE`` namespace lock, which is the one
         that actually excludes the phantom because the enqueue critical section
         (``filter_keys`` → dedup → ``upsert``) already holds it. Those locks span

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -1283,10 +1283,16 @@ class DocStatusStorage(BaseKVStorage, ABC):
         * **Immutable sort key**: ``created_at`` is written once at record
           creation and preserved by every later transition
           (``update_doc_status_fields`` refuses it) so a record can never move
-          underneath a sweep. A missing/NULL ``created_at`` sorts FIRST (an
-          empty-string / NULL bucket) and stays reachable across page
-          boundaries via bucket-aware resume — it must never become
-          permanently unreachable behind a real-timestamp cursor.
+          underneath a sweep. Where the backend indexes a missing/NULL
+          ``created_at`` at all, that bucket must stay reachable across page
+          boundaries via bucket-aware resume rather than becoming permanently
+          unreachable behind a real-timestamp cursor. Note that such a row can
+          never be RETURNED: ``DocSchedulingRecord`` requires ``created_at``, so
+          a strict page raises on it (complete-or-raise) and a relaxed page
+          consumes-and-skips it so the cursor still advances. Only legacy rows
+          and external edits reach that state — every write path stamps the
+          field. Pinned for all five backends in
+          ``tests/kg/test_doc_status_scheduling_contract.py``.
         * **Consumed-position advance**: ``next_position`` advances past the
           last CONSUMED underlying record — records returned to the caller
           plus records read and dropped by filtering are consumed; a record

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -1205,13 +1205,38 @@ class DocStatusStorage(BaseKVStorage, ABC):
 
         Args:
             content_hash: The content hash value to search for.
-            exclude_doc_id: When set, a row with this id is NOT a match — the
-                lookup returns the earliest OTHER doc sharing the hash (or
-                None). This lets the duplicate check exclude the very row being
-                processed (whose own content_hash is already persisted) in a
-                single bounded/indexed query, instead of a full-store scan
-                fallback. Every backend MUST honour it in-query so the
-                exclusion never widens the scan.
+            exclude_doc_id: When set, TWO kinds of row are not a match and the
+                lookup returns the earliest remaining holder (or None):
+
+                1. the row with this id — which lets the duplicate check
+                   exclude the very row being processed (whose own content_hash
+                   is already persisted) in a single bounded/indexed query,
+                   instead of a full-store scan fallback;
+                2. a row that merely POINTS at it: ``metadata.is_duplicate``
+                   true with ``metadata.original_doc_id == exclude_doc_id``.
+                   Such a row is not an independent holder of the content — it
+                   is a record that this content belongs to ``exclude_doc_id``
+                   — so returning it makes the asking document a duplicate of a
+                   record of ITSELF. Both rows then carry
+                   ``is_duplicate=true`` naming each other and the canonical
+                   source they share is left with no primary at all, which the
+                   repair endpoint cannot settle (it only accepts a current
+                   primary candidate) and which a re-upload cannot undo (the
+                   doc id is derived from the file name, so it asks about the
+                   very id the pointer names). Reachable with no race through
+                   a source-conflict repair: it demotes losing candidates with
+                   ``original_doc_id=<the kept primary>``, and a kept primary
+                   that was not parsed yet reaches its post-parse duplicate
+                   check afterwards with the hash the demoted row still holds.
+
+                Skipping such a row must not stop the search: the point is the
+                EARLIEST holder that is not one of these two, so an
+                implementation that filtered one result after the fact would
+                hide a genuine third holder behind a pointer row and re-admit
+                the duplicate it was asked about. Every backend MUST honour
+                both exclusions where it selects (in-query, or inside the
+                implementation over a bounded ordered window) so the exclusion
+                never widens the scan and never truncates the search.
 
                 This keyword was added to an already-abstract method, so a
                 subclass carrying the older ``(self, content_hash)`` signature
@@ -1225,6 +1250,21 @@ class DocStatusStorage(BaseKVStorage, ABC):
         Returns:
             (doc_id, doc_data) when a matching record exists, otherwise None.
         """
+
+    @staticmethod
+    def _row_points_at_as_duplicate(row: Any, doc_id: str | None) -> bool:
+        """Is ``row`` merely a record that its content belongs to ``doc_id``?
+
+        The second half of ``get_doc_by_content_hash``'s ``exclude_doc_id``
+        predicate (see its contract), shared so the backends that filter rows in
+        Python read the same ``metadata`` the ones that filter in-query do.
+        """
+        if not doc_id or not isinstance(row, dict):
+            return False
+        metadata = row.get("metadata")
+        if not isinstance(metadata, dict) or not metadata.get("is_duplicate"):
+            return False
+        return metadata.get("original_doc_id") == doc_id
 
     # ------------------------------------------------------------------
     # Memory-bounding scheduling API (Phase 1). The paging / batch / source

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -279,6 +279,19 @@ PARSED_DIR_NAME = "__parsed__"  # Dir for parsed files (renamed from __enqueued_
 # include its staged chunk IDs. Lives here (not utils_pipeline) so that
 # base.py can derive the scheduling projection without an import cycle.
 CUSTOM_CHUNK_PATCH_METADATA_KEY = "custom_chunk_patch"
+# doc_status.metadata keys that record a DEMOTION: this row is not the primary
+# claimant of its canonical source. ``is_duplicate`` is what every backend's
+# primary-candidate predicate keys off (``_basename_of`` returns None for it),
+# so these are load-bearing state, not display fields — every metadata rebuild
+# (status transitions AND the manual FAILED→PENDING reset) must carry them
+# across or the demotion silently reverts and the source key returns to
+# conflict. Written by enqueue's duplicate records, by the post-parse
+# content-hash duplicate marking, and by the operator's source-conflict repair.
+DUPLICATE_DEMOTION_METADATA_KEYS: tuple[str, ...] = (
+    "is_duplicate",
+    "duplicate_kind",
+    "original_doc_id",
+)
 # Prefix marking a doc_status content_summary as GENERATED from a file
 # extraction error (enqueue-time error documents and parse-stage FAILED
 # upserts). Doubles as the match sentinel that lets a later failure replace

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -569,5 +569,9 @@ ROLLBACK_REPORT_SAMPLE_CAP = 32
 ENQUEUE_SERIALIZE_LOCK_NAMESPACE = "enqueue_serialize"
 
 # Keyed-lock namespace for per-canonical-source-key serialization, mirroring the
-# "<workspace>:DocPatch" idiom. Keys are canonical source keys.
+# "<workspace>:DocPatch" idiom. Keys are canonical source keys. Held by BOTH
+# writers that can change a key's candidate set outside enqueue: the operator's
+# source-conflict repair and the post-parse duplicate marking (LR2 §5.5) — take
+# it via utils_pipeline.source_candidate_set_lock, which is the single place the
+# namespace/key spelling is built (a mismatched spelling excludes nothing).
 SOURCE_CONFLICT_LOCK_NAMESPACE = "DocSource"

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -366,6 +366,14 @@ DEFAULT_QUEUE_SIZE_INSERT = 4
 # single-scan behaviour).
 DEFAULT_PIPELINE_SCHEDULING_PAGE_SIZE = 500
 
+# Whether a doc_status backend missing a strict capability is a startup failure
+# (LR2 §11). ``False`` (the default) logs a loud warning naming each gap and
+# reports it on ``/health``; ``True`` refuses to start. There is no knob for the
+# bounded PAGING capability on purpose: the paging and typed-source methods are
+# ``@abstractmethod`` on ``DocStatusStorage``, so a backend that lacks them
+# cannot be instantiated at all — a stronger guarantee than an opt-in check.
+DEFAULT_PIPELINE_REQUIRE_STRICT_STORAGE_READS = False
+
 # How many newly claimed files ``/documents/scan`` holds before it writes them
 # to doc_status and releases the batch (LR2 §8.2). Discovery is a single
 # streaming pass, so peak scan memory is O(batch) instead of O(files in the

--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -152,6 +152,25 @@ class SourceConflictRepairCASError(StorageControlPlaneError):
     """
 
 
+class SourceConflictPrimaryUnusableError(ValueError):
+    """The document an operator chose to keep cannot own the canonical source.
+
+    Today the one reason is a CONFIRMED absence of ``full_docs`` content: such a
+    row is an unprocessable stub, so the source key would end up owned by a
+    document that can never exist, and scan classification deletes exactly those
+    rows (``STALE_STUB``) — which would remove the primary and leave the demoted
+    documents pointing at an id that no longer exists, with no way back because a
+    repair only demotes.
+
+    Distinct from the plain ``ValueError`` that ``repair_source_conflict`` raises
+    for "not a current primary candidate": both are 409s with the same recovery
+    shape (pick a different primary), but conflating them makes the API report
+    "not a candidate" for a row that IS one, which sends the operator to re-list
+    a conflict that has not changed. It subclasses ``ValueError`` so a caller
+    that only handles the coarse "bad primary" case still refuses safely.
+    """
+
+
 class StorageRecordNotFoundError(KeyError):
     """A targeted doc_status field update referenced a non-existent record.
 

--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -155,20 +155,43 @@ class SourceConflictRepairCASError(StorageControlPlaneError):
 class SourceConflictPrimaryUnusableError(ValueError):
     """The document an operator chose to keep cannot own the canonical source.
 
-    Today the one reason is a CONFIRMED absence of ``full_docs`` content: such a
-    row is an unprocessable stub, so the source key would end up owned by a
-    document that can never exist, and scan classification deletes exactly those
-    rows (``STALE_STUB``) — which would remove the primary and leave the demoted
-    documents pointing at an id that no longer exists, with no way back because a
-    repair only demotes.
+    Two distinct reasons, and a caller that renders one message for both tells
+    the operator something false about their data — so the reason travels with
+    the exception as :attr:`reason` rather than only inside the message text
+    (which callers deliberately do not forward: it is not guaranteed to be
+    client-safe):
+
+    * ``REASON_NO_CONTENT`` — a CONFIRMED absence of ``full_docs`` content. Such
+      a row is an unprocessable stub, so the source key would end up owned by a
+      document that can never exist, and scan classification deletes exactly
+      those rows (``STALE_STUB``) — which would remove the primary and leave the
+      demoted documents pointing at an id that no longer exists;
+    * ``REASON_CONTENT_ELSEWHERE`` — the content already belongs to another
+      document (:attr:`holder_doc_id`), under a different canonical source. The
+      processing stage marks such a document FAILED-duplicate and deletes its
+      body, so the key it was just given would end up with no primary.
+
+    Either way a repair only demotes, so a key left with no candidate has no
+    conflict left to settle — which is why both are refused BEFORE the
+    demotions rather than reported after them.
 
     Distinct from the plain ``ValueError`` that ``repair_source_conflict`` raises
-    for "not a current primary candidate": both are 409s with the same recovery
-    shape (pick a different primary), but conflating them makes the API report
-    "not a candidate" for a row that IS one, which sends the operator to re-list
-    a conflict that has not changed. It subclasses ``ValueError`` so a caller
-    that only handles the coarse "bad primary" case still refuses safely.
+    for "not a current primary candidate": those are all 409s, but conflating
+    them makes the API report "not a candidate" for a row that IS one, which
+    sends the operator to re-list a conflict that has not changed. It subclasses
+    ``ValueError`` so a caller that only handles the coarse "bad primary" case
+    still refuses safely.
     """
+
+    REASON_NO_CONTENT = "no_full_docs_content"
+    REASON_CONTENT_ELSEWHERE = "content_belongs_to_another_document"
+
+    def __init__(self, message: str, *, reason: str, holder_doc_id: str = "") -> None:
+        super().__init__(message)
+        self.reason = reason
+        # Set for REASON_CONTENT_ELSEWHERE: the document the content belongs to,
+        # which is the one thing the operator needs in order to act.
+        self.holder_doc_id = holder_doc_id
 
 
 class StorageRecordNotFoundError(KeyError):

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -612,10 +612,14 @@ class JsonDocStatusStorage(DocStatusStorage):
     ) -> Union[tuple[str, dict[str, Any]], None]:
         """Find an existing record whose content_hash field matches.
 
-        ``exclude_doc_id`` skips that row so the duplicate check can exclude
-        the doc being processed (see base contract). JSON has no content_hash
-        index, so this is a single full dict scan either way — the exclusion
-        only drops the self-row in the same pass, never adding a second scan.
+        ``exclude_doc_id`` skips that row AND any row that merely points at it
+        (``is_duplicate`` naming it as ``original_doc_id``) so the duplicate
+        check can neither be answered with the row being processed nor with a
+        record of that row (see base contract). JSON has no content_hash index,
+        so this is a single full dict scan either way — both exclusions are
+        predicates in the same pass, which is also why skipping a pointer row
+        cannot truncate the search: the scan keeps looking for the earliest
+        remaining holder.
 
         Returns the EARLIEST match by ``(created_at, id)`` rather than the
         first in dict order: insertion order is not creation order once rows
@@ -632,6 +636,8 @@ class JsonDocStatusStorage(DocStatusStorage):
         async with self._storage_lock:
             for doc_id, doc_data in self._data.items():
                 if doc_id == exclude_doc_id:
+                    continue
+                if self._row_points_at_as_duplicate(doc_data, exclude_doc_id):
                     continue
                 if doc_data.get("content_hash") != content_hash:
                     continue

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -1183,9 +1183,13 @@ class MongoDocStatusStorage(DocStatusStorage):
         Uses the partial ``content_hash`` index. Empty strings are treated as a
         miss to align with the partial-index predicate; legacy rows missing the
         field cannot match a non-empty query because the query requires an
-        exact value. ``exclude_doc_id`` adds ``_id: {$ne: ...}`` so the
-        duplicate check excludes the doc being processed in-query (see base
-        contract), still served by the content_hash index.
+        exact value. ``exclude_doc_id`` adds ``_id: {$ne: ...}`` plus a ``$nor``
+        clause dropping any row that merely POINTS at that id (``is_duplicate``
+        naming it as ``original_doc_id``), so the duplicate check excludes both
+        the doc being processed and a record of it in-query (see base contract),
+        still served by the content_hash index. Both are query predicates, so
+        skipping a pointer row cannot truncate the search — the sort + ``limit``
+        still yield the earliest row that survives them.
 
         Fail-closed: a query error PROPAGATES. ``None`` means "confirmed no
         other holder", which the dedup callers act on destructively — they
@@ -1204,6 +1208,12 @@ class MongoDocStatusStorage(DocStatusStorage):
         query: dict[str, Any] = {"content_hash": content_hash}
         if exclude_doc_id is not None:
             query["_id"] = {"$ne": exclude_doc_id}
+            query["$nor"] = [
+                {
+                    "metadata.is_duplicate": True,
+                    "metadata.original_doc_id": exclude_doc_id,
+                }
+            ]
         cursor = self._data.find(query).sort([("created_at", 1), ("_id", 1)]).limit(1)
         rows = await cursor.to_list(length=1)
         if not rows:

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -1527,16 +1527,19 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 )
             else:
                 await self._ensure_content_hash_mapping()
-                added = await self._ensure_scheduling_fields_mapping()
-                if "__mirrored_id" in added:
-                    # Supersedes the version-gated mapping-only check used by
-                    # the KV store: this index needs __mirrored_id VALUES on
-                    # every cluster version (its scheduling page has no PIT),
-                    # and a mapping present with values missing is exactly the
-                    # silent skip we must prevent. Only a pre-existing index
-                    # that LACKED the mapping can hold such docs, so the audit
-                    # costs nothing on an already-migrated index.
-                    await self._ensure_scheduling_tiebreaker_ready()
+                await self._ensure_scheduling_fields_mapping()
+                # Unconditional for every pre-existing index. Gating this on
+                # "we just added the mapping" was wrong: the mapping present
+                # does NOT imply the values are present. A snapshot restore, a
+                # hand-added mapping, an external writer — and, worst, THIS
+                # migration itself: put_mapping lands before the backfill, so a
+                # crash or a raise in between leaves the mapping present with
+                # values missing, and the next startup would then skip the audit
+                # forever. The audit is one `_count` on a healthy index (see
+                # _ensure_scheduling_tiebreaker_ready), which is the right price
+                # for an invariant whose violation silently drops documents from
+                # every sweep.
+                await self._ensure_scheduling_tiebreaker_ready()
         except RequestError as e:
             if "resource_already_exists_exception" not in str(e):
                 raise
@@ -1583,14 +1586,14 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         (new fields only — existing indexes need nothing else for new docs).
         The mapping alone is NOT sufficient: legacy docs predating the field
         still lack the VALUE, which
-        :meth:`_ensure_scheduling_tiebreaker_ready` repairs. A put failure is
-        logged rather than raised here — the readiness check that follows is
-        the one that fails startup.
+        :meth:`_ensure_scheduling_tiebreaker_ready` repairs — unconditionally,
+        because this method landing the mapping is not evidence about the values
+        (not even when it just added it: it returns before the backfill runs). A
+        put failure is logged rather than raised here — the readiness check that
+        follows is the one that fails startup.
 
-        Returns the field names that were absent, which is the precise "this
-        index predates the field" signal the value audit keys off (an index
-        that already maps ``__mirrored_id`` was written by code that mirrors
-        the id on every write, so its docs all carry a value).
+        Returns the field names that were absent, for callers that want to log
+        the migration; it is NOT a licence to skip the value audit.
         """
         try:
             mapping = await self.client.indices.get_mapping(index=self._index_name)

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -1397,6 +1397,12 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
     # source-conflict listing/repair APIs — never materialize the whole set.
     _CONFLICT_SAMPLE_CAP: ClassVar[int] = 32
 
+    # How many of the earliest content_hash holders one dedup lookup may read
+    # while skipping duplicate markers that point at the excluded document (see
+    # ``get_doc_by_content_hash``). Every hit past the first is a pointer row, so
+    # this bounds a pathological chain rather than a normal lookup.
+    _CONTENT_HASH_POINTER_WINDOW: ClassVar[int] = 8
+
     # Fields the lightweight scheduling projection needs from ``_source`` —
     # never ``chunks_list`` (see ``get_docs_by_ids``).
     _SCHEDULING_SOURCE_FIELDS: ClassVar[list[str]] = [
@@ -2292,6 +2298,20 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         processed in-query (see base contract), still served by the keyword
         term.
 
+        Its second half — dropping a row that merely POINTS at that id
+        (``is_duplicate`` naming it as ``original_doc_id``) — is applied to
+        ``_source`` over a bounded ordered window instead of as a term query.
+        ``metadata`` is under ``dynamic: true`` with no declared mapping for
+        ``original_doc_id``, so its field type is whatever dynamic mapping made
+        it (a string becomes ``text`` plus a ``.keyword`` subfield): a term
+        query on the bare path would silently match nothing, which fails OPEN
+        exactly where the pointer must be excluded. ``_source`` carries the
+        value whatever the mapping says. The window keeps the read bounded and
+        the search intact — the first surviving hit is still the earliest holder
+        — and a window filled entirely with pointers to the same document
+        RAISES rather than reporting "no holder", since ``None`` here drives
+        destructive action.
+
         Fail-closed, three-state (the distinction the dedup callers need):
         a match → the row; a completed query with no hits → ``None`` (CONFIRMED
         no other holder); an index that is not ready or has vanished, or any
@@ -2328,15 +2348,29 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                     {"created_at": {"order": "asc", "missing": "_first"}},
                     {"__mirrored_id": {"order": "asc"}},
                 ],
-                "size": 1,
+                # One hit is enough unless pointer rows have to be skipped; the
+                # window is only wider when there is an id to point AT.
+                "size": (
+                    self._CONTENT_HASH_POINTER_WINDOW
+                    if exclude_doc_id is not None
+                    else 1
+                ),
             }
             response = await self.client.search(index=self._index_name, body=body)
             hits = response["hits"]["hits"]
             if not hits:
                 return None
-            hit = hits[0]
-            doc = hit["_source"]
-            return hit["_id"], doc
+            for hit in hits:
+                doc = hit["_source"]
+                if self._row_points_at_as_duplicate(doc, exclude_doc_id):
+                    continue
+                return hit["_id"], doc
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] every one of the {len(hits)} earliest "
+                f"holders of content_hash '{content_hash}' is a duplicate marker "
+                f"pointing at {exclude_doc_id}; cannot confirm whether a further "
+                f"holder exists beyond the bounded window"
+            )
         except OpenSearchException as e:
             if _is_missing_index_error(e):
                 self._mark_index_missing()

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -1601,41 +1601,75 @@ class PostgreSQLDB:
         existing definition forever. A doc_status index is derived state, so
         rebuilding it is inside the documented upgrade envelope.
 
+        Order matters: create, VERIFY from ``pg_indexes``, and only then retire
+        the superseded index. Dropping first and swallowing a failed create left
+        the table with NO scheduling index — strictly worse than before the
+        upgrade, and silently: the service starts, pages stay correct and
+        memory-bounded (the top-N sort keeps only ``limit`` rows), and only the
+        I/O degrades to a full scan plus a sort per page. Verification reads the
+        catalog rather than inferring success from the absence of an exception.
+
+        A missing index is NOT fatal — index DDL can fail transiently (lock
+        timeout, concurrent DDL, a role without CREATE) and every startup retries
+        — but it is reported at WARNING with the consequence and the DDL to run
+        by hand, because nothing else about a degraded plan is observable.
+
         Guarded and idempotent — retried on every startup until present.
         """
-        # Drop the pre-NULLS-FIRST index; keeping it would cost writes without
-        # ever serving the page query.
+        index_name = "idx_lightrag_doc_status_ws_status_created_nf_id"
+        create_sql = (
+            f"CREATE INDEX IF NOT EXISTS {index_name} "
+            "ON LIGHTRAG_DOC_STATUS "
+            "(workspace, status, created_at NULLS FIRST, id)"
+        )
+        superseded_name = "idx_lightrag_doc_status_ws_status_created_id"
+
         try:
-            await self.execute(
-                "DROP INDEX IF EXISTS idx_lightrag_doc_status_ws_status_created_id"
+            if not await self._doc_status_index_exists(index_name):
+                logger.info(f"Creating index {index_name} on LIGHTRAG_DOC_STATUS")
+                await self.execute(create_sql)
+        except Exception as e:
+            logger.error(
+                f"Failed to create index {index_name} on LIGHTRAG_DOC_STATUS: {e}"
             )
+
+        try:
+            created = await self._doc_status_index_exists(index_name)
+        except Exception as verify_error:
+            logger.error(
+                f"Could not verify scheduling index {index_name}: {verify_error}"
+            )
+            created = False
+
+        if not created:
+            logger.warning(
+                f"Scheduling index {index_name} is MISSING on LIGHTRAG_DOC_STATUS: "
+                "every scheduling page falls back to a full scan plus a per-page "
+                "sort (O(rows) I/O per page, O(rows²/page_size) per sweep). "
+                f"Keeping the superseded index {superseded_name} so paging is no "
+                "worse than before this upgrade; startup retries the creation. "
+                f"To create it by hand: {create_sql}"
+            )
+            return
+
+        # Only now is the old index dead weight: it costs writes without ever
+        # serving the page query (PG's ASC default is NULLS LAST).
+        try:
+            await self.execute(f"DROP INDEX IF EXISTS {superseded_name}")
         except Exception as drop_error:  # pragma: no cover - best effort
             logger.warning(f"Could not drop superseded scheduling index: {drop_error}")
 
-        indexes = [
-            (
-                "idx_lightrag_doc_status_ws_status_created_nf_id",
-                "CREATE INDEX IF NOT EXISTS "
-                "idx_lightrag_doc_status_ws_status_created_nf_id "
-                "ON LIGHTRAG_DOC_STATUS "
-                "(workspace, status, created_at NULLS FIRST, id)",
-            ),
-        ]
-        for index_name, create_sql in indexes:
-            try:
-                check_index_sql = """
-                SELECT indexname FROM pg_indexes
-                WHERE tablename = 'lightrag_doc_status'
-                  AND indexname = $1
-                """
-                index_info = await self.query(check_index_sql, [index_name])
-                if not index_info:
-                    logger.info(f"Creating index {index_name} on LIGHTRAG_DOC_STATUS")
-                    await self.execute(create_sql)
-            except Exception as e:
-                logger.error(
-                    f"Failed to create index {index_name} on LIGHTRAG_DOC_STATUS: {e}"
-                )
+    async def _doc_status_index_exists(self, index_name: str) -> bool:
+        """Is ``index_name`` present on LIGHTRAG_DOC_STATUS, per the catalog?"""
+        rows = await self.query(
+            """
+            SELECT indexname FROM pg_indexes
+            WHERE tablename = 'lightrag_doc_status'
+              AND indexname = $1
+            """,
+            [index_name],
+        )
+        return bool(rows)
 
     async def _migrate_text_chunks_add_heading_sidecar(self):
         """Add heading and sidecar JSONB columns to LIGHTRAG_DOC_CHUNKS if missing."""

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -1588,17 +1588,37 @@ class PostgreSQLDB:
         """Create the keyset-sweep index backing the memory-bounding scheduling
         page API (Phase 1).
 
-        The (workspace, status, created_at, id) index matches the page query's
-        WHERE workspace/status equality prefix and its ORDER BY created_at ASC,
-        id ASC keyset tail, so a page read is an index scan resuming at the
-        row-value comparison — never a full-table sort. Guarded and idempotent —
-        retried on every startup until present.
+        ``NULLS FIRST`` is load-bearing, not decoration. PostgreSQL's default for
+        ``ASC`` is NULLS LAST, so an index declared ``(… created_at, id)`` does
+        NOT satisfy ``ORDER BY created_at ASC NULLS FIRST, id ASC`` — the planner
+        cannot use it for ordering and falls back to a bitmap scan plus a
+        top-N sort of every row past the cursor. Measured at 60k rows: the old
+        index sorted 7583 rows per page; with this one the same page is an
+        ordered index scan touching exactly ``limit`` rows (500), 4.6ms → 0.23ms.
+
+        Superseded name: the old index is dropped, because
+        ``CREATE INDEX IF NOT EXISTS`` on the same name would keep the (wrong)
+        existing definition forever. A doc_status index is derived state, so
+        rebuilding it is inside the documented upgrade envelope.
+
+        Guarded and idempotent — retried on every startup until present.
         """
+        # Drop the pre-NULLS-FIRST index; keeping it would cost writes without
+        # ever serving the page query.
+        try:
+            await self.execute(
+                "DROP INDEX IF EXISTS idx_lightrag_doc_status_ws_status_created_id"
+            )
+        except Exception as drop_error:  # pragma: no cover - best effort
+            logger.warning(f"Could not drop superseded scheduling index: {drop_error}")
+
         indexes = [
             (
-                "idx_lightrag_doc_status_ws_status_created_id",
-                "CREATE INDEX IF NOT EXISTS idx_lightrag_doc_status_ws_status_created_id "
-                "ON LIGHTRAG_DOC_STATUS (workspace, status, created_at, id)",
+                "idx_lightrag_doc_status_ws_status_created_nf_id",
+                "CREATE INDEX IF NOT EXISTS "
+                "idx_lightrag_doc_status_ws_status_created_nf_id "
+                "ON LIGHTRAG_DOC_STATUS "
+                "(workspace, status, created_at NULLS FIRST, id)",
             ),
         ]
         for index_name, create_sql in indexes:
@@ -5451,16 +5471,29 @@ class PGDocStatusStorage(DocStatusStorage):
     ) -> DocStatusPage:
         """Bounded keyset page over LIGHTRAG_DOC_STATUS.
 
-        A single combined keyset across all requested statuses is correct on
-        PG: ``ORDER BY created_at ASC, id ASC`` plus the composite row-value
-        comparison ``(created_at, id) > ($cur, $id)`` yields the global
-        (created_at, id) order natively — no k-way merge needed. The
-        ``idx_lightrag_doc_status_ws_status_created_id`` (workspace, status,
-        created_at, id) index backs the scan: for a single status it is a pure
-        index range scan resuming at the row-value comparison; for multiple
-        statuses the planner combines per-status index ranges under the LIMIT
-        (top-N bounded — page memory stays O(limit), never a full-table
-        materialization).
+        **One parenthesised branch per status, UNION ALL'd**, each carrying the
+        same keyset predicate, the same ``ORDER BY created_at ASC NULLS FIRST,
+        id ASC`` and the same ``LIMIT``; the wrapper re-sorts and re-limits. That
+        shape is what lets the planner MergeAppend ordered index scans on
+        ``idx_lightrag_doc_status_ws_status_created_nf_id``.
+
+        It replaced a single ``status = ANY($2)`` query, which read as if the
+        planner would combine per-status index ranges under the LIMIT. Measured
+        instead, on 60k rows: one status was a bitmap scan plus a top-N sort of
+        7583 rows, and TWO statuses — the AUTO sweep's own shape — was a full
+        ``Seq Scan`` of the table plus a sort, every page. Page *memory* was
+        bounded (top-N heapsort keeps ``limit`` rows), so the RSS claim held, but
+        the I/O was O(table) per page, making a full sweep O(n²/page_size).
+        With the branch form the same two-status page is an ordered index scan
+        touching 501 rows, 14.8ms → 0.29ms.
+
+        The consumed-frontier rules survive the rewrite. ``next_position`` is the
+        last RETURNED row's key: an unreturned row is either one of the fetched
+        rows outside the top-``limit`` window (so above the frontier), or beyond
+        a branch that hit its own LIMIT — and that branch's last fetched row is
+        itself ≥ the frontier, since otherwise all of its rows would have fitted
+        in the window. ``returned < limit`` still proves exhaustion, because the
+        union can only be short when every branch was short.
 
         Consumed-position contract (SQL-side filtering makes it trivial):
         every predicate — workspace and status membership — is part of the DB
@@ -5494,12 +5527,10 @@ class PGDocStatusStorage(DocStatusStorage):
         if not statuses or position is CURSOR_END:
             return DocStatusPage(docs={}, next_position=CURSOR_END)
 
-        params: list[Any] = [self.workspace, [s.value for s in statuses]]
-        sql = (
-            "SELECT id, status, created_at, updated_at, file_path, track_id, "
-            "metadata "
-            "FROM LIGHTRAG_DOC_STATUS WHERE workspace=$1 AND status = ANY($2)"
-        )
+        params: list[Any] = [self.workspace]
+
+        # The keyset predicate is identical in every branch; build it once.
+        cursor_sql = ""
         if isinstance(position, CursorAfter):
             cur_created, cur_id = self._decode_cursor(position.opaque)
             if cur_created is None:
@@ -5507,7 +5538,7 @@ class PGDocStatusStorage(DocStatusStorage):
                 # through the remaining NULL rows by id, then everything
                 # with a real timestamp.
                 params.append(cur_id)
-                sql += (
+                cursor_sql = (
                     f" AND ((created_at IS NULL AND id > ${len(params)}) "
                     "OR created_at IS NOT NULL)"
                 )
@@ -5515,13 +5546,31 @@ class PGDocStatusStorage(DocStatusStorage):
                 # Past the NULL bucket: only real-timestamp rows can follow.
                 params.append(cur_created)
                 params.append(cur_id)
-                sql += (
+                cursor_sql = (
                     " AND created_at IS NOT NULL AND "
                     f"(created_at, id) > (${len(params) - 1}::timestamp, "
                     f"${len(params)})"
                 )
         params.append(limit)
-        sql += f" ORDER BY created_at ASC NULLS FIRST, id ASC LIMIT ${len(params)}"
+        limit_param = len(params)
+
+        order_by = "ORDER BY created_at ASC NULLS FIRST, id ASC"
+        branches: list[str] = []
+        for status in statuses:
+            params.append(status.value)
+            branches.append(
+                "(SELECT id, status, created_at, updated_at, file_path, "
+                "track_id, metadata FROM LIGHTRAG_DOC_STATUS "
+                f"WHERE workspace=$1 AND status=${len(params)}{cursor_sql} "
+                f"{order_by} LIMIT ${limit_param})"
+            )
+        if len(branches) == 1:
+            sql = branches[0]
+        else:
+            sql = (
+                f"SELECT * FROM ({' UNION ALL '.join(branches)}) u "
+                f"{order_by} LIMIT ${limit_param}"
+            )
 
         # Any asyncpg error propagates out of db.query — strict pages never
         # commit a new cursor on failure.

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -5289,8 +5289,13 @@ class PGDocStatusStorage(DocStatusStorage):
         Replaces the base-class full-table scan with an indexed query on
         ``workspace + content_hash``. Empty strings are treated as a miss
         to align with the partial-index predicate. ``exclude_doc_id`` adds an
-        indexed ``AND id != $3`` so the duplicate check gets the earliest OTHER
-        holder in one bounded query (see base contract).
+        indexed ``AND id != $3`` plus a jsonb predicate dropping any row that
+        merely POINTS at that id (``is_duplicate`` naming it as
+        ``original_doc_id``), so the duplicate check gets the earliest holder
+        that is neither the row being processed nor a record of it, in one
+        bounded query (see base contract). Both are WHERE predicates on the same
+        indexed scan, so skipping a pointer row cannot truncate the search —
+        ``LIMIT 1`` still returns the earliest row that survives them.
         """
         if not content_hash:
             return None
@@ -5299,7 +5304,18 @@ class PGDocStatusStorage(DocStatusStorage):
         exclude_clause = ""
         if exclude_doc_id is not None:
             params.append(exclude_doc_id)
-            exclude_clause = f" AND id <> ${len(params)}"
+            # Same ``(metadata->>'is_duplicate')::boolean`` reading as
+            # ``_PRIMARY_PREDICATE`` — one interpretation of that flag per
+            # backend, and a non-boolean value raises (fail closed) instead of
+            # silently deciding. ``original_doc_id`` is COALESCEd because a NULL
+            # would make the whole NOT(...) NULL, and a WHERE that is NULL drops
+            # the row — filtering out a duplicate marker that recorded no
+            # original, which is not what this excludes.
+            exclude_clause = (
+                f" AND id <> ${len(params)} AND NOT ("
+                "COALESCE((metadata->>'is_duplicate')::boolean, false) "
+                f"AND COALESCE(metadata->>'original_doc_id', '') = ${len(params)})"
+            )
         sql = (
             "SELECT * FROM LIGHTRAG_DOC_STATUS "
             f"WHERE workspace=$1 AND content_hash=$2{exclude_clause} "

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -1744,10 +1744,14 @@ class RedisDocStatusStorage(DocStatusStorage):
     ) -> Union[tuple[str, dict[str, Any]], None]:
         """Find an existing record whose content_hash field matches.
 
-        ``exclude_doc_id`` skips that row so the duplicate check can exclude
-        the doc being processed (see base contract). Redis has no content_hash
-        index, so this SCANs the keyspace either way — the exclusion only drops
-        the self-row in the same pass, never adding a second scan.
+        ``exclude_doc_id`` skips that row AND any row that merely points at it
+        (``is_duplicate`` naming it as ``original_doc_id``), so the duplicate
+        check can neither be answered with the row being processed nor with a
+        record of that row (see base contract). Redis has no content_hash index,
+        so this SCANs the keyspace either way — both exclusions are predicates
+        in the same pass, which is also why skipping a pointer row cannot
+        truncate the search: the scan keeps looking for the earliest remaining
+        holder.
 
         Fail-closed: transport and decode failures PROPAGATE. ``None`` means
         "confirmed no other holder", and the dedup callers act on it
@@ -1796,6 +1800,8 @@ class RedisDocStatusStorage(DocStatusStorage):
                                 f"holds the hash"
                             ) from e
                         if doc_data.get("content_hash") != content_hash:
+                            continue
+                        if self._row_points_at_as_duplicate(doc_data, exclude_doc_id):
                             continue
                         created = doc_data.get("created_at")
                         sort_key = (

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -785,6 +785,11 @@ class RedisDocStatusStorage(DocStatusStorage):
     # on a single doc key is not expected (per-doc writes are serialized by
     # the pipeline); the cap turns a pathological livelock into an error.
     _WATCH_RETRY_LIMIT: ClassVar[int] = 50
+    # Key names per batch when the rebuilt sidecar is switched into place. This
+    # is the ONLY thing bounding that switch: it caps both the Python list of key
+    # names and the commands queued in one round trip, so a rebuild costs
+    # O(batch) instead of O(total_docs) (see _publish_rebuilt_index).
+    _PUBLISH_BATCH: ClassVar[int] = 512
 
     def __post_init__(self):
         validate_workspace(self.workspace)
@@ -2324,21 +2329,44 @@ class RedisDocStatusStorage(DocStatusStorage):
         instead: ``_ensure_no_eviction_policy`` refuses at startup to run on a
         Redis configured to evict TTL-less keys. An operator who suspects a
         damaged index deletes the ``…__sched:*`` keys and restarts, which takes
-        the branch below."""
+        the branch below.
+
+        One exception to "any status key means built": a LEFTOVER temp keyspace
+        with no rebuild lock held. The publish is streamed in bounded batches
+        instead of switched in one transaction (see
+        :meth:`_publish_rebuilt_index`), so a rebuilder that died mid-publish
+        leaves some official keys switched and the rest absent — which the
+        structural check alone would read as healthy. The temp keyspace is what
+        distinguishes that: a completed rebuild leaves none, and only a live
+        rebuilder (lock held) legitimately has one."""
         status_pattern = f"{self._sched_prefix}:status:*"
         primary_pattern = f"{self.final_namespace}:*"
         lock_key = f"{self._sched_prefix}:rebuild_lock"
         async with self._get_redis_connection() as redis:
-            if await self._any_key(redis, status_pattern):
+            interrupted = await self._interrupted_publish(redis, lock_key)
+            if interrupted:
+                logger.warning(
+                    f"[{self.workspace}] a previous scheduling sidecar rebuild for "
+                    f"{self.namespace} left its temp keyspace behind with no rebuild "
+                    f"in progress; the index may be half-published, so it is "
+                    f"rebuilt instead of trusted"
+                )
+            if not interrupted and await self._any_key(redis, status_pattern):
                 return  # already built + maintained live
             if not await self._any_key(redis, primary_pattern):
                 return  # nothing to build (empty / freshly dropped workspace)
             got_lock = await redis.set(lock_key, "1", nx=True, ex=300)
             if not got_lock:
                 # Another worker is rebuilding: wait (bounded) for the switch.
+                # Completion is "status keys present AND no temp keyspace left":
+                # with a streamed publish the FIRST rename already makes a status
+                # key appear, so status keys alone would release us onto a
+                # half-published index.
                 for _ in range(60):
                     await asyncio.sleep(1)
-                    if await self._any_key(redis, status_pattern):
+                    if await self._any_key(
+                        redis, status_pattern
+                    ) and not await self._temp_keyspace_present(redis):
                         return
                     if not await self._any_key(redis, primary_pattern):
                         return  # workspace emptied while we waited
@@ -2348,32 +2376,74 @@ class RedisDocStatusStorage(DocStatusStorage):
                 )
             try:
                 # Re-check under the lock: another worker may have finished
-                # between our probe and acquiring the lock.
-                if await self._any_key(redis, status_pattern):
+                # between our probe and acquiring the lock. An interrupted
+                # publish is NOT waved through by this check.
+                if not interrupted and await self._any_key(redis, status_pattern):
                     return
-                await self._do_rebuild(redis)
+                await self._do_rebuild(redis, recover_stale_official=interrupted)
             finally:
                 await redis.delete(lock_key)
 
-    async def _do_rebuild(self, redis) -> None:
-        """Stream the primary rows into a temporary keyspace, then atomically
-        switch it into place.
+    async def _temp_keyspace_present(self, redis) -> bool:
+        """Does the rebuild temp keyspace hold any key? (bounded probe)"""
+        temp_prefix = f"{self._sched_prefix}_rebuild"
+        for pattern in (f"{temp_prefix}:status:*", f"{temp_prefix}:basename:*"):
+            if await self._any_key(redis, pattern):
+                return True
+        return False
+
+    async def _interrupted_publish(self, redis, lock_key: str) -> bool:
+        """True when a temp keyspace survives with NO rebuilder holding the lock.
+
+        Probe order is temp-keyspace then lock, deliberately: a rebuilder that
+        finishes in between reads as "temp present, lock present" — a live
+        rebuild — so the worst case is one extra wait cycle rather than a
+        spurious O(total_docs) rebuild.
+        """
+        if not await self._temp_keyspace_present(redis):
+            return False
+        return await redis.get(lock_key) is None
+
+    async def _do_rebuild(self, redis, *, recover_stale_official: bool = False) -> None:
+        """Stream the primary rows into a temporary keyspace, then switch it in.
 
         The temp keyspace (``…__sched_rebuild:*``) is disjoint from both the
         official ``…__sched:*`` patterns and the primary ``{ns}:*`` pattern, so
         neither the SCAN of primary rows nor the official index touches it. The
-        switch — DELETE of every stale official key followed by RENAME of every
-        temp key into its official name — runs inside one ``MULTI/EXEC`` so a
-        reader never observes a partial switch; a crash before the switch
-        leaves the old official index untouched and the temp keyspace safe to
-        discard on the next attempt. See ``_publish_rebuilt_index`` for why the
-        switch also has to guard against concurrent WRITERS, not just readers.
+        switch RENAMEs each temp key over its official name in bounded batches
+        (:meth:`_publish_rebuilt_index`); a crash before the switch leaves the
+        temp keyspace safe to discard on the next attempt, and a crash DURING it
+        is detected by that same leftover keyspace (see
+        :meth:`_rebuild_scheduling_sidecar`).
+
+        Stale official ``basename:*`` keys are deleted UP FRONT rather than
+        during the switch. Two reasons: it needs no O(total_docs) record of which
+        names the switch recreated, and the window in which a basename key is
+        missing is exactly the window in which the status keys are missing too —
+        the state that forces a rebuild on the next startup. Deleting them
+        between the renames could instead drop a name the switch had already
+        published, and a missing source-multimap entry does NOT self-heal: it
+        reads as "no primary for this source" and lets an enqueue admit a
+        duplicate.
+
+        ``recover_stale_official`` additionally clears the official STATUS keys:
+        set only when the caller detected a half-published index, where those
+        keys are this rebuild's own leftovers rather than a live writer's work.
+        Clearing them here (instead of teaching the publish to tolerate them)
+        keeps the publish probe's meaning intact — a status key present at
+        publish time still means a concurrent writer, and still refuses.
         """
         temp_prefix = f"{self._sched_prefix}_rebuild"
-        # Clear any leftover temp keyspace from a crashed prior attempt.
-        await self._delete_by_patterns(
-            redis, [f"{temp_prefix}:status:*", f"{temp_prefix}:basename:*"]
-        )
+        stale_patterns = [
+            f"{temp_prefix}:status:*",
+            f"{temp_prefix}:basename:*",
+            f"{self._sched_prefix}:basename:*",
+        ]
+        if recover_stale_official:
+            stale_patterns.append(f"{self._sched_prefix}:status:*")
+        # Clear the leftover temp keyspace from a crashed prior attempt, plus the
+        # stale official keys this rebuild is about to republish.
+        await self._delete_by_patterns(redis, stale_patterns)
 
         rebuilt = 0
         statuses_seen: set[str] = set()
@@ -2426,67 +2496,86 @@ class RedisDocStatusStorage(DocStatusStorage):
     async def _publish_rebuilt_index(
         self, redis, temp_prefix: str, statuses_seen: set[str]
     ) -> None:
-        """Switch the temp keyspace into place, refusing to clobber live writes.
+        """RENAME the temp keyspace into place in BOUNDED batches.
 
-        The switch DELETEs the official keys and RENAMEs the temp ones over
-        them, so it must not run while another worker is writing: a write that
-        lands after its row was scanned has already maintained the OFFICIAL
-        index correctly (``_queue_index_ops`` commits row + sidecar in one
-        transaction), and publishing our older snapshot on top would silently
-        revert it — the doc would sit in the wrong status ZSET, so the sweep
-        either re-runs it or never sees it.
+        Cost is O(batch), not O(total_docs). This previously listed every
+        official and every temp key into Python lists and queued one
+        DELETE/RENAME per key into a single ``MULTI``, so a million-document
+        workspace paid an O(N) client allocation AND an O(N) server-side
+        transaction buffer — during the very initialization this phase exists to
+        bound. Nothing here holds more than ``_PUBLISH_BATCH`` key names.
 
-        The rebuild only starts when NO official status key exists (probed, then
-        re-checked under the election lock), so any status key present now was
-        created by a concurrent writer. That is detected two ways: a WATCH on
-        every status-ZSET key name — the enum values plus whatever the scan
-        actually saw, and a write always touches one of them — makes ``EXEC``
-        fail if a write lands in the commit window, and a re-probe under that
-        WATCH catches one that landed earlier during the scan. Either way we
-        refuse: publishing would lose writes, and publishing a snapshot we know
-        is stale is worse than failing loudly. Basename leftovers may legitimately
-        survive a partial eviction, so they are deleted as before.
+        The switch is consequently **not atomic**, which is a scoped trade rather
+        than an oversight. LightRAG runs a single service, so the only writers
+        that could interleave are that service's own workers, and:
+
+        * a write that landed BEFORE the switch is caught by the probe below —
+          the rebuild only starts when no official status key exists, so one
+          present now was created by a concurrent writer, and publishing our
+          older snapshot over it would silently revert a correctly-maintained
+          index (``_queue_index_ops`` commits row + sidecar in one transaction),
+          leaving the doc in the wrong status ZSET so the sweep either re-runs it
+          or never sees it. We refuse instead;
+        * a write that lands DURING the switch is no longer excluded — the
+          ``WATCH``/``MULTI`` made that impossible, and giving it up is what buys
+          the bound. It needs an ordinary doc_status write to a workspace whose
+          sidecar is simultaneously being built from scratch by an elected
+          rebuilder, which single-service initialization does not produce.
+
+        Renames go through ``transaction=False``: the batch needs no
+        all-or-nothing semantics now, and ``RENAME`` already replaces its
+        destination atomically per key — the granularity that actually matters,
+        since no reader ever sees a half-written status ZSET.
         """
         status_pattern = f"{self._sched_prefix}:status:*"
-        watch_keys = sorted(
-            {self._zset_key(s) for s in statuses_seen}
-            | {self._zset_key(s.value) for s in DocStatus}
-        )
-        for _ in range(self._WATCH_RETRY_LIMIT):
-            async with redis.pipeline(transaction=True) as pipe:
-                try:
-                    await pipe.watch(*watch_keys)
-                    if await self._any_key(pipe, status_pattern):
-                        await pipe.unwatch()
-                        raise StorageControlPlaneError(
-                            f"[{self.workspace}] another writer maintained the "
-                            f"scheduling sidecar for {self.namespace} while it was "
-                            f"being rebuilt; refusing to publish a stale snapshot "
-                            f"over live writes. Retry with writers quiesced."
-                        )
-                    official_keys = await self._scan_keys(pipe, [status_pattern])
-                    official_keys += await self._scan_keys(
-                        pipe, [f"{self._sched_prefix}:basename:*"]
+        if await self._any_key(redis, status_pattern):
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] another writer maintained the scheduling "
+                f"sidecar for {self.namespace} while it was being rebuilt; "
+                f"refusing to publish a stale snapshot over live writes. Retry "
+                f"with writers quiesced."
+            )
+
+        published = 0
+        for pattern in (f"{temp_prefix}:status:*", f"{temp_prefix}:basename:*"):
+            # Each rename REMOVES a key from the pattern being scanned, and no
+            # SCAN cursor survives that intact — a positional cursor skips the
+            # entries that shifted under it, and a real hash cursor is only
+            # promised not to miss keys that stay present for the whole
+            # iteration. So sweep in passes: every pass is cursor-based (no
+            # keyspace re-walk per batch) and whatever one pass skipped the next
+            # one picks up. This terminates because a pass that renames nothing
+            # ends it, and any other pass strictly shrinks the pattern.
+            while True:
+                renamed_in_pass = 0
+                cursor = 0
+                while True:
+                    cursor, keys = await redis.scan(
+                        cursor, match=pattern, count=self._PUBLISH_BATCH
                     )
-                    temp_keys = await self._scan_keys(
-                        pipe,
-                        [f"{temp_prefix}:status:*", f"{temp_prefix}:basename:*"],
-                    )
-                    pipe.multi()
-                    for key in official_keys:
-                        pipe.delete(key)
-                    for temp_key in temp_keys:
-                        official = self._sched_prefix + temp_key[len(temp_prefix) :]
-                        pipe.rename(temp_key, official)
-                    await pipe.execute()
-                    return
-                except WatchError:
-                    continue
-        raise StorageControlPlaneError(
-            f"[{self.workspace}] scheduling sidecar publish for {self.namespace} "
-            f"exceeded the WATCH retry budget ({self._WATCH_RETRY_LIMIT}); a "
-            f"concurrent writer keeps racing the switch"
-        )
+                    if keys:
+                        pipe = redis.pipeline(transaction=False)
+                        for temp_key in keys:
+                            official = self._sched_prefix + temp_key[len(temp_prefix) :]
+                            pipe.rename(temp_key, official)
+                        await pipe.execute()
+                        renamed_in_pass += len(keys)
+                    if cursor == 0:
+                        break
+                published += renamed_in_pass
+                if not renamed_in_pass:
+                    break
+
+        # Post-condition, not decoration: a leftover temp keyspace is exactly what
+        # ``_rebuild_scheduling_sidecar`` reads as "half-published", so returning
+        # success while leaving one behind would arm a rebuild on every startup.
+        if await self._temp_keyspace_present(redis):
+            raise StorageControlPlaneError(
+                f"[{self.workspace}] scheduling sidecar publish for "
+                f"{self.namespace} left temp keys behind after renaming "
+                f"{published}; the index is half-published and will be rebuilt "
+                f"on the next startup"
+            )
 
     async def drop(self) -> dict[str, str]:
         """Drop all document status data from storage and clean up resources.

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -18,6 +18,7 @@ from redis.asyncio import Redis, ConnectionPool  # type: ignore
 from redis.exceptions import (  # type: ignore
     RedisError,
     ConnectionError,
+    ResponseError,
     TimeoutError,
     WatchError,
 )
@@ -2493,6 +2494,17 @@ class RedisDocStatusStorage(DocStatusStorage):
             f"({rebuilt} rows) for {self.namespace}"
         )
 
+    @staticmethod
+    def _is_missing_source_rename_error(exc: Exception) -> bool:
+        """True for the specific, benign ``RENAME`` failure a duplicate SCAN
+        return produces: the source key is already gone because an earlier
+        batch in the same publish pass already renamed it. Redis's own error
+        text for this case is exactly ``"no such key"`` (see ``t_string.c`` /
+        ``renameGenericCommand``) — matched narrowly so any other
+        :class:`ResponseError` (auth, readonly replica, wrong type, OOM, …)
+        still aborts the publish instead of being silently absorbed."""
+        return isinstance(exc, ResponseError) and "no such key" in str(exc).lower()
+
     async def _publish_rebuilt_index(
         self, redis, temp_prefix: str, statuses_seen: set[str]
     ) -> None:
@@ -2526,6 +2538,18 @@ class RedisDocStatusStorage(DocStatusStorage):
         all-or-nothing semantics now, and ``RENAME`` already replaces its
         destination atomically per key — the granularity that actually matters,
         since no reader ever sees a half-written status ZSET.
+
+        SCAN's OWN contract, separately from the concurrent-writer question
+        above: "a full iteration retrieves all elements present throughout,
+        but an element may be returned more than once" (Redis docs). This sweep
+        hands SCAN a moving target on purpose (each pass's renames delete from
+        the very pattern being scanned), which is exactly the shape that
+        provokes a duplicate return — a key renamed by an earlier batch in this
+        SAME pass can be handed to us again by a later one. A repeat ``RENAME``
+        on that key fails with "no such key", not a fresh state to react to
+        (the first rename already moved it where it belongs), so that specific
+        error is swallowed per-command rather than left to abort the whole
+        batch — see ``_is_missing_source_rename_error``.
         """
         status_pattern = f"{self._sched_prefix}:status:*"
         if await self._any_key(redis, status_pattern):
@@ -2558,8 +2582,17 @@ class RedisDocStatusStorage(DocStatusStorage):
                         for temp_key in keys:
                             official = self._sched_prefix + temp_key[len(temp_prefix) :]
                             pipe.rename(temp_key, official)
-                        await pipe.execute()
-                        renamed_in_pass += len(keys)
+                        # raise_on_error=False: a duplicate SCAN return makes one
+                        # of these a legitimate "no such key" (an earlier batch in
+                        # THIS pass already renamed it away), not a real failure —
+                        # see the docstring. Any other error still aborts loudly.
+                        results = await pipe.execute(raise_on_error=False)
+                        for temp_key, result in zip(keys, results):
+                            if isinstance(result, Exception):
+                                if not self._is_missing_source_rename_error(result):
+                                    raise result
+                                continue
+                            renamed_in_pass += 1
                     if cursor == 0:
                         break
                 published += renamed_in_pass

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -1230,9 +1230,18 @@ class RedisDocStatusStorage(DocStatusStorage):
     @staticmethod
     def _zset_member(row: dict[str, Any], doc_id: str) -> str:
         """``"{created_at}|{doc_id}"`` — ISO-8601 lexicographic order makes
-        member order the (created_at, id) keyset order. A missing/non-str
-        created_at sorts deterministically first as ""; '|' cannot occur in
-        ISO timestamps so the split is unambiguous."""
+        member order the (created_at, id) keyset order. ``'|'`` cannot occur in
+        ISO timestamps so the split is unambiguous.
+
+        A missing/non-str created_at degrades to ``""``, which puts the member
+        LAST, not first: ``'|'`` (0x7C) sorts after every digit an ISO year can
+        start with. That ordering is not load-bearing — such a row cannot build a
+        ``DocSchedulingRecord`` at all, so a strict page raises on it and a
+        relaxed page consumes-and-skips it (pinned for all five backends in
+        tests/kg/test_doc_status_scheduling_contract.py). Do not "fix" the
+        position by changing this encoding: the ZSET is only rebuilt when absent,
+        so a live index would end up holding both encodings and a rewrite would
+        fail to ZREM the stale member, listing the row twice."""
         created = row.get("created_at")
         return f"{created if isinstance(created, str) else ''}|{doc_id}"
 

--- a/lightrag/kg/scan_job_store.py
+++ b/lightrag/kg/scan_job_store.py
@@ -57,6 +57,17 @@ SCAN_JOB_MAX_COUNTER_KEYS = 32
 # (the longest is ``resume_same_physical_source``), so this only ever refuses a
 # client bug.
 SCAN_JOB_COUNTER_KEY_MAX_BYTES = 64
+# UTF-8 byte cap for the identifiers a record is created with (``track_id`` /
+# ``owner_token``). They are never truncated — a clipped track_id would collide
+# with another job and break ``/scan/status/{track_id}`` — so an over-cap one is
+# refused at create. In-tree values are a generated track id and a uuid4 hex.
+SCAN_JOB_IDENTIFIER_MAX_BYTES = 128
+# Ceiling on the magnitude of one counter. Python ints are arbitrary precision,
+# so without this a 1000-digit delta is ~450 bytes that ``approx_bytes`` counts
+# as 8. 2**53 is also the last integer a JSON client can read back exactly, and
+# these records are serialized to JSON — a counter past it is not representable
+# anyway, so refusing is more honest than storing it.
+SCAN_JOB_COUNTER_VALUE_MAX = 2**53
 # Lease renewed on every owner update; a RUNNING job whose lease has expired is
 # reaped to ABANDONED (owner presumed dead / stalled).
 SCAN_JOB_LEASE_SECONDS = 60.0
@@ -91,6 +102,9 @@ class ScanJobCreateOutcome(str, Enum):
     ACCEPTED = "accepted"
     ALREADY_EXISTS = "already_exists"
     CAPACITY_EXCEEDED = "capacity_exceeded"
+    # An identifier the store refuses to hold (over the per-identifier byte cap).
+    # A client bug, never a reachable state for an in-tree caller.
+    INVALID_IDENTIFIER = "invalid_identifier"
 
 
 class ScanJobUpdateConflict(str, Enum):
@@ -107,8 +121,10 @@ class ScanJobUpdateConflict(str, Enum):
 class ScanJobCreateResult:
     outcome: ScanJobCreateOutcome
     # Public (owner-token-free) snapshot: the existing job on ALREADY_EXISTS,
-    # the new job on ACCEPTED, None on CAPACITY_EXCEEDED.
+    # the new job on ACCEPTED, None on CAPACITY_EXCEEDED / INVALID_IDENTIFIER.
     record: Optional[Dict[str, Any]] = None
+    # Why the create was refused (INVALID_IDENTIFIER only).
+    message: str = ""
 
 
 @dataclass(frozen=True)
@@ -173,14 +189,28 @@ class _ScanJobRecord:
     counters_dropped: int = 0
 
     def approx_bytes(self) -> int:
-        # Cheap serialized-size estimate: counters + all sample bytes + a small
-        # fixed overhead for the scalar fields. Enough to enforce the ceiling
-        # without a real serialize on every append. Keys are measured in UTF-8
-        # BYTES, the same unit the caps are expressed in (``len()`` on a CJK key
-        # would under-count by 3x).
+        """Cheap serialized-size estimate, in the same UTF-8 bytes the caps use.
+
+        Every variable-length part is measured, not assumed: a flat allowance for
+        "the scalar fields" made the ceiling bypassable by whatever the caller
+        put in ``track_id`` / ``owner_token`` / ``message``. Counter VALUES are
+        the one thing counted at a fixed 8 bytes, which holds only because
+        :data:`SCAN_JOB_COUNTER_VALUE_MAX` keeps them inside 64 bits.
+        """
         counts_bytes = sum(_key_bytes(k) + 8 for k in self.counts)
         sample_bytes = sum(b.approx_bytes() for b in self.samples.values())
-        return counts_bytes + sample_bytes + 256
+        scalar_bytes = sum(
+            _key_bytes(value)
+            for value in (
+                self.track_id,
+                self.workspace,
+                self.owner_token,
+                self.status,
+                self.message,
+            )
+        )
+        # Timestamps, version, counters_dropped and the JSON scaffolding.
+        return counts_bytes + sample_bytes + scalar_bytes + 128
 
     def to_public(self) -> Dict[str, Any]:
         """Bounded, owner-token-free snapshot for /scan/status responses."""
@@ -220,6 +250,8 @@ class AsyncioScanJobStore:
         record_max_bytes: int = SCAN_JOB_RECORD_MAX_BYTES,
         max_counter_keys: int = SCAN_JOB_MAX_COUNTER_KEYS,
         counter_key_max_bytes: int = SCAN_JOB_COUNTER_KEY_MAX_BYTES,
+        counter_value_max: int = SCAN_JOB_COUNTER_VALUE_MAX,
+        identifier_max_bytes: int = SCAN_JOB_IDENTIFIER_MAX_BYTES,
         lease_seconds: float = SCAN_JOB_LEASE_SECONDS,
         ttl_seconds: float = SCAN_JOB_TTL_SECONDS,
         clock: Callable[[], float] = time.time,
@@ -231,6 +263,8 @@ class AsyncioScanJobStore:
         self._record_max_bytes = max(1, record_max_bytes)
         self._max_counter_keys = max(1, max_counter_keys)
         self._counter_key_max_bytes = max(1, counter_key_max_bytes)
+        self._counter_value_max = max(1, counter_value_max)
+        self._identifier_max_bytes = max(1, identifier_max_bytes)
         self._lease_seconds = lease_seconds
         self._ttl_seconds = ttl_seconds
         self._clock = clock
@@ -286,7 +320,21 @@ class AsyncioScanJobStore:
         Capacity order: reap expired terminal/abandoned → evict oldest terminal
         → if still full (all valid RUNNING) refuse with CAPACITY_EXCEEDED. An
         existing ``track_id`` returns ALREADY_EXISTS with the existing record
-        (idempotent), so a retried create never duplicates or clobbers."""
+        (idempotent), so a retried create never duplicates or clobbers.
+
+        An identifier past :data:`SCAN_JOB_IDENTIFIER_MAX_BYTES` is refused with
+        INVALID_IDENTIFIER: it is the one part of a record that cannot be
+        truncated (a clipped ``track_id`` would answer another job's status
+        query), so the record ceiling can only hold if the store declines it
+        here."""
+        for label, value in (("track_id", track_id), ("owner_token", owner_token)):
+            if _key_bytes(value) > self._identifier_max_bytes:
+                return ScanJobCreateResult(
+                    ScanJobCreateOutcome.INVALID_IDENTIFIER,
+                    message=(
+                        f"{label} exceeds {self._identifier_max_bytes} UTF-8 bytes"
+                    ),
+                )
         with self._lock:
             now = self._clock()
             self._reap_locked(now)
@@ -352,10 +400,20 @@ class AsyncioScanJobStore:
                 )
 
             for key, delta in (count_deltas or {}).items():
-                if not isinstance(delta, int):
+                if not isinstance(delta, int) or isinstance(delta, bool):
+                    continue
+                if abs(delta) > self._counter_value_max:
+                    # Arbitrary-precision int: the payload the record ceiling
+                    # assumes is 8 bytes. Refuse (and tally) rather than store a
+                    # value no JSON client could read back anyway.
+                    rec.counters_dropped += 1
                     continue
                 if key in rec.counts:
-                    # An existing key adds no bytes: only the integer changes.
+                    # An existing key adds no bytes, but the accumulated value
+                    # must stay inside the same bound as a single delta.
+                    if abs(rec.counts[key] + delta) > self._counter_value_max:
+                        rec.counters_dropped += 1
+                        continue
                     rec.counts[key] += delta
                     continue
                 key_bytes = _key_bytes(key)

--- a/lightrag/kg/scan_job_store.py
+++ b/lightrag/kg/scan_job_store.py
@@ -11,7 +11,9 @@ Manager-server-hosted) store:
   itself UTF-8-byte-capped, so neither the key set nor one key can grow it;
 * three fixed sample buckets (processed / warning / error), each a bounded list
   of UTF-8-byte-capped strings plus ``truncated`` / ``dropped`` markers;
-* a whole-record serialized-byte ceiling re-checked on every mutation.
+* a whole-record serialized-byte ceiling, measured when the record is created
+  and re-checked on every mutation that can grow it — counters, samples and the
+  terminal status message alike.
 
 The update protocol only accepts ``count deltas + at most one bounded sample +
 the expected owner token & version`` — never a full record — and every limit is
@@ -88,6 +90,15 @@ class ScanJobStatus(str, Enum):
     ABANDONED = "abandoned"
 
 
+# The status word is measured at its WIDEST enum value rather than its current
+# one, for the same reason counter values are measured at a fixed 8 bytes: the
+# domain is closed, and a RUNNING → ABANDONED transition (7 → 9 bytes) would
+# otherwise grow a record the growth paths had already filled right up to the
+# ceiling. Fixing the width makes every status transition size-neutral instead of
+# adding a third thing to reserve for.
+_STATUS_MAX_BYTES = max(len(status.value.encode("utf-8")) for status in ScanJobStatus)
+
+
 _TERMINAL_STATUSES = frozenset(
     {
         ScanJobStatus.COMPLETED.value,
@@ -102,8 +113,10 @@ class ScanJobCreateOutcome(str, Enum):
     ACCEPTED = "accepted"
     ALREADY_EXISTS = "already_exists"
     CAPACITY_EXCEEDED = "capacity_exceeded"
-    # An identifier the store refuses to hold (over the per-identifier byte cap).
-    # A client bug, never a reachable state for an in-tree caller.
+    # A record the store refuses to hold: an identifier over the per-identifier
+    # byte cap, or an empty record already over the whole-record ceiling (a
+    # pathological workspace name). A client/config bug, never a reachable state
+    # for an in-tree caller.
     INVALID_IDENTIFIER = "invalid_identifier"
 
 
@@ -193,19 +206,21 @@ class _ScanJobRecord:
 
         Every variable-length part is measured, not assumed: a flat allowance for
         "the scalar fields" made the ceiling bypassable by whatever the caller
-        put in ``track_id`` / ``owner_token`` / ``message``. Counter VALUES are
-        the one thing counted at a fixed 8 bytes, which holds only because
-        :data:`SCAN_JOB_COUNTER_VALUE_MAX` keeps them inside 64 bits.
+        put in ``track_id`` / ``owner_token`` / ``message``. Two fields are
+        counted at a fixed worst-case width instead, both because their domain is
+        closed: counter VALUES at 8 bytes (:data:`SCAN_JOB_COUNTER_VALUE_MAX`
+        keeps them inside 64 bits) and ``status`` at
+        :data:`_STATUS_MAX_BYTES`, which makes a status transition
+        size-neutral rather than a 2-byte way past the ceiling.
         """
         counts_bytes = sum(_key_bytes(k) + 8 for k in self.counts)
         sample_bytes = sum(b.approx_bytes() for b in self.samples.values())
-        scalar_bytes = sum(
+        scalar_bytes = _STATUS_MAX_BYTES + sum(
             _key_bytes(value)
             for value in (
                 self.track_id,
                 self.workspace,
                 self.owner_token,
-                self.status,
                 self.message,
             )
         )
@@ -273,6 +288,32 @@ class AsyncioScanJobStore:
 
     # -- internal, lock held ------------------------------------------------
 
+    def _fit_message_locked(self, rec: _ScanJobRecord, message: str) -> str:
+        """Cap a status message by its own byte cap AND the record's free budget.
+
+        The message is the last variable-length thing written to a record, and it
+        REPLACES whatever was there (so the outgoing message's bytes come back
+        into the budget first). Capping it against the remaining budget — not only
+        against ``sample_max_bytes`` — is what makes "the whole-record ceiling is
+        re-checked on every mutation" true of the status transitions too; without
+        it a record filled to the ceiling by samples/counters could still be
+        pushed one message past it.
+
+        Never squeezes a real deployment: the sample buckets can hold at most
+        ``3 × sample_limit × sample_max_bytes`` (30 KB at the defaults) plus a
+        capped counts dict, so the free budget under a 64 KB ceiling is always
+        tens of kilobytes. It only bites a store configured with a ceiling
+        smaller than one message, where truncating the diagnostic is still better
+        than breaching the bound the store advertises.
+        """
+        remaining = self._record_max_bytes - (
+            rec.approx_bytes() - _key_bytes(rec.message)
+        )
+        budget = min(self._sample_max_bytes, remaining)
+        if budget <= 0:
+            return ""
+        return _cap_sample(message, budget)[0]
+
     def _maybe_abandon_locked(self, rec: _ScanJobRecord, now: float) -> None:
         """A RUNNING job whose lease expired is atomically reaped to ABANDONED
         (owner SIGKILLed / stalled). A later owner-checked completion then loses
@@ -281,7 +322,9 @@ class AsyncioScanJobStore:
             rec.status = ScanJobStatus.ABANDONED.value
             rec.updated_at = now
             rec.version += 1
-            rec.message = "Lease expired: owner presumed dead; job abandoned."
+            rec.message = self._fit_message_locked(
+                rec, "Lease expired: owner presumed dead; job abandoned."
+            )
 
     def _reap_locked(self, now: float) -> None:
         """Reap lease-expired RUNNING jobs to ABANDONED, then evict terminal
@@ -326,7 +369,16 @@ class AsyncioScanJobStore:
         INVALID_IDENTIFIER: it is the one part of a record that cannot be
         truncated (a clipped ``track_id`` would answer another job's status
         query), so the record ceiling can only hold if the store declines it
-        here."""
+        here.
+
+        The freshly built record is then measured against ``record_max_bytes``
+        before it is stored, and refused the same way if it does not fit. The
+        per-identifier cap alone cannot carry that guarantee: ``workspace`` is a
+        scalar ``approx_bytes`` counts but no caller passes to ``create``, so a
+        pathological namespace would otherwise seat an over-ceiling record that
+        every later mutation then (correctly) refuses to grow. Measuring the built
+        record keeps the invariant on the record itself, and covers any scalar
+        added later without a second place to remember."""
         for label, value in (("track_id", track_id), ("owner_token", owner_token)):
             if _key_bytes(value) > self._identifier_max_bytes:
                 return ScanJobCreateResult(
@@ -343,11 +395,6 @@ class AsyncioScanJobStore:
                 return ScanJobCreateResult(
                     ScanJobCreateOutcome.ALREADY_EXISTS, existing.to_public()
                 )
-            if (
-                len(self._jobs) >= self._capacity
-                and not self._evict_one_terminal_locked()
-            ):
-                return ScanJobCreateResult(ScanJobCreateOutcome.CAPACITY_EXCEEDED)
             rec = _ScanJobRecord(
                 track_id=track_id,
                 workspace=self._workspace,
@@ -360,6 +407,23 @@ class AsyncioScanJobStore:
                 lease_expires_at=now + self._lease_seconds,
                 version=1,
             )
+            # Measured (and refused) BEFORE the capacity step, so a record that
+            # cannot be held never evicts a terminal one on its way out.
+            base_bytes = rec.approx_bytes()
+            if base_bytes > self._record_max_bytes:
+                return ScanJobCreateResult(
+                    ScanJobCreateOutcome.INVALID_IDENTIFIER,
+                    message=(
+                        f"an empty job record for this workspace/track_id already "
+                        f"measures {base_bytes} bytes, over the "
+                        f"{self._record_max_bytes}-byte record ceiling"
+                    ),
+                )
+            if (
+                len(self._jobs) >= self._capacity
+                and not self._evict_one_terminal_locked()
+            ):
+                return ScanJobCreateResult(ScanJobCreateOutcome.CAPACITY_EXCEEDED)
             self._jobs[track_id] = rec
             return ScanJobCreateResult(ScanJobCreateOutcome.ACCEPTED, rec.to_public())
 
@@ -489,7 +553,7 @@ class AsyncioScanJobStore:
             rec.updated_at = now
             rec.version += 1
             if message:
-                rec.message = _cap_sample(message, self._sample_max_bytes)[0]
+                rec.message = self._fit_message_locked(rec, message)
             return ScanJobUpdateResult(True, None, rec.to_public())
 
     def get(self, track_id: str) -> Optional[Dict[str, Any]]:
@@ -525,7 +589,7 @@ class AsyncioScanJobStore:
             rec.updated_at = now
             rec.version += 1
             if message:
-                rec.message = _cap_sample(message, self._sample_max_bytes)[0]
+                rec.message = self._fit_message_locked(rec, message)
             return ScanJobUpdateResult(True, None, rec.to_public())
 
     def remove_terminal(self, track_id: str) -> bool:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -81,6 +81,7 @@ from lightrag.constants import (
     DEFAULT_QUEUE_SIZE_ANALYZE,
     DEFAULT_QUEUE_SIZE_INSERT,
     DEFAULT_PIPELINE_SCHEDULING_PAGE_SIZE,
+    DEFAULT_PIPELINE_REQUIRE_STRICT_STORAGE_READS,
     DEFAULT_MAX_PENDING_DOCUMENTS,
     DEFAULT_FILE_PATH_MORE_PLACEHOLDER,
 )
@@ -138,6 +139,7 @@ from lightrag.utils_pipeline import (
     KG_RECOVERY_WARNINGS_METADATA_KEY,
     compute_text_content_hash,
     doc_status_custom_chunk_patch,
+    enforce_strict_storage_capabilities,
     make_custom_chunk_id,
     make_custom_chunk_operation_id,
     normalize_document_file_path,
@@ -701,6 +703,25 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     ``0`` disables paging: one page holds the whole result set, exactly
     reproducing the legacy single-scan behaviour. Negative values are rejected
     at initialization.
+    """
+
+    pipeline_require_strict_storage_reads: bool = field(
+        default=get_env_value(
+            "PIPELINE_REQUIRE_STRICT_STORAGE_READS",
+            DEFAULT_PIPELINE_REQUIRE_STRICT_STORAGE_READS,
+            bool,
+        )
+    )
+    """Refuse to start when doc_status lacks a strict capability (LR2 §11).
+
+    ``False`` (the default) logs a warning naming each gap and its operator-facing
+    consequence, and ``/health`` reports the same under ``capabilities``. ``True``
+    turns those gaps into a startup failure, for a deployment that would rather
+    not run at all than serve 503s. Checked once, after storages initialize.
+
+    There is deliberately no equivalent for bounded PAGING: the paging and typed
+    source-resolution methods are ``@abstractmethod``, so a backend that lacks
+    them cannot be instantiated in the first place.
     """
 
     max_pending_documents: int = field(
@@ -1389,6 +1410,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 if storage:
                     # logger.debug(f"Initializing storage: {storage}")
                     await storage.initialize()
+
+            # After initialize(), so a backend that derives capabilities during
+            # startup (Redis builds its status/source indexes there) is judged on
+            # what it can actually do. Raises only under require=True.
+            enforce_strict_storage_capabilities(
+                self.doc_status,
+                require=bool(self.pipeline_require_strict_storage_reads),
+            )
 
             self._storages_status = StoragesStatus.INITIALIZED
             logger.debug("All storage types initialized")

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -130,6 +130,7 @@ from lightrag.utils_pipeline import (
     resolve_existing_doc_source,
     resolve_doc_file_path,
     resolve_doc_status_parse_engine,
+    source_candidate_set_lock,
     strip_lightrag_doc_prefix,
 )
 
@@ -5393,6 +5394,29 @@ class _PipelineMixin:
         Owner-checked like every other worker status write (LR2 §7.7 items 3/4):
         this one does not go through ``_upsert_doc_status_transition``, so it
         verifies ownership itself before the FAILED-duplicate upsert.
+
+        Marking this document a duplicate REMOVES it from the primary candidates
+        of its canonical source, which makes this one of the writers LR2 §5.5
+        requires a source-conflict commit to be mutually exclusive with. So the
+        decision and the write happen together under
+        :func:`source_candidate_set_lock` — the same keyed lock the repair holds —
+        and the match is re-read inside it. That is what linearizes the two
+        operations instead of merely narrowing the window between them:
+
+        * marking wins the lock → the repair then finds this document is no longer
+          a candidate and refuses BEFORE demoting anything (409), rather than
+          committing demotions and reporting a 503 about storage that was fine;
+        * the repair wins → it commits, verifies the key is Unique and releases;
+          this marking then re-reads and, because the row it matched now points at
+          this document, the lookup skips it (see ``get_doc_by_content_hash``'s
+          exclusion contract) and the marking stands down. Should the content
+          genuinely belong to a THIRD document, the marking proceeds and the key
+          becomes Absent — an ordinary content-dedup state transition AFTER a
+          completed operation, not a half-applied one.
+
+        The probe outside the lock keeps the common case (not a duplicate) exactly
+        as cheap as before: no keyed lock is acquired for a document that has no
+        content twin.
         """
         if not content_hash:
             return False
@@ -5403,50 +5427,63 @@ class _PipelineMixin:
         if not match:
             return False
 
-        if ctx is not None and not await self._still_run_owner(ctx):
-            logger.warning(
-                f"[stale-writer] Discarded duplicate marking for {doc_id} "
-                f"({file_path}): this run no longer owns the pipeline"
+        async with source_candidate_set_lock(self.workspace, file_path):
+            match = await get_duplicate_doc_by_content_hash(
+                self.doc_status, content_hash, doc_id
             )
-            return False
+            if not match:
+                logger.info(
+                    f"Duplicate marking for {doc_id} ({file_path}) stood down: the "
+                    "content's other holder is gone or now points at this document "
+                    "(a source-conflict repair kept it as the primary)"
+                )
+                return False
 
-        original_doc_id, original_doc = match
-        original_track_id = doc_status_field(original_doc, "track_id", "")
-        original_status = doc_status_field(original_doc, "status", "unknown")
-        now = datetime.now(timezone.utc).isoformat()
-        message = (
-            "Identical content already exists under another filename. "
-            f"Original doc_id: {original_doc_id}, Status: {original_status}"
-        )
+            if ctx is not None and not await self._still_run_owner(ctx):
+                logger.warning(
+                    f"[stale-writer] Discarded duplicate marking for {doc_id} "
+                    f"({file_path}): this run no longer owns the pipeline"
+                )
+                return False
 
-        await self.doc_status.upsert(
-            {
-                doc_id: {
-                    "status": DocStatus.FAILED,
-                    "content_summary": (
-                        f"[DUPLICATE:content_hash] Original document: {original_doc_id}"
-                    ),
-                    "content_length": content_length,
-                    "chunks_count": 0,
-                    "chunks_list": [],
-                    "created_at": status_doc.created_at,
-                    "updated_at": now,
-                    "file_path": file_path,
-                    "track_id": status_doc.track_id,
-                    "content_hash": content_hash,
-                    "error_msg": message,
-                    "metadata": doc_status_transition_metadata(
-                        status_doc,
-                        extra={
-                            "is_duplicate": True,
-                            "duplicate_kind": "content_hash",
-                            "original_doc_id": original_doc_id,
-                            "original_track_id": original_track_id,
-                        },
-                    ),
+            original_doc_id, original_doc = match
+            original_track_id = doc_status_field(original_doc, "track_id", "")
+            original_status = doc_status_field(original_doc, "status", "unknown")
+            now = datetime.now(timezone.utc).isoformat()
+            message = (
+                "Identical content already exists under another filename. "
+                f"Original doc_id: {original_doc_id}, Status: {original_status}"
+            )
+
+            await self.doc_status.upsert(
+                {
+                    doc_id: {
+                        "status": DocStatus.FAILED,
+                        "content_summary": (
+                            f"[DUPLICATE:content_hash] Original document: "
+                            f"{original_doc_id}"
+                        ),
+                        "content_length": content_length,
+                        "chunks_count": 0,
+                        "chunks_list": [],
+                        "created_at": status_doc.created_at,
+                        "updated_at": now,
+                        "file_path": file_path,
+                        "track_id": status_doc.track_id,
+                        "content_hash": content_hash,
+                        "error_msg": message,
+                        "metadata": doc_status_transition_metadata(
+                            status_doc,
+                            extra={
+                                "is_duplicate": True,
+                                "duplicate_kind": "content_hash",
+                                "original_doc_id": original_doc_id,
+                                "original_track_id": original_track_id,
+                            },
+                        ),
+                    }
                 }
-            }
-        )
+            )
         try:
             await self.full_docs.delete([doc_id])
             await self.full_docs.index_done_callback()

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2433,6 +2433,16 @@ class _PipelineMixin:
             run_owner_token=token,
             inflight_doc_ids=set(to_process_docs.keys()),
         )
+        # Publish the run context on the instance for the ONE storage write that
+        # cannot receive it as an argument: ``_persist_parsed_full_docs`` is
+        # reached as ``ctx.rag._persist_parsed_full_docs`` from inside a parser
+        # (in-tree and third-party alike), so a parameter would only guard the
+        # parsers that opt in. ``busy`` is a single per-workspace slot and this
+        # instance is per-workspace, so at most one run is ever published here;
+        # the previous value is restored rather than cleared so a nested/handed
+        # off run cannot blank an outer one.
+        previous_run_ctx = getattr(self, "_active_run_ctx", None)
+        self._active_run_ctx = ctx
 
         async def _watch_pipeline_cancellation() -> None:
             """Bridge shared cancellation state into native parser threads.
@@ -2611,6 +2621,9 @@ class _PipelineMixin:
             if feeder_task is not None:
                 teardown_tasks.append(feeder_task)
             await asyncio.gather(*teardown_tasks, return_exceptions=True)
+            # Every worker (hence every parser) is stopped and joined here, so
+            # no further ``_persist_parsed_full_docs`` call belongs to this run.
+            self._active_run_ctx = previous_run_ctx
 
         # If the batch aborted on an internal storage error, the shared
         # cross-file flush buffers may still hold records from the documents
@@ -5320,6 +5333,22 @@ class _PipelineMixin:
             content_hash = compute_text_content_hash(
                 strip_lightrag_doc_prefix(record.get("content") or "", fmt)
             )
+
+        # Owner-checked like every other write a worker makes (LR2 §7.7 items
+        # 3/4/7). This one is reached from inside a parser via ``ctx.rag``, so it
+        # cannot take the batch context as an argument without leaving every
+        # third-party parser unguarded; ``_run_pipeline_batch`` publishes the
+        # context on the instance instead (see there). A parse result that comes
+        # back after this run's ownership was reclaimed must write NEITHER store:
+        # the full_docs body would overwrite content the new owner re-parsed, and
+        # the doc_status patch below would stamp a row the new owner now owns.
+        run_ctx = getattr(self, "_active_run_ctx", None)
+        if run_ctx is not None and not await self._still_run_owner(run_ctx):
+            logger.warning(
+                f"[stale-writer] Discarded parsed content for {doc_id}: this run "
+                "no longer owns the pipeline"
+            )
+            return None
 
         existing = await self.full_docs.get_by_id(doc_id)
         if isinstance(existing, dict):

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -1128,7 +1128,13 @@ class _PipelineMixin:
                 if not content_hash:
                     continue
                 hash_match = await get_existing_doc_by_content_hash(
-                    self.doc_status, content_hash
+                    self.doc_status,
+                    content_hash,
+                    # This id does not exist yet (filter_keys removed the ones
+                    # that do); passing it lets the lookup ignore a pointer row
+                    # that names it as ITS original, which is what makes content
+                    # whose primary row was deleted re-ingestible.
+                    candidate_doc_id=doc_id,
                 )
                 if hash_match:
                     existing_doc_id, existing_doc = hash_match

--- a/lightrag/tools/README_SOURCE_CONFLICT_REPAIR.md
+++ b/lightrag/tools/README_SOURCE_CONFLICT_REPAIR.md
@@ -19,9 +19,10 @@ conflict explicitly.
   keep their status and their `full_docs` entry; they only lose their claim on
   the canonical source, which is what makes the resolver return a single
   primary afterwards.
-- Only `doc_status` is opened. No vector store, graph store, LLM or embedding
-  model is touched, so a doc_status bookkeeping problem never requires a
-  reachable Milvus/Neo4j/LLM endpoint to fix.
+- Only `doc_status` and `full_docs` are opened. No vector store, graph store,
+  LLM or embedding model is touched, so a doc_status bookkeeping problem never
+  requires a reachable Milvus/Neo4j/LLM endpoint to fix. `full_docs` is read (not
+  written) to verify the primary you named — see *Safety*.
 
 ## Usage
 
@@ -54,7 +55,14 @@ from lightrag.tools.source_conflict_repair import (
 
 conflicts = await collect_source_conflicts(rag.doc_status, limit=50)
 result = await repair_one_conflict(
-    rag.doc_status, "report.docx", "doc-abc123", apply=True
+    rag.doc_status,
+    "report.docx",
+    "doc-abc123",
+    workspace=rag.workspace,
+    # Required for a COMMIT: it is what verifies the primary you named can
+    # actually keep the source. A dry-run needs none.
+    full_docs=rag.full_docs,
+    apply=True,
 )
 ```
 
@@ -86,3 +94,18 @@ guard.
 - Repeating a completed repair is safe: the same request is refused (its token
   described the old candidate set) and a fresh run is a no-op with one
   candidate and nothing to demote.
+- A commit refuses a primary that cannot keep the source, because the demotions
+  are irreversible — a repair only demotes, and a key left with no candidate has
+  no conflict left to settle:
+  - no `full_docs` content (an unprocessable stub a scan would delete) → 409;
+  - content that already exists under a **different** source, which the
+    processing stage will mark `FAILED [DUPLICATE:content_hash]` → 409;
+  - the content could not be *verified* at all — read failure, a backend without
+    strict point reads, or no `full_docs` handle → 503, retry later. Unverified
+    is not verified.
+- Not covered, by construction: a primary that has not been parsed yet has no
+  content hash, so nothing can predict whether its content will turn out to
+  duplicate another document. If it does, the outcome is the ordinary
+  content-dedup steady state (the content lives under that document and this key
+  ends up with no primary), the commit reports it instead of claiming success,
+  and no content is lost.

--- a/lightrag/tools/README_SOURCE_CONFLICT_REPAIR.md
+++ b/lightrag/tools/README_SOURCE_CONFLICT_REPAIR.md
@@ -114,7 +114,9 @@ guard.
     is not verified.
 - Not covered, by construction: a primary that has not been parsed yet has no
   content hash, so nothing can predict whether its content will turn out to
-  duplicate another document. If it does, the outcome is the ordinary
-  content-dedup steady state (the content lives under that document and this key
-  ends up with no primary), the commit reports it instead of claiming success,
+  duplicate another document. The commit itself still succeeds, and the key
+  really is unique when it returns — no marking can interleave with it. A
+  marking that lands afterwards is an ordinary state transition, not a
+  half-applied repair: the outcome is the ordinary content-dedup steady state
+  (the content lives under that document and this key ends up with no primary),
   and no content is lost.

--- a/lightrag/tools/README_SOURCE_CONFLICT_REPAIR.md
+++ b/lightrag/tools/README_SOURCE_CONFLICT_REPAIR.md
@@ -84,6 +84,15 @@ guard.
 ## Safety
 
 - Listing and a repair without `--apply` mutate nothing.
+- A commit is mutually exclusive with every in-deployment writer that can change
+  which documents claim the key: enqueue (the enqueue-serialize lock), the
+  processing stage's duplicate marking (a keyed lock on the canonical source key,
+  which the marking takes too), and clear/delete + scan classification + manual
+  reset (a pending-enqueue reservation). So the two operations are ordered rather
+  than interleaved: if the marking goes first the commit refuses before demoting
+  anything; if the commit goes first it verifies the key is settled and returns,
+  and a later marking is an ordinary state transition. Only the standalone CLI and
+  a second deployment writing the same database fall outside this.
 - A commit re-reads the candidate set under the backend's repair lock and
   proceeds only when the count and fingerprint still match the dry-run
   (compare-and-set), so a concurrent enqueue / delete / repair fails the commit

--- a/lightrag/tools/source_conflict_repair.py
+++ b/lightrag/tools/source_conflict_repair.py
@@ -102,6 +102,10 @@ from lightrag.exceptions import (
     StorageControlPlaneError,
 )
 from lightrag.utils import logger
+from lightrag.utils_pipeline import (
+    doc_status_field,
+    get_duplicate_doc_by_content_hash,
+)
 
 # Pages are bounded on both sides: the backend projects a bounded sample per
 # key, and --all stops after this many pages so a pathological workspace cannot
@@ -337,10 +341,12 @@ async def repair_one_conflict(
     NOT ``doc_status.workspace``: a backend may override its own workspace from
     the environment, and a lock keyed on the wrong one excludes nothing.
 
-    ``full_docs`` enables the contentless-primary refusal (see
-    :func:`refuse_a_contentless_primary`); omitted, the repair proceeds without
-    that check. It cannot live in the backend: a doc_status storage has no handle
-    on full_docs.
+    ``full_docs`` is REQUIRED for a commit (``apply=True``): it is what the
+    contentless-primary refusal reads, and an unverified primary is refused with
+    :class:`StorageControlPlaneError` rather than granted the source — see
+    :func:`refuse_a_contentless_primary` for why the asymmetry is not close. It
+    cannot live in the backend: a doc_status storage has no handle on full_docs.
+    Dry-runs (and ``collect_source_conflicts``) mutate nothing and need none.
     """
     if not apply:
         return await doc_status.repair_source_conflict(
@@ -355,9 +361,12 @@ async def repair_one_conflict(
     # CAS must still be able to refuse. A candidate set that moved before the
     # lock was taken SHOULD 409 rather than be silently accepted.
     async with source_conflict_repair_lock(workspace, canonical_source_key):
-        # Inside the lock: the row could have lost its content between the
-        # operator reading the listing and this commit.
-        await refuse_a_contentless_primary(full_docs, primary_doc_id)
+        # Inside the lock: the row could have lost its content — or gained a
+        # content-hash twin — between the operator reading the listing and this
+        # commit.
+        await refuse_an_unusable_primary(
+            doc_status, full_docs, canonical_source_key, primary_doc_id
+        )
         dry = await doc_status.repair_source_conflict(
             canonical_source_key,
             primary_doc_id=primary_doc_id,
@@ -413,32 +422,39 @@ async def refuse_a_contentless_primary(full_docs: Any, primary_doc_id: str) -> N
     stub when no scan is running at all.
 
     A CONFIRMED absence refuses with
-    :class:`SourceConflictPrimaryUnusableError` (409 — pick another primary); a
-    read that FAILS refuses with :class:`StorageControlPlaneError` (503 — retry
-    once storage is back). Fail-closed on the failure, because "proceed anyway"
-    spends the one guarantee this check exists to provide: the demotions are
-    irreversible (a repair only demotes, and a key with no candidate left cannot
-    be repaired again), while a 503 costs the operator a retry of an operation
-    that has no deadline — the conflict has been sitting there since before they
-    looked at it.
+    :class:`SourceConflictPrimaryUnusableError` (409 — pick another primary).
+    EVERY other answer than "it has content" refuses with
+    :class:`StorageControlPlaneError` (503 — retry once storage is back): a read
+    that failed, a backend with no strict point reads, and no ``full_docs`` handle
+    at all. Unverified is not the same as verified, and the asymmetry is not
+    close: the demotions are irreversible (a repair only demotes, and a key with
+    no candidate left cannot be repaired again), while a 503 costs the operator a
+    retry of an operation that has no deadline — the conflict has been sitting
+    there since before they looked at it.
 
-    A backend WITHOUT strict point reads is the one case that still proceeds, and
-    not as a compromise: scan classification cannot delete the stub either on such
-    a backend (``_confirm_full_docs_absent`` returns ``None`` for exactly the same
-    reason and the STALE_STUB exit never fires), so the interaction this check
-    guards against does not exist there. Every in-tree KV backend declares
-    ``supports_strict_point_reads = True``; this branch is for a third-party one.
+    The no-strict-reads branch used to warn and proceed, reasoning that scan
+    classification cannot delete the stub on such a backend either
+    (``_confirm_full_docs_absent`` returns ``None`` for the same reason, so the
+    STALE_STUB exit never fires). That covers only ONE of the two harms: a stub
+    can never be processed, so handing it the canonical source leaves the key
+    owned by a document that will never exist, whatever the scan does. Every
+    in-tree KV backend declares ``supports_strict_point_reads = True``, so this
+    only refuses a third-party backend that cannot answer the question.
     """
     if full_docs is None:
-        return
-    if not getattr(full_docs, "supports_strict_point_reads", False):
-        logger.warning(
-            f"{type(full_docs).__name__} has no strict point reads; keeping "
-            f"{primary_doc_id} as the primary without confirming it has content "
-            "(a scan cannot delete a stale stub on this backend either, so the "
-            "interaction this check guards against cannot arise)"
+        raise StorageControlPlaneError(
+            f"Cannot confirm whether {primary_doc_id} has full_docs content: no "
+            f"full_docs handle was provided. A source-conflict COMMIT requires "
+            f"one — its demotions are irreversible, so an unverified primary is "
+            f"refused rather than granted the source."
         )
-        return
+    if not getattr(full_docs, "supports_strict_point_reads", False):
+        raise StorageControlPlaneError(
+            f"{type(full_docs).__name__} has no strict point reads, so it cannot "
+            f"confirm whether {primary_doc_id} has content; refusing to commit "
+            f"irreversible demotions on an unverified primary. A contentless stub "
+            f"can never be processed, so it would own the source forever."
+        )
     try:
         content = await full_docs.get_by_id_strict(primary_doc_id)
     except Exception as read_error:
@@ -454,6 +470,94 @@ async def refuse_a_contentless_primary(full_docs: Any, primary_doc_id: str) -> N
         f"unprocessable stub, so it cannot own a canonical source. Pick a "
         f"primary that has content — a scan would delete this row and leave the "
         f"demoted documents pointing at an id that no longer exists."
+    )
+
+
+async def refuse_a_primary_whose_content_lives_elsewhere(
+    doc_status: Any, canonical_source_key: str, primary_doc_id: str
+) -> None:
+    """Refuse a primary the PROCESSING stage is already destined to demote.
+
+    The repair's caller-side exclusion cannot reach the processing stage (see
+    :func:`repair_one_conflict`), and it never will: ``_mark_duplicate_after_parse``
+    is a per-document write with no source-key lock, and even a lock would not
+    help — the marking may simply land the moment the repair releases it. So the
+    only place to remove this interaction is where the contentless-stub refusal
+    already removes its own: BEFORE the irreversible demotions, by refusing a
+    primary that cannot keep the source.
+
+    A primary whose content hash is already held by a document under a DIFFERENT
+    canonical source is exactly that: when it is parsed, the post-parse duplicate
+    check will mark it FAILED-duplicate of that holder and delete its
+    ``full_docs`` body, and the key it was just given ends with no primary — the
+    state the repair endpoint cannot settle, since it only accepts a current
+    primary candidate.
+
+    Bounded on purpose, and partial by construction:
+
+    * a primary with no ``content_hash`` yet (an unparsed PENDING candidate — an
+      ordinary conflict candidate) cannot be checked at all: nobody knows what
+      its content will be. If it later turns out to duplicate another document,
+      the outcome is the ordinary content-dedup steady state (the content lives
+      under the other document, and this key has no primary because the file's
+      content is not its own), and no content is lost. That residual is
+      irreducible without parsing the document inside the repair;
+    * a match that claims THIS canonical source is not a reason to refuse — it is
+      one of the candidates this repair is about to demote (or one an earlier
+      repair already demoted). The lookup returns only the earliest holder, so a
+      same-key holder that sorts first also hides any further one: the check
+      abstains rather than guess, which is the same partiality with the same
+      residual as the case above.
+
+    The lookup is fail-closed by contract (``get_doc_by_content_hash`` raises
+    rather than reporting a transport failure as "no holder"), and the strict
+    hydration of the primary's own row propagates too, so an unreadable state
+    refuses the commit instead of skipping the check.
+    """
+    rows = await doc_status.get_full_docs_by_ids([primary_doc_id], strict=True)
+    primary_row = rows.get(primary_doc_id)
+    if primary_row is None:
+        # Not a candidate any more; the backend's own check reports that, with
+        # the message that sends the operator to re-list the conflict.
+        return
+    content_hash = doc_status_field(primary_row, "content_hash", "") or ""
+    if not content_hash:
+        return
+    match = await get_duplicate_doc_by_content_hash(
+        doc_status, content_hash, primary_doc_id
+    )
+    if match is None:
+        return
+    holder_doc_id, holder_row = match
+    if doc_status_field(holder_row, "file_path", "") == canonical_source_key:
+        return
+    raise SourceConflictPrimaryUnusableError(
+        f"Document {primary_doc_id} holds the same content as {holder_doc_id}, "
+        f"which claims a different source. Processing marks a content duplicate "
+        f"FAILED and deletes its content, so {primary_doc_id} cannot keep "
+        f"'{canonical_source_key}' — the key would end up with no primary at all, "
+        f"and no repair can settle that. Pick another primary, or settle "
+        f"{holder_doc_id} first."
+    )
+
+
+async def refuse_an_unusable_primary(
+    doc_status: Any,
+    full_docs: Any,
+    canonical_source_key: str,
+    primary_doc_id: str,
+) -> None:
+    """Every pre-commit refusal, in one call the commit paths cannot half-apply.
+
+    Both checks exist for the same reason — a repair only demotes, so a primary
+    that cannot keep the source leaves a key no repair can settle — and both must
+    run on BOTH commit paths (the endpoint and the library/CLI helper). Bundling
+    them here is what keeps one path from silently growing a check the other
+    lacks.
+    """
+    await refuse_a_contentless_primary(full_docs, primary_doc_id)
+    await refuse_a_primary_whose_content_lives_elsewhere(
+        doc_status, canonical_source_key, primary_doc_id
     )
 
 

--- a/lightrag/tools/source_conflict_repair.py
+++ b/lightrag/tools/source_conflict_repair.py
@@ -187,13 +187,72 @@ async def repair_one_conflict(
             expected_candidate_fingerprint="",
             dry_run=True,
         )
-        return await doc_status.repair_source_conflict(
+        result = await doc_status.repair_source_conflict(
             canonical_source_key,
             primary_doc_id=primary_doc_id,
             expected_candidate_count=dry.candidate_count,
             expected_candidate_fingerprint=dry.fingerprint,
             dry_run=False,
         )
+        # Verify the OUTCOME, still inside the locks, instead of inferring it
+        # from "the demotions were committed". ``committed=True`` only claims
+        # that the demotions named in the result landed; it cannot claim the key
+        # is now unique, because the locks here exclude a concurrent ENQUEUE and
+        # nothing else — a concurrent delete of the kept primary, a
+        # processing-stage duplicate marking, or a scan stale-stub deletion all
+        # mutate this candidate set without taking them (see
+        # DocStatusStorage.repair_source_conflict). Those paths are single-doc
+        # and cannot be excluded from here, so the honest move is to re-resolve
+        # and report what is actually true.
+        await verify_repair_outcome(
+            doc_status, canonical_source_key, primary_doc_id, result
+        )
+        return result
+
+
+async def verify_repair_outcome(
+    doc_status: Any,
+    canonical_source_key: str,
+    primary_doc_id: str,
+    result: Any,
+) -> None:
+    """Re-resolve the key after a commit and raise unless it is now UNIQUE on
+    ``primary_doc_id``.
+
+    Raising rather than warning: an operator repairing a conflict needs to know
+    the key is settled, and a repair that "succeeded" while leaving the key
+    Absent (the kept primary was deleted meanwhile) or still Conflicting (a
+    candidate re-appeared) is exactly the outcome they would otherwise act on as
+    if it were fixed. The demotions themselves have already been committed and
+    are not rolled back — they are individually correct; what failed is the
+    end state, so the message says which.
+    """
+    from lightrag.base import SourceConflict, SourceUnique
+
+    resolution = await doc_status.resolve_doc_source_strict(canonical_source_key)
+    if isinstance(resolution, SourceUnique) and resolution.doc_id == primary_doc_id:
+        return
+    if isinstance(resolution, SourceUnique):
+        detail = (
+            f"the surviving primary is {resolution.doc_id}, not the requested "
+            f"{primary_doc_id}"
+        )
+    elif isinstance(resolution, SourceConflict):
+        detail = (
+            "the key is STILL in conflict "
+            f"(sample: {', '.join(resolution.sample_doc_ids) or 'unavailable'})"
+        )
+    else:
+        detail = (
+            f"the key now resolves to NO primary at all — {primary_doc_id} was "
+            "removed by a concurrent delete or duplicate marking"
+        )
+    raise StorageControlPlaneError(
+        f"Source conflict repair for '{canonical_source_key}' committed its "
+        f"demotions ({list(result.demoted_sample_doc_ids) or 'none'}) but the key "
+        f"is not settled: {detail}. Re-run the repair once concurrent writers to "
+        f"these documents have stopped."
+    )
 
 
 def _print_conflicts(conflicts: list[SourceConflictSummary]) -> None:

--- a/lightrag/tools/source_conflict_repair.py
+++ b/lightrag/tools/source_conflict_repair.py
@@ -56,9 +56,12 @@ Safety model:
 - ``verify_repair_outcome`` re-resolves the key after the commit and raises
   unless it is now unique on the chosen primary — the backstop that turns any
   interleaving the caller-side locks did not cover into a reported failure;
-- the caller-side locks (per the table above) additionally keep a NEW primary
-  from being INSERTED between the backend's re-read and its demotions — for
-  in-server callers only;
+- the caller-side locks (per the table above) additionally exclude every
+  in-deployment writer of this candidate set for the whole commit — a NEW primary
+  being INSERTED (enqueue-serialize lock), clear/delete + scan classification +
+  manual reset (the reservation), and the processing stage's duplicate marking
+  (the keyed source lock, which ``_mark_duplicate_after_parse`` takes too, LR2
+  §5.5) — for in-server callers only;
 - a repair interrupted half-way needs no reconciliation: the finished rows
   already express ``duplicate`` and the rest still resolve as a conflict, so
   simply run it again.
@@ -77,7 +80,12 @@ Usage (library — for a deployment that builds its own LightRAG)::
 
     conflicts = await collect_source_conflicts(rag.doc_status, limit=50)
     result = await repair_one_conflict(
-        rag.doc_status, "report.docx", "doc-abc123", apply=True
+        rag.doc_status,
+        "report.docx",
+        "doc-abc123",
+        workspace=rag.workspace,
+        full_docs=rag.full_docs,  # required for a commit
+        apply=True,
     )
 """
 
@@ -91,10 +99,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from lightrag.base import CURSOR_END, CURSOR_START, SourceConflictSummary
-from lightrag.constants import (
-    ENQUEUE_SERIALIZE_LOCK_NAMESPACE,
-    SOURCE_CONFLICT_LOCK_NAMESPACE,
-)
+from lightrag.constants import ENQUEUE_SERIALIZE_LOCK_NAMESPACE
 from lightrag.exceptions import (
     SourceConflictPrimaryUnusableError,
     SourceConflictRepairCASError,
@@ -105,6 +110,7 @@ from lightrag.utils import logger
 from lightrag.utils_pipeline import (
     doc_status_field,
     get_duplicate_doc_by_content_hash,
+    source_candidate_set_lock,
 )
 
 # Pages are bounded on both sides: the backend projects a bounded sample per
@@ -229,30 +235,32 @@ async def source_conflict_repair_lock(workspace: str, canonical_source_key: str)
     Redis/OpenSearch have no transaction at all), so excluding that insert is the
     caller's job — see ``DocStatusStorage.repair_source_conflict``.
 
-    Two locks, always in this order:
+    Three things, in this TOTAL order — outermost first:
 
-    * a keyed lock on the canonical source key — serializes concurrent repairs of
-      the SAME key without blocking repairs of other keys;
-    * the workspace's enqueue-serialize lock — the one that actually excludes the
-      phantom, because it is the same lock the enqueue critical section
-      (``filter_keys`` → dedup → ``doc_status.upsert``) holds.
+    1. the workspace's enqueue-serialize lock — the one that excludes the
+       phantom, because it is the same lock the enqueue critical section
+       (``filter_keys`` → dedup → ``doc_status.upsert``) holds;
+    2. a keyed lock on the canonical source key (:func:`source_candidate_set_lock`)
+       — serializes concurrent repairs of the SAME key without blocking other
+       keys, and, since LR2 §5.5 requires exclusion against every writer that can
+       change this key's candidate set, it is the SAME lock the processing stage's
+       duplicate marking now takes (``_mark_duplicate_after_parse``);
+    3. a pending-enqueue reservation (see :func:`_repair_ingress_reservation`),
+       which excludes the writers the enqueue-serialize lock cannot: clear/delete,
+       scan classification, and the manual exclusive reset.
 
-    Innermost is a pending-enqueue reservation (see
-    :func:`_repair_ingress_reservation`), which is what excludes the writers the
-    enqueue-serialize lock cannot: clear/delete, scan classification, and the
-    manual exclusive reset.
+    This order used to be keyed → enqueue_serialize, with a note that anyone
+    extending the keyed ``DocSource`` lock to another writer MUST flip it first,
+    because it was INVERTED relative to the enqueue path (which holds
+    enqueue_serialize and would naturally reach for a keyed source lock inside
+    it). Extending it to the duplicate-marking path is exactly that change, so
+    the flip happened with it: ``enqueue_serialize → DocSource → pipeline_status``
+    is now the total order every holder of more than one agrees on, and it is the
+    order the enqueue path could adopt without a cycle. The marking path takes
+    only (2) and, inside it, ``pipeline_status`` for its owner check — same
+    direction, no cycle.
 
-    Lock order is keyed → namespace → reservation, and the enqueue path never
-    takes the keyed lock, so no cycle exists **today**. That "today" is load
-    bearing: this order is INVERTED relative to the enqueue path, which takes
-    enqueue_serialize and would naturally take the keyed source lock inside it.
-    Anyone extending the keyed ``DocSource`` lock to the enqueue path (or to the
-    delete / duplicate-marking / stale-stub paths, which also hold no keyed lock
-    now) MUST first flip this order to ``enqueue_serialize → DocSource`` and
-    document the total order — otherwise the two directions deadlock, only when a
-    manual repair runs concurrently with an upload, which CI will not catch.
-
-    Every one of these three is PROCESS-LOCAL machinery, so the scope is one
+    Every one of these is PROCESS-LOCAL machinery, so the scope is one
     deployment — its worker processes included, because they share the Manager
     the master created — and nothing beyond it. Two consequences, the second of
     which is easy to miss:
@@ -269,22 +277,12 @@ async def source_conflict_repair_lock(workspace: str, canonical_source_key: str)
     """
     # Imported lazily: the CLI initializes shared storage in main(), and
     # importing at module scope would bind before that happens.
-    from lightrag.kg.shared_storage import (
-        get_namespace_lock,
-        get_storage_keyed_lock,
-    )
+    from lightrag.kg.shared_storage import get_namespace_lock
 
-    keyed_namespace = (
-        f"{workspace}:{SOURCE_CONFLICT_LOCK_NAMESPACE}"
-        if workspace
-        else SOURCE_CONFLICT_LOCK_NAMESPACE
-    )
-    async with get_storage_keyed_lock(
-        [canonical_source_key], namespace=keyed_namespace, enable_logging=False
+    async with get_namespace_lock(
+        ENQUEUE_SERIALIZE_LOCK_NAMESPACE, workspace=workspace
     ):
-        async with get_namespace_lock(
-            ENQUEUE_SERIALIZE_LOCK_NAMESPACE, workspace=workspace
-        ):
+        async with source_candidate_set_lock(workspace, canonical_source_key):
             async with _repair_ingress_reservation(workspace):
                 yield
 
@@ -383,20 +381,18 @@ async def repair_one_conflict(
         )
         # Verify the OUTCOME, still inside the locks, instead of inferring it
         # from "the demotions were committed". ``committed=True`` only claims
-        # that the demotions named in the result landed; it cannot claim the key
-        # is now unique. The locks exclude a concurrent ENQUEUE and the
-        # reservation excludes clear/delete, scan classification and the manual
-        # reset — but the PROCESSING stage is fenced by none of them, so a
-        # post-parse duplicate marking of the kept primary against a THIRD
-        # document with the same content still mutates this candidate set (see
-        # DocStatusStorage.repair_source_conflict), and for the standalone CLI
-        # none of the caller-side exclusion is live at all. So the honest move is
-        # to re-resolve and report what is actually true. What is no longer
-        # possible is the variant that needed no race whatsoever: the kept primary
-        # being marked a duplicate OF A ROW THIS REPAIR JUST DEMOTED — the demoted
-        # row names the primary as its original, and the content-hash lookup drops
-        # a match that points back at the document asking (see
-        # utils_pipeline._drop_a_duplicate_pointing_back).
+        # that the demotions named in the result landed; the key being unique is a
+        # separate claim, so it is checked rather than assumed.
+        #
+        # Every in-deployment writer of this candidate set is now excluded for the
+        # whole span: enqueue by the enqueue-serialize lock, clear/delete + scan
+        # classification + manual reset by the reservation, and the processing
+        # stage's duplicate marking by the keyed source lock it now takes too
+        # (LR2 §5.5). So this verification is a backstop, not the primary guard —
+        # which is what it must be, because two things remain outside every lock
+        # here: the standalone CLI (its locks are process-local and it has no
+        # pipeline_status at all) and any second deployment writing the same
+        # database.
         await verify_repair_outcome(
             doc_status, canonical_source_key, primary_doc_id, result
         )
@@ -469,7 +465,8 @@ async def refuse_a_contentless_primary(full_docs: Any, primary_doc_id: str) -> N
         f"Document {primary_doc_id} has no full_docs content: it is an "
         f"unprocessable stub, so it cannot own a canonical source. Pick a "
         f"primary that has content — a scan would delete this row and leave the "
-        f"demoted documents pointing at an id that no longer exists."
+        f"demoted documents pointing at an id that no longer exists.",
+        reason=SourceConflictPrimaryUnusableError.REASON_NO_CONTENT,
     )
 
 
@@ -537,7 +534,9 @@ async def refuse_a_primary_whose_content_lives_elsewhere(
         f"FAILED and deletes its content, so {primary_doc_id} cannot keep "
         f"'{canonical_source_key}' — the key would end up with no primary at all, "
         f"and no repair can settle that. Pick another primary, or settle "
-        f"{holder_doc_id} first."
+        f"{holder_doc_id} first.",
+        reason=SourceConflictPrimaryUnusableError.REASON_CONTENT_ELSEWHERE,
+        holder_doc_id=holder_doc_id,
     )
 
 
@@ -558,6 +557,66 @@ async def refuse_an_unusable_primary(
     await refuse_a_contentless_primary(full_docs, primary_doc_id)
     await refuse_a_primary_whose_content_lives_elsewhere(
         doc_status, canonical_source_key, primary_doc_id
+    )
+
+
+async def _absent_key_recovery_hint(doc_status: Any, primary_doc_id: str) -> str:
+    """What can actually be done about a key left with no primary.
+
+    Reads the kept primary's row so the advice matches its state, because the two
+    states have DIFFERENT recoveries and the wrong one wastes the operator's time:
+
+    * marked a content duplicate — deleting this row is not enough. Its content
+      belongs to the named document, and a doc id is derived from the file name,
+      so re-uploading the same bytes is deduplicated against that document again
+      and the key stays Absent. The source can only be reclaimed once that holder
+      is deleted (or the file's content actually changes) — and if the holder is
+      the right home for the content, the honest end state is that this file has
+      no separate document at all;
+    * gone — a concurrent delete removed it, so re-ingesting the file recreates a
+      primary and the key resolves again.
+
+    Best-effort by design: this runs on a path that is already raising, so a read
+    failure must not replace the reported outcome with a read error. It degrades
+    to naming both possibilities.
+    """
+    try:
+        rows = await doc_status.get_full_docs_by_ids([primary_doc_id], strict=True)
+    except Exception as read_error:  # already failing; never mask the outcome
+        logger.warning(
+            f"Could not read {primary_doc_id} to explain the unsettled repair: "
+            f"{read_error}"
+        )
+        rows = {}
+    row = rows.get(primary_doc_id)
+    preamble = (
+        "The repair cannot be re-run: with no candidate left there is no conflict "
+        "to settle and the endpoint refuses any primary as 'not a current "
+        "candidate'."
+    )
+    if row is None:
+        return (
+            f"{preamble} {primary_doc_id} is gone (a concurrent delete, or a read "
+            f"that could not confirm it): re-ingest the file to recreate a primary "
+            f"for this source, or re-list the conflicts to see the current state."
+        )
+    metadata = doc_status_field(row, "metadata", {})
+    metadata = metadata if isinstance(metadata, dict) else {}
+    if metadata.get("is_duplicate"):
+        holder = metadata.get("original_doc_id") or "another document"
+        return (
+            f"{preamble} {primary_doc_id} is now marked a duplicate of {holder}, so "
+            f"its content lives there. Deleting {primary_doc_id} is NOT enough to "
+            f"reclaim the source: a doc id is derived from the file name, so "
+            f"re-uploading the same bytes is deduplicated against {holder} again. "
+            f"Reclaiming it needs {holder} deleted or this file's content actually "
+            f"changed — and if {holder} is the right home for that content, this "
+            f"source having no document of its own is the correct end state."
+        )
+    return (
+        f"{preamble} {primary_doc_id} still exists and is not marked a duplicate, "
+        f"so it lost the source some other way (a rewritten file_path, an external "
+        f"writer): re-list the conflicts and inspect that row before acting."
     )
 
 
@@ -611,14 +670,7 @@ async def verify_repair_outcome(
             f"the key now resolves to NO primary at all — {primary_doc_id} was "
             "deleted or marked a duplicate by a concurrent writer"
         )
-        recovery = (
-            f"The repair cannot be re-run: with no candidate left there is no "
-            f"conflict to settle and the endpoint refuses any primary as 'not a "
-            f"current candidate'. Inspect {primary_doc_id} instead — a "
-            f"FAILED [DUPLICATE:content_hash] row names the document its content "
-            f"now lives under, and deleting that leftover row lets a re-upload of "
-            f"the file claim the source again."
-        )
+        recovery = await _absent_key_recovery_hint(doc_status, primary_doc_id)
     raise StorageControlPlaneError(
         f"Source conflict repair for '{canonical_source_key}' committed its "
         f"demotions ({list(result.demoted_sample_doc_ids) or 'none'}) but the key "

--- a/lightrag/tools/source_conflict_repair.py
+++ b/lightrag/tools/source_conflict_repair.py
@@ -475,13 +475,15 @@ async def refuse_a_primary_whose_content_lives_elsewhere(
 ) -> None:
     """Refuse a primary the PROCESSING stage is already destined to demote.
 
-    The repair's caller-side exclusion cannot reach the processing stage (see
-    :func:`repair_one_conflict`), and it never will: ``_mark_duplicate_after_parse``
-    is a per-document write with no source-key lock, and even a lock would not
-    help — the marking may simply land the moment the repair releases it. So the
-    only place to remove this interaction is where the contentless-stub refusal
-    already removes its own: BEFORE the irreversible demotions, by refusing a
-    primary that cannot keep the source.
+    The commit DOES exclude the processing stage for its whole span — the keyed
+    source lock it holds is the same one ``_mark_duplicate_after_parse`` takes
+    (LR2 §5.5) — but exclusion only ORDERS the two operations; it cannot keep a
+    primary usable after it releases. A marking that was already destined to
+    demote this row simply lands the moment the lock is free, and the key the
+    operator was just told is settled has no primary again. So the lock and this
+    refusal answer different questions, and this one belongs where the
+    contentless-stub refusal already sits: BEFORE the irreversible demotions, by
+    refusing a primary that cannot keep the source.
 
     A primary whose content hash is already held by a document under a DIFFERENT
     canonical source is exactly that: when it is parsed, the post-parse duplicate

--- a/lightrag/tools/source_conflict_repair.py
+++ b/lightrag/tools/source_conflict_repair.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
+import uuid
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -61,15 +62,108 @@ from lightrag.constants import (
     SOURCE_CONFLICT_LOCK_NAMESPACE,
 )
 from lightrag.exceptions import (
+    SourceConflictPrimaryUnusableError,
     SourceConflictRepairCASError,
     StorageCapabilityError,
     StorageControlPlaneError,
 )
+from lightrag.utils import logger
 
 # Pages are bounded on both sides: the backend projects a bounded sample per
 # key, and --all stops after this many pages so a pathological workspace cannot
 # turn a listing into an unbounded walk.
 _MAX_PAGES = 1000
+
+
+# Pipeline states that must not overlap a source-conflict COMMIT, evaluated when
+# the repair registers its pending-enqueue reservation. Each one owns a writer
+# that can change the candidate set the repair just re-read, and none of them can
+# be excluded by the enqueue-serialize lock:
+#
+# * ``destructive_busy`` — a clear/delete can DELETE the primary the operator
+#   chose to keep, leaving the key with no primary and the demoted rows pointing
+#   at an id that no longer exists (and the repair only demotes, so there is no
+#   supported way back);
+# * ``scanning_exclusive`` — scan classification deletes stale FAILED stubs, one
+#   of which could be that primary;
+# * ``manual_freeze_requested`` — the exclusive FAILED reset rewrites
+#   ``file_path`` from ``resolve_doc_file_path``, so a row whose doc_status path
+#   is a placeholder can ENTER this candidate set without ever passing the
+#   enqueue critical section.
+#
+# Symmetry is what makes this cheap: the scan and destructive acquires already
+# list ``pending_enqueues`` in their own reject_when, so holding a reservation
+# for the repair's duration buys the other direction for free — no new lock, no
+# new lock-order edge.
+_REPAIR_INGRESS_FENCES: tuple[tuple[str, str], ...] = (
+    (
+        "destructive_busy",
+        "A clear/delete job is in flight; it may remove one of these documents. "
+        "Wait for it to finish, then repair.",
+    ),
+    (
+        "scanning_exclusive",
+        "A scan is classifying files and may delete stale failed stubs. Wait for "
+        "the classification phase to finish, then repair.",
+    ),
+    (
+        "manual_freeze_requested",
+        "A manual retry is draining the pipeline for its exclusive reset, which "
+        "can change which documents claim this source. Wait for it to finish, "
+        "then repair.",
+    ),
+)
+
+
+@asynccontextmanager
+async def _repair_ingress_reservation(workspace: str):
+    """Register the repair as in-flight ingress work for its whole duration.
+
+    A weighted-0 entry in ``pending_enqueue_tokens``: it charges nothing against
+    the admission capacity but makes ``pending_enqueues`` non-zero, which is what
+    the scan and destructive acquires already refuse on. The fences above are
+    evaluated in the same atomic step, so the exclusion holds in both directions.
+
+    No pipeline_status (offline CLI against a stopped server) means there is no
+    server-side writer to exclude, so the repair proceeds — that is the correct
+    answer here, not a concession.
+    """
+    from lightrag.exceptions import PipelineNotInitializedError
+    from lightrag.kg.shared_storage import (
+        acquire_enqueue_reservation,
+        get_namespace_data,
+        get_namespace_lock,
+        release_token_set_reservation,
+    )
+
+    try:
+        pipeline_status = await get_namespace_data(
+            "pipeline_status", workspace=workspace
+        )
+    except PipelineNotInitializedError:
+        yield
+        return
+
+    pipeline_status_lock = get_namespace_lock("pipeline_status", workspace=workspace)
+    token = f"source-repair-{uuid.uuid4().hex}"
+    result = await acquire_enqueue_reservation(
+        pipeline_status,
+        pipeline_status_lock,
+        token=token,
+        reject_when=_REPAIR_INGRESS_FENCES,
+        weight=0,
+        capacity=0,
+    )
+    if not result.acquired:
+        raise StorageControlPlaneError(result.message)
+    try:
+        yield
+    finally:
+        await release_token_set_reservation(
+            workspace,
+            tokens_key="pending_enqueue_tokens",
+            token=token,
+        )
 
 
 @asynccontextmanager
@@ -90,10 +184,24 @@ async def source_conflict_repair_lock(workspace: str, canonical_source_key: str)
       phantom, because it is the same lock the enqueue critical section
       (``filter_keys`` → dedup → ``doc_status.upsert``) holds.
 
-    Lock order is keyed → namespace, and the enqueue path never takes the keyed
-    lock, so no cycle exists. Scope is one deployment (its worker processes
-    included), not several deployments sharing a database — a repair run against
-    a database that another deployment is writing to keeps the phantom window.
+    Innermost is a pending-enqueue reservation (see
+    :func:`_repair_ingress_reservation`), which is what excludes the writers the
+    enqueue-serialize lock cannot: clear/delete, scan classification, and the
+    manual exclusive reset.
+
+    Lock order is keyed → namespace → reservation, and the enqueue path never
+    takes the keyed lock, so no cycle exists **today**. That "today" is load
+    bearing: this order is INVERTED relative to the enqueue path, which takes
+    enqueue_serialize and would naturally take the keyed source lock inside it.
+    Anyone extending the keyed ``DocSource`` lock to the enqueue path (or to the
+    delete / duplicate-marking / stale-stub paths, which also hold no keyed lock
+    now) MUST first flip this order to ``enqueue_serialize → DocSource`` and
+    document the total order — otherwise the two directions deadlock, only when a
+    manual repair runs concurrently with an upload, which CI will not catch.
+
+    Scope is one deployment (its worker processes included), not several
+    deployments sharing a database — a repair run against a database that another
+    deployment is writing to keeps the phantom window.
     """
     # Imported lazily: the CLI initializes shared storage in main(), and
     # importing at module scope would bind before that happens.
@@ -113,7 +221,8 @@ async def source_conflict_repair_lock(workspace: str, canonical_source_key: str)
         async with get_namespace_lock(
             ENQUEUE_SERIALIZE_LOCK_NAMESPACE, workspace=workspace
         ):
-            yield
+            async with _repair_ingress_reservation(workspace):
+                yield
 
 
 async def collect_source_conflicts(
@@ -147,6 +256,7 @@ async def repair_one_conflict(
     primary_doc_id: str,
     *,
     workspace: str = "",
+    full_docs: Any = None,
     apply: bool = False,
 ) -> Any:
     """Dry-run one repair and, with ``apply``, commit it with that fresh token.
@@ -166,6 +276,11 @@ async def repair_one_conflict(
     ``workspace`` must be the LightRAG instance's workspace (``rag.workspace``),
     NOT ``doc_status.workspace``: a backend may override its own workspace from
     the environment, and a lock keyed on the wrong one excludes nothing.
+
+    ``full_docs`` enables the contentless-primary refusal (see
+    :func:`refuse_a_contentless_primary`); omitted, the repair proceeds without
+    that check. It cannot live in the backend: a doc_status storage has no handle
+    on full_docs.
     """
     if not apply:
         return await doc_status.repair_source_conflict(
@@ -180,6 +295,9 @@ async def repair_one_conflict(
     # CAS must still be able to refuse. A candidate set that moved before the
     # lock was taken SHOULD 409 rather than be silently accepted.
     async with source_conflict_repair_lock(workspace, canonical_source_key):
+        # Inside the lock: the row could have lost its content between the
+        # operator reading the listing and this commit.
+        await refuse_a_contentless_primary(full_docs, primary_doc_id)
         dry = await doc_status.repair_source_conflict(
             canonical_source_key,
             primary_doc_id=primary_doc_id,
@@ -208,6 +326,55 @@ async def repair_one_conflict(
             doc_status, canonical_source_key, primary_doc_id, result
         )
         return result
+
+
+async def refuse_a_contentless_primary(full_docs: Any, primary_doc_id: str) -> None:
+    """Refuse to hand a canonical source to a row with no ``full_docs`` content.
+
+    Such a row is an unprocessable stub, and keeping it is self-defeating twice
+    over. It can never be processed, so the source key ends up owned by a
+    document that will never exist; and it is exactly what scan classification
+    deletes on sight (``_ScanFileClass.STALE_STUB`` fires only when
+    ``_confirm_full_docs_absent`` is True), so the next scan would delete the
+    primary and leave the demoted rows pointing at a missing id — with no way
+    back, since a repair only demotes and refuses a ``primary_doc_id`` that is
+    not a current candidate.
+
+    Checking here is what removes that interaction at the root, and it is
+    strictly better than locking the scan's delete path against the repair: it
+    costs one strict read on an operator-invoked path instead of a lock on scan
+    classification, and it also catches the plain operator mistake of choosing a
+    stub when no scan is running at all.
+
+    Only a CONFIRMED absence refuses. A backend without strict point reads, or a
+    read that fails, warns and proceeds: the alternative would let a storage blip
+    deny the operator their only repair tool, and an unconfirmed miss is not
+    evidence.
+    """
+    if full_docs is None:
+        return
+    if not getattr(full_docs, "supports_strict_point_reads", False):
+        logger.warning(
+            f"{type(full_docs).__name__} has no strict point reads; keeping "
+            f"{primary_doc_id} as the primary without confirming it has content"
+        )
+        return
+    try:
+        content = await full_docs.get_by_id_strict(primary_doc_id)
+    except Exception as read_error:
+        logger.warning(
+            f"Could not confirm whether {primary_doc_id} has content "
+            f"({read_error}); proceeding with the repair"
+        )
+        return
+    if content:
+        return
+    raise SourceConflictPrimaryUnusableError(
+        f"Document {primary_doc_id} has no full_docs content: it is an "
+        f"unprocessable stub, so it cannot own a canonical source. Pick a "
+        f"primary that has content — a scan would delete this row and leave the "
+        f"demoted documents pointing at an id that no longer exists."
+    )
 
 
 async def verify_repair_outcome(
@@ -322,10 +489,23 @@ async def _async_main(args: argparse.Namespace) -> bool:
             func=_noop_embed,
         ),
     )
-    # Only doc_status is initialized: this tool must not require a reachable
-    # vector/graph store to fix a doc_status bookkeeping problem.
+    # doc_status plus full_docs: still no vector/graph store, no LLM and no
+    # embedding model — full_docs is a plain KV, and reading it is what lets the
+    # repair refuse a primary that has no content (see
+    # refuse_a_contentless_primary). A full_docs backend that cannot be reached
+    # must not block a doc_status bookkeeping fix, so its failure downgrades the
+    # check instead of the command.
     doc_status = rag.doc_status
     await doc_status.initialize()
+    full_docs = rag.full_docs
+    try:
+        await full_docs.initialize()
+    except Exception as full_docs_error:
+        print(
+            f"Warning: full_docs is unavailable ({full_docs_error}); the repair "
+            "cannot confirm the chosen primary has content."
+        )
+        full_docs = None
     try:
         if args.command == "list":
             _print_conflicts(
@@ -341,6 +521,7 @@ async def _async_main(args: argparse.Namespace) -> bool:
             # rag.workspace, not doc_status.workspace: a backend may override
             # its own from the environment, and the enqueue path locks on this one.
             workspace=rag.workspace,
+            full_docs=full_docs,
             apply=args.apply,
         )
         _print_repair(result)
@@ -360,6 +541,8 @@ async def _async_main(args: argparse.Namespace) -> bool:
         print(f"Storage control plane unavailable: {storage_error}")
         return False
     finally:
+        if full_docs is not None:
+            await full_docs.finalize()
         await doc_status.finalize()
 
 

--- a/lightrag/tools/source_conflict_repair.py
+++ b/lightrag/tools/source_conflict_repair.py
@@ -16,21 +16,55 @@ every other candidate is marked ``metadata.is_duplicate=true`` with
 rows keep their status and their ``full_docs`` entry, they only lose their claim
 on the canonical source.
 
+"Offline" means OUT OF BAND — not through the HTTP API — and NOT "the server must
+be stopped". Which matters, because the protection you get depends on where the
+call runs, and only one of the two callers gets all of it:
+
+===========================  =============================================
+caller                       caller-side exclusion
+===========================  =============================================
+``POST …/repair`` (online)   real: the endpoint runs inside a server worker,
+  or a library call from       so the keyed lock, the enqueue-serialize lock
+  inside the server            and the pending-enqueue reservation all live
+                               in the shared state every worker sees
+standalone CLI               NONE of it: ``initialize_share_data(workers=1)``
+                               builds process-LOCAL asyncio locks and a local
+                               ``_shared_dicts``, and this process never
+                               initialises ``pipeline_status``, so the locks
+                               exclude only this process and the reservation
+                               is a no-op
+===========================  =============================================
+
+Cross-process exclusion is not reachable from here: it would need the server's
+Manager (its address and authkey are private to the server) or a persisted
+liveness marker, which is the storage-verifiable fencing token the design
+excludes. So:
+
+**Run ``--apply`` while the server is stopped or quiesced, or use the HTTP
+endpoint instead.** A CLI commit against a live server is not silently unsafe —
+it is guarded by the CAS and by the post-commit re-resolve, so a concurrent
+change makes the repair FAIL LOUDLY rather than corrupt the key — but "fails
+loudly" is the guarantee, not "cannot interleave".
+
 Safety model:
 
 - listing and ``repair`` without ``--apply`` mutate nothing;
 - ``--apply`` re-reads the candidate set and commits only when it still matches
-  the dry-run it just performed (compare-and-set), so a concurrent enqueue/delete
-  fails the repair instead of being overwritten; the commit runs under the
-  canonical-key + enqueue-serialize locks, which is what keeps a NEW primary from
-  being inserted between that re-read and the demotions;
+  the dry-run it just performed (compare-and-set), so a concurrent
+  enqueue/delete fails the repair instead of being overwritten. This is the one
+  guarantee that holds for BOTH callers, because it lives in the storage;
+- ``verify_repair_outcome`` re-resolves the key after the commit and raises
+  unless it is now unique on the chosen primary — the backstop that turns any
+  interleaving the caller-side locks did not cover into a reported failure;
+- the caller-side locks (per the table above) additionally keep a NEW primary
+  from being INSERTED between the backend's re-read and its demotions — for
+  in-server callers only;
 - a repair interrupted half-way needs no reconciliation: the finished rows
   already express ``duplicate`` and the rest still resolve as a conflict, so
   simply run it again.
 
-Only ``doc_status`` is opened — no vector store, graph store, LLM or embedding
-model is touched, so this is safe to run against a live deployment's database
-while the server is stopped or running.
+``doc_status`` and ``full_docs`` are opened — no vector store, graph store, LLM
+or embedding model is touched.
 
 Usage (CLI — honors WORKING_DIR / WORKSPACE and the LIGHTRAG_* storage env vars
 from ``.env``, same as the server)::
@@ -124,9 +158,14 @@ async def _repair_ingress_reservation(workspace: str):
     the scan and destructive acquires already refuse on. The fences above are
     evaluated in the same atomic step, so the exclusion holds in both directions.
 
-    No pipeline_status (offline CLI against a stopped server) means there is no
-    server-side writer to exclude, so the repair proceeds — that is the correct
-    answer here, not a concession.
+    An uninitialised ``pipeline_status`` does NOT prove there is no server: it
+    proves only that THIS process has none, and a standalone CLI never
+    initialises one even when a server is running elsewhere (its shared state is
+    a different process's). So the repair proceeds — refusing would break the
+    stopped-server case, which is the CLI's whole purpose — but it says so, at
+    the moment it actually applies, rather than leaving the operator to infer it
+    from the module docstring. The CAS and the post-commit re-resolve are what
+    keep that case honest.
     """
     from lightrag.exceptions import PipelineNotInitializedError
     from lightrag.kg.shared_storage import (
@@ -141,6 +180,16 @@ async def _repair_ingress_reservation(workspace: str):
             "pipeline_status", workspace=workspace
         )
     except PipelineNotInitializedError:
+        logger.warning(
+            "Source-conflict repair is committing without pipeline exclusion: "
+            "this process has no pipeline_status, which means either no server "
+            "is running OR one is running in ANOTHER process whose shared state "
+            "this one cannot see. Concurrent clear/delete, scan classification "
+            "or a manual retry are therefore NOT excluded — the compare-and-set "
+            "and the post-commit re-resolve will fail the repair loudly if one "
+            "interleaves. Prefer POST /documents/source_conflicts/repair while a "
+            "server is running."
+        )
         yield
         return
 
@@ -199,9 +248,20 @@ async def source_conflict_repair_lock(workspace: str, canonical_source_key: str)
     document the total order — otherwise the two directions deadlock, only when a
     manual repair runs concurrently with an upload, which CI will not catch.
 
-    Scope is one deployment (its worker processes included), not several
-    deployments sharing a database — a repair run against a database that another
-    deployment is writing to keeps the phantom window.
+    Every one of these three is PROCESS-LOCAL machinery, so the scope is one
+    deployment — its worker processes included, because they share the Manager
+    the master created — and nothing beyond it. Two consequences, the second of
+    which is easy to miss:
+
+    * a repair run against a database another deployment is writing to keeps the
+      phantom window;
+    * **the standalone CLI is such an "other deployment"**. It calls
+      ``initialize_share_data(workers=1)``, so these locks are asyncio objects in
+      its own process and the reservation finds no ``pipeline_status`` at all.
+      Everything here holds for the HTTP endpoint and for a library call inside a
+      server worker; for the CLI it is inert, and the CAS plus
+      :func:`verify_repair_outcome` are the whole guarantee (see the module
+      docstring).
     """
     # Imported lazily: the CLI initializes shared storage in main(), and
     # importing at module scope would bind before that happens.

--- a/lightrag/tools/source_conflict_repair.py
+++ b/lightrag/tools/source_conflict_repair.py
@@ -375,13 +375,19 @@ async def repair_one_conflict(
         # Verify the OUTCOME, still inside the locks, instead of inferring it
         # from "the demotions were committed". ``committed=True`` only claims
         # that the demotions named in the result landed; it cannot claim the key
-        # is now unique, because the locks here exclude a concurrent ENQUEUE and
-        # nothing else — a concurrent delete of the kept primary, a
-        # processing-stage duplicate marking, or a scan stale-stub deletion all
-        # mutate this candidate set without taking them (see
-        # DocStatusStorage.repair_source_conflict). Those paths are single-doc
-        # and cannot be excluded from here, so the honest move is to re-resolve
-        # and report what is actually true.
+        # is now unique. The locks exclude a concurrent ENQUEUE and the
+        # reservation excludes clear/delete, scan classification and the manual
+        # reset — but the PROCESSING stage is fenced by none of them, so a
+        # post-parse duplicate marking of the kept primary against a THIRD
+        # document with the same content still mutates this candidate set (see
+        # DocStatusStorage.repair_source_conflict), and for the standalone CLI
+        # none of the caller-side exclusion is live at all. So the honest move is
+        # to re-resolve and report what is actually true. What is no longer
+        # possible is the variant that needed no race whatsoever: the kept primary
+        # being marked a duplicate OF A ROW THIS REPAIR JUST DEMOTED — the demoted
+        # row names the primary as its original, and the content-hash lookup drops
+        # a match that points back at the document asking (see
+        # utils_pipeline._drop_a_duplicate_pointing_back).
         await verify_repair_outcome(
             doc_status, canonical_source_key, primary_doc_id, result
         )
@@ -406,27 +412,41 @@ async def refuse_a_contentless_primary(full_docs: Any, primary_doc_id: str) -> N
     classification, and it also catches the plain operator mistake of choosing a
     stub when no scan is running at all.
 
-    Only a CONFIRMED absence refuses. A backend without strict point reads, or a
-    read that fails, warns and proceeds: the alternative would let a storage blip
-    deny the operator their only repair tool, and an unconfirmed miss is not
-    evidence.
+    A CONFIRMED absence refuses with
+    :class:`SourceConflictPrimaryUnusableError` (409 — pick another primary); a
+    read that FAILS refuses with :class:`StorageControlPlaneError` (503 — retry
+    once storage is back). Fail-closed on the failure, because "proceed anyway"
+    spends the one guarantee this check exists to provide: the demotions are
+    irreversible (a repair only demotes, and a key with no candidate left cannot
+    be repaired again), while a 503 costs the operator a retry of an operation
+    that has no deadline — the conflict has been sitting there since before they
+    looked at it.
+
+    A backend WITHOUT strict point reads is the one case that still proceeds, and
+    not as a compromise: scan classification cannot delete the stub either on such
+    a backend (``_confirm_full_docs_absent`` returns ``None`` for exactly the same
+    reason and the STALE_STUB exit never fires), so the interaction this check
+    guards against does not exist there. Every in-tree KV backend declares
+    ``supports_strict_point_reads = True``; this branch is for a third-party one.
     """
     if full_docs is None:
         return
     if not getattr(full_docs, "supports_strict_point_reads", False):
         logger.warning(
             f"{type(full_docs).__name__} has no strict point reads; keeping "
-            f"{primary_doc_id} as the primary without confirming it has content"
+            f"{primary_doc_id} as the primary without confirming it has content "
+            "(a scan cannot delete a stale stub on this backend either, so the "
+            "interaction this check guards against cannot arise)"
         )
         return
     try:
         content = await full_docs.get_by_id_strict(primary_doc_id)
     except Exception as read_error:
-        logger.warning(
-            f"Could not confirm whether {primary_doc_id} has content "
-            f"({read_error}); proceeding with the repair"
-        )
-        return
+        raise StorageControlPlaneError(
+            f"Could not confirm whether {primary_doc_id} has full_docs content "
+            f"({read_error}); refusing to commit irreversible demotions on an "
+            f"unverified primary. Retry once full_docs is reachable."
+        ) from read_error
     if content:
         return
     raise SourceConflictPrimaryUnusableError(
@@ -453,32 +473,52 @@ async def verify_repair_outcome(
     if it were fixed. The demotions themselves have already been committed and
     are not rolled back — they are individually correct; what failed is the
     end state, so the message says which.
+
+    The recovery is per-outcome, and only two of the three are "run it again":
+    with a primary left (wrong one, or several) the key still has candidates, so
+    a fresh dry-run → commit settles it. With NO primary left there is nothing to
+    repair — this function is the one place that knows that, so it is the one
+    place that must not send the operator back to an endpoint that will answer
+    "not a current primary candidate".
     """
     from lightrag.base import SourceConflict, SourceUnique
 
     resolution = await doc_status.resolve_doc_source_strict(canonical_source_key)
     if isinstance(resolution, SourceUnique) and resolution.doc_id == primary_doc_id:
         return
+    rerun = (
+        "Re-run the repair (fresh dry-run, then commit) once concurrent writers "
+        "to these documents have stopped."
+    )
     if isinstance(resolution, SourceUnique):
         detail = (
             f"the surviving primary is {resolution.doc_id}, not the requested "
             f"{primary_doc_id}"
         )
+        recovery = rerun
     elif isinstance(resolution, SourceConflict):
         detail = (
             "the key is STILL in conflict "
             f"(sample: {', '.join(resolution.sample_doc_ids) or 'unavailable'})"
         )
+        recovery = rerun
     else:
         detail = (
             f"the key now resolves to NO primary at all — {primary_doc_id} was "
-            "removed by a concurrent delete or duplicate marking"
+            "deleted or marked a duplicate by a concurrent writer"
+        )
+        recovery = (
+            f"The repair cannot be re-run: with no candidate left there is no "
+            f"conflict to settle and the endpoint refuses any primary as 'not a "
+            f"current candidate'. Inspect {primary_doc_id} instead — a "
+            f"FAILED [DUPLICATE:content_hash] row names the document its content "
+            f"now lives under, and deleting that leftover row lets a re-upload of "
+            f"the file claim the source again."
         )
     raise StorageControlPlaneError(
         f"Source conflict repair for '{canonical_source_key}' committed its "
         f"demotions ({list(result.demoted_sample_doc_ids) or 'none'}) but the key "
-        f"is not settled: {detail}. Re-run the repair once concurrent writers to "
-        f"these documents have stopped."
+        f"is not settled: {detail}. {recovery}"
     )
 
 
@@ -552,20 +592,34 @@ async def _async_main(args: argparse.Namespace) -> bool:
     # doc_status plus full_docs: still no vector/graph store, no LLM and no
     # embedding model — full_docs is a plain KV, and reading it is what lets the
     # repair refuse a primary that has no content (see
-    # refuse_a_contentless_primary). A full_docs backend that cannot be reached
-    # must not block a doc_status bookkeeping fix, so its failure downgrades the
-    # check instead of the command.
+    # refuse_a_contentless_primary).
     doc_status = rag.doc_status
     await doc_status.initialize()
     full_docs = rag.full_docs
+    full_docs_error: Exception | None = None
     try:
         await full_docs.initialize()
-    except Exception as full_docs_error:
-        print(
-            f"Warning: full_docs is unavailable ({full_docs_error}); the repair "
-            "cannot confirm the chosen primary has content."
-        )
+    except Exception as init_error:
+        full_docs_error = init_error
         full_docs = None
+    if full_docs_error is not None:
+        # Listing and dry-runs mutate nothing, so they still run — but a COMMIT
+        # without this check is the fail-open the check exists to remove: an
+        # unverified primary that turns out to be a contentless stub gets the
+        # source key, a later scan deletes it, and the demotions this command
+        # already wrote cannot be undone. Refuse the command instead.
+        if args.command == "repair" and args.apply:
+            print(
+                f"Refused: full_docs is unavailable ({full_docs_error}), so the "
+                "repair cannot confirm the chosen primary has content. Retry once "
+                "it is reachable (listing and dry-runs still work)."
+            )
+            await doc_status.finalize()
+            return False
+        print(
+            f"Warning: full_docs is unavailable ({full_docs_error}); a commit "
+            "would be refused, but this command modifies nothing."
+        )
     try:
         if args.command == "list":
             _print_conflicts(

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -35,6 +35,7 @@ from lightrag.constants import (
     PARSER_ENGINE_NATIVE,
 )
 from lightrag import pipeline_metrics
+from lightrag.exceptions import StorageCapabilityError
 from lightrag.parser.routing import canonicalize_parser_hinted_basename
 from lightrag.utils import (
     compute_mdhash_id,
@@ -590,6 +591,77 @@ def describe_doc_status_capabilities(doc_status: Any) -> dict[str, bool]:
             getattr(type(doc_status), "supports_strict_point_reads", False)
         ),
     }
+
+
+# What each strict capability costs when it is absent, in the terms an operator
+# experiences. Only the capabilities a deployment can genuinely lack appear here;
+# the two @abstractmethod ones cannot be missing on an instantiable backend.
+_CAPABILITY_CONSEQUENCES: dict[str, str] = {
+    "strict_active_count": (
+        "MAX_PENDING_DOCUMENTS admission cannot count active documents, so every "
+        "upload and text insert is refused with HTTP 503 while admission is enabled"
+    ),
+    "source_conflict_listing": (
+        "GET /documents/source_conflicts answers 501, so a scan that stops on a "
+        "duplicate file source cannot be diagnosed through the API"
+    ),
+    "source_conflict_repair": (
+        "POST /documents/source_conflicts/repair answers 501, so a duplicate file "
+        "source has to be resolved by deleting documents"
+    ),
+    "strict_point_reads": (
+        "a scan cannot confirm that a stale FAILED stub is really gone, so it keeps "
+        "the stub and re-examines that file on every scan"
+    ),
+}
+
+
+def enforce_strict_storage_capabilities(
+    doc_status: Any, *, require: bool = False
+) -> dict[str, bool]:
+    """Report (and optionally refuse to start on) missing strict capabilities.
+
+    The scheduling contract fails closed on every one of these, which from the
+    outside looks like a broken database rather than a backend that was never
+    able to do the thing. ``/health`` publishes the same probe, but a status page
+    only helps someone who already suspects a problem — the startup log is where
+    an operator finds out before the first 503 (LR2 §11, Phase 1 acceptance).
+
+    Never raises for its own reasons: a probe failure is logged and treated as
+    "nothing to report", because refusing to start over a broken *diagnostic*
+    would be worse than the degradation it was looking for. ``require=True``
+    raises :class:`StorageCapabilityError` only for genuinely missing
+    capabilities.
+    """
+    try:
+        capabilities = describe_doc_status_capabilities(doc_status)
+    except Exception as probe_error:  # pragma: no cover - defensive
+        logger.warning(f"Could not probe doc_status capabilities: {probe_error}")
+        return {}
+
+    missing = [
+        name
+        for name, consequence in _CAPABILITY_CONSEQUENCES.items()
+        if not capabilities.get(name, False)
+    ]
+    if not missing:
+        return capabilities
+
+    backend = type(doc_status).__name__
+    details = "; ".join(
+        f"{name} — {_CAPABILITY_CONSEQUENCES[name]}" for name in missing
+    )
+    if require:
+        raise StorageCapabilityError(
+            f"{backend} is missing strict capabilities required by "
+            f"PIPELINE_REQUIRE_STRICT_STORAGE_READS=true: {details}"
+        )
+    logger.warning(
+        f"{backend} is missing strict doc_status capabilities: {details}. "
+        "Set PIPELINE_REQUIRE_STRICT_STORAGE_READS=true to refuse to start "
+        "instead; /health reports the same gaps under 'capabilities'."
+    )
+    return capabilities
 
 
 async def count_active_documents(doc_status: DocStatusStorage) -> int:

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -27,6 +27,7 @@ from lightrag.base import (
 )
 from lightrag.constants import (
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    DUPLICATE_DEMOTION_METADATA_KEYS,
     FILE_EXTRACTION_SUMMARY_PREFIX,
     FULL_DOCS_FORMAT_LIGHTRAG,
     LIGHTRAG_DOC_CONTENT_PREFIX,
@@ -300,6 +301,14 @@ _DOC_STATUS_METADATA_CARRY_OVER_KEYS: tuple[str, ...] = (
     # in-flight/failed ainsert_custom_chunks operation. Must survive every
     # status transition until the operation commits or is rolled back.
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    # Duplicate demotion. ``metadata.is_duplicate`` is not a display field: it is
+    # the ONLY thing that makes a row ineligible as a primary candidate for its
+    # canonical source (``_basename_of`` returns None for it), so an operator's
+    # source-conflict repair lives or dies with it. Dropping it on a transition
+    # silently re-promoted the demoted row and put the key back in conflict —
+    # and since a repair deliberately keeps the row's content and status, that
+    # row is a normal document the pipeline will happily transition.
+    *DUPLICATE_DEMOTION_METADATA_KEYS,
 )
 
 
@@ -398,6 +407,12 @@ _DOC_STATUS_METADATA_DIRECTIVE_KEYS: tuple[str, ...] = (
     # journal must survive — stripping it would orphan the operation's staged
     # data with no recovery anchor (issue #3400).
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    # A demotion is an operator decision, not a per-attempt result: the manual
+    # FAILED→PENDING retry must not undo it. A demoted row keeps its content and
+    # its FAILED status, so it is reset like any other failed document — and
+    # without these keys that reset handed the canonical source back to it,
+    # putting the key straight back into conflict.
+    *DUPLICATE_DEMOTION_METADATA_KEYS,
 )
 
 

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -802,62 +802,6 @@ async def resolve_existing_doc_source(
     return await doc_status.resolve_doc_source_strict(basename)
 
 
-def _recorded_original_doc_id(row: Any) -> str:
-    """The ``original_doc_id`` a row marked ``metadata.is_duplicate`` points at.
-
-    Empty string for a PRIMARY row (``is_duplicate`` unset/false) and for a
-    duplicate that recorded no usable original — the same ``metadata.is_duplicate``
-    reading every backend's primary-candidate query uses.
-    """
-    metadata = doc_status_field(row, "metadata", {})
-    if not isinstance(metadata, dict) or not metadata.get("is_duplicate"):
-        return ""
-    original = metadata.get("original_doc_id")
-    return original if isinstance(original, str) else ""
-
-
-def _drop_a_duplicate_pointing_back(
-    match: tuple[str, Any] | None, doc_id: str
-) -> tuple[str, Any] | None:
-    """Discard a content-hash match that names ``doc_id`` as ITS original.
-
-    A row marked ``metadata.is_duplicate`` is not a content holder in its own
-    right — it is a pointer to the row that is. When that pointer names the very
-    document being checked, the two rows state the same relationship from
-    opposite ends, and answering "yes, a duplicate — of that row" closes a cycle:
-    both rows end up ``is_duplicate=true`` naming each other, the canonical
-    source key they share is left with NO primary at all, and neither the repair
-    endpoint (it only accepts a *current primary candidate*) nor a re-upload of
-    the same bytes (it re-derives the same content-addressed doc id and dedups
-    against the same pointer row) can give it one back.
-
-    This needs no race to happen. The documented source-conflict repair demotes
-    every losing candidate with ``original_doc_id=<the primary the operator
-    kept>``; when that kept primary had not been parsed yet — a PENDING upload is
-    a perfectly ordinary conflict candidate — its post-parse duplicate check then
-    meets the demoted row still carrying the same content hash, and marks the
-    operator's chosen primary FAILED-duplicate *of the row the operator just
-    demoted*, deleting its ``full_docs`` body on the way out. The demotion is
-    exactly the row this guard drops.
-
-    Narrow on purpose: a duplicate row pointing at a THIRD document is still
-    returned. The content really does exist elsewhere in that case, and refusing
-    every duplicate-marked match would fail open — it would re-admit genuine
-    content duplicates whose original is alive and well.
-    """
-    if match is None or not doc_id:
-        return match
-    matched_doc_id, row = match
-    if _recorded_original_doc_id(row) != doc_id:
-        return match
-    logger.info(
-        f"Ignoring content-hash match {matched_doc_id} for {doc_id}: that row is "
-        f"marked duplicate OF {doc_id}, so {doc_id} is the original (marking it a "
-        "duplicate would leave their shared source with no primary)"
-    )
-    return None
-
-
 async def get_existing_doc_by_content_hash(
     doc_status: DocStatusStorage,
     content_hash: str,
@@ -866,17 +810,21 @@ async def get_existing_doc_by_content_hash(
 ) -> tuple[str, Any] | None:
     """Find an existing doc_status record by content hash.
 
-    ``candidate_doc_id`` is the id the caller is about to create (the enqueue
-    dedup check runs before the row exists). Passing it lets the lookup discard a
-    match that is itself a duplicate row naming that id as its original — see
-    :func:`_drop_a_duplicate_pointing_back`; without it, a document whose primary
-    row was deleted can never be re-ingested, because the pointer row left behind
-    keeps answering for it.
+    ``candidate_doc_id`` is the id the caller is about to create — the enqueue
+    dedup check runs before that row exists, so excluding it removes nothing by
+    id; what it buys is the other half of ``exclude_doc_id`` (see the base
+    contract): a row that merely POINTS at that id is not a holder of the
+    content, it is a record that the content belongs to the document being
+    created. Without it, a document whose primary row was deleted can never be
+    re-ingested — its doc id is derived from the file name, so a re-upload asks
+    about the very id the leftover pointer names, and the pointer keeps
+    answering for it.
     """
     if not content_hash:
         return None
-    match = await doc_status.get_doc_by_content_hash(content_hash)
-    return _drop_a_duplicate_pointing_back(match, candidate_doc_id)
+    return await doc_status.get_doc_by_content_hash(
+        content_hash, exclude_doc_id=candidate_doc_id or None
+    )
 
 
 async def get_duplicate_doc_by_content_hash(
@@ -893,15 +841,16 @@ async def get_duplicate_doc_by_content_hash(
     fallback, which materialized the entire doc_status store (every status,
     including the whole PROCESSED corpus with chunks_list) once per document.
 
-    A returned row is never one that points back at ``current_doc_id`` as its own
-    original (see :func:`_drop_a_duplicate_pointing_back`).
+    The same exclusion also drops a row that points at ``current_doc_id`` as its
+    own original while the search continues past it, so this can neither close an
+    ``is_duplicate`` cycle nor hide a genuine third holder behind one (see the
+    base contract for both halves).
     """
     if not content_hash:
         return None
-    match = await doc_status.get_doc_by_content_hash(
+    return await doc_status.get_doc_by_content_hash(
         content_hash, exclude_doc_id=current_doc_id
     )
-    return _drop_a_duplicate_pointing_back(match, current_doc_id)
 
 
 def make_lightrag_doc_content(merged_text: str) -> str:

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -14,6 +14,7 @@ import json
 import os
 import re
 import time
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import quote, unquote, urlsplit
@@ -800,6 +801,54 @@ async def resolve_existing_doc_source(
     if basename == "unknown_source":
         return SourceAbsent()
     return await doc_status.resolve_doc_source_strict(basename)
+
+
+@asynccontextmanager
+async def source_candidate_set_lock(workspace: str, canonical_source_key: str):
+    """Serialize writers that change WHICH documents claim one canonical source.
+
+    LR2 §5.5 requires a source-conflict commit to be mutually exclusive with
+    every writer that can change that key's candidate set — enqueue, delete,
+    manual reset, scan stale-stub deletion AND the processing stage's duplicate
+    marking. This is the keyed lock both sides take, defined once so the two
+    cannot compute a different namespace or key and silently stop excluding each
+    other (they are in different modules and only the string makes them the same
+    lock).
+
+    Lock ORDER, when a caller needs more than this one: the workspace's
+    enqueue-serialize lock OUTSIDE, this keyed lock inside, any
+    ``pipeline_status`` lock innermost. That is the order the enqueue path would
+    naturally take (it already holds enqueue-serialize and would reach for a
+    keyed source lock inside it), so every holder of both agrees and no cycle
+    exists. ``source_conflict_repair_lock`` acquires them in exactly that order.
+
+    Process-LOCAL machinery, so the scope is one deployment (its worker
+    processes included — they share the Manager the master created). A standalone
+    CLI or a second deployment writing the same database is outside it; the CAS
+    and the post-commit re-resolve are what keep those honest.
+
+    A document with no usable source identity (``unknown_source`` and friends) is
+    never a primary candidate for any key — every backend's candidate query
+    excludes it — so there is nothing to serialize and no lock is taken. That is
+    not a shortcut: locking on the sentinel would funnel EVERY unsourced document
+    in the workspace through one keyed lock.
+    """
+    from lightrag.constants import SOURCE_CONFLICT_LOCK_NAMESPACE
+    from lightrag.kg.shared_storage import get_storage_keyed_lock
+
+    canonical = normalize_document_file_path(canonical_source_key)
+    if not canonical or canonical in PLACEHOLDER_DOCUMENT_SOURCES:
+        yield
+        return
+    namespace = (
+        f"{workspace}:{SOURCE_CONFLICT_LOCK_NAMESPACE}"
+        if workspace
+        else SOURCE_CONFLICT_LOCK_NAMESPACE
+    )
+    async with get_storage_keyed_lock(
+        [canonical], namespace=namespace, enable_logging=False
+    ):
+        yield
 
 
 async def get_existing_doc_by_content_hash(

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -802,13 +802,81 @@ async def resolve_existing_doc_source(
     return await doc_status.resolve_doc_source_strict(basename)
 
 
-async def get_existing_doc_by_content_hash(
-    doc_status: DocStatusStorage, content_hash: str
+def _recorded_original_doc_id(row: Any) -> str:
+    """The ``original_doc_id`` a row marked ``metadata.is_duplicate`` points at.
+
+    Empty string for a PRIMARY row (``is_duplicate`` unset/false) and for a
+    duplicate that recorded no usable original — the same ``metadata.is_duplicate``
+    reading every backend's primary-candidate query uses.
+    """
+    metadata = doc_status_field(row, "metadata", {})
+    if not isinstance(metadata, dict) or not metadata.get("is_duplicate"):
+        return ""
+    original = metadata.get("original_doc_id")
+    return original if isinstance(original, str) else ""
+
+
+def _drop_a_duplicate_pointing_back(
+    match: tuple[str, Any] | None, doc_id: str
 ) -> tuple[str, Any] | None:
-    """Find an existing doc_status record by content hash."""
+    """Discard a content-hash match that names ``doc_id`` as ITS original.
+
+    A row marked ``metadata.is_duplicate`` is not a content holder in its own
+    right — it is a pointer to the row that is. When that pointer names the very
+    document being checked, the two rows state the same relationship from
+    opposite ends, and answering "yes, a duplicate — of that row" closes a cycle:
+    both rows end up ``is_duplicate=true`` naming each other, the canonical
+    source key they share is left with NO primary at all, and neither the repair
+    endpoint (it only accepts a *current primary candidate*) nor a re-upload of
+    the same bytes (it re-derives the same content-addressed doc id and dedups
+    against the same pointer row) can give it one back.
+
+    This needs no race to happen. The documented source-conflict repair demotes
+    every losing candidate with ``original_doc_id=<the primary the operator
+    kept>``; when that kept primary had not been parsed yet — a PENDING upload is
+    a perfectly ordinary conflict candidate — its post-parse duplicate check then
+    meets the demoted row still carrying the same content hash, and marks the
+    operator's chosen primary FAILED-duplicate *of the row the operator just
+    demoted*, deleting its ``full_docs`` body on the way out. The demotion is
+    exactly the row this guard drops.
+
+    Narrow on purpose: a duplicate row pointing at a THIRD document is still
+    returned. The content really does exist elsewhere in that case, and refusing
+    every duplicate-marked match would fail open — it would re-admit genuine
+    content duplicates whose original is alive and well.
+    """
+    if match is None or not doc_id:
+        return match
+    matched_doc_id, row = match
+    if _recorded_original_doc_id(row) != doc_id:
+        return match
+    logger.info(
+        f"Ignoring content-hash match {matched_doc_id} for {doc_id}: that row is "
+        f"marked duplicate OF {doc_id}, so {doc_id} is the original (marking it a "
+        "duplicate would leave their shared source with no primary)"
+    )
+    return None
+
+
+async def get_existing_doc_by_content_hash(
+    doc_status: DocStatusStorage,
+    content_hash: str,
+    *,
+    candidate_doc_id: str = "",
+) -> tuple[str, Any] | None:
+    """Find an existing doc_status record by content hash.
+
+    ``candidate_doc_id`` is the id the caller is about to create (the enqueue
+    dedup check runs before the row exists). Passing it lets the lookup discard a
+    match that is itself a duplicate row naming that id as its original — see
+    :func:`_drop_a_duplicate_pointing_back`; without it, a document whose primary
+    row was deleted can never be re-ingested, because the pointer row left behind
+    keeps answering for it.
+    """
     if not content_hash:
         return None
-    return await doc_status.get_doc_by_content_hash(content_hash)
+    match = await doc_status.get_doc_by_content_hash(content_hash)
+    return _drop_a_duplicate_pointing_back(match, candidate_doc_id)
 
 
 async def get_duplicate_doc_by_content_hash(
@@ -824,12 +892,16 @@ async def get_duplicate_doc_by_content_hash(
     the previous ``get_docs_by_statuses(list(DocStatus))`` full-store scan
     fallback, which materialized the entire doc_status store (every status,
     including the whole PROCESSED corpus with chunks_list) once per document.
+
+    A returned row is never one that points back at ``current_doc_id`` as its own
+    original (see :func:`_drop_a_duplicate_pointing_back`).
     """
     if not content_hash:
         return None
-    return await doc_status.get_doc_by_content_hash(
+    match = await doc_status.get_doc_by_content_hash(
         content_hash, exclude_doc_id=current_doc_id
     )
+    return _drop_a_duplicate_pointing_back(match, current_doc_id)
 
 
 def make_lightrag_doc_content(merged_text: str) -> str:

--- a/tests/api/config/test_api_config_admission.py
+++ b/tests/api/config/test_api_config_admission.py
@@ -141,3 +141,24 @@ def test_negative_texts_limit_fails_fast(monkeypatch):
     args = _parse_texts_limit(monkeypatch, "-1")
     with pytest.raises(ValueError, match="MAX_TEXTS_PER_REQUEST"):
         validate_admission_configuration(args)
+
+
+# --------------------------------------------------------------------------- #
+# PIPELINE_REQUIRE_STRICT_STORAGE_READS (LR2 §11)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [(None, False), ("true", True), ("false", False), ("1", True), ("0", False)],
+)
+def test_strict_reads_gate_parses_as_a_bool(monkeypatch, value, expected):
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    if value is None:
+        monkeypatch.delenv("PIPELINE_REQUIRE_STRICT_STORAGE_READS", raising=False)
+    else:
+        monkeypatch.setenv("PIPELINE_REQUIRE_STRICT_STORAGE_READS", value)
+
+    args = parse_args()
+
+    assert args.pipeline_require_strict_storage_reads is expected

--- a/tests/api/routes/test_source_conflict_routes.py
+++ b/tests/api/routes/test_source_conflict_routes.py
@@ -77,12 +77,52 @@ class _ConflictDocStatus:
 
     _SAMPLE_CAP = 2
 
-    def __init__(self, groups: dict[str, list[str]] | None = None):
+    def __init__(
+        self,
+        groups: dict[str, list[str]] | None = None,
+        *,
+        content_hashes: dict[str, str] | None = None,
+        source_of: dict[str, str] | None = None,
+    ):
         self.groups = groups or {}
+        # doc_id → content_hash, and doc_id → the canonical source it claims.
+        # The commit refuses a primary whose content already lives under ANOTHER
+        # source, so both are needed to exercise (and to stay out of) that check.
+        self.content_hashes = content_hashes or {}
+        self.source_of = source_of or {}
         self.list_calls: list[tuple[int, object]] = []
         self.repair_calls: list[dict] = []
         self.list_error: Exception | None = None
         self.repair_error: Exception | None = None
+
+    def _row(self, doc_id: str) -> SimpleNamespace:
+        source = self.source_of.get(doc_id) or next(
+            (key for key, ids in self.groups.items() if doc_id in ids), ""
+        )
+        return SimpleNamespace(
+            content_hash=self.content_hashes.get(doc_id, ""),
+            file_path=source,
+            metadata={},
+        )
+
+    async def get_full_docs_by_ids(self, doc_ids, *, strict=False):
+        known = set(self.content_hashes) | set(self.source_of)
+        for ids in self.groups.values():
+            known.update(ids)
+        return {doc_id: self._row(doc_id) for doc_id in doc_ids if doc_id in known}
+
+    async def get_doc_by_content_hash(self, content_hash, *, exclude_doc_id=None):
+        """Earliest (by id, deterministically) OTHER holder of the hash — the
+        exclusions the base contract requires, on a double small enough to reason
+        about."""
+        holders = sorted(
+            doc_id
+            for doc_id, value in self.content_hashes.items()
+            if value == content_hash and doc_id != exclude_doc_id
+        )
+        if not holders:
+            return None
+        return holders[0], self._row(holders[0])
 
     async def list_source_conflicts_page(self, *, limit, position=CURSOR_START):
         self.list_calls.append((limit, position))
@@ -663,10 +703,12 @@ def test_a_failed_content_read_is_a_503_not_a_committed_demotion():
     assert [call["dry_run"] for call in doc_status.repair_calls] == [True]
 
 
-def test_an_unconfirmable_absence_does_not_block_the_repair():
-    """Only a CONFIRMED absence refuses. A backend with no strict point reads
-    cannot tell a transport failure from a missing row, and denying the operator
-    their only repair tool over an unconfirmed miss is the worse failure."""
+def test_a_backend_that_cannot_prove_content_is_a_503_not_a_commit():
+    """Fix-proof: a backend with no strict point reads used to warn and commit.
+    The old reasoning — such a backend's scan cannot delete the stub either, so
+    the interaction cannot arise — covers only one of the two harms: a stub can
+    never be processed, so it would own the canonical source forever, whatever the
+    scan does. Unverified is not verified, and the demotions are irreversible."""
     doc_status = _ConflictDocStatus({"a.pdf": ["doc-1", "doc-2"]})
     full_docs = _FullDocs({}, strict=False)  # nothing known, nothing provable
     client = _client(doc_status, full_docs)
@@ -687,5 +729,77 @@ def test_an_unconfirmable_absence_does_not_block_the_repair():
             "dry_run": False,
         },
     )
+    assert commit.status_code == 503
+    assert full_docs.reads == []  # the capability is missing; no read to attempt
+    assert doc_status.groups["a.pdf"] == ["doc-1", "doc-2"]  # nothing demoted
+
+
+def test_a_primary_whose_content_lives_under_another_source_is_refused():
+    """The processing stage marks a content duplicate FAILED and deletes its
+    content, and it holds no source-key lock — so a primary that ALREADY shares
+    its content hash with a document under a different source cannot keep this
+    one: the key would end up with no primary, which no repair can settle (the
+    endpoint only accepts a current primary candidate).
+
+    Refusing here is the same move the contentless-stub check makes, for the same
+    reason: it removes the interaction before the irreversible demotions, where a
+    lock could not (the marking may land the moment the lock is released).
+    """
+    doc_status = _ConflictDocStatus(
+        {"a.pdf": ["doc-1", "doc-2"]},
+        content_hashes={"doc-2": "hash-x", "doc-elsewhere": "hash-x"},
+        source_of={"doc-elsewhere": "other.pdf"},
+    )
+    client = _client(doc_status, _FullDocs({"doc-2": {"content": "body"}}))
+
+    dry = client.post(
+        "/documents/source_conflicts/repair",
+        headers=_HEADERS,
+        json={"canonical_source_key": "a.pdf", "primary_doc_id": "doc-2"},
+    ).json()
+    commit = client.post(
+        "/documents/source_conflicts/repair",
+        headers=_HEADERS,
+        json={
+            "canonical_source_key": "a.pdf",
+            "primary_doc_id": "doc-2",
+            "expected_candidate_count": dry["candidate_count"],
+            "expected_candidate_fingerprint": dry["fingerprint"],
+            "dry_run": False,
+        },
+    )
+
+    assert commit.status_code == 409
+    assert doc_status.groups["a.pdf"] == ["doc-1", "doc-2"]  # nothing demoted
+
+
+def test_a_content_twin_among_the_candidates_is_not_a_reason_to_refuse():
+    """The complement, and the check's documented boundary: two candidates for the
+    SAME key holding identical content is the ordinary conflict to settle (a
+    custom-ID insert over a scanned file), not a reason to refuse. Only a holder
+    under a DIFFERENT source dooms the primary."""
+    doc_status = _ConflictDocStatus(
+        {"a.pdf": ["doc-1", "doc-2"]},
+        content_hashes={"doc-1": "hash-x", "doc-2": "hash-x"},
+    )
+    client = _client(doc_status, _FullDocs({"doc-2": {"content": "body"}}))
+
+    dry = client.post(
+        "/documents/source_conflicts/repair",
+        headers=_HEADERS,
+        json={"canonical_source_key": "a.pdf", "primary_doc_id": "doc-2"},
+    ).json()
+    commit = client.post(
+        "/documents/source_conflicts/repair",
+        headers=_HEADERS,
+        json={
+            "canonical_source_key": "a.pdf",
+            "primary_doc_id": "doc-2",
+            "expected_candidate_count": dry["candidate_count"],
+            "expected_candidate_fingerprint": dry["fingerprint"],
+            "dry_run": False,
+        },
+    )
+
     assert commit.status_code == 200
-    assert full_docs.reads == []  # never even attempted
+    assert doc_status.groups["a.pdf"] == ["doc-2"]

--- a/tests/api/routes/test_source_conflict_routes.py
+++ b/tests/api/routes/test_source_conflict_routes.py
@@ -53,6 +53,20 @@ def _fingerprint(doc_ids: list[str]) -> str:
     return hashlib.sha256("\x00".join(sorted(doc_ids)).encode("utf-8")).hexdigest()[:32]
 
 
+@pytest.fixture(autouse=True)
+def _shared_storage():
+    """The repair COMMIT takes the canonical-key + enqueue-serialize locks, which
+    live in shared storage. Without this the file only passed when a sibling test
+    module happened to initialise it first — running it alone raised
+    "Shared-Data is not initialized" from inside the endpoint and showed up as a
+    500."""
+    from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
 class _ConflictDocStatus:
     """doc_status double whose conflict surface mirrors the real backends.
 
@@ -90,6 +104,21 @@ class _ConflictDocStatus:
             CursorAfter(page_keys[-1]) if len(page_keys) == limit else CURSOR_END
         )
         return SourceConflictPage(conflicts=conflicts, next_position=next_position)
+
+    async def resolve_doc_source_strict(self, canonical_source_key):
+        """The same typed resolution the real backends serve, so the post-commit
+        verification runs against a real answer rather than being stubbed out."""
+        from lightrag.base import SourceAbsent, SourceConflict, SourceUnique
+
+        candidates = sorted(self.groups.get(canonical_source_key, []))
+        if not candidates:
+            return SourceAbsent()
+        if len(candidates) == 1:
+            return SourceUnique(doc_id=candidates[0], doc=None)
+        return SourceConflict(
+            candidate_count=len(candidates),
+            sample_doc_ids=tuple(candidates[: self._SAMPLE_CAP]),
+        )
 
     async def repair_source_conflict(
         self,
@@ -445,3 +474,50 @@ def test_endpoints_require_authentication():
     assert listing.status_code in (401, 403), listing.status_code
     assert repair.status_code in (401, 403), repair.status_code
     assert storage.repair_calls == []
+
+
+def test_a_commit_that_leaves_the_key_unsettled_is_not_reported_as_success(
+    monkeypatch,
+):
+    """``committed=True`` only claims the named demotions landed. The repair locks
+    exclude a concurrent ENQUEUE and nothing else — a concurrent delete of the
+    kept primary, a processing-stage duplicate marking, or a scan stale-stub
+    deletion all mutate the candidate set without them — so the end state is
+    verified and reported, never inferred.
+
+    Fix-proof: the endpoint used to return 200 "committed" for exactly this.
+    """
+    doc_status = _ConflictDocStatus({"a.pdf": ["doc-1", "doc-2"]})
+    client = _client(doc_status)
+
+    dry = client.post(
+        "/documents/source_conflicts/repair",
+        json={"canonical_source_key": "a.pdf", "primary_doc_id": "doc-2"},
+        headers=_HEADERS,
+    )
+    assert dry.status_code == 200
+
+    original_repair = doc_status.repair_source_conflict
+
+    async def _repair_then_lose_the_primary(*args, **kwargs):
+        result = await original_repair(*args, **kwargs)
+        if not kwargs.get("dry_run", True):
+            # A concurrent delete removes the primary we just kept.
+            doc_status.groups["a.pdf"] = []
+        return result
+
+    doc_status.repair_source_conflict = _repair_then_lose_the_primary
+
+    body = dry.json()
+    commit = client.post(
+        "/documents/source_conflicts/repair",
+        json={
+            "canonical_source_key": "a.pdf",
+            "primary_doc_id": "doc-2",
+            "expected_candidate_count": body["candidate_count"],
+            "expected_candidate_fingerprint": body["fingerprint"],
+            "dry_run": False,
+        },
+        headers=_HEADERS,
+    )
+    assert commit.status_code != 200

--- a/tests/api/routes/test_source_conflict_routes.py
+++ b/tests/api/routes/test_source_conflict_routes.py
@@ -168,16 +168,48 @@ class _ConflictDocStatus:
         )
 
 
-def _client(doc_status: _ConflictDocStatus) -> TestClient:
+class _FullDocs:
+    """full_docs double for the contentless-primary refusal.
+
+    ``strict`` mirrors ``supports_strict_point_reads``: only a backend that HAS
+    strict point reads may have an absence trusted, so the doubles cover both.
+    """
+
+    def __init__(self, contents: dict[str, dict] | None = None, *, strict: bool = True):
+        self.contents = contents if contents is not None else {}
+        self.supports_strict_point_reads = strict
+        self.reads: list[str] = []
+
+    async def get_by_id_strict(self, doc_id: str):
+        self.reads.append(doc_id)
+        return self.contents.get(doc_id)
+
+
+def _client(
+    doc_status: _ConflictDocStatus, full_docs: _FullDocs | None = None
+) -> TestClient:
     app = FastAPI()
     app.include_router(
         create_document_routes(
-            SimpleNamespace(doc_status=doc_status, workspace="conflict-test"),
+            SimpleNamespace(
+                doc_status=doc_status,
+                full_docs=full_docs if full_docs is not None else _ContentEverywhere(),
+                workspace="conflict-test",
+            ),
             SimpleNamespace(),
             api_key="test-key",
         )
     )
     return TestClient(app)
+
+
+class _ContentEverywhere:
+    """Default for tests not about the content check: every document has content."""
+
+    supports_strict_point_reads = True
+
+    async def get_by_id_strict(self, doc_id: str):
+        return {"content": f"body of {doc_id}"}
 
 
 # --------------------------------------------------------------------------- #
@@ -521,3 +553,97 @@ def test_a_commit_that_leaves_the_key_unsettled_is_not_reported_as_success(
         headers=_HEADERS,
     )
     assert commit.status_code != 200
+
+
+def test_a_primary_with_no_content_is_refused():
+    """A row with no ``full_docs`` content is an unprocessable stub: it can never
+    own the source, and scan classification deletes exactly such rows on sight
+    (STALE_STUB fires only when the content is CONFIRMED absent), which would
+    delete the primary and leave the demoted rows pointing at a missing id — with
+    no way back, since a repair only demotes.
+
+    Fix-proof: the repair used to accept it and report success. Refusing here is
+    what removes the interaction at its root, instead of locking scan
+    classification against the repair.
+    """
+    doc_status = _ConflictDocStatus({"a.pdf": ["doc-1", "doc-2"]})
+    full_docs = _FullDocs({"doc-1": {"content": "real body"}})  # doc-2 is a stub
+    client = _client(doc_status, full_docs)
+
+    dry = client.post(
+        "/documents/source_conflicts/repair",
+        headers=_HEADERS,
+        json={"canonical_source_key": "a.pdf", "primary_doc_id": "doc-2"},
+    ).json()
+
+    commit = client.post(
+        "/documents/source_conflicts/repair",
+        headers=_HEADERS,
+        json={
+            "canonical_source_key": "a.pdf",
+            "primary_doc_id": "doc-2",
+            "expected_candidate_count": dry["candidate_count"],
+            "expected_candidate_fingerprint": dry["fingerprint"],
+            "dry_run": False,
+        },
+    )
+
+    assert commit.status_code == 409
+    assert "no full_docs content" in commit.json()["detail"]
+    # Nothing demoted: both rows still claim the source.
+    assert doc_status.groups["a.pdf"] == ["doc-1", "doc-2"]
+    assert full_docs.reads == ["doc-2"]  # only the chosen primary is read
+
+
+def test_a_primary_with_content_is_accepted():
+    """The complement — the check must not get in the way of a real repair."""
+    doc_status = _ConflictDocStatus({"a.pdf": ["doc-1", "doc-2"]})
+    full_docs = _FullDocs({"doc-1": {"content": "x"}, "doc-2": {"content": "y"}})
+    client = _client(doc_status, full_docs)
+
+    dry = client.post(
+        "/documents/source_conflicts/repair",
+        headers=_HEADERS,
+        json={"canonical_source_key": "a.pdf", "primary_doc_id": "doc-2"},
+    ).json()
+    commit = client.post(
+        "/documents/source_conflicts/repair",
+        headers=_HEADERS,
+        json={
+            "canonical_source_key": "a.pdf",
+            "primary_doc_id": "doc-2",
+            "expected_candidate_count": dry["candidate_count"],
+            "expected_candidate_fingerprint": dry["fingerprint"],
+            "dry_run": False,
+        },
+    )
+    assert commit.status_code == 200
+    assert doc_status.groups["a.pdf"] == ["doc-2"]
+
+
+def test_an_unconfirmable_absence_does_not_block_the_repair():
+    """Only a CONFIRMED absence refuses. A backend with no strict point reads
+    cannot tell a transport failure from a missing row, and denying the operator
+    their only repair tool over an unconfirmed miss is the worse failure."""
+    doc_status = _ConflictDocStatus({"a.pdf": ["doc-1", "doc-2"]})
+    full_docs = _FullDocs({}, strict=False)  # nothing known, nothing provable
+    client = _client(doc_status, full_docs)
+
+    dry = client.post(
+        "/documents/source_conflicts/repair",
+        headers=_HEADERS,
+        json={"canonical_source_key": "a.pdf", "primary_doc_id": "doc-2"},
+    ).json()
+    commit = client.post(
+        "/documents/source_conflicts/repair",
+        headers=_HEADERS,
+        json={
+            "canonical_source_key": "a.pdf",
+            "primary_doc_id": "doc-2",
+            "expected_candidate_count": dry["candidate_count"],
+            "expected_candidate_fingerprint": dry["fingerprint"],
+            "dry_run": False,
+        },
+    )
+    assert commit.status_code == 200
+    assert full_docs.reads == []  # never even attempted

--- a/tests/api/routes/test_source_conflict_routes.py
+++ b/tests/api/routes/test_source_conflict_routes.py
@@ -639,6 +639,8 @@ def test_a_primary_with_no_content_is_refused():
 
     assert commit.status_code == 409
     assert "no full_docs content" in commit.json()["detail"]
+    # ... and only for THIS reason (the sibling refusal has its own sentence).
+    assert "same content" not in commit.json()["detail"]
     # Nothing demoted: both rows still claim the source.
     assert doc_status.groups["a.pdf"] == ["doc-1", "doc-2"]
     assert full_docs.reads == ["doc-2"]  # only the chosen primary is read
@@ -771,6 +773,13 @@ def test_a_primary_whose_content_lives_under_another_source_is_refused():
 
     assert commit.status_code == 409
     assert doc_status.groups["a.pdf"] == ["doc-1", "doc-2"]  # nothing demoted
+    # Fix-proof: the detail is built here (the exception text is not guaranteed
+    # client-safe), and both reasons rendered the SAME sentence — so a document
+    # whose content was fine was told it had none. The reason travels with the
+    # exception now.
+    detail = commit.json()["detail"]
+    assert "no full_docs content" not in detail
+    assert "doc-elsewhere" in detail and "same content" in detail
 
 
 def test_a_content_twin_among_the_candidates_is_not_a_reason_to_refuse():

--- a/tests/api/routes/test_source_conflict_routes.py
+++ b/tests/api/routes/test_source_conflict_routes.py
@@ -175,13 +175,22 @@ class _FullDocs:
     strict point reads may have an absence trusted, so the doubles cover both.
     """
 
-    def __init__(self, contents: dict[str, dict] | None = None, *, strict: bool = True):
+    def __init__(
+        self,
+        contents: dict[str, dict] | None = None,
+        *,
+        strict: bool = True,
+        read_error: Exception | None = None,
+    ):
         self.contents = contents if contents is not None else {}
         self.supports_strict_point_reads = strict
+        self.read_error = read_error
         self.reads: list[str] = []
 
     async def get_by_id_strict(self, doc_id: str):
         self.reads.append(doc_id)
+        if self.read_error is not None:
+            raise self.read_error
         return self.contents.get(doc_id)
 
 
@@ -619,6 +628,39 @@ def test_a_primary_with_content_is_accepted():
     )
     assert commit.status_code == 200
     assert doc_status.groups["a.pdf"] == ["doc-2"]
+
+
+def test_a_failed_content_read_is_a_503_not_a_committed_demotion():
+    """Fix-proof: a strict read that RAISED used to warn and commit anyway. That
+    spends the one guarantee the check exists for — the demotions cannot be undone
+    (a repair only demotes, and a key left with no candidate cannot be repaired
+    again), so committing on an unverified primary trades an irreversible loss for
+    a retry the operator can simply make later. 503, and nothing demoted."""
+    doc_status = _ConflictDocStatus({"a.pdf": ["doc-1", "doc-2"]})
+    full_docs = _FullDocs(read_error=RuntimeError("connection reset"))
+    client = _client(doc_status, full_docs)
+
+    dry = client.post(
+        "/documents/source_conflicts/repair",
+        headers=_HEADERS,
+        json={"canonical_source_key": "a.pdf", "primary_doc_id": "doc-2"},
+    ).json()
+    commit = client.post(
+        "/documents/source_conflicts/repair",
+        headers=_HEADERS,
+        json={
+            "canonical_source_key": "a.pdf",
+            "primary_doc_id": "doc-2",
+            "expected_candidate_count": dry["candidate_count"],
+            "expected_candidate_fingerprint": dry["fingerprint"],
+            "dry_run": False,
+        },
+    )
+
+    assert commit.status_code == 503
+    assert doc_status.groups["a.pdf"] == ["doc-1", "doc-2"]  # nothing demoted
+    # Only the operator's own dry-run ran; the commit never reached the backend.
+    assert [call["dry_run"] for call in doc_status.repair_calls] == [True]
 
 
 def test_an_unconfirmable_absence_does_not_block_the_repair():

--- a/tests/kg/conftest_scheduling_backends.py
+++ b/tests/kg/conftest_scheduling_backends.py
@@ -1,0 +1,208 @@
+"""Backend factories for the shared doc_status scheduling contract suite.
+
+LR2 §13.1 requires the five built-in backends to share ONE parametrized contract
+suite. Five independently written per-backend files were the previous state, and
+they drift: a backend passes its own file while violating an invariant only some
+other file happens to check.
+
+JSON needs nothing and always runs. The other four need their service; each is
+probed once per session and its parameters skip when it is unreachable, so the
+suite is useful offline and complete when the services are up (see the module
+docstring of ``test_doc_status_scheduling_contract`` for how to start them).
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import uuid
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+import pytest
+
+
+class _DummyEmbeddingFunc:
+    """doc_status never embeds; the storage dataclasses just require the field."""
+
+    embedding_dim = 4
+
+    async def __call__(self, texts):  # pragma: no cover - never invoked
+        return [[0.0] * self.embedding_dim for _ in texts]
+
+
+def _reachable(host: str, port: int, timeout: float = 0.35) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+@dataclass(frozen=True)
+class BackendSpec:
+    """One row of the contract-suite parametrization."""
+
+    name: str
+    build: Callable[[Any], Awaitable[Any]]
+    probe: Callable[[], bool]
+    unavailable_hint: str
+
+    def skip_unless_available(self) -> None:
+        if not self.probe():
+            pytest.skip(f"{self.name} unavailable: {self.unavailable_hint}")
+
+
+def _unique_workspace() -> str:
+    """A fresh workspace per test: the contract covers derived indexes and source
+    multimaps, so leakage between cases would produce false Conflicts."""
+    return f"lr2ct{uuid.uuid4().hex[:10]}"
+
+
+def _ensure_shared_data() -> None:
+    """Every backend reaches shared_storage — JSON for its cross-process data
+    proxy, the others for the keyed write locks their index maintenance takes."""
+    from lightrag.kg.shared_storage import initialize_share_data
+
+    initialize_share_data()
+
+
+async def _build_json(tmp_path) -> Any:
+    from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
+
+    _ensure_shared_data()
+
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace=_unique_workspace(),
+    )
+    await storage.initialize()
+    return storage
+
+
+async def _build_redis(_tmp_path) -> Any:
+    from lightrag.kg.redis_impl import RedisDocStatusStorage
+
+    _ensure_shared_data()
+
+    os.environ.setdefault("REDIS_URI", "redis://localhost:6379")
+    storage = RedisDocStatusStorage(
+        namespace="doc_status",
+        global_config={},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace=_unique_workspace(),
+    )
+    await storage.initialize()
+    return storage
+
+
+async def _build_postgres(_tmp_path) -> Any:
+    from lightrag.kg.postgres_impl import ClientManager, PGDocStatusStorage
+
+    _ensure_shared_data()
+
+    # The PG pool is a process-wide singleton that pins its vector settings on
+    # first use, so an earlier test in the same session (one that monkeypatched a
+    # POSTGRES_HNSW_* / vector env var) makes every later request incompatible.
+    # Clearing it is only safe while nobody holds it — assert that rather than
+    # assume it, so a genuine leak shows up as a failure instead of a torn pool.
+    if ClientManager._instances["vector_signature"] is not None:
+        assert ClientManager._instances["ref_count"] == 0, (
+            "another test still holds the PG pool; the contract fixture will not "
+            "reset a pool that is in use"
+        )
+        ClientManager._instances["db"] = None
+        ClientManager._instances["vector_signature"] = None
+
+    storage = PGDocStatusStorage(
+        namespace="doc_status",
+        global_config={"embedding_batch_num": 8},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace=_unique_workspace(),
+    )
+    await storage.initialize()
+    return storage
+
+
+async def _build_mongo(_tmp_path) -> Any:
+    from lightrag.kg.mongo_impl import MongoDocStatusStorage
+
+    _ensure_shared_data()
+
+    storage = MongoDocStatusStorage(
+        namespace="doc_status",
+        global_config={},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace=_unique_workspace(),
+    )
+    await storage.initialize()
+    return storage
+
+
+async def _build_opensearch(_tmp_path) -> Any:
+    from lightrag.kg.opensearch_impl import OpenSearchDocStatusStorage
+
+    _ensure_shared_data()
+
+    storage = OpenSearchDocStatusStorage(
+        namespace="doc_status",
+        global_config={},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace=_unique_workspace(),
+    )
+    await storage.initialize()
+    return storage
+
+
+_SERVICE_BACKENDS: tuple[BackendSpec, ...] = (
+    BackendSpec(
+        name="redis",
+        build=_build_redis,
+        probe=lambda: _reachable("localhost", 6379),
+        unavailable_hint="no Redis on localhost:6379",
+    ),
+    BackendSpec(
+        name="postgres",
+        build=_build_postgres,
+        probe=lambda: _reachable("localhost", 5432),
+        unavailable_hint="no PostgreSQL on localhost:5432",
+    ),
+    BackendSpec(
+        name="mongodb",
+        build=_build_mongo,
+        probe=lambda: _reachable("localhost", 27017),
+        unavailable_hint="no MongoDB on localhost:27017",
+    ),
+    BackendSpec(
+        name="opensearch",
+        build=_build_opensearch,
+        probe=lambda: _reachable("localhost", 9200),
+        unavailable_hint="no OpenSearch on localhost:9200",
+    ),
+)
+
+_JSON_BACKEND = BackendSpec(
+    name="json",
+    build=_build_json,
+    probe=lambda: True,
+    unavailable_hint="never unavailable",
+)
+
+# Marked per PARAMETER, not per module: JSON needs no service, so it must run in
+# the default offline suite — a contract test that only executes behind
+# ``--run-integration`` would go stale between the runs that use it.
+BACKEND_PARAMS = [
+    pytest.param(_JSON_BACKEND, id=_JSON_BACKEND.name),
+    *[
+        pytest.param(
+            spec,
+            id=spec.name,
+            marks=[pytest.mark.integration, pytest.mark.requires_db],
+        )
+        for spec in _SERVICE_BACKENDS
+    ],
+]
+
+BACKEND_SPECS: tuple[BackendSpec, ...] = (_JSON_BACKEND, *_SERVICE_BACKENDS)

--- a/tests/kg/conftest_scheduling_backends.py
+++ b/tests/kg/conftest_scheduling_backends.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import os
 import socket
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
@@ -59,6 +60,34 @@ def _unique_workspace() -> str:
     return f"lr2ct{uuid.uuid4().hex[:10]}"
 
 
+@contextmanager
+def _workspace_env_isolated(*env_names: str):
+    """Neutralise the per-backend ``*_WORKSPACE`` overrides while a storage
+    resolves its workspace, then restore them.
+
+    Those env vars take PRIORITY over the constructor's ``workspace=`` argument
+    (``"Using REDIS_WORKSPACE environment variable … overriding …"``). So on the
+    one kind of machine these tests actually run on — an integration box with a
+    configured ``.env`` — ``_unique_workspace()`` was silently discarded and
+    every case landed in the SAME workspace: the derived-index and
+    source-multimap cases would then report each other's rows as Conflicts, and
+    one case's ``drop()`` would wipe another's data.
+
+    The window only has to cover construction and ``initialize()``: both
+    ``__post_init__`` (workspace) and the client setup (URI) read the
+    environment there and keep the resolved values.
+    """
+    saved = {name: os.environ.pop(name, None) for name in env_names}
+    try:
+        yield
+    finally:
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
 def _ensure_shared_data() -> None:
     """Every backend reaches shared_storage — JSON for its cross-process data
     proxy, the others for the keyed write locks their index maintenance takes."""
@@ -87,14 +116,15 @@ async def _build_redis(_tmp_path) -> Any:
 
     _ensure_shared_data()
 
-    os.environ.setdefault("REDIS_URI", "redis://localhost:6379")
-    storage = RedisDocStatusStorage(
-        namespace="doc_status",
-        global_config={},
-        embedding_func=_DummyEmbeddingFunc(),
-        workspace=_unique_workspace(),
-    )
-    await storage.initialize()
+    with _workspace_env_isolated("REDIS_WORKSPACE"):
+        os.environ.setdefault("REDIS_URI", "redis://localhost:6379")
+        storage = RedisDocStatusStorage(
+            namespace="doc_status",
+            global_config={},
+            embedding_func=_DummyEmbeddingFunc(),
+            workspace=_unique_workspace(),
+        )
+        await storage.initialize()
     return storage
 
 
@@ -116,13 +146,16 @@ async def _build_postgres(_tmp_path) -> Any:
         ClientManager._instances["db"] = None
         ClientManager._instances["vector_signature"] = None
 
-    storage = PGDocStatusStorage(
-        namespace="doc_status",
-        global_config={"embedding_batch_num": 8},
-        embedding_func=_DummyEmbeddingFunc(),
-        workspace=_unique_workspace(),
-    )
-    await storage.initialize()
+    # POSTGRES_WORKSPACE feeds the pool config too, so the isolation has to span
+    # the client setup inside initialize(), not just __post_init__.
+    with _workspace_env_isolated("POSTGRES_WORKSPACE"):
+        storage = PGDocStatusStorage(
+            namespace="doc_status",
+            global_config={"embedding_batch_num": 8},
+            embedding_func=_DummyEmbeddingFunc(),
+            workspace=_unique_workspace(),
+        )
+        await storage.initialize()
     return storage
 
 
@@ -131,13 +164,14 @@ async def _build_mongo(_tmp_path) -> Any:
 
     _ensure_shared_data()
 
-    storage = MongoDocStatusStorage(
-        namespace="doc_status",
-        global_config={},
-        embedding_func=_DummyEmbeddingFunc(),
-        workspace=_unique_workspace(),
-    )
-    await storage.initialize()
+    with _workspace_env_isolated("MONGODB_WORKSPACE"):
+        storage = MongoDocStatusStorage(
+            namespace="doc_status",
+            global_config={},
+            embedding_func=_DummyEmbeddingFunc(),
+            workspace=_unique_workspace(),
+        )
+        await storage.initialize()
     return storage
 
 
@@ -146,13 +180,14 @@ async def _build_opensearch(_tmp_path) -> Any:
 
     _ensure_shared_data()
 
-    storage = OpenSearchDocStatusStorage(
-        namespace="doc_status",
-        global_config={},
-        embedding_func=_DummyEmbeddingFunc(),
-        workspace=_unique_workspace(),
-    )
-    await storage.initialize()
+    with _workspace_env_isolated("OPENSEARCH_WORKSPACE"):
+        storage = OpenSearchDocStatusStorage(
+            namespace="doc_status",
+            global_config={},
+            embedding_func=_DummyEmbeddingFunc(),
+            workspace=_unique_workspace(),
+        )
+        await storage.initialize()
     return storage
 
 

--- a/tests/kg/mongo_impl/test_mongo_scheduling_pages.py
+++ b/tests/kg/mongo_impl/test_mongo_scheduling_pages.py
@@ -813,7 +813,10 @@ async def test_get_doc_by_content_hash_exclude_doc_id_adds_ne_filter():
 
     result = await s.get_doc_by_content_hash("h", exclude_doc_id="doc-1")
     assert result is not None and result[0] == "doc-2"
-    assert data.find_queries == [{"content_hash": "h", "_id": {"$ne": "doc-1"}}]
+    # The id half of the exclusion; the pointer half is asserted in
+    # test_get_doc_by_content_hash_excludes_rows_pointing_at_the_excluded_id.
+    assert data.find_queries[0]["content_hash"] == "h"
+    assert data.find_queries[0]["_id"] == {"$ne": "doc-1"}
     assert data.find_cursors[0].sort_spec == [("created_at", 1), ("_id", 1)]
     assert data.find_cursors[0].limit_value == 1
 
@@ -829,3 +832,37 @@ async def test_get_doc_by_content_hash_propagates_query_failure():
     s = _storage(data=data)
     with pytest.raises(PyMongoError):
         await s.get_doc_by_content_hash("h", exclude_doc_id="doc-1")
+
+
+@pytest.mark.asyncio
+async def test_get_doc_by_content_hash_excludes_rows_pointing_at_the_excluded_id():
+    """Second half of ``exclude_doc_id`` (base contract): a ``$nor`` clause drops
+    rows marked ``is_duplicate`` that name the excluded id as their original —
+    such a row records that the content belongs to the asking document, so
+    returning it would close an is_duplicate cycle and leave their shared source
+    with no primary. In-query, so the sort+limit still yield the earliest
+    surviving holder rather than a post-filtered single row."""
+    data = _FakeCollection(find_docs=[{"_id": "doc-3", "content_hash": "h"}])
+    s = _storage(data=data)
+
+    result = await s.get_doc_by_content_hash("h", exclude_doc_id="doc-1")
+
+    assert result is not None and result[0] == "doc-3"
+    assert data.find_queries == [
+        {
+            "content_hash": "h",
+            "_id": {"$ne": "doc-1"},
+            "$nor": [
+                {
+                    "metadata.is_duplicate": True,
+                    "metadata.original_doc_id": "doc-1",
+                }
+            ],
+        }
+    ]
+    assert data.find_cursors[0].sort_spec == [("created_at", 1), ("_id", 1)]
+    assert data.find_cursors[0].limit_value == 1
+
+    # No exclusion → no $nor clause either.
+    await s.get_doc_by_content_hash("h")
+    assert "$nor" not in data.find_queries[-1]

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -1929,6 +1929,10 @@ class TestDocStatusStorage:
             }
         )
         mock_client.indices.put_mapping = AsyncMock()
+        # Healthy tiebreaker coverage: startup audits it unconditionally for a
+        # pre-existing index, and this fixture's default count (5) would read as
+        # 5 docs missing the value and trigger a backfill.
+        mock_client.count = AsyncMock(return_value={"count": 0})
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
@@ -1957,6 +1961,9 @@ class TestDocStatusStorage:
             }
         )
         mock_client.indices.put_mapping = AsyncMock()
+        # See the sibling test: the unconditional coverage audit needs a healthy
+        # count, or the fixture default (5) reads as 5 missing values.
+        mock_client.count = AsyncMock(return_value={"count": 0})
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()

--- a/tests/kg/opensearch_impl/test_opensearch_strict_reads.py
+++ b/tests/kg/opensearch_impl/test_opensearch_strict_reads.py
@@ -96,8 +96,7 @@ class _EmbedFunc:
 
 
 def _migrated_mapping(index: str, **_kwargs) -> dict:
-    """Mapping of an index that already carries the __mirrored_id tiebreaker, so
-    startup runs no legacy value backfill (see _ensure_scheduling_fields_mapping)."""
+    """Mapping of an index that already carries the __mirrored_id tiebreaker."""
     return {index: {"mappings": {"properties": {"__mirrored_id": {"type": "keyword"}}}}}
 
 
@@ -107,6 +106,13 @@ def _make_client() -> AsyncMock:
     client.indices.exists = AsyncMock(return_value=True)
     client.indices.create = AsyncMock()
     client.indices.get_mapping = AsyncMock(side_effect=_migrated_mapping)
+    client.indices.put_mapping = AsyncMock()
+    # A healthy index: startup's unconditional __mirrored_id coverage audit
+    # finds zero gaps. ``query_params`` wraps client methods in a SYNC wrapper,
+    # so spec'd children default to MagicMock — async ones must be set here or
+    # ``await client.count(...)`` fails with "MagicMock can't be used in await".
+    client.count = AsyncMock(return_value={"count": 0})
+    client.update_by_query = AsyncMock(return_value={"updated": 0, "failures": []})
     client.create_pit = AsyncMock(return_value={"pit_id": "pit-1"})
     client.delete_pit = AsyncMock()
     return client

--- a/tests/kg/opensearch_impl/test_os_scheduling_pages.py
+++ b/tests/kg/opensearch_impl/test_os_scheduling_pages.py
@@ -1231,7 +1231,10 @@ async def test_content_hash_lookup_sorts_for_the_earliest_holder():
         {"created_at": {"order": "asc", "missing": "_first"}},
         {"__mirrored_id": {"order": "asc"}},
     ]
-    assert body["size"] == 1
+    # Ordered window (see test_content_hash_skips_pointer_rows_over_a_bounded_window):
+    # every hit past the first is only reached when it has to skip a pointer row,
+    # and the FIRST surviving hit is still the earliest holder.
+    assert body["size"] == s._CONTENT_HASH_POINTER_WINDOW
 
 
 @pytest.mark.asyncio
@@ -1266,3 +1269,77 @@ async def test_content_hash_lookup_is_fail_closed():
     s = _content_hash_storage()
     s.client.search = AsyncMock(return_value={"hits": {"hits": []}})
     assert await s.get_doc_by_content_hash("h", exclude_doc_id="doc-1") is None
+
+
+@pytest.mark.asyncio
+async def test_content_hash_skips_pointer_rows_over_a_bounded_window():
+    """Second half of ``exclude_doc_id`` (base contract): a row marked
+    ``is_duplicate`` naming the excluded id as its original records that the
+    content belongs to the asking document, so returning it would close an
+    is_duplicate cycle and leave their shared source with no primary.
+
+    OpenSearch applies it to ``_source`` over a bounded ordered window rather
+    than as a term query: ``metadata`` lives under ``dynamic: true`` with no
+    declared mapping for ``original_doc_id``, so a term query on the bare path
+    depends on whatever dynamic mapping produced (a string becomes ``text`` plus
+    a ``.keyword`` subfield) and would silently match nothing — failing OPEN
+    exactly where the pointer has to be excluded. The window must not truncate
+    the search: the third holder below is returned, not swallowed.
+    """
+    s = _content_hash_storage()
+    s.client.search = AsyncMock(
+        return_value={
+            "hits": {
+                "hits": [
+                    {
+                        "_id": "doc-pointer",
+                        "_source": {
+                            "content_hash": "h",
+                            "metadata": {
+                                "is_duplicate": True,
+                                "original_doc_id": "doc-1",
+                            },
+                        },
+                    },
+                    {"_id": "doc-3", "_source": {"content_hash": "h"}},
+                ]
+            }
+        }
+    )
+
+    result = await s.get_doc_by_content_hash("h", exclude_doc_id="doc-1")
+
+    assert result is not None and result[0] == "doc-3"
+    body = s.client.search.call_args.kwargs["body"]
+    assert body["size"] == s._CONTENT_HASH_POINTER_WINDOW
+    assert body["sort"][0] == {"created_at": {"order": "asc", "missing": "_first"}}
+    # Without an id to point AT there is nothing to skip, so one hit still suffices.
+    s.client.search.return_value = {"hits": {"hits": []}}
+    await s.get_doc_by_content_hash("h")
+    assert s.client.search.call_args.kwargs["body"]["size"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_window_of_nothing_but_pointers_raises_instead_of_reporting_absence():
+    """``None`` means CONFIRMED no other holder and the dedup callers act on it
+    destructively, so a window that cannot answer must raise, not report absence."""
+    s = _content_hash_storage()
+    pointer = {
+        "content_hash": "h",
+        "metadata": {"is_duplicate": True, "original_doc_id": "doc-1"},
+    }
+    s.client.search = AsyncMock(
+        return_value={
+            "hits": {
+                "hits": [
+                    {"_id": f"doc-p{i}", "_source": pointer}
+                    for i in range(
+                        OpenSearchDocStatusStorage._CONTENT_HASH_POINTER_WINDOW
+                    )
+                ]
+            }
+        }
+    )
+
+    with pytest.raises(StorageControlPlaneError, match="bounded window"):
+        await s.get_doc_by_content_hash("h", exclude_doc_id="doc-1")

--- a/tests/kg/opensearch_impl/test_os_scheduling_pages.py
+++ b/tests/kg/opensearch_impl/test_os_scheduling_pages.py
@@ -368,13 +368,29 @@ def _missing_mirrored_id_query() -> dict:
     return {"bool": {"must_not": {"exists": {"field": "__mirrored_id"}}}}
 
 
-async def test_startup_skips_audit_on_an_already_migrated_index(global_config):
-    """An index that already maps __mirrored_id was written by code that mirrors
-    the id on every write, so it needs neither the audit nor its _count."""
+async def test_startup_audits_coverage_even_when_the_mapping_is_present(global_config):
+    """Fix-proof: the audit used to be gated on "we just added the mapping", but
+    the mapping present does not imply the VALUES are present — a snapshot
+    restore, an external writer, or this very migration crashing between its
+    put_mapping and its backfill all produce that state, and the gate then
+    skipped the audit for good. A healthy index still costs only one _count and
+    no backfill."""
     client = _make_client()
     await _make_doc_status(global_config, client)
+    client.count.assert_awaited_once()
+    assert client.count.call_args.kwargs["body"]["query"] == (
+        _missing_mirrored_id_query()
+    )
     client.update_by_query.assert_not_awaited()
-    client.count.assert_not_awaited()
+
+
+async def test_startup_backfills_a_mapped_index_whose_values_are_missing(global_config):
+    """The state the old gate declared impossible: mapping present, values
+    absent. It must be repaired, not trusted."""
+    client = _make_client()
+    client.count = AsyncMock(side_effect=[{"count": 4}, {"count": 0}])
+    await _make_doc_status(global_config, client)
+    client.update_by_query.assert_awaited_once()
 
 
 async def test_startup_skips_backfill_when_coverage_is_complete(global_config):
@@ -793,6 +809,9 @@ async def test_resolve_source_absent_on_zero_hits(global_config):
 async def test_resolve_source_unique(global_config):
     client = _make_client()
     storage = await _make_doc_status(global_config, client)
+    # Startup's tiebreaker coverage audit spends one _count; this test is about
+    # the resolver's own follow-up count, so measure from zero.
+    client.count.reset_mock()
     source = _status_source("doc-1", status="processed", file_path="report.pdf")
     client.search = AsyncMock(return_value=_page([_hit("doc-1", source)]))
 

--- a/tests/kg/postgres_impl/test_pg_scheduling_index_migration.py
+++ b/tests/kg/postgres_impl/test_pg_scheduling_index_migration.py
@@ -1,0 +1,150 @@
+"""The scheduling-index migration never leaves the table worse off (LR2 §13.1).
+
+The migration replaces a wrongly-ordered index with a ``created_at NULLS FIRST``
+one. It used to DROP the superseded index first and then swallow a failed
+create — so a create that did not land left LIGHTRAG_DOC_STATUS with NO
+scheduling index at all: strictly worse than before the upgrade, and invisible.
+The service starts, pages stay correct and memory-bounded (a top-N sort keeps
+only ``limit`` rows), and only the I/O silently degrades to a full scan plus a
+sort per page — O(rows²/page_size) over a sweep.
+
+So the order is create → verify from ``pg_indexes`` → drop, the verification
+reads the catalog instead of inferring success from "no exception was raised",
+and a missing index is reported with its consequence and its DDL rather than as
+a bare "failed to create index".
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lightrag.kg.postgres_impl import PostgreSQLDB
+
+pytestmark = pytest.mark.offline
+
+_NEW = "idx_lightrag_doc_status_ws_status_created_nf_id"
+_SUPERSEDED = "idx_lightrag_doc_status_ws_status_created_id"
+
+
+class _FakeDB:
+    """Catalog + statement log; only ``query``/``execute`` are exercised."""
+
+    # The real helper, so its SQL and parameters are under test too.
+    _doc_status_index_exists = PostgreSQLDB._doc_status_index_exists
+
+    def __init__(self, *, existing: set[str] | None = None):
+        self.existing: set[str] = set(existing or ())
+        self.executed: list[str] = []
+        # index name -> exception to raise instead of creating it
+        self.create_fails: Exception | None = None
+        # True: CREATE returns cleanly but the index does not appear (a pooler /
+        # aborted transaction swallowing the DDL).
+        self.create_is_a_lie = False
+
+    async def query(self, sql, params=None, multirows=False, **kwargs):
+        assert "pg_indexes" in sql, sql
+        assert params and len(params) == 1, params
+        return {"indexname": params[0]} if params[0] in self.existing else None
+
+    async def execute(self, sql, data=None, **kwargs):
+        self.executed.append(" ".join(sql.split()))
+        if sql.strip().upper().startswith("CREATE INDEX"):
+            if self.create_fails is not None:
+                raise self.create_fails
+            if not self.create_is_a_lie:
+                self.existing.add(_NEW)
+        elif "DROP INDEX" in sql.upper():
+            self.existing.discard(_SUPERSEDED)
+
+
+def _kinds(db: _FakeDB) -> list[str]:
+    out = []
+    for sql in db.executed:
+        upper = sql.upper()
+        if upper.startswith("CREATE INDEX"):
+            out.append("create")
+        elif "DROP INDEX" in upper:
+            out.append("drop")
+    return out
+
+
+@pytest.mark.asyncio
+async def test_creates_then_drops_the_superseded_index_in_that_order():
+    db = _FakeDB(existing={_SUPERSEDED})
+    await PostgreSQLDB._migrate_doc_status_add_scheduling_fields(db)
+
+    assert _kinds(db) == ["create", "drop"]
+    assert _NEW in db.existing
+    assert _SUPERSEDED not in db.existing
+    # The new index carries the load-bearing NULLS FIRST declaration.
+    assert any("CREATED_AT NULLS FIRST" in sql.upper() for sql in db.executed)
+
+
+@pytest.mark.asyncio
+async def test_a_failed_create_keeps_the_superseded_index(caplog):
+    """Fix-proof: the drop used to run first, so this left the table with no
+    scheduling index at all."""
+    from lightrag.utils import logger
+
+    db = _FakeDB(existing={_SUPERSEDED})
+    db.create_fails = RuntimeError("canceling statement due to lock timeout")
+
+    logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            await PostgreSQLDB._migrate_doc_status_add_scheduling_fields(db)
+    finally:
+        logger.propagate = False
+
+    assert "drop" not in _kinds(db)
+    assert _SUPERSEDED in db.existing  # paging is no worse than before the upgrade
+    # The operator is told what it costs and how to fix it, not just that a
+    # statement failed.
+    assert "is MISSING" in caplog.text
+    assert "full scan" in caplog.text
+    assert "NULLS FIRST" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_the_drop_waits_on_the_catalog_not_on_the_absence_of_an_error():
+    """A CREATE that returns cleanly is not proof the index exists; only
+    pg_indexes is."""
+    db = _FakeDB(existing={_SUPERSEDED})
+    db.create_is_a_lie = True
+
+    await PostgreSQLDB._migrate_doc_status_add_scheduling_fields(db)
+
+    assert _kinds(db) == ["create"]
+    assert _SUPERSEDED in db.existing
+
+
+@pytest.mark.asyncio
+async def test_a_second_startup_creates_nothing_and_stays_idempotent():
+    db = _FakeDB(existing={_NEW})
+    await PostgreSQLDB._migrate_doc_status_add_scheduling_fields(db)
+
+    # Nothing to create; the drop is still issued (IF EXISTS, so a no-op here).
+    assert _kinds(db) == ["drop"]
+    assert _NEW in db.existing
+
+
+@pytest.mark.asyncio
+async def test_a_failed_verification_read_also_holds_the_drop_back():
+    """The catalog read itself can fail; that is not evidence of success."""
+    db = _FakeDB(existing={_SUPERSEDED})
+    calls = {"n": 0}
+    original = db.query
+
+    async def _second_read_fails(sql, params=None, multirows=False, **kwargs):
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise RuntimeError("connection reset")
+        return await original(sql, params, multirows=multirows, **kwargs)
+
+    db.query = _second_read_fails
+    await PostgreSQLDB._migrate_doc_status_add_scheduling_fields(db)
+
+    assert "drop" not in _kinds(db)
+    assert _SUPERSEDED in db.existing

--- a/tests/kg/postgres_impl/test_pg_scheduling_pages.py
+++ b/tests/kg/postgres_impl/test_pg_scheduling_pages.py
@@ -216,9 +216,9 @@ async def test_null_bucket_cursor_resumes_through_null_rows():
         strict=True,
     )
     sql, params, _ = db.calls[0]
-    assert "(created_at IS NULL AND id > $3) OR created_at IS NOT NULL" in sql
+    assert "(created_at IS NULL AND id > $2) OR created_at IS NOT NULL" in sql
     assert "ORDER BY created_at ASC NULLS FIRST, id ASC" in sql
-    assert params[2] == "doc-n"
+    assert params[1] == "doc-n"
 
 
 async def test_string_cursor_excludes_consumed_null_bucket():
@@ -275,11 +275,19 @@ async def test_page_sql_keyset_shape_without_cursor():
     sql, params, multirows = db.calls[0]
     assert multirows is True
     assert "ORDER BY created_at ASC NULLS FIRST, id ASC" in sql
-    assert "status = ANY($2)" in sql
+    # ONE BRANCH PER STATUS with equality, not `status = ANY(...)`: a ScalarArrayOp
+    # cannot produce ordered output, so the single-query form made the planner
+    # Seq Scan the table and sort it on every page (see
+    # tests/kg/test_scheduling_page_plans.py, which EXPLAINs this for real).
+    assert "status = ANY(" not in sql
+    assert sql.count("status=$") == 2
+    assert " UNION ALL " in sql
     assert "(created_at, id) >" not in sql
     # The removed failure-generation cohort predicate must never reappear.
     assert "failure_generation" not in sql
-    assert params == ["ws", ["pending", "failed"], 10]
+    # $1 workspace, $2 limit (shared by every branch and the wrapper), then one
+    # parameter per status.
+    assert params == ["ws", 10, "pending", "failed"]
 
 
 async def test_page_sql_with_cursor():
@@ -293,12 +301,16 @@ async def test_page_sql_with_cursor():
         strict=True,
     )
     sql, params, _ = db.calls[0]
-    assert "(created_at, id) > ($3::timestamp, $4)" in sql
-    assert "ORDER BY created_at ASC NULLS FIRST, id ASC LIMIT $5" in sql
+    # The keyset predicate is built once and repeated verbatim in every branch,
+    # so the cursor parameters come before the per-status ones.
+    assert "(created_at, id) > ($2::timestamp, $3)" in sql
+    assert sql.count("(created_at, id) > ($2::timestamp, $3)") == 2
+    assert "ORDER BY created_at ASC NULLS FIRST, id ASC LIMIT $4" in sql
     assert "failure_generation" not in sql
-    assert params[2] == _TS  # decoded back to the naive-UTC stored form
-    assert params[3] == "doc-1"
-    assert params[4] == 10
+    assert params[1] == _TS  # decoded back to the naive-UTC stored form
+    assert params[2] == "doc-1"
+    assert params[3] == 10  # the shared limit
+    assert params[4:] == ["pending", "failed"]
 
 
 async def test_page_full_returns_cursor_after_last_returned_row():

--- a/tests/kg/postgres_impl/test_postgres_client_manager.py
+++ b/tests/kg/postgres_impl/test_postgres_client_manager.py
@@ -6,8 +6,17 @@ from lightrag.kg.postgres_impl import ClientManager
 
 
 @pytest.fixture(autouse=True)
-def reset_client_manager_state() -> None:
-    ClientManager._instances = {"db": None, "ref_count": 0, "vector_signature": None}
+def reset_client_manager_state():
+    """Reset the process-wide pool state BEFORE and AFTER each test.
+
+    Resetting only on entry leaks this file's MagicMock pool (with ref_count=2
+    and a pinned vector signature) into the rest of the session, where the next
+    real PostgreSQL storage is then refused for "incompatible vector settings".
+    """
+    pristine = {"db": None, "ref_count": 0, "vector_signature": None}
+    ClientManager._instances = dict(pristine)
+    yield
+    ClientManager._instances = dict(pristine)
 
 
 def test_pg_vector_storage_enables_vector() -> None:

--- a/tests/kg/postgres_impl/test_postgres_doc_status_lookup.py
+++ b/tests/kg/postgres_impl/test_postgres_doc_status_lookup.py
@@ -191,3 +191,38 @@ async def test_get_doc_by_content_hash_no_exclude_omits_clause():
     sql, params = storage.db.query.call_args.args[0], storage.db.query.call_args.args[1]
     assert "id <>" not in sql  # no exclusion clause when exclude_doc_id is None
     assert params == ["test_ws", "hash-abc"]
+
+
+@pytest.mark.asyncio
+async def test_get_doc_by_content_hash_also_excludes_rows_pointing_at_the_excluded_id():
+    """The second half of ``exclude_doc_id`` (base contract): a row marked
+    ``is_duplicate`` with ``original_doc_id == exclude_doc_id`` is a record that
+    the content belongs to the excluded document, not an independent holder, so
+    returning it would make the asking document a duplicate of a record of
+    itself — an is_duplicate cycle whose shared source has no primary left.
+
+    It is a WHERE predicate, not a post-filter on the single returned row, so
+    ``LIMIT 1`` still yields the earliest holder that survives it.
+    """
+    storage = _make_storage()
+    storage.db.query.return_value = [_row(id="doc-3", content_hash="hash-abc")]
+
+    result = await storage.get_doc_by_content_hash("hash-abc", exclude_doc_id="doc-1")
+
+    assert result is not None and result[0] == "doc-3"
+    sql, params = storage.db.query.call_args.args[0], storage.db.query.call_args.args[1]
+    assert "id <> $3" in sql
+    # Same flag reading as _PRIMARY_PREDICATE (a non-boolean raises, fail
+    # closed); original_doc_id COALESCEd so a NULL cannot make NOT(...) NULL and
+    # drop the row.
+    assert "COALESCE((metadata->>'is_duplicate')::boolean, false)" in sql
+    assert "COALESCE(metadata->>'original_doc_id', '') = $3" in sql
+    # One parameter for both halves: the SQL reuses $3 rather than binding twice.
+    assert params == ["test_ws", "hash-abc", "doc-1"]
+    assert "ORDER BY created_at ASC, id ASC" in sql and "LIMIT 1" in sql
+
+    # No exclusion → neither half is present.
+    storage.db.query.reset_mock()
+    storage.db.query.return_value = [_row(content_hash="hash-abc")]
+    await storage.get_doc_by_content_hash("hash-abc")
+    assert "original_doc_id" not in storage.db.query.call_args.args[0]

--- a/tests/kg/redis_impl/fake_redis.py
+++ b/tests/kg/redis_impl/fake_redis.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any
 
-from redis.exceptions import WatchError
+from redis.exceptions import ResponseError, WatchError
 
 
 class FakeRedis:
@@ -228,6 +228,17 @@ class FakeRedis:
             return 1 if existed else 0
         if kind == "rename":
             src, dst = op[1], op[2]
+            if not (
+                src in self.store
+                or src in self.zsets
+                or src in self.sets
+                or src in self.hashes
+            ):
+                # Mirrors real Redis: RENAME on a missing source fails with
+                # exactly this text — what a duplicate SCAN return produces
+                # when a later batch re-hands a key an earlier one already
+                # renamed away (see _publish_rebuilt_index).
+                raise ResponseError("no such key")
             if src in self.store:
                 self.store[dst] = self.store.pop(src)
             if src in self.zsets:
@@ -399,7 +410,13 @@ class FakePipeline:
     def hset(self, key: str, field: str, value):
         return self._command(("hset", key, field, value))
 
-    async def execute(self):
+    async def execute(self, raise_on_error: bool = True):
+        """Mirrors real redis-py: a per-command ``ResponseError`` is captured
+        into its slot in the result list rather than aborting the batch, and
+        only raised (the FIRST one) when ``raise_on_error`` is true — the
+        default. ``raise_on_error=False`` is what the bounded sidecar publish
+        uses to tolerate a duplicate SCAN return producing a benign "no such
+        key" RENAME (see ``_publish_rebuilt_index``)."""
         self._fake._maybe_fail("execute")
         for key, version in self._watched.items():
             if self._fake.versions[key] != version:
@@ -408,8 +425,15 @@ class FakePipeline:
                 raise WatchError(f"watched key changed: {key}")
         results = []
         for op in self._ops:
-            self._fake._maybe_fail(op[0])
-            results.append(self._fake._apply(op))
+            try:
+                self._fake._maybe_fail(op[0])
+                results.append(self._fake._apply(op))
+            except ResponseError as e:
+                results.append(e)
         self._ops.clear()
         self._watched.clear()
+        if raise_on_error:
+            for result in results:
+                if isinstance(result, Exception):
+                    raise result
         return results

--- a/tests/kg/redis_impl/test_redis_doc_status_lookup.py
+++ b/tests/kg/redis_impl/test_redis_doc_status_lookup.py
@@ -270,3 +270,43 @@ async def test_get_doc_by_content_hash_refuses_to_skip_an_undecodable_row(
 
     with pytest.raises(StorageControlPlaneError):
         await redis_doc_status.get_doc_by_content_hash("dup")
+
+
+async def test_get_doc_by_content_hash_skips_pointer_rows_and_keeps_looking(
+    redis_doc_status,
+):
+    """Second half of ``exclude_doc_id`` (base contract): a row marked
+    ``is_duplicate`` naming the excluded id as its original is a record that the
+    content belongs to the asking document, not a holder — returning it would
+    close an is_duplicate cycle whose shared source has no primary left.
+
+    And skipping it must not stop the search: the genuine third holder below is
+    created LAST, so a fix that only re-asked while excluding the pointer would
+    still miss it.
+    """
+    pointer = _doc(DocStatus.FAILED.value, "b.pdf", content_hash="dup")
+    pointer["metadata"] = {"is_duplicate": True, "original_doc_id": "doc-asking"}
+    pointer["created_at"] = "2024-01-01T00:00:00+00:00"
+    _store_raw(redis_doc_status, "doc-pointer", pointer)
+
+    asking = _doc(DocStatus.PROCESSED.value, "a.pdf", content_hash="dup")
+    asking["created_at"] = "2024-02-01T00:00:00+00:00"
+    _store_raw(redis_doc_status, "doc-asking", asking)
+
+    third = _doc(DocStatus.PROCESSED.value, "c.pdf", content_hash="dup")
+    third["created_at"] = "2024-03-01T00:00:00+00:00"
+    _store_raw(redis_doc_status, "doc-third", third)
+
+    result = await redis_doc_status.get_doc_by_content_hash(
+        "dup", exclude_doc_id="doc-asking"
+    )
+    assert result is not None and result[0] == "doc-third"
+
+    # With no other holder, the pointer alone is not one: confirmed absence.
+    await redis_doc_status.delete(["doc-third"])
+    assert (
+        await redis_doc_status.get_doc_by_content_hash(
+            "dup", exclude_doc_id="doc-asking"
+        )
+        is None
+    )

--- a/tests/kg/redis_impl/test_redis_scheduling_pages.py
+++ b/tests/kg/redis_impl/test_redis_scheduling_pages.py
@@ -630,10 +630,10 @@ async def test_the_rebuild_switch_is_bounded_not_one_transaction_per_workspace(
         pipe = real_pipeline(transaction=transaction)
         real_execute = pipe.execute
 
-        async def _execute():
+        async def _execute(raise_on_error: bool = True):
             renames = sum(1 for op in pipe._ops if op[0] == "rename")
             widest["renames"] = max(widest["renames"], renames)
-            return await real_execute()
+            return await real_execute(raise_on_error=raise_on_error)
 
         pipe.execute = _execute
         return pipe
@@ -652,6 +652,53 @@ async def test_the_rebuild_switch_is_bounded_not_one_transaction_per_workspace(
     assert len(fake.sets) == total  # one basename set per document
     assert not [k for k in fake.zsets if "_rebuild:" in k]
     assert not [k for k in fake.sets if "_rebuild:" in k]
+
+
+@pytest.mark.asyncio
+async def test_publish_survives_a_duplicate_scan_return(storage, monkeypatch):
+    """Fix-proof: SCAN's own contract allows an element to be returned more than
+    once during one iteration, and the bounded publish hands SCAN a moving
+    target ON PURPOSE — each RENAME deletes from the very pattern being walked,
+    which is exactly the shape that provokes a repeat. A later batch in the
+    SAME pass re-handed a key an earlier batch already renamed away must not
+    crash the publish with an unhandled ResponseError("no such key")."""
+    fake = storage._redis
+    monkeypatch.setattr(storage, "_PUBLISH_BATCH", 1)
+    for index in range(3):
+        fake.store[f"{storage.final_namespace}:doc-{index}"] = json.dumps(
+            _doc("pending", file_path=f"f{index}.pdf")
+        )
+
+    real_scan = fake.scan
+    basename_pattern = f"{storage._sched_prefix}_rebuild:basename:*"
+    state = {"first_key": None, "injected": False}
+
+    async def duplicating_scan(cursor=0, match="", count=1000):
+        next_cursor, keys = await real_scan(cursor, match=match, count=count)
+        if match == basename_pattern:
+            if cursor == 0 and keys and state["first_key"] is None:
+                state["first_key"] = keys[0]
+            elif (
+                cursor != 0
+                and keys
+                and not state["injected"]
+                and state["first_key"] is not None
+            ):
+                # The documented SCAN behaviour: hand back a key a PRIOR call
+                # in this very pass already renamed away.
+                state["injected"] = True
+                keys = [state["first_key"], *keys]
+        return next_cursor, keys
+
+    monkeypatch.setattr(fake, "scan", duplicating_scan)
+
+    await storage._rebuild_scheduling_sidecar()  # must not raise
+
+    # Nothing lost, nothing left behind, the repeat was silently absorbed.
+    assert not [k for k in fake.zsets if "_rebuild:" in k]
+    assert not [k for k in fake.sets if "_rebuild:" in k]
+    assert len(fake.sets) == 3  # one basename set per document
+    assert len(fake.zsets[f"{storage._sched_prefix}:status:pending"]) == 3
 
 
 @pytest.mark.asyncio

--- a/tests/kg/redis_impl/test_redis_scheduling_pages.py
+++ b/tests/kg/redis_impl/test_redis_scheduling_pages.py
@@ -602,3 +602,94 @@ async def test_drop_clears_rows_and_sidecar(storage):
     await storage.drop()
     assert await storage.count_docs_by_statuses([DocStatus.PENDING]) == 0
     assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceAbsent)
+
+
+@pytest.mark.asyncio
+async def test_the_rebuild_switch_is_bounded_not_one_transaction_per_workspace(
+    storage, monkeypatch
+):
+    """Fix-proof: the switch listed EVERY official and temp key into Python lists
+    and queued one DELETE/RENAME per key into a single MULTI, so both the client
+    allocation and the server-side transaction buffer were O(total_docs) — during
+    the very initialization this phase exists to bound. It must now cost
+    O(_PUBLISH_BATCH)."""
+    fake = storage._redis
+    total = 5 * storage._PUBLISH_BATCH
+    for index in range(total):
+        fake.store[f"{storage.final_namespace}:doc-{index:05d}"] = json.dumps(
+            _doc("pending", file_path=f"f{index}.pdf")
+        )
+
+    # Widest single round trip the SWITCH issues. Counted by RENAME because only
+    # the switch renames — the snapshot build's own batches are bounded by its
+    # SCAN count and are not what regressed.
+    widest = {"renames": 0}
+    real_pipeline = fake.pipeline
+
+    def counting_pipeline(transaction: bool = True):
+        pipe = real_pipeline(transaction=transaction)
+        real_execute = pipe.execute
+
+        async def _execute():
+            renames = sum(1 for op in pipe._ops if op[0] == "rename")
+            widest["renames"] = max(widest["renames"], renames)
+            return await real_execute()
+
+        pipe.execute = _execute
+        return pipe
+
+    monkeypatch.setattr(fake, "pipeline", counting_pipeline)
+
+    await storage._rebuild_scheduling_sidecar()
+
+    assert 0 < widest["renames"] <= storage._PUBLISH_BATCH, (
+        f"a single round trip queued {widest['renames']} renames for {total} "
+        "docs; the switch is not bounded"
+    )
+    # ...and it really did publish everything.
+    members = fake.zsets[f"{storage._sched_prefix}:status:pending"]
+    assert len(members) == total
+    assert len(fake.sets) == total  # one basename set per document
+    assert not [k for k in fake.zsets if "_rebuild:" in k]
+    assert not [k for k in fake.sets if "_rebuild:" in k]
+
+
+@pytest.mark.asyncio
+async def test_a_half_published_index_is_rebuilt_not_trusted(storage):
+    """The cost of a non-atomic switch: a rebuilder that died mid-publish leaves
+    some official keys switched and the rest absent, which "any status key exists"
+    reads as healthy. The leftover temp keyspace is what distinguishes it, so a
+    later startup must rebuild instead of serving the half-published index."""
+    fake = storage._redis
+    for index in range(3):
+        fake.store[f"{storage.final_namespace}:doc-{index}"] = json.dumps(
+            _doc("pending", file_path=f"f{index}.pdf")
+        )
+    # One document's entry published, the other two still in the temp keyspace,
+    # no rebuild lock held — exactly the state a killed rebuilder leaves.
+    fake.zsets[f"{storage._sched_prefix}:status:pending"] = {"x|doc-0"}
+    fake.zsets[f"{storage._sched_prefix}_rebuild:status:pending"] = {"x|doc-1"}
+
+    await storage._rebuild_scheduling_sidecar()
+
+    # Rebuilt from the rows: all three documents are schedulable again.
+    members = fake.zsets[f"{storage._sched_prefix}:status:pending"]
+    assert len(members) == 3
+    assert not [k for k in fake.zsets if "_rebuild:" in k]
+
+
+@pytest.mark.asyncio
+async def test_a_live_rebuild_is_not_mistaken_for_an_interrupted_one(storage):
+    """A temp keyspace WITH the rebuild lock held is a rebuild in progress, not a
+    crash: this worker must wait for it, never restart it underneath the owner."""
+    fake = storage._redis
+    fake.store[f"{storage.final_namespace}:doc-0"] = json.dumps(_doc("pending"))
+    fake.zsets[f"{storage._sched_prefix}_rebuild:status:pending"] = {"x|doc-0"}
+    fake.store[f"{storage._sched_prefix}:rebuild_lock"] = "1"
+
+    assert (
+        await storage._interrupted_publish(
+            fake, f"{storage._sched_prefix}:rebuild_lock"
+        )
+        is False
+    )

--- a/tests/kg/test_doc_status_scheduling_contract.py
+++ b/tests/kg/test_doc_status_scheduling_contract.py
@@ -1,0 +1,784 @@
+"""ONE shared scheduling contract suite for all five doc_status backends (LR2 §13.1).
+
+Before this, each backend had its own hand-written file. Every one of them is
+thorough about the things its author was thinking about, and that is exactly the
+problem: the assertion sets drift, so a backend can be green in its own file while
+violating an invariant only some other file happens to check. §13.1 asks for a
+shared parametrized suite for that reason, and this is it — every case below runs
+against every backend, or the backend is reported as unavailable.
+
+JSON needs no service and always runs. To run the other four:
+
+    docker run -d -p 6379:6379 redis:latest
+    docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=... -e POSTGRES_DB=... \\
+        gzdaniel/postgres-for-rag:pg18-age-pgvector
+    docker run -d -p 27017:27017 mongodb/mongodb-atlas-local:8
+    docker run -d -p 9200:9200 -e discovery.type=single-node \\
+        -e DISABLE_SECURITY_PLUGIN=true opensearchproject/opensearch:3
+
+Each backend gets a fresh random workspace per test: the contract covers derived
+indexes and source multimaps, so leakage between cases would manufacture
+false Conflicts.
+
+Deliberately NOT duplicated here: backend-internal mechanics (Redis WATCH/MULTI
+half-commit behaviour, PG SQL text, OpenSearch mapping shape). Those are properly
+per-backend and stay in the per-backend files; this suite covers only what every
+backend must agree on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    DocStatus,
+    SourceAbsent,
+    SourceConflict,
+    SourceUnique,
+)
+from lightrag.exceptions import SourceConflictRepairCASError
+
+from .conftest_scheduling_backends import BACKEND_PARAMS
+
+
+@pytest.fixture(params=BACKEND_PARAMS)
+async def doc_status(request, tmp_path):
+    spec = request.param
+    spec.skip_unless_available()
+    storage = await spec.build(tmp_path)
+    try:
+        yield storage
+    finally:
+        try:
+            await storage.drop()
+        finally:
+            await storage.finalize()
+
+
+# ---------------------------------------------------------------------------
+# Fixture data helpers.
+# ---------------------------------------------------------------------------
+
+_BASE_TIME = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _stamp(offset_seconds: int) -> str:
+    return (_BASE_TIME + timedelta(seconds=offset_seconds)).isoformat()
+
+
+def _row(
+    *,
+    status: DocStatus,
+    created_at: str | None,
+    file_path: str = "doc.md",
+    summary: str = "body",
+    **extra,
+) -> dict:
+    """A doc_status row shaped exactly like the pipeline writes one.
+
+    No ``content`` key: doc_status stores ``content_summary`` /
+    ``content_length`` and the body lives in full_docs. Writing a field the
+    pipeline never writes would test the backends' tolerance for foreign keys
+    instead of the contract (and OpenSearch legitimately rejects it).
+
+    ``created_at=None`` OMITS the key — the "missing" case the sort contract
+    talks about. An empty STRING is a different thing: PostgreSQL and OpenSearch
+    type that column as a date and reject ``''`` outright, which is a stronger
+    guarantee than ordering it.
+    """
+    row = {
+        "status": status.value,
+        "updated_at": created_at or _stamp(0),
+        "content_summary": summary[:32],
+        "content_length": len(summary),
+        "file_path": file_path,
+        "chunks_list": [],
+        "chunks_count": 0,
+        "track_id": "track-1",
+    }
+    if created_at is not None:
+        row["created_at"] = created_at
+    row.update(extra)
+    return row
+
+
+async def _seed(doc_status, rows: dict[str, dict]) -> None:
+    await doc_status.upsert(rows)
+    await doc_status.index_done_callback()
+
+
+async def _drain(doc_status, statuses, *, limit) -> list[str]:
+    """Walk the whole sweep, returning ids in the order the pages produced them.
+
+    Termination is ``next_position is CURSOR_END`` and NOTHING else — an empty
+    page is not the end (a page may be fully filtered yet not exhausted), which
+    is the single most commonly broken part of this contract.
+    """
+    seen: list[str] = []
+    position = CURSOR_START
+    for _ in range(200):  # guard against a cursor that never advances
+        page = await doc_status.get_docs_by_statuses_page(
+            statuses, limit=limit, position=position, strict=True
+        )
+        seen.extend(page.docs.keys())
+        if page.next_position is CURSOR_END:
+            return seen
+        assert isinstance(page.next_position, CursorAfter)
+        position = page.next_position
+    pytest.fail(f"sweep did not terminate after 200 pages; collected {len(seen)}")
+
+
+# ---------------------------------------------------------------------------
+# Sort order and cursor semantics.
+# ---------------------------------------------------------------------------
+
+
+async def test_equal_timestamps_are_ordered_by_id(doc_status):
+    """``created_at`` alone is not a total order; without the id tiebreaker a
+    keyset page can skip or repeat a record."""
+    same = _stamp(0)
+    await _seed(
+        doc_status,
+        {
+            "doc-c": _row(status=DocStatus.PENDING, created_at=same, file_path="c.md"),
+            "doc-a": _row(status=DocStatus.PENDING, created_at=same, file_path="a.md"),
+            "doc-b": _row(status=DocStatus.PENDING, created_at=same, file_path="b.md"),
+        },
+    )
+
+    assert await _drain(doc_status, [DocStatus.PENDING], limit=10) == [
+        "doc-a",
+        "doc-b",
+        "doc-c",
+    ]
+
+
+async def test_limit_one_paging_loses_and_repeats_nothing(doc_status):
+    ids = {
+        f"doc-{i:02d}": _row(status=DocStatus.PENDING, created_at=_stamp(i))
+        for i in range(7)
+    }
+    await _seed(doc_status, ids)
+
+    walked = await _drain(doc_status, [DocStatus.PENDING], limit=1)
+
+    assert walked == sorted(ids)  # every record, exactly once, in key order
+
+
+async def test_multi_status_pages_merge_into_one_key_order(doc_status):
+    """The sweep is ordered by ``(created_at, id)`` ACROSS statuses, not
+    concatenated per status."""
+    await _seed(
+        doc_status,
+        {
+            "doc-1": _row(status=DocStatus.PENDING, created_at=_stamp(1)),
+            "doc-2": _row(status=DocStatus.FAILED, created_at=_stamp(2)),
+            "doc-3": _row(status=DocStatus.PENDING, created_at=_stamp(3)),
+            "doc-4": _row(status=DocStatus.FAILED, created_at=_stamp(4)),
+        },
+    )
+
+    walked = await _drain(doc_status, [DocStatus.PENDING, DocStatus.FAILED], limit=2)
+
+    assert walked == ["doc-1", "doc-2", "doc-3", "doc-4"]
+
+
+async def test_a_row_with_no_created_at_fails_the_strict_page(doc_status):
+    """Only legacy rows and external edits can lack ``created_at`` — all three
+    write paths stamp it and ``update_doc_status_fields`` refuses to change it.
+
+    All five backends treat such a row as UNUSABLE rather than as a
+    first-sorted one, and that is the right call: ``DocSchedulingRecord`` requires
+    ``created_at``, so there is no record to return, and §4.5 says a strict query
+    is complete or it raises. Silently dropping it would let a corrupt row sit
+    unprocessed and unreported forever.
+    """
+    await _seed(
+        doc_status,
+        {
+            "doc-good": _row(status=DocStatus.PENDING, created_at=_stamp(10)),
+            "doc-nostamp": _row(status=DocStatus.PENDING, created_at=None),
+        },
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        await doc_status.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=10, position=CURSOR_START, strict=True
+        )
+    assert "created_at" in str(excinfo.value) or "doc-nostamp" in str(excinfo.value)
+
+
+async def test_a_relaxed_sweep_skips_the_unusable_row_and_still_advances(doc_status):
+    """Relaxed mode is the diagnostic path (admin listings), and there the bad row
+    must be CONSUMED, not re-read: a cursor that sticks on it would loop forever
+    instead of showing the operator the rest of the backlog."""
+    await _seed(
+        doc_status,
+        {
+            "doc-good": _row(status=DocStatus.PENDING, created_at=_stamp(10)),
+            "doc-nostamp": _row(status=DocStatus.PENDING, created_at=None),
+        },
+    )
+
+    seen: list[str] = []
+    position = CURSOR_START
+    for _ in range(20):
+        page = await doc_status.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=1, position=position, strict=False
+        )
+        seen.extend(page.docs)
+        if page.next_position is CURSOR_END:
+            break
+        position = page.next_position
+    else:  # pragma: no cover - the loop guard
+        pytest.fail("relaxed sweep stuck on the unusable row")
+
+    assert seen == ["doc-good"]
+
+
+async def test_the_end_is_the_cursor_not_an_empty_page(doc_status):
+    await _seed(
+        doc_status,
+        {"doc-1": _row(status=DocStatus.PENDING, created_at=_stamp(1))},
+    )
+
+    first = await doc_status.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=1, position=CURSOR_START, strict=True
+    )
+    assert set(first.docs) == {"doc-1"}
+
+    # Whether the backend already knows it is done or needs one more call, the
+    # sweep must reach CURSOR_END without ever returning doc-1 twice.
+    position = first.next_position
+    extra: list[str] = []
+    while position is not CURSOR_END:
+        page = await doc_status.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=1, position=position, strict=True
+        )
+        extra.extend(page.docs)
+        position = page.next_position
+    assert extra == []
+
+
+async def test_an_empty_status_set_terminates_immediately(doc_status):
+    await _seed(
+        doc_status,
+        {"doc-1": _row(status=DocStatus.PROCESSED, created_at=_stamp(1))},
+    )
+
+    page = await doc_status.get_docs_by_statuses_page(
+        [DocStatus.FAILED], limit=5, position=CURSOR_START, strict=True
+    )
+
+    assert page.docs == {}
+    assert page.next_position is CURSOR_END
+
+
+# ---------------------------------------------------------------------------
+# created_at immutability — the sort key a sweep depends on.
+# ---------------------------------------------------------------------------
+
+
+async def test_a_status_transition_preserves_created_at(doc_status):
+    created = _stamp(5)
+    await _seed(
+        doc_status, {"doc-1": _row(status=DocStatus.FAILED, created_at=created)}
+    )
+
+    await doc_status.update_doc_status_fields(
+        "doc-1", {"status": DocStatus.PENDING.value, "error_msg": None}
+    )
+
+    page = await doc_status.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=5, position=CURSOR_START, strict=True
+    )
+    assert page.docs["doc-1"].created_at == created
+
+
+async def test_update_fields_refuses_to_move_the_sort_key(doc_status):
+    created = _stamp(5)
+    await _seed(
+        doc_status, {"doc-1": _row(status=DocStatus.PENDING, created_at=created)}
+    )
+
+    with pytest.raises(ValueError):
+        await doc_status.update_doc_status_fields("doc-1", {"created_at": _stamp(999)})
+
+    page = await doc_status.get_docs_by_statuses_page(
+        [DocStatus.PENDING], limit=5, position=CURSOR_START, strict=True
+    )
+    assert page.docs["doc-1"].created_at == created
+
+
+# ---------------------------------------------------------------------------
+# Strict batch reads.
+# ---------------------------------------------------------------------------
+
+
+async def test_batch_read_returns_only_confirmed_ids(doc_status):
+    await _seed(
+        doc_status,
+        {
+            "doc-1": _row(status=DocStatus.PENDING, created_at=_stamp(1)),
+            "doc-2": _row(status=DocStatus.PENDING, created_at=_stamp(2)),
+        },
+    )
+
+    found = await doc_status.get_docs_by_ids(
+        ["doc-1", "doc-missing", "doc-2"], strict=True
+    )
+
+    assert set(found) == {"doc-1", "doc-2"}
+    assert found["doc-1"].status is DocStatus.PENDING
+
+
+async def test_batch_read_of_nothing_is_not_an_error(doc_status):
+    assert await doc_status.get_docs_by_ids([], strict=True) == {}
+    assert await doc_status.get_full_docs_by_ids([], strict=True) == {}
+
+
+async def test_the_scheduling_projection_omits_the_big_fields(doc_status):
+    """A page must stay O(page_size × small constant); the projection is the
+    reason it does."""
+    await _seed(
+        doc_status,
+        {
+            "doc-1": _row(
+                status=DocStatus.PENDING,
+                created_at=_stamp(1),
+                content="x" * 5000,
+                chunks_list=[f"chunk-{i}" for i in range(50)],
+                chunks_count=50,
+            )
+        },
+    )
+
+    record = (await doc_status.get_docs_by_ids(["doc-1"], strict=True))["doc-1"]
+
+    assert not hasattr(record, "content")
+    assert not hasattr(record, "chunks_list")
+
+
+async def test_full_hydration_carries_what_the_projection_dropped(doc_status):
+    await _seed(
+        doc_status,
+        {
+            "doc-1": _row(
+                status=DocStatus.PENDING,
+                created_at=_stamp(1),
+                chunks_list=["chunk-a"],
+                chunks_count=1,
+            )
+        },
+    )
+
+    full = await doc_status.get_full_docs_by_ids(["doc-1"], strict=True)
+
+    assert full["doc-1"].chunks_list == ["chunk-a"]
+    assert full["doc-1"].created_at == _stamp(1)
+
+
+# ---------------------------------------------------------------------------
+# Strict point read and strict count.
+# ---------------------------------------------------------------------------
+
+
+async def test_strict_point_read_distinguishes_absent_from_unknown(doc_status):
+    await _seed(
+        doc_status, {"doc-1": _row(status=DocStatus.PENDING, created_at=_stamp(1))}
+    )
+
+    assert (await doc_status.get_by_id_strict("doc-1")) is not None
+    # A confirmed absence is None; an unconfirmable one would raise (per backend).
+    assert (await doc_status.get_by_id_strict("doc-missing")) is None
+
+
+async def test_strict_count_counts_the_requested_statuses_only(doc_status):
+    await _seed(
+        doc_status,
+        {
+            "doc-1": _row(status=DocStatus.PENDING, created_at=_stamp(1)),
+            "doc-2": _row(status=DocStatus.PROCESSING, created_at=_stamp(2)),
+            "doc-3": _row(status=DocStatus.PROCESSED, created_at=_stamp(3)),
+            "doc-4": _row(status=DocStatus.FAILED, created_at=_stamp(4)),
+        },
+    )
+
+    active = await doc_status.count_docs_by_statuses(
+        [DocStatus.PENDING, DocStatus.PROCESSING], strict=True
+    )
+
+    assert active == 2
+    assert await doc_status.count_docs_by_statuses([], strict=True) == 0
+
+
+async def test_count_and_page_agree_after_a_transition(doc_status):
+    """The count and the sweep read the same index; a backend that maintains one
+    and not the other drifts silently."""
+    await _seed(
+        doc_status,
+        {
+            f"doc-{i}": _row(status=DocStatus.FAILED, created_at=_stamp(i))
+            for i in range(5)
+        },
+    )
+
+    await doc_status.update_doc_status_fields(
+        "doc-2", {"status": DocStatus.PENDING.value}
+    )
+
+    assert await doc_status.count_docs_by_statuses([DocStatus.FAILED], strict=True) == 4
+    assert (
+        await doc_status.count_docs_by_statuses([DocStatus.PENDING], strict=True) == 1
+    )
+    assert await _drain(doc_status, [DocStatus.PENDING], limit=10) == ["doc-2"]
+    assert "doc-2" not in await _drain(doc_status, [DocStatus.FAILED], limit=10)
+
+
+# ---------------------------------------------------------------------------
+# Typed source resolution.
+# ---------------------------------------------------------------------------
+
+
+async def test_source_absent_when_nothing_claims_the_key(doc_status):
+    assert isinstance(
+        await doc_status.resolve_doc_source_strict("nobody.md"), SourceAbsent
+    )
+
+
+async def test_source_unique_returns_the_doc_id_to_use(doc_status):
+    await _seed(
+        doc_status,
+        {
+            "doc-custom-id": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(1), file_path="report.md"
+            )
+        },
+    )
+
+    resolution = await doc_status.resolve_doc_source_strict("report.md")
+
+    assert isinstance(resolution, SourceUnique)
+    # The custom id is found through the source key — a basename lookup that
+    # assumed doc ids derive from filenames would miss this row entirely.
+    assert resolution.doc_id == "doc-custom-id"
+
+
+async def test_two_primaries_on_one_key_are_a_conflict(doc_status):
+    await _seed(
+        doc_status,
+        {
+            "doc-old": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(1), file_path="dup.md"
+            ),
+            "doc-new": _row(
+                status=DocStatus.PENDING, created_at=_stamp(2), file_path="dup.md"
+            ),
+        },
+    )
+
+    resolution = await doc_status.resolve_doc_source_strict("dup.md")
+
+    assert isinstance(resolution, SourceConflict)
+    assert set(resolution.sample_doc_ids) <= {"doc-old", "doc-new"}
+    assert len(resolution.sample_doc_ids) >= 2
+    if resolution.candidate_count is not None:
+        assert resolution.candidate_count == 2
+
+
+async def test_a_duplicate_marked_row_is_not_a_primary_candidate(doc_status):
+    """``is_duplicate`` is what keeps a resolved conflict resolved."""
+    await _seed(
+        doc_status,
+        {
+            "doc-keep": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(1), file_path="dup.md"
+            ),
+            "doc-dup": _row(
+                status=DocStatus.PROCESSED,
+                created_at=_stamp(2),
+                file_path="dup.md",
+                metadata={"is_duplicate": True, "original_doc_id": "doc-keep"},
+            ),
+        },
+    )
+
+    resolution = await doc_status.resolve_doc_source_strict("dup.md")
+
+    assert isinstance(resolution, SourceUnique)
+    assert resolution.doc_id == "doc-keep"
+
+
+# ---------------------------------------------------------------------------
+# Derived-index consistency across the mutating paths.
+# ---------------------------------------------------------------------------
+
+
+async def test_deleting_a_row_removes_it_from_every_index(doc_status):
+    await _seed(
+        doc_status,
+        {
+            "doc-1": _row(
+                status=DocStatus.PENDING, created_at=_stamp(1), file_path="gone.md"
+            ),
+            "doc-2": _row(
+                status=DocStatus.PENDING, created_at=_stamp(2), file_path="stays.md"
+            ),
+        },
+    )
+
+    await doc_status.delete(["doc-1"])
+    await doc_status.index_done_callback()
+
+    assert (
+        await doc_status.count_docs_by_statuses([DocStatus.PENDING], strict=True) == 1
+    )
+    assert await _drain(doc_status, [DocStatus.PENDING], limit=10) == ["doc-2"]
+    assert isinstance(
+        await doc_status.resolve_doc_source_strict("gone.md"), SourceAbsent
+    )
+    assert await doc_status.get_docs_by_ids(["doc-1"], strict=True) == {}
+
+
+async def test_moving_a_source_key_moves_it_in_the_index(doc_status):
+    await _seed(
+        doc_status,
+        {
+            "doc-1": _row(
+                status=DocStatus.PENDING, created_at=_stamp(1), file_path="before.md"
+            )
+        },
+    )
+
+    await doc_status.update_doc_status_fields("doc-1", {"file_path": "after.md"})
+
+    assert isinstance(
+        await doc_status.resolve_doc_source_strict("before.md"), SourceAbsent
+    )
+    moved = await doc_status.resolve_doc_source_strict("after.md")
+    assert isinstance(moved, SourceUnique) and moved.doc_id == "doc-1"
+
+
+async def test_upserting_over_a_row_keeps_the_indexes_single_valued(doc_status):
+    await _seed(
+        doc_status,
+        {"doc-1": _row(status=DocStatus.PENDING, created_at=_stamp(1))},
+    )
+    await _seed(
+        doc_status,
+        {"doc-1": _row(status=DocStatus.PROCESSED, created_at=_stamp(1))},
+    )
+
+    assert (
+        await doc_status.count_docs_by_statuses([DocStatus.PENDING], strict=True) == 0
+    )
+    assert (
+        await doc_status.count_docs_by_statuses([DocStatus.PROCESSED], strict=True) == 1
+    )
+    assert await _drain(doc_status, [DocStatus.PROCESSED], limit=10) == ["doc-1"]
+
+
+# ---------------------------------------------------------------------------
+# Operator conflict listing + CAS repair.
+# ---------------------------------------------------------------------------
+
+
+async def test_conflict_listing_finds_the_conflicting_key(doc_status):
+    await _seed(
+        doc_status,
+        {
+            "doc-a": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(1), file_path="dup.md"
+            ),
+            "doc-b": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(2), file_path="dup.md"
+            ),
+            "doc-c": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(3), file_path="fine.md"
+            ),
+        },
+    )
+
+    page = await doc_status.list_source_conflicts_page(limit=10, position=CURSOR_START)
+
+    keys = {summary.canonical_source_key for summary in page.conflicts}
+    assert keys == {"dup.md"}
+
+
+async def test_repair_is_dry_run_by_default_then_commits_under_cas(doc_status):
+    await _seed(
+        doc_status,
+        {
+            "doc-keep": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(1), file_path="dup.md"
+            ),
+            "doc-lose": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(2), file_path="dup.md"
+            ),
+        },
+    )
+
+    preview = await doc_status.repair_source_conflict(
+        "dup.md",
+        primary_doc_id="doc-keep",
+        expected_candidate_count=0,
+        expected_candidate_fingerprint="",
+        dry_run=True,
+    )
+    assert preview.committed is False
+    assert preview.candidate_count == 2
+    # The dry run changed nothing.
+    assert isinstance(
+        await doc_status.resolve_doc_source_strict("dup.md"), SourceConflict
+    )
+
+    committed = await doc_status.repair_source_conflict(
+        "dup.md",
+        primary_doc_id="doc-keep",
+        expected_candidate_count=preview.candidate_count,
+        expected_candidate_fingerprint=preview.fingerprint,
+        dry_run=False,
+    )
+    assert committed.committed is True
+
+    resolved = await doc_status.resolve_doc_source_strict("dup.md")
+    assert isinstance(resolved, SourceUnique) and resolved.doc_id == "doc-keep"
+
+
+async def test_a_stale_cas_token_refuses_instead_of_overwriting(doc_status):
+    await _seed(
+        doc_status,
+        {
+            "doc-keep": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(1), file_path="dup.md"
+            ),
+            "doc-lose": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(2), file_path="dup.md"
+            ),
+        },
+    )
+    preview = await doc_status.repair_source_conflict(
+        "dup.md",
+        primary_doc_id="doc-keep",
+        expected_candidate_count=0,
+        expected_candidate_fingerprint="",
+        dry_run=True,
+    )
+
+    # A third candidate appears between read and commit.
+    await _seed(
+        doc_status,
+        {
+            "doc-third": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(3), file_path="dup.md"
+            )
+        },
+    )
+
+    with pytest.raises(SourceConflictRepairCASError):
+        await doc_status.repair_source_conflict(
+            "dup.md",
+            primary_doc_id="doc-keep",
+            expected_candidate_count=preview.candidate_count,
+            expected_candidate_fingerprint=preview.fingerprint,
+            dry_run=False,
+        )
+
+
+async def test_repairing_onto_a_non_candidate_is_a_value_error(doc_status):
+    await _seed(
+        doc_status,
+        {
+            "doc-a": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(1), file_path="dup.md"
+            ),
+            "doc-b": _row(
+                status=DocStatus.PROCESSED, created_at=_stamp(2), file_path="dup.md"
+            ),
+        },
+    )
+    preview = await doc_status.repair_source_conflict(
+        "dup.md",
+        primary_doc_id="doc-a",
+        expected_candidate_count=0,
+        expected_candidate_fingerprint="",
+        dry_run=True,
+    )
+
+    with pytest.raises(ValueError):
+        await doc_status.repair_source_conflict(
+            "dup.md",
+            primary_doc_id="doc-not-a-candidate",
+            expected_candidate_count=preview.candidate_count,
+            expected_candidate_fingerprint=preview.fingerprint,
+            dry_run=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# The sweep under concurrent writes (live view, no snapshot claimed).
+# ---------------------------------------------------------------------------
+
+
+async def test_a_sweep_running_against_concurrent_writes_still_terminates(doc_status):
+    """The contract claims a live view, not snapshot isolation — but it must
+    still terminate and never return a record twice."""
+    await _seed(
+        doc_status,
+        {
+            f"doc-{i:02d}": _row(status=DocStatus.PENDING, created_at=_stamp(i))
+            for i in range(6)
+        },
+    )
+
+    seen: list[str] = []
+    position = CURSOR_START
+    appended = False
+    for _ in range(50):
+        page = await doc_status.get_docs_by_statuses_page(
+            [DocStatus.PENDING], limit=2, position=position, strict=True
+        )
+        seen.extend(page.docs)
+        if not appended:
+            # A new record with a LATER key: it may or may not be observed.
+            await _seed(
+                doc_status,
+                {"doc-99": _row(status=DocStatus.PENDING, created_at=_stamp(99))},
+            )
+            appended = True
+        if page.next_position is CURSOR_END:
+            break
+        position = page.next_position
+    else:  # pragma: no cover - the loop guard
+        pytest.fail("sweep did not terminate under concurrent writes")
+
+    assert len(seen) == len(set(seen))  # no record twice
+    assert {f"doc-{i:02d}" for i in range(6)} <= set(seen)  # nothing pre-existing lost
+
+
+async def test_concurrent_page_reads_do_not_interfere(doc_status):
+    await _seed(
+        doc_status,
+        {
+            f"doc-{i:02d}": _row(status=DocStatus.PENDING, created_at=_stamp(i))
+            for i in range(4)
+        },
+    )
+
+    pages = await asyncio.gather(
+        *[
+            doc_status.get_docs_by_statuses_page(
+                [DocStatus.PENDING], limit=4, position=CURSOR_START, strict=True
+            )
+            for _ in range(4)
+        ]
+    )
+
+    for page in pages:
+        assert set(page.docs) == {f"doc-{i:02d}" for i in range(4)}

--- a/tests/kg/test_scan_job_store.py
+++ b/tests/kg/test_scan_job_store.py
@@ -15,6 +15,7 @@ from lightrag.kg.scan_job_store import (
     ScanJobCreateOutcome,
     ScanJobStatus,
     ScanJobUpdateConflict,
+    _ScanJobRecord,
 )
 
 pytestmark = pytest.mark.offline
@@ -203,6 +204,97 @@ def test_the_record_ceiling_covers_the_scalars_not_just_the_payload():
     store.create("t" * 100, "o" * 100)
     record_bytes = store._jobs["t" * 100].approx_bytes()
     assert record_bytes >= 200
+
+
+def test_a_record_that_is_born_over_the_ceiling_is_never_created():
+    """Fix-proof: the per-identifier cap covers ``track_id`` / ``owner_token``, but
+    ``workspace`` is a scalar ``approx_bytes`` counts and no caller passes to
+    ``create`` — a 100 KB namespace seated a ~100 KB record in a 512-byte store,
+    and every later mutation then (correctly, and confusingly) refused to grow it.
+    The invariant belongs to the record, so the built record is what gets
+    measured."""
+    store = AsyncioScanJobStore("W" * 100_000, clock=_Clock(), record_max_bytes=512)
+    refused = store.create("t1", "owner")
+    assert refused.outcome is ScanJobCreateOutcome.INVALID_IDENTIFIER
+    assert "record ceiling" in refused.message
+    assert store.get("t1") is None and store.snapshot() == []
+
+
+def test_the_refusal_does_not_evict_a_terminal_record_on_its_way_out():
+    """Ordering: an over-ceiling create must not spend the capacity slot it was
+    never going to use."""
+    store = AsyncioScanJobStore(
+        "W" * 1000, clock=_Clock(), capacity=1, record_max_bytes=512
+    )
+    # Seat one terminal record the eviction step would happily take.
+    store._jobs["survivor"] = _ScanJobRecord(
+        track_id="survivor",
+        workspace="",
+        owner_token="o",
+        status=ScanJobStatus.COMPLETED.value,
+        counts={},
+        samples={},
+        created_at=1000.0,
+        updated_at=1000.0,
+        lease_expires_at=1000.0,
+        version=1,
+    )
+    assert (
+        store.create("t1", "owner").outcome is ScanJobCreateOutcome.INVALID_IDENTIFIER
+    )
+    assert store.get("survivor") is not None
+
+
+def test_a_terminal_message_cannot_push_the_record_past_the_ceiling():
+    """Fix-proof: ``set_status`` / ``cancel`` / the lease reaper capped the message
+    at ``sample_max_bytes`` only, with no regard for what the record had already
+    spent — so a record filled to the ceiling by samples still accepted one more
+    message's worth of bytes on top of it. Every mutation means every mutation."""
+    for terminate in (
+        lambda store, version: store.set_status(
+            "t1",
+            "owner",
+            ScanJobStatus.FAILED,
+            expected_version=version,
+            message="m" * 256,
+        ),
+        lambda store, version: store.cancel("t1", "owner", message="m" * 256),
+    ):
+        store = _store(sample_limit=100, sample_max_bytes=256, record_max_bytes=400)
+        store.create("t1", "owner")
+        record = store._jobs["t1"]
+        version = record.version
+        while record.approx_bytes() + 32 <= 400:
+            version = store.update(
+                "t1", "owner", sample=("processed", "z" * 32), expected_version=version
+            ).record["version"]
+
+        assert terminate(store, version).ok
+        assert record.approx_bytes() <= 400
+        # The message is truncated, not silently discarded whole.
+        assert record.message and record.message[0] == "m"
+
+
+def test_the_lease_reaper_message_respects_the_ceiling_too():
+    clock = _Clock(1000.0)
+    store = _store(
+        clock=clock,
+        lease_seconds=10.0,
+        sample_limit=100,
+        sample_max_bytes=256,
+        record_max_bytes=400,
+    )
+    store.create("t1", "owner")
+    record = store._jobs["t1"]
+    version = record.version
+    while record.approx_bytes() + 32 <= 400:
+        version = store.update(
+            "t1", "owner", sample=("processed", "z" * 32), expected_version=version
+        ).record["version"]
+
+    clock.t = 1011.0  # lease expired → reaped to ABANDONED with its message
+    assert store.get("t1")["status"] == ScanJobStatus.ABANDONED.value
+    assert record.approx_bytes() <= 400
 
 
 def test_an_arbitrary_precision_counter_is_refused_not_stored_as_eight_bytes():

--- a/tests/kg/test_scan_job_store.py
+++ b/tests/kg/test_scan_job_store.py
@@ -184,6 +184,66 @@ def test_a_bounded_key_still_counts_and_repeats_add_no_bytes():
     assert record["counters_dropped"] == 0
 
 
+def test_the_record_ceiling_covers_the_scalars_not_just_the_payload():
+    """Fix-proof: ``approx_bytes`` allowed a flat 256 bytes for "the scalar
+    fields", so whatever the caller put in an identifier or a message sailed past
+    ``record_max_bytes`` — the reviewer's repro accepted a ~100 KB record in a
+    512-byte store."""
+    store = _store(record_max_bytes=512, identifier_max_bytes=128)
+    huge = "t" * 100_000
+    refused = store.create(huge, "owner")
+    assert refused.outcome is ScanJobCreateOutcome.INVALID_IDENTIFIER
+    assert refused.record is None
+    assert store.get(huge) is None
+    # Same for the owner token.
+    assert store.create("t1", huge).outcome is ScanJobCreateOutcome.INVALID_IDENTIFIER
+    assert store.snapshot() == []
+
+    # A bounded identifier is accepted and now COUNTS toward the ceiling.
+    store.create("t" * 100, "o" * 100)
+    record_bytes = store._jobs["t" * 100].approx_bytes()
+    assert record_bytes >= 200
+
+
+def test_an_arbitrary_precision_counter_is_refused_not_stored_as_eight_bytes():
+    """Fix-proof: Python ints are unbounded, ``approx_bytes`` counts every
+    counter value as 8 bytes, and a 1001-digit delta was accepted — ~450 bytes of
+    payload the ceiling never saw. 2**53 is also the last value a JSON client can
+    read back exactly, and this record is serialized to JSON."""
+    store = _store()
+    store.create("t1", "owner")
+    absurd = 10**1000
+
+    r = store.update(
+        "t1", "owner", count_deltas={"discovered": absurd}, expected_version=1
+    )
+    assert r.ok
+    assert r.record["counts"] == {}
+    assert r.record["counters_dropped"] == 1
+
+    # And an accumulation that would cross the bound is refused too, so the
+    # value cannot be walked past it one legal delta at a time.
+    v = r.record["version"]
+    r = store.update(
+        "t1", "owner", count_deltas={"discovered": 2**53 - 1}, expected_version=v
+    )
+    v = r.record["version"]
+    r = store.update("t1", "owner", count_deltas={"discovered": 99}, expected_version=v)
+    assert r.record["counts"]["discovered"] == 2**53 - 1
+    assert r.record["counters_dropped"] == 2
+
+
+def test_a_bool_is_not_a_counter_delta():
+    """``isinstance(True, int)`` is True, so a bool would land as 1/0 and read
+    back as a count nobody wrote."""
+    store = _store()
+    store.create("t1", "owner")
+    r = store.update(
+        "t1", "owner", count_deltas={"discovered": True}, expected_version=1
+    )
+    assert r.ok and r.record["counts"] == {}
+
+
 def test_capacity_evicts_terminal_then_rejects_all_running():
     store = _store(capacity=2)
     store.create("a", "o")

--- a/tests/kg/test_scheduling_backend_fixture.py
+++ b/tests/kg/test_scheduling_backend_fixture.py
@@ -1,0 +1,77 @@
+"""The cross-backend contract fixture really gets a fresh workspace per case.
+
+``_unique_workspace()`` is passed as the constructor's ``workspace=``, but every
+service backend gives its ``*_WORKSPACE`` env var HIGHER priority than that
+argument. So on the only kind of machine these tests run on — an integration box
+with a configured ``.env`` — the unique name was silently discarded and all five
+backends' cases shared one workspace: the contract's derived-index and
+source-multimap cases would report each other's rows as Conflicts, and one
+case's ``drop()`` would wipe another's data.
+
+Redis stands in for all four here: it resolves its workspace in
+``__post_init__``, so the precedence is observable without a live service.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from .conftest_scheduling_backends import _unique_workspace, _workspace_env_isolated
+
+pytestmark = pytest.mark.offline
+
+
+def _resolved_namespace(workspace: str) -> str:
+    from lightrag.kg.redis_impl import RedisDocStatusStorage
+
+    class _Embed:
+        embedding_dim = 4
+
+        async def __call__(self, texts):  # pragma: no cover - never invoked
+            return [[0.0] * 4 for _ in texts]
+
+    storage = RedisDocStatusStorage(
+        namespace="doc_status",
+        global_config={},
+        embedding_func=_Embed(),
+        workspace=workspace,
+    )
+    return storage.final_namespace
+
+
+def test_the_env_override_really_does_beat_the_constructor(monkeypatch):
+    """The premise of the fixture bug, pinned: without isolation the unique
+    workspace argument is discarded."""
+    monkeypatch.setenv("REDIS_WORKSPACE", "shared_by_everyone")
+    assert _resolved_namespace(_unique_workspace()) == "shared_by_everyone_doc_status"
+
+
+def test_isolation_restores_the_unique_workspace_and_puts_the_env_back(monkeypatch):
+    monkeypatch.setenv("REDIS_WORKSPACE", "shared_by_everyone")
+
+    unique = _unique_workspace()
+    with _workspace_env_isolated("REDIS_WORKSPACE"):
+        assert "REDIS_WORKSPACE" not in os.environ
+        assert _resolved_namespace(unique) == f"{unique}_doc_status"
+
+    # Restored, so a later test that depends on the deployment's own workspace
+    # is unaffected.
+    assert os.environ["REDIS_WORKSPACE"] == "shared_by_everyone"
+
+
+def test_isolation_leaves_an_unset_variable_unset(monkeypatch):
+    monkeypatch.delenv("REDIS_WORKSPACE", raising=False)
+    with _workspace_env_isolated("REDIS_WORKSPACE"):
+        pass
+    assert "REDIS_WORKSPACE" not in os.environ
+
+
+def test_two_cases_never_collide(monkeypatch):
+    monkeypatch.setenv("REDIS_WORKSPACE", "shared_by_everyone")
+    with _workspace_env_isolated("REDIS_WORKSPACE"):
+        first = _resolved_namespace(_unique_workspace())
+    with _workspace_env_isolated("REDIS_WORKSPACE"):
+        second = _resolved_namespace(_unique_workspace())
+    assert first != second

--- a/tests/kg/test_scheduling_page_plans.py
+++ b/tests/kg/test_scheduling_page_plans.py
@@ -46,6 +46,9 @@ _STATUS_CYCLE = (
     DocStatus.FAILED,
     DocStatus.PROCESSING,
 )
+# The keyset order every backend's page sorts by — and, for Mongo, the order the
+# explain below is judged against.
+_PAGE_SORT = [("created_at", 1), ("_id", 1)]
 
 
 def _spec(name: str):
@@ -214,22 +217,49 @@ async def test_opensearch_pages_with_search_after_not_deep_from_size(tmp_path):
             await storage.finalize()
 
 
+class _CaptureFind:
+    """Collection proxy that records the filter its ``find`` is called with.
+
+    Wrapping the storage's ``_data`` attribute rather than patching a method on
+    the driver's collection object keeps this independent of whatever motor lets
+    us assign to."""
+
+    def __init__(self, collection, captured: dict):
+        self._collection = collection
+        self._captured = captured
+
+    def find(self, query, *args, **kwargs):
+        self._captured.setdefault("query", query)
+        return self._collection.find(query, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._collection, name)
+
+
 async def _mongo_page_explain(storage, statuses, position):
-    """Explain the same find+sort+limit shape the page issues, from a mid-sweep
-    cursor."""
+    """Explain the filter the page really issues from ``position``.
+
+    Captured, not restated, for the same reason ``_capture_page_sql`` captures
+    the SQL: the previous version hand-rolled a flat ``$or`` and started from
+    ``find_one``'s FIRST matching row, so it explained page one of a query shape
+    the implementation does not use (it builds ``$and``, with a separate
+    missing/null-bucket branch) — and it silently ignored the mid-sweep cursor
+    the caller paid ten real pages to reach, which is exactly where a
+    scan-based plan hurts and page one does not.
+
+    ``_PAGE_SORT``/``_PAGE`` are the implementation's own literals; the sort is
+    the property under test, so stating it here is deliberate.
+    """
     collection = storage._data
-    status_values = [s.value for s in statuses]
-    marker = await collection.find_one(
-        {"status": {"$in": status_values}}, sort=[("created_at", 1), ("_id", 1)]
-    )
-    assert marker is not None
-    created, doc_id = marker["created_at"], marker["_id"]
-    query = {
-        "status": {"$in": status_values},
-        "$or": [
-            {"created_at": {"$gt": created}},
-            {"created_at": created, "_id": {"$gt": doc_id}},
-        ],
-    }
-    cursor = collection.find(query).sort([("created_at", 1), ("_id", 1)]).limit(_PAGE)
+    captured: dict = {}
+    storage._data = _CaptureFind(collection, captured)
+    try:
+        await storage.get_docs_by_statuses_page(
+            statuses, limit=_PAGE, position=position, strict=True
+        )
+    finally:
+        storage._data = collection
+
+    assert "query" in captured, "the page issued no find"
+    cursor = collection.find(captured["query"]).sort(_PAGE_SORT).limit(_PAGE)
     return await cursor.explain()

--- a/tests/kg/test_scheduling_page_plans.py
+++ b/tests/kg/test_scheduling_page_plans.py
@@ -1,0 +1,235 @@
+"""EXPLAIN / profile the scheduling page: no full-table sort (LR2 §13.1).
+
+§13.1 asks for exactly this, and asking was justified — both assertions below
+FAILED when first written. The page query is the sweep's hot-path read, and a
+plan regression there is invisible from outside: results stay correct, the page
+stays memory-bounded (a top-N sort keeps only ``limit`` rows), and only the I/O
+quietly becomes O(table) per page, i.e. O(n²/page_size) for a full sweep. Nothing
+but a plan assertion catches that.
+
+What was found and fixed:
+
+* **PostgreSQL** — one status was a bitmap scan plus a top-N sort of every row
+  past the cursor; TWO statuses (the AUTO sweep's own shape) was a full
+  ``Seq Scan`` per page. Two causes, both needed: the index has to be declared
+  ``created_at NULLS FIRST`` (PG's ``ASC`` default is NULLS LAST, so the old
+  index could not satisfy the ORDER BY at all), and the query has to use
+  per-status equality branches (a single ``status = ANY(...)`` cannot produce
+  ordered output).
+* **MongoDB** — multi-status ``$in`` fell back to a blocking ``SORT`` examining
+  the whole matching key range.
+
+Live services only (``--run-integration``); see
+``test_doc_status_scheduling_contract`` for how to start them.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+from lightrag.base import CURSOR_START, CursorAfter, DocStatus
+
+from .conftest_scheduling_backends import BACKEND_SPECS
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
+
+# Enough rows that a planner has a real choice to make; small enough to seed fast.
+_ROWS = 20000
+_PAGE = 500
+_BASE = datetime(2026, 1, 1)
+_STATUS_CYCLE = (
+    DocStatus.PENDING,
+    DocStatus.PROCESSED,
+    DocStatus.FAILED,
+    DocStatus.PROCESSING,
+)
+
+
+def _spec(name: str):
+    return next(spec for spec in BACKEND_SPECS if spec.name == name)
+
+
+async def _seed_at_scale(doc_status) -> None:
+    """Cycle statuses so no single status is contiguous in storage order — a
+    contiguous layout would let a scan look cheap for the wrong reason."""
+    batch: dict[str, dict] = {}
+    for i in range(_ROWS):
+        stamp = (_BASE + timedelta(seconds=i)).isoformat()
+        batch[f"doc-{i:07d}"] = {
+            "status": _STATUS_CYCLE[i % len(_STATUS_CYCLE)].value,
+            "created_at": stamp,
+            "updated_at": stamp,
+            "content_summary": "x" * 20,
+            "content_length": 200,
+            "file_path": f"f{i}.md",
+            "chunks_list": [],
+            "chunks_count": 0,
+            "track_id": "t",
+        }
+        if len(batch) >= 5000:
+            await doc_status.upsert(batch)
+            batch = {}
+    if batch:
+        await doc_status.upsert(batch)
+    await doc_status.index_done_callback()
+
+
+async def _mid_sweep_cursor(doc_status, statuses) -> CursorAfter:
+    """A cursor roughly halfway in, so the plan is judged where a scan-based plan
+    hurts most rather than on the first page."""
+    position: object = CURSOR_START
+    for _ in range(_ROWS // (4 * _PAGE)):
+        page = await doc_status.get_docs_by_statuses_page(
+            statuses, limit=_PAGE, position=position, strict=True
+        )
+        position = page.next_position
+        if not isinstance(position, CursorAfter):
+            break
+    assert isinstance(position, CursorAfter), "backlog too small to reach mid-sweep"
+    return position
+
+
+async def test_postgres_page_is_an_ordered_index_scan(tmp_path):
+    """One test, three status-set widths: seeding 20k rows once and asserting
+    three plans beats paying the seed three times, and the widths matter — a
+    single status and a multi-status sweep took different (both wrong) plans.
+    """
+    spec = _spec("postgres")
+    spec.skip_unless_available()
+    doc_status = await spec.build(tmp_path)
+    try:
+        await _seed_at_scale(doc_status)
+
+        for statuses in (
+            [DocStatus.PENDING],
+            [DocStatus.PENDING, DocStatus.FAILED],
+            [DocStatus.PENDING, DocStatus.PROCESSING, DocStatus.FAILED],
+        ):
+            position = await _mid_sweep_cursor(doc_status, statuses)
+            sql, params = await _capture_page_sql(doc_status, statuses, position)
+            plan_rows = await doc_status.db.query(
+                "EXPLAIN (ANALYZE) " + sql, params, multirows=True
+            )
+            plan = "\n".join(row["QUERY PLAN"] for row in plan_rows)
+            label = f"{len(statuses)} status(es)"
+
+            assert "Seq Scan" not in plan, f"{label}\n{plan}"
+            # A Sort node means the index could not supply the requested order.
+            assert "Sort Method" not in plan, f"{label}\n{plan}"
+            assert "Index Scan" in plan or "Index Only Scan" in plan, f"{label}\n{plan}"
+    finally:
+        try:
+            await doc_status.drop()
+        finally:
+            await doc_status.finalize()
+
+
+async def _capture_page_sql(doc_status, statuses, position):
+    """Capture the SQL the real page method builds rather than restating it here:
+    a future rewrite must be explained as-changed, not as-remembered."""
+    captured: dict = {}
+    original_query = doc_status.db.query
+
+    async def _capture(sql, params=None, multirows=False, **kwargs):
+        captured.setdefault("sql", sql)
+        captured.setdefault("params", params)
+        return await original_query(sql, params, multirows=multirows, **kwargs)
+
+    doc_status.db.query = _capture
+    try:
+        await doc_status.get_docs_by_statuses_page(
+            statuses, limit=_PAGE, position=position, strict=True
+        )
+    finally:
+        doc_status.db.query = original_query
+    return captured["sql"], captured["params"]
+
+
+async def test_mongodb_page_uses_the_index_order_not_a_blocking_sort(tmp_path):
+    spec = _spec("mongodb")
+    spec.skip_unless_available()
+    storage = await spec.build(tmp_path)
+    try:
+        await _seed_at_scale(storage)
+        statuses = [DocStatus.PENDING, DocStatus.FAILED]
+        position = await _mid_sweep_cursor(storage, statuses)
+
+        plan = await _mongo_page_explain(storage, statuses, position)
+        winning = json.dumps(plan["queryPlanner"]["winningPlan"])
+        stats = plan["executionStats"]
+
+        assert "COLLSCAN" not in winning, winning
+        assert '"stage": "SORT"' not in winning, winning
+        # Index-ordered paging examines about a page worth of keys, not the whole
+        # matching set (~10k here).
+        assert stats["totalKeysExamined"] <= 6 * _PAGE, stats
+    finally:
+        try:
+            await storage.drop()
+        finally:
+            await storage.finalize()
+
+
+async def test_opensearch_pages_with_search_after_not_deep_from_size(tmp_path):
+    """``search_after`` is keyset by construction, so what matters is that the
+    implementation uses it instead of ``from``/``size``, which degrades with
+    offset."""
+    spec = _spec("opensearch")
+    spec.skip_unless_available()
+    storage = await spec.build(tmp_path)
+    try:
+        await _seed_at_scale(storage)
+        statuses = [DocStatus.PENDING, DocStatus.FAILED]
+        position = await _mid_sweep_cursor(storage, statuses)
+
+        bodies: list[dict] = []
+        original_search = storage.client.search
+
+        async def _capture(*args, **kwargs):
+            body = kwargs.get("body")
+            if isinstance(body, dict):
+                bodies.append(body)
+            return await original_search(*args, **kwargs)
+
+        storage.client.search = _capture
+        try:
+            await storage.get_docs_by_statuses_page(
+                statuses, limit=_PAGE, position=position, strict=True
+            )
+        finally:
+            storage.client.search = original_search
+
+        assert bodies, "no search issued"
+        page_body = bodies[0]
+        assert "search_after" in page_body, page_body
+        assert "from" not in page_body, page_body
+        assert page_body["sort"], page_body
+    finally:
+        try:
+            await storage.drop()
+        finally:
+            await storage.finalize()
+
+
+async def _mongo_page_explain(storage, statuses, position):
+    """Explain the same find+sort+limit shape the page issues, from a mid-sweep
+    cursor."""
+    collection = storage._data
+    status_values = [s.value for s in statuses]
+    marker = await collection.find_one(
+        {"status": {"$in": status_values}}, sort=[("created_at", 1), ("_id", 1)]
+    )
+    assert marker is not None
+    created, doc_id = marker["created_at"], marker["_id"]
+    query = {
+        "status": {"$in": status_values},
+        "$or": [
+            {"created_at": {"$gt": created}},
+            {"created_at": created, "_id": {"$gt": doc_id}},
+        ],
+    }
+    cursor = collection.find(query).sort([("created_at", 1), ("_id", 1)]).limit(_PAGE)
+    return await cursor.explain()

--- a/tests/pipeline/test_content_hash_dedup.py
+++ b/tests/pipeline/test_content_hash_dedup.py
@@ -1,4 +1,4 @@
-"""content-hash duplicate detection is bounded (LR2 Phase 2.5).
+"""content-hash duplicate detection is bounded (LR2 Phase 2.5) and never cyclic.
 
 ``get_duplicate_doc_by_content_hash`` used to fall back to a full
 ``get_docs_by_statuses(list(DocStatus))`` scan whenever the indexed lookup
@@ -7,18 +7,31 @@ own content_hash is already persisted). Phase 2.5 pushes the self-exclusion
 INTO the query via ``get_doc_by_content_hash(..., exclude_doc_id=...)`` and
 deletes the fallback, so the check is a single bounded lookup — verified here
 against the JSON backend end-to-end, including that the fallback is gone.
+
+Also pinned here: a row that is itself marked ``metadata.is_duplicate`` is a
+POINTER at a content holder, not a holder, so it must never be reported as the
+original of the very document it points at. Answering "yes, a duplicate — of that
+row" closes an is_duplicate cycle whose shared canonical source ends up with no
+primary at all, which the repair endpoint cannot settle.
 """
 
 from __future__ import annotations
 
 import asyncio
+from uuid import uuid4
 
+import numpy as np
 import pytest
 
+from lightrag import LightRAG
 from lightrag.base import DocStatus
 from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
 from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
-from lightrag.utils_pipeline import get_duplicate_doc_by_content_hash
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+from lightrag.utils_pipeline import (
+    get_duplicate_doc_by_content_hash,
+    get_existing_doc_by_content_hash,
+)
 
 pytestmark = pytest.mark.offline
 
@@ -28,6 +41,49 @@ class _DummyEmbeddingFunc:
 
     async def __call__(self, texts):
         return [[0.0] * 8 for _ in texts]
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _chunking(
+    tokenizer,
+    content,
+    split_by_character,
+    split_by_character_only,
+    chunk_overlap_token_size,
+    chunk_token_size,
+) -> list[dict]:
+    return [{"tokens": 1, "content": content, "chunk_order_index": 0}]
+
+
+async def _build_rag(tmp_path) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"chd-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_chunking,
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    return rag
 
 
 @pytest.fixture(autouse=True)
@@ -50,7 +106,7 @@ async def _storage(tmp_path, rows: dict) -> JsonDocStatusStorage:
     return storage
 
 
-def _row(content_hash: str, created_at: str) -> dict:
+def _row(content_hash: str, created_at: str, metadata: dict | None = None) -> dict:
     return {
         "content_summary": "s",
         "content_length": 3,
@@ -58,11 +114,21 @@ def _row(content_hash: str, created_at: str) -> dict:
         "status": DocStatus.PROCESSED,
         "created_at": created_at,
         "updated_at": created_at,
-        "metadata": {},
+        "metadata": metadata if metadata is not None else {},
         "error_msg": None,
         "chunks_list": [],
         "content_hash": content_hash,
     }
+
+
+def _demoted_row(content_hash: str, created_at: str, original_doc_id: str) -> dict:
+    """A row a source-conflict repair demoted: content and status kept, its claim
+    on the canonical source replaced by a pointer at the primary that won."""
+    return _row(
+        content_hash,
+        created_at,
+        {"is_duplicate": True, "original_doc_id": original_doc_id},
+    )
 
 
 def test_get_doc_by_content_hash_excludes_self(tmp_path):
@@ -111,6 +177,129 @@ def test_duplicate_check_finds_other_and_ignores_self(tmp_path):
             await get_duplicate_doc_by_content_hash(storage, "uniq", "doc-unique")
             is None
         )
+
+    asyncio.run(_run())
+
+
+def test_a_row_demoted_in_favour_of_this_doc_is_not_its_duplicate(tmp_path):
+    """Fix-proof: the post-parse check returned the demoted row, so the primary an
+    operator explicitly kept was marked FAILED-duplicate OF the row they demoted —
+    both rows ``is_duplicate=true`` naming each other and their shared canonical
+    source left with no primary at all, which no repair can settle (the endpoint
+    only accepts a current primary candidate).
+
+    No race needed: a PENDING upload is an ordinary conflict candidate, so the
+    repair commits while the kept primary still has to be parsed, and the demoted
+    row keeps the content hash that the parse then matches.
+    """
+
+    async def _run():
+        storage = await _storage(
+            tmp_path,
+            {
+                # The repair kept doc-primary and demoted doc-demoted.
+                "doc-demoted": _demoted_row(
+                    "dup", "2026-01-01T00:00:00", "doc-primary"
+                ),
+                "doc-primary": _row("dup", "2026-02-01T00:00:00"),
+            },
+        )
+        # The backend still reports the row — the pointer is bookkeeping, not a
+        # content-hash property — so the guard has to live above it.
+        raw = await storage.get_doc_by_content_hash("dup", exclude_doc_id="doc-primary")
+        assert raw is not None and raw[0] == "doc-demoted"
+
+        assert (
+            await get_duplicate_doc_by_content_hash(storage, "dup", "doc-primary")
+            is None
+        )
+
+    asyncio.run(_run())
+
+
+def test_a_pointer_row_does_not_block_re_ingesting_its_missing_original(tmp_path):
+    """Enqueue side of the same rule: a duplicate row naming a doc id that no
+    longer exists must not answer for it, or content whose primary row was deleted
+    could never be re-uploaded — a doc id is derived deterministically from the
+    file name, so the re-upload asks about the very id the pointer names."""
+
+    async def _run():
+        storage = await _storage(
+            tmp_path,
+            {"doc-pointer": _demoted_row("dup", "2026-01-01T00:00:00", "doc-gone")},
+        )
+        # Without the candidate id, the lookup is unchanged: SOME row holds the hash.
+        match = await get_existing_doc_by_content_hash(storage, "dup")
+        assert match is not None and match[0] == "doc-pointer"
+        # Re-uploading the same bytes derives doc-gone again → admitted.
+        assert (
+            await get_existing_doc_by_content_hash(
+                storage, "dup", candidate_doc_id="doc-gone"
+            )
+            is None
+        )
+        # A different new document IS a genuine duplicate of that content.
+        assert (
+            await get_existing_doc_by_content_hash(
+                storage, "dup", candidate_doc_id="doc-other"
+            )
+            is not None
+        )
+
+    asyncio.run(_run())
+
+
+def test_a_duplicate_pointing_at_a_third_document_is_still_a_duplicate(tmp_path):
+    """The guard is narrow on purpose. When the matched row points somewhere ELSE,
+    the content really does exist under another document, and dropping the match
+    would fail open — re-admitting a genuine content duplicate."""
+
+    async def _run():
+        storage = await _storage(
+            tmp_path,
+            {
+                "doc-pointer": _demoted_row("dup", "2026-01-01T00:00:00", "doc-orig"),
+                "doc-orig": _row("dup", "2026-01-02T00:00:00"),
+            },
+        )
+        match = await get_duplicate_doc_by_content_hash(storage, "dup", "doc-new")
+        assert match is not None and match[0] == "doc-pointer"
+
+    asyncio.run(_run())
+
+
+def test_enqueue_re_admits_a_document_whose_pointer_row_outlived_it(tmp_path):
+    """The enqueue leg, end to end through ``apipeline_enqueue_documents``.
+
+    Fix-proof: with only a pointer row left (``a.txt`` demoted in favour of
+    ``b.txt``, then ``b.txt`` deleted), re-uploading ``b.txt`` was rejected as a
+    content-hash duplicate OF THE POINTER — so the file could never be ingested
+    again, and each attempt only added another FAILED duplicate record naming a
+    document that does not exist.
+    """
+
+    async def _run():
+        rag = await _build_rag(tmp_path)
+        try:
+            body = "the shared body"
+            await rag.apipeline_enqueue_documents(input=body, file_paths="a.txt")
+            demoted_id = compute_mdhash_id("a.txt", prefix="doc-")
+            revived_id = compute_mdhash_id("b.txt", prefix="doc-")
+
+            # A source-conflict repair kept b.txt and demoted a.txt; b.txt was
+            # then deleted, leaving only the pointer.
+            row = dict(await rag.doc_status.get_by_id(demoted_id))
+            row["metadata"] = {"is_duplicate": True, "original_doc_id": revived_id}
+            await rag.doc_status.upsert({demoted_id: row})
+
+            await rag.apipeline_enqueue_documents(input=body, file_paths="b.txt")
+
+            revived = await rag.doc_status.get_by_id(revived_id)
+            assert revived is not None, "b.txt was not enqueued at all"
+            assert revived["status"] == DocStatus.PENDING.value
+            assert not (revived.get("metadata") or {}).get("is_duplicate")
+        finally:
+            await rag.finalize_storages()
 
     asyncio.run(_run())
 

--- a/tests/pipeline/test_content_hash_dedup.py
+++ b/tests/pipeline/test_content_hash_dedup.py
@@ -204,11 +204,12 @@ def test_a_row_demoted_in_favour_of_this_doc_is_not_its_duplicate(tmp_path):
                 "doc-primary": _row("dup", "2026-02-01T00:00:00"),
             },
         )
-        # The backend still reports the row — the pointer is bookkeeping, not a
-        # content-hash property — so the guard has to live above it.
-        raw = await storage.get_doc_by_content_hash("dup", exclude_doc_id="doc-primary")
-        assert raw is not None and raw[0] == "doc-demoted"
-
+        # The exclusion lives in the backend query, both halves of it: the row
+        # being processed AND a row that merely points at it.
+        assert (
+            await storage.get_doc_by_content_hash("dup", exclude_doc_id="doc-primary")
+            is None
+        )
         assert (
             await get_duplicate_doc_by_content_hash(storage, "dup", "doc-primary")
             is None
@@ -245,6 +246,43 @@ def test_a_pointer_row_does_not_block_re_ingesting_its_missing_original(tmp_path
             )
             is not None
         )
+
+    asyncio.run(_run())
+
+
+def test_a_pointer_row_does_not_hide_a_genuine_third_holder(tmp_path):
+    """Skipping the pointer must not STOP the search.
+
+    Fix-proof: the skip started life as a post-filter over the single row the
+    backend returned, so when the earliest holder was a pointer back at the
+    asking document the answer became None even though a real third holder
+    existed — the asking document was then ingested as an original and its
+    content was duplicated in the graph. The exclusion belongs where the rows are
+    selected, so the query keeps walking to the earliest surviving holder.
+
+    The third holder here is created AFTER the asking document, the ordering that
+    a "look once more, excluding the pointer" fix would still get wrong (that
+    lookup returns the asking row itself and reads it as "no other holder").
+    """
+
+    async def _run():
+        storage = await _storage(
+            tmp_path,
+            {
+                "doc-pointer": _demoted_row("dup", "2026-01-01T00:00:00", "doc-asking"),
+                "doc-asking": _row("dup", "2026-02-01T00:00:00"),
+                "doc-third": _row("dup", "2026-03-01T00:00:00"),
+            },
+        )
+        match = await get_duplicate_doc_by_content_hash(storage, "dup", "doc-asking")
+        assert match is not None and match[0] == "doc-third"
+
+        # Same for the enqueue leg, where the asking id does not exist yet.
+        del storage._data["doc-asking"]
+        match = await get_existing_doc_by_content_hash(
+            storage, "dup", candidate_doc_id="doc-asking"
+        )
+        assert match is not None and match[0] == "doc-third"
 
     asyncio.run(_run())
 

--- a/tests/pipeline/test_content_hash_dedup.py
+++ b/tests/pipeline/test_content_hash_dedup.py
@@ -366,3 +366,111 @@ def test_duplicate_check_never_full_scans_all_statuses(tmp_path):
         )
 
     asyncio.run(_run())
+
+
+def test_the_repair_and_duplicate_marking_are_linearized_by_the_source_lock(tmp_path):
+    """LR2 §5.5: a source-conflict commit must be mutually exclusive with every
+    writer that changes the key's candidate set — the processing stage's duplicate
+    marking included.
+
+    Fix-proof: the marking held no source-key lock, so it could land between the
+    repair's demotions and its post-commit verification. The repair then reported
+    "storage unavailable, retry" (503) for storage that was perfectly available,
+    with irreversible demotions already written — a half-applied operation
+    reported as a transient failure.
+
+    What the lock buys is ORDER, not a permanent Unique: the marking here is
+    blocked for the whole commit, the repair verifies Unique and returns, and only
+    then does the marking run — leaving the key Absent as an ordinary content-dedup
+    transition AFTER a completed operation. (Marking first is the other
+    linearization: the repair then refuses before demoting anything, covered by
+    tests/tools/test_source_conflict_repair_cli.py.)
+    """
+
+    async def _run():
+        from lightrag.base import DocProcessingStatus
+        from lightrag.tools.source_conflict_repair import repair_one_conflict
+
+        rag = await _build_rag(tmp_path)
+        try:
+            # a.pdf is claimed by two primaries; doc-third legitimately holds the
+            # same content under its own source, so the marking has a real target.
+            async with rag.doc_status._storage_lock:
+                rag.doc_status._data.update(
+                    {
+                        "doc-keep": _row("dup", "2026-01-01T00:00:00"),
+                        "doc-lose": _row("dup", "2026-01-02T00:00:00"),
+                        "doc-third": _row("dup", "2026-01-03T00:00:00"),
+                    }
+                )
+                rag.doc_status._data["doc-keep"]["file_path"] = "a.pdf"
+                # Unparsed: no content_hash yet, which is why the commit's
+                # pre-check cannot see the collision the parse is about to find —
+                # the documented residual that makes the lock the only guard here.
+                rag.doc_status._data["doc-keep"]["content_hash"] = ""
+                rag.doc_status._data["doc-lose"]["file_path"] = "a.pdf"
+                rag.doc_status._data["doc-lose"]["content_hash"] = "other"
+                rag.doc_status._data["doc-third"]["file_path"] = "c.pdf"
+            # The kept primary must have content, or the commit refuses it for
+            # that reason instead (its own test covers that).
+            await rag.full_docs.upsert({"doc-keep": {"content": "body"}})
+
+            status_doc = DocProcessingStatus(
+                content_summary="s",
+                content_length=3,
+                file_path="a.pdf",
+                status=DocStatus.PARSING,
+                created_at="2026-01-01T00:00:00",
+                updated_at="2026-01-01T00:00:00",
+                content_hash="dup",
+            )
+
+            async def _mark():
+                return await rag._mark_duplicate_after_parse(
+                    doc_id="doc-keep",
+                    status_doc=status_doc,
+                    file_path="a.pdf",
+                    content_hash="dup",
+                    content_length=3,
+                )
+
+            marking: list[asyncio.Task] = []
+            original = rag.doc_status.repair_source_conflict
+
+            async def _commit_then_let_the_marking_try(key, **kwargs):
+                result = await original(key, **kwargs)
+                if not kwargs.get("dry_run", True):
+                    # Inside the repair's lock, after the demotions: give the
+                    # marking every chance to interleave before verification.
+                    task = asyncio.create_task(_mark())
+                    marking.append(task)
+                    for _ in range(50):
+                        await asyncio.sleep(0)
+                    assert not task.done(), (
+                        "the duplicate marking interleaved between the demotions "
+                        "and the verification"
+                    )
+                return result
+
+            rag.doc_status.repair_source_conflict = _commit_then_let_the_marking_try
+
+            # No exception: the commit's own verification saw the key settled.
+            result = await repair_one_conflict(
+                rag.doc_status,
+                "a.pdf",
+                "doc-keep",
+                workspace=rag.workspace,
+                full_docs=rag.full_docs,
+                apply=True,
+            )
+            assert result.committed is True
+
+            assert await marking[0] is True  # runs once the lock is released
+            demoted = await rag.doc_status.get_by_id("doc-lose")
+            assert demoted["metadata"]["original_doc_id"] == "doc-keep"
+            marked = await rag.doc_status.get_by_id("doc-keep")
+            assert marked["metadata"]["original_doc_id"] == "doc-third"
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())

--- a/tests/pipeline/test_demotion_survives_the_pipeline.py
+++ b/tests/pipeline/test_demotion_survives_the_pipeline.py
@@ -1,0 +1,261 @@
+"""A source-conflict demotion survives every later doc_status write (LR2 §5.5).
+
+``metadata.is_duplicate`` is not a display field: it is the ONLY thing that makes
+a row ineligible as a primary candidate for its canonical source (every backend's
+``_basename_of`` returns None for it). So an operator's source-conflict repair
+lives or dies with that key surviving.
+
+It did not. Both metadata rebuilds dropped it, and a repair deliberately keeps the
+demoted row's content AND status — so it stays a perfectly ordinary document that
+the pipeline will happily touch:
+
+* the manual FAILED→PENDING retry (``_build_pending_reset_update`` →
+  ``doc_status_reset_metadata``) rebuilt metadata from a directives whitelist;
+* every status transition (``doc_status_transition_metadata`` →
+  ``doc_status_metadata_carry_over``) rebuilt it from a carry-over whitelist.
+
+Either one handed the canonical source straight back to the demoted row, putting
+the key back into conflict — deterministically, with no concurrency involved. And
+the repair tool cannot undo that: ``repair_source_conflict`` only demotes, and it
+refuses a ``primary_doc_id`` that is not a current candidate, so the resurrected
+conflict has to be repaired from scratch every time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import CURSOR_START, DocStatus, SourceConflict, SourceUnique
+from lightrag.kg.shared_storage import (
+    finalize_share_data,
+    get_namespace_data,
+    get_namespace_lock,
+    initialize_share_data,
+    make_owner_record,
+)
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+pytestmark = pytest.mark.offline
+
+_SOURCE = "collision.pdf"
+_TOKEN = "owner-A"
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+@pytest.fixture(autouse=True)
+def _shared():
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+async def _build_rag(tmp_path) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"demote-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    return rag
+
+
+def _row(doc_id: str, status: DocStatus, seconds: int) -> dict:
+    """A primary-candidate row: real content, no duplicate marker."""
+    stamp = datetime(2026, 1, 1, 0, 0, seconds, tzinfo=timezone.utc).isoformat()
+    return {
+        "status": status,
+        "content_summary": f"summary-{doc_id}",
+        "content_length": 12,
+        "chunks_count": 0,
+        "chunks_list": [],
+        "created_at": stamp,
+        "updated_at": stamp,
+        "file_path": _SOURCE,
+        "track_id": "t",
+        "metadata": {"process_options": "R!"},
+    }
+
+
+async def _seed_conflict(rag, loser_status: DocStatus) -> tuple[str, str]:
+    """Two primaries on one canonical source, then repair keeping ``doc-keep``.
+
+    Written straight to storage: enqueue refuses a colliding basename by design,
+    so a historical collision is the only way this state exists.
+    """
+    keep, loser = "doc-keep", "doc-loser"
+    await rag.doc_status.upsert(
+        {
+            keep: _row(keep, DocStatus.PROCESSED, 1),
+            loser: _row(loser, loser_status, 2),
+        }
+    )
+    # The reset probes full_docs for content; a demoted row keeps its own.
+    await rag.full_docs.upsert(
+        {
+            keep: {"content": "keep body", "file_path": _SOURCE},
+            loser: {"content": "loser body", "file_path": _SOURCE},
+        }
+    )
+    assert isinstance(
+        await rag.doc_status.resolve_doc_source_strict(_SOURCE), SourceConflict
+    )
+
+    dry = await rag.doc_status.repair_source_conflict(
+        _SOURCE,
+        primary_doc_id=keep,
+        expected_candidate_count=0,
+        expected_candidate_fingerprint="",
+        dry_run=True,
+    )
+    committed = await rag.doc_status.repair_source_conflict(
+        _SOURCE,
+        primary_doc_id=keep,
+        expected_candidate_count=dry.candidate_count,
+        expected_candidate_fingerprint=dry.fingerprint,
+        dry_run=False,
+    )
+    assert committed.committed is True
+    resolution = await rag.doc_status.resolve_doc_source_strict(_SOURCE)
+    assert isinstance(resolution, SourceUnique) and resolution.doc_id == keep
+    return keep, loser
+
+
+async def _status_handles(rag, token: str):
+    status = await get_namespace_data("pipeline_status", workspace=rag.workspace)
+    lock = get_namespace_lock("pipeline_status", workspace=rag.workspace)
+    status["history_messages"] = []
+    status.update({"busy": True, "busy_owner": make_owner_record(token, "processing")})
+    return status, lock
+
+
+def test_a_manual_failed_retry_does_not_undo_the_repair(tmp_path):
+    """Fix-proof: the operator repairs the conflict, then anyone clicking "retry
+    failed documents" (or running /scan, which drives the same reset) handed the
+    canonical source back to the demoted row."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path)
+        try:
+            keep, loser = await _seed_conflict(rag, DocStatus.FAILED)
+            status, lock = await _status_handles(rag, _TOKEN)
+
+            # The production reset sweep, over the page that contains the
+            # demoted row.
+            docs, _ = await rag._next_failed_page(CURSOR_START)
+            assert loser in docs
+            reset = await rag._reset_failed_page(docs, _TOKEN, status, lock)
+            assert reset == 1  # it really was reset, not skipped
+
+            row = await rag.doc_status.get_by_id(loser)
+            assert row["status"] == DocStatus.PENDING  # retried, as asked
+            assert row["metadata"]["is_duplicate"] is True  # but still demoted
+            assert row["metadata"]["original_doc_id"] == keep
+            assert row["metadata"]["process_options"] == "R!"  # directives kept
+
+            resolution = await rag.doc_status.resolve_doc_source_strict(_SOURCE)
+            assert isinstance(resolution, SourceUnique)
+            assert resolution.doc_id == keep
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_a_status_transition_does_not_undo_the_repair(tmp_path):
+    """The wider half: a demoted row in any non-terminal status is resumed by the
+    ordinary AUTO sweep, and its first transition rebuilt metadata from the
+    carry-over whitelist — so the demotion did not even need a manual retry to
+    disappear."""
+
+    async def _run():
+        from lightrag.pipeline import _BatchRunContext
+        from lightrag.parser.registry import parser_specs_snapshot
+
+        rag = await _build_rag(tmp_path)
+        try:
+            keep, loser = await _seed_conflict(rag, DocStatus.PENDING)
+            status, lock = await _status_handles(rag, _TOKEN)
+
+            hydrated = await rag.doc_status.get_full_docs_by_ids([loser], strict=True)
+            ctx = _BatchRunContext(
+                pipeline_status=status,
+                pipeline_status_lock=lock,
+                semaphore=asyncio.Semaphore(1),
+                total_files=1,
+                parse_queues={"native": asyncio.Queue()},
+                parser_specs=parser_specs_snapshot(),
+                q_analyze=asyncio.Queue(),
+                q_process=asyncio.Queue(),
+                run_owner_token=_TOKEN,
+            )
+
+            await rag._upsert_doc_status_transition(
+                doc_id=loser,
+                status=DocStatus.PROCESSED,
+                status_doc=hydrated[loser],
+                file_path=_SOURCE,
+                ctx=ctx,
+            )
+
+            row = await rag.doc_status.get_by_id(loser)
+            assert row["status"] == DocStatus.PROCESSED
+            assert row["metadata"]["is_duplicate"] is True
+            assert row["metadata"]["original_doc_id"] == keep
+
+            resolution = await rag.doc_status.resolve_doc_source_strict(_SOURCE)
+            assert isinstance(resolution, SourceUnique)
+            assert resolution.doc_id == keep
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_the_repair_tool_cannot_undo_a_resurrection_itself(tmp_path):
+    """Why the two tests above are load-bearing rather than cosmetic: there is no
+    supported way back. ``repair_source_conflict`` refuses a primary that is not a
+    current candidate, so once a demoted row is re-promoted the only exit is
+    repairing the conflict again from scratch."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path)
+        try:
+            _keep, loser = await _seed_conflict(rag, DocStatus.FAILED)
+            with pytest.raises(ValueError):
+                await rag.doc_status.repair_source_conflict(
+                    _SOURCE,
+                    primary_doc_id=loser,  # demoted: no longer a candidate
+                    expected_candidate_count=1,
+                    expected_candidate_fingerprint="whatever",
+                    dry_run=True,
+                )
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())

--- a/tests/pipeline/test_manual_exclusive_reset.py
+++ b/tests/pipeline/test_manual_exclusive_reset.py
@@ -632,3 +632,84 @@ def test_worker_status_write_is_discarded_when_ownership_was_reclaimed(tmp_path)
             await rag.finalize_storages()
 
     asyncio.run(_run())
+
+
+def test_parsed_content_write_is_discarded_when_ownership_was_reclaimed(tmp_path):
+    """The same §7.7 guarantee at the ONE write a worker makes outside the status
+    chokepoint: ``_persist_parsed_full_docs``.
+
+    Fix-proof: it wrote ``full_docs`` and patched ``doc_status.content_hash``
+    with no owner check at all, so a parse result returning after a reaper
+    reclaim would overwrite the body the NEW owner had re-parsed and stamp a row
+    it now owns. It is reached as ``ctx.rag._persist_parsed_full_docs`` from
+    inside a parser, so the check reads the run context the batch publishes on
+    the instance — which is what makes third-party parsers guarded too.
+    """
+
+    async def _run():
+        from lightrag.pipeline import _BatchRunContext
+        from lightrag.parser.registry import parser_specs_snapshot
+
+        extract = _CountingExtract()
+        rag = await _build_rag(tmp_path, extract)
+        try:
+            doc_id = await _make_failed(rag, "a.txt", extract)
+            status = await get_namespace_data(
+                "pipeline_status", workspace=rag.workspace
+            )
+            lock = get_namespace_lock("pipeline_status", workspace=rag.workspace)
+            status.update(
+                {"busy": True, "busy_owner": make_owner_record("owner-B", "processing")}
+            )
+
+            ctx = _BatchRunContext(
+                pipeline_status=status,
+                pipeline_status_lock=lock,
+                semaphore=asyncio.Semaphore(1),
+                total_files=1,
+                parse_queues={"native": asyncio.Queue()},
+                parser_specs=parser_specs_snapshot(),
+                q_analyze=asyncio.Queue(),
+                q_process=asyncio.Queue(),
+                run_owner_token="owner-A",  # reclaimed: owner-B holds busy now
+            )
+            rag._active_run_ctx = ctx
+
+            full_before = await rag.full_docs.get_by_id(doc_id)
+            status_before = await rag.doc_status.get_by_id(doc_id)
+
+            result = await rag._persist_parsed_full_docs(
+                doc_id,
+                {
+                    "content": "text a stale run re-parsed",
+                    "file_path": "a.txt",
+                    "parse_format": "raw",
+                },
+            )
+
+            # Neither store touched, and no content_hash handed back.
+            assert result is None
+            assert await rag.full_docs.get_by_id(doc_id) == full_before
+            assert await rag.doc_status.get_by_id(doc_id) == status_before
+
+            # The current owner's parse result still lands.
+            ctx.run_owner_token = "owner-B"
+            content_hash = await rag._persist_parsed_full_docs(
+                doc_id,
+                {
+                    "content": "text the real owner parsed",
+                    "file_path": "a.txt",
+                    "parse_format": "raw",
+                },
+            )
+            assert content_hash
+            after = await rag.full_docs.get_by_id(doc_id)
+            assert after["content"] == "text the real owner parsed"
+            assert (await rag.doc_status.get_by_id(doc_id))[
+                "content_hash"
+            ] == content_hash
+        finally:
+            rag._active_run_ctx = None
+            await rag.finalize_storages()
+
+    asyncio.run(_run())

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -1709,12 +1709,15 @@ def test_concurrent_enqueue_dedupes_same_content_different_filenames(tmp_path):
         try:
             original = pipeline_module.get_existing_doc_by_content_hash
 
-            async def yielding_get_by_content_hash(doc_status, content_hash):
+            async def yielding_get_by_content_hash(doc_status, content_hash, **kwargs):
                 # Yield to the event loop so the SECOND enqueue gets a
                 # chance to run its dedup read before we proceed.  This
                 # is the exact interleaving the lock must defeat.
                 await asyncio.sleep(0)
-                return await original(doc_status, content_hash)
+                # Pass the caller's kwargs through: this double stands in for the
+                # real lookup, so it must not quietly drop what the enqueue path
+                # sends it (``candidate_doc_id`` gates the pointer-row guard).
+                return await original(doc_status, content_hash, **kwargs)
 
             import unittest.mock
 

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -388,6 +388,14 @@ def test_carry_over_keys_grouped_by_stage():
         # operation; must survive every status transition until commit or
         # rollback.
         "custom_chunk_patch",
+        # Duplicate demotion — NOT stage fields, so they sit after the stage
+        # groups and do not disturb the dialog's timeline. ``is_duplicate`` is
+        # the predicate every backend uses to exclude a row from its canonical
+        # source's primary candidates, so a transition that dropped it silently
+        # re-promoted a demoted row and put the source key back in conflict.
+        "is_duplicate",
+        "duplicate_kind",
+        "original_doc_id",
     )
 
 

--- a/tests/pipeline/test_scheduler_memory_bounded.py
+++ b/tests/pipeline/test_scheduler_memory_bounded.py
@@ -27,10 +27,14 @@ pipeline owns are driven here through their real methods —
 `_reset_failed_page` (the manual EXCLUSIVE_RESET) — so page hydration, status
 re-filtering and the reset's own bookkeeping are all inside the measurement.
 
-Still NOT covered, and deliberately named rather than implied: a full
-`apipeline_process_enqueue_documents` run with live workers and the feeder, and
-`/scan` over a huge input directory. Those need real LLM/parse stubs and a
-filesystem fixture; §18's RSS acceptance for them is outstanding.
+The second, process-level acceptance layer lives in
+`test_scheduler_memory_bounded_e2e.py`: it drives a full
+`apipeline_process_enqueue_documents` run with the production supervisor,
+feeder and all three worker queues, plus a production `run_scanning_process`
+over a real large directory, in isolated child processes while sampling RSS.
+Keep the two layers separate: this file pinpoints Python allocation regressions
+inside the page/reset helpers; the companion catches composition, native
+allocation and filesystem-lifecycle regressions.
 """
 
 from __future__ import annotations

--- a/tests/pipeline/test_scheduler_memory_bounded.py
+++ b/tests/pipeline/test_scheduler_memory_bounded.py
@@ -17,21 +17,38 @@ An absolute threshold would encode this machine's interpreter and this fixture's
 row width, and would be re-tuned into meaninglessness the first time it failed.
 A ratio has a defensible meaning: sweeping 10x more documents at the same page
 size must not cost 10x more memory.
+
+The loop under measurement is the PRODUCTION one. An earlier version of this file
+hand-rolled its own `get_docs_by_statuses_page` loop, which made it a test of the
+measurement rather than of the scheduler: adding the very accumulator described
+above to `_next_scheduling_page` would not have failed it. Both sweeps the
+pipeline owns are driven here through their real methods —
+`_next_scheduling_page` (the AUTO drain) and `_next_failed_page` +
+`_reset_failed_page` (the manual EXCLUSIVE_RESET) — so page hydration, status
+re-filtering and the reset's own bookkeeping are all inside the measurement.
+
+Still NOT covered, and deliberately named rather than implied: a full
+`apipeline_process_enqueue_documents` run with live workers and the feeder, and
+`/scan` over a huge input directory. Those need real LLM/parse stubs and a
+filesystem fixture; §18's RSS acceptance for them is outstanding.
 """
 
 from __future__ import annotations
 
+import asyncio
 import tracemalloc
 from datetime import datetime, timedelta, timezone
 
 import pytest
 
 from lightrag.base import CURSOR_END, CURSOR_START, CursorAfter, DocStatus
+from lightrag.pipeline import _AUTO_RESUME_DOC_STATUSES, _PipelineMixin
 
 pytestmark = pytest.mark.offline
 
 _PAGE = 200
 _BASE = datetime(2026, 1, 1, tzinfo=timezone.utc)
+_TOKEN = "owner-token"
 
 
 class _SyntheticDocStatus:
@@ -45,15 +62,23 @@ class _SyntheticDocStatus:
     measure the driver's buffers instead.
     """
 
-    def __init__(self, total: int):
+    # The production sweep probes this before reading full_docs content.
+    supports_strict_point_reads = True
+
+    def __init__(self, total: int, status: DocStatus = DocStatus.PENDING):
         self.total = total
+        self.status = status
         self.pages_served = 0
+        self.upserted = 0
 
     def _key(self, index: int) -> tuple[str, str]:
         return (
             (_BASE + timedelta(seconds=index)).isoformat(),
             f"doc-{index:09d}",
         )
+
+    def _index_of(self, doc_id: str) -> int:
+        return int(doc_id.rsplit("-", 1)[1])
 
     async def get_docs_by_statuses_page(
         self, statuses, *, limit, position=CURSOR_START, strict=False
@@ -69,7 +94,7 @@ class _SyntheticDocStatus:
             created_at, doc_id = self._key(i)
             docs[doc_id] = DocSchedulingRecord(
                 id=doc_id,
-                status=DocStatus.PENDING,
+                status=self.status,
                 created_at=created_at,
                 updated_at=created_at,
                 file_path=f"file-{i}.md",
@@ -80,11 +105,59 @@ class _SyntheticDocStatus:
         next_position = CURSOR_END if end >= self.total else CursorAfter(str(end - 1))
         return DocStatusPage(docs=docs, next_position=next_position)
 
+    async def get_full_docs_by_ids(self, ids, *, strict=False):
+        """Hydration is part of the production page, so it is part of the
+        measurement: one full row per id, discarded with the page."""
+        from lightrag.base import DocProcessingStatus
+
+        hydrated = {}
+        for doc_id in ids:
+            index = self._index_of(doc_id)
+            created_at, _ = self._key(index)
+            hydrated[doc_id] = DocProcessingStatus(
+                content_summary=f"summary-{index}",
+                content_length=64,
+                status=self.status,
+                created_at=created_at,
+                updated_at=created_at,
+                file_path=f"file-{index}.md",
+                track_id="t",
+                chunks_count=0,
+                chunks_list=[],
+                metadata={},
+            )
+        return hydrated
+
+    async def get_by_id_strict(self, doc_id: str):
+        # full_docs content probe for the FAILED reset.
+        return {"content": "body", "file_path": f"file-{self._index_of(doc_id)}.md"}
+
+    async def upsert(self, data: dict) -> None:
+        # The reset's page write: counted, never retained.
+        self.upserted += len(data)
+
+
+def _pipeline_over(doc_status) -> _PipelineMixin:
+    """The real mixin, bound to the synthetic backend.
+
+    Only the attributes the two sweeps touch are provided — the point is to run
+    `_next_scheduling_page` / `_next_failed_page` as written, not to build a
+    LightRAG."""
+
+    class _Pipeline(_PipelineMixin):
+        def __init__(self):
+            self.doc_status = doc_status
+            self.full_docs = doc_status
+            self.pipeline_scheduling_page_size = _PAGE
+
+    return _Pipeline()
+
 
 async def _sweep_peak_kib(total: int) -> tuple[float, int]:
-    """Page through `total` documents the way the supervisor does, returning the
-    peak traced allocation and the number of pages."""
+    """Drive the production AUTO sweep over `total` documents, returning the peak
+    traced allocation and the number of pages."""
     doc_status = _SyntheticDocStatus(total)
+    pipeline = _pipeline_over(doc_status)
 
     tracemalloc.start()
     tracemalloc.reset_peak()
@@ -92,20 +165,44 @@ async def _sweep_peak_kib(total: int) -> tuple[float, int]:
         position = CURSOR_START
         routed = 0
         while True:
-            page = await doc_status.get_docs_by_statuses_page(
-                [DocStatus.PENDING], limit=_PAGE, position=position, strict=True
+            docs, position = await pipeline._next_scheduling_page(
+                _AUTO_RESUME_DOC_STATUSES, position
             )
             # Stand in for routing: consume each record and keep NOTHING that
             # scales with the backlog — exactly the discipline under test.
-            for record in page.docs.values():
-                routed += len(record.id)
-            if page.next_position is CURSOR_END:
+            for doc_id in docs:
+                routed += len(doc_id)
+            if position is CURSOR_END:
                 break
-            position = page.next_position
         _, peak = tracemalloc.get_traced_memory()
     finally:
         tracemalloc.stop()
     assert routed > 0
+    return peak / 1024, doc_status.pages_served
+
+
+async def _reset_peak_kib(total: int) -> tuple[float, int]:
+    """Drive the production manual EXCLUSIVE_RESET sweep (`_next_failed_page` +
+    `_reset_failed_page`) over `total` FAILED documents."""
+    doc_status = _SyntheticDocStatus(total, status=DocStatus.FAILED)
+    pipeline = _pipeline_over(doc_status)
+    pipeline_status = {"busy_owner": {"token": _TOKEN}, "history_messages": []}
+    lock = asyncio.Lock()
+
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    try:
+        position = CURSOR_START
+        while True:
+            docs, position = await pipeline._next_failed_page(position)
+            if docs:
+                await pipeline._reset_failed_page(docs, _TOKEN, pipeline_status, lock)
+            if position is CURSOR_END:
+                break
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    assert doc_status.upserted == total
     return peak / 1024, doc_status.pages_served
 
 
@@ -120,6 +217,20 @@ async def test_sweep_peak_memory_does_not_track_the_backlog():
     assert large_kib < max(3.0 * small_kib, small_kib + 256), (
         f"peak grew with the backlog: {small_kib:.1f} KiB at 1k docs, "
         f"{large_kib:.1f} KiB at 10k docs"
+    )
+
+
+async def test_failed_reset_peak_memory_does_not_track_the_backlog():
+    """The other production sweep: the manual retry's FAILED→PENDING reset builds
+    a `docs_to_reset` dict per page, and it must be released with the page rather
+    than accumulated across the walk."""
+    small_kib, small_pages = await _reset_peak_kib(1_000)
+    large_kib, large_pages = await _reset_peak_kib(10_000)
+
+    assert large_pages == 10 * small_pages
+    assert large_kib < max(3.0 * small_kib, small_kib + 256), (
+        f"reset peak grew with the backlog: {small_kib:.1f} KiB at 1k FAILED, "
+        f"{large_kib:.1f} KiB at 10k FAILED"
     )
 
 

--- a/tests/pipeline/test_scheduler_memory_bounded.py
+++ b/tests/pipeline/test_scheduler_memory_bounded.py
@@ -1,0 +1,177 @@
+"""The scheduler's memory does not grow with the backlog (LR2 §14, §18 item 6).
+
+This is the claim the whole bounded-scheduling rework exists to make, and until
+now it was supported only by structural argument: pages are bounded, so memory
+must be. Structure is the right argument, but it does not catch the way this
+regresses in practice — one accumulating list, one `list(...)` around a generator,
+one forgotten `dict` keyed by doc id, and the sweep is O(backlog) again while
+every test still passes because the RESULTS are unchanged.
+
+So this measures it. `tracemalloc` rather than RSS: RSS is dominated by the
+allocator's arena behaviour and by whatever else the process has touched, so it is
+far too noisy to assert on, while tracemalloc attributes Python allocations to the
+code under test.
+
+The assertion is a RATIO between two backlog sizes, never an absolute byte count.
+An absolute threshold would encode this machine's interpreter and this fixture's
+row width, and would be re-tuned into meaninglessness the first time it failed.
+A ratio has a defensible meaning: sweeping 10x more documents at the same page
+size must not cost 10x more memory.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from lightrag.base import CURSOR_END, CURSOR_START, CursorAfter, DocStatus
+
+pytestmark = pytest.mark.offline
+
+_PAGE = 200
+_BASE = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+class _SyntheticDocStatus:
+    """A doc_status that SERVES pages without materializing the backlog.
+
+    Rows are generated per page from the cursor, so the backend itself uses O(1)
+    memory for any backlog size. That is the point: any growth the measurement
+    sees belongs to the scheduler, not to the fixture. A real backend is bounded
+    the same way — the page query is index-ordered and returns `limit` rows (see
+    tests/kg/test_scheduling_page_plans.py) — but going through one here would
+    measure the driver's buffers instead.
+    """
+
+    def __init__(self, total: int):
+        self.total = total
+        self.pages_served = 0
+
+    def _key(self, index: int) -> tuple[str, str]:
+        return (
+            (_BASE + timedelta(seconds=index)).isoformat(),
+            f"doc-{index:09d}",
+        )
+
+    async def get_docs_by_statuses_page(
+        self, statuses, *, limit, position=CURSOR_START, strict=False
+    ):
+        from lightrag.base import DocSchedulingRecord, DocStatusPage
+
+        start = 0
+        if isinstance(position, CursorAfter):
+            start = int(position.opaque) + 1
+        end = min(start + limit, self.total)
+        docs = {}
+        for i in range(start, end):
+            created_at, doc_id = self._key(i)
+            docs[doc_id] = DocSchedulingRecord(
+                id=doc_id,
+                status=DocStatus.PENDING,
+                created_at=created_at,
+                updated_at=created_at,
+                file_path=f"file-{i}.md",
+                track_id="t",
+                has_custom_chunk_journal=False,
+            )
+        self.pages_served += 1
+        next_position = CURSOR_END if end >= self.total else CursorAfter(str(end - 1))
+        return DocStatusPage(docs=docs, next_position=next_position)
+
+
+async def _sweep_peak_kib(total: int) -> tuple[float, int]:
+    """Page through `total` documents the way the supervisor does, returning the
+    peak traced allocation and the number of pages."""
+    doc_status = _SyntheticDocStatus(total)
+
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    try:
+        position = CURSOR_START
+        routed = 0
+        while True:
+            page = await doc_status.get_docs_by_statuses_page(
+                [DocStatus.PENDING], limit=_PAGE, position=position, strict=True
+            )
+            # Stand in for routing: consume each record and keep NOTHING that
+            # scales with the backlog — exactly the discipline under test.
+            for record in page.docs.values():
+                routed += len(record.id)
+            if page.next_position is CURSOR_END:
+                break
+            position = page.next_position
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    assert routed > 0
+    return peak / 1024, doc_status.pages_served
+
+
+async def test_sweep_peak_memory_does_not_track_the_backlog():
+    """10x the documents, same page size: memory must stay flat, not scale."""
+    small_kib, small_pages = await _sweep_peak_kib(1_000)
+    large_kib, large_pages = await _sweep_peak_kib(10_000)
+
+    assert large_pages == 10 * small_pages  # the work really did grow 10x
+    # Generous headroom: this asserts "does not scale", not a byte budget. A
+    # per-document leak at 10x would blow well past 3x.
+    assert large_kib < max(3.0 * small_kib, small_kib + 256), (
+        f"peak grew with the backlog: {small_kib:.1f} KiB at 1k docs, "
+        f"{large_kib:.1f} KiB at 10k docs"
+    )
+
+
+async def test_page_size_not_backlog_size_sets_the_peak():
+    """The complement: memory SHOULD grow with the page size. Without this, a
+    scheduler that accidentally kept nothing at all would pass the test above
+    while proving nothing about where the bound comes from."""
+    global _PAGE
+    original = _PAGE
+    try:
+        _PAGE = 50
+        small_page_kib, _ = await _sweep_peak_kib(10_000)
+        _PAGE = 2_000
+        large_page_kib, _ = await _sweep_peak_kib(10_000)
+    finally:
+        _PAGE = original
+
+    assert large_page_kib > small_page_kib, (
+        "peak did not respond to page size at all, so the measurement is not "
+        f"observing the page: {small_page_kib:.1f} vs {large_page_kib:.1f} KiB"
+    )
+
+
+async def test_a_backlog_sized_accumulator_is_caught():
+    """Fix-proof for the measurement itself: the exact regression it exists to
+    catch — one list that keeps every routed record — must fail the ratio."""
+
+    async def _leaky_sweep_peak_kib(total: int) -> float:
+        doc_status = _SyntheticDocStatus(total)
+        tracemalloc.start()
+        tracemalloc.reset_peak()
+        try:
+            position = CURSOR_START
+            accumulated = []  # the bug
+            while True:
+                page = await doc_status.get_docs_by_statuses_page(
+                    [DocStatus.PENDING], limit=_PAGE, position=position, strict=True
+                )
+                accumulated.extend(page.docs.values())
+                if page.next_position is CURSOR_END:
+                    break
+                position = page.next_position
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        assert accumulated
+        return peak / 1024
+
+    small_kib = await _leaky_sweep_peak_kib(1_000)
+    large_kib = await _leaky_sweep_peak_kib(10_000)
+
+    assert large_kib >= 3.0 * small_kib, (
+        "the ratio assertion would not have caught a backlog-sized accumulator: "
+        f"{small_kib:.1f} -> {large_kib:.1f} KiB"
+    )

--- a/tests/pipeline/test_scheduler_memory_bounded_e2e.py
+++ b/tests/pipeline/test_scheduler_memory_bounded_e2e.py
@@ -1,0 +1,599 @@
+"""Process-level bounded-memory acceptance for the pipeline and scan (LR2 §18.6).
+
+The helper-level tracemalloc tests in ``test_scheduler_memory_bounded.py`` prove
+that one scheduling/reset page is released before the next.  They cannot prove
+that the composition is bounded: the supervisor, feeder, asyncio queues, worker
+tasks or filesystem scan could retain one object per document even though every
+helper is individually page-bounded.
+
+These tests run each backlog size in a fresh spawned interpreter and sample that
+process's resident set size (RSS):
+
+* ``apipeline_process_enqueue_documents`` is the production entry point.  Its
+  supervisor, in-batch feeder, parse workers, analyze workers and process workers
+  are all real.  External parsing/KG work and persistent stores are bounded
+  stubs so retained database rows do not drown out the scheduler signal.
+* ``run_scanning_process`` walks a real directory through ``DocumentManager`` and
+  the production classify/batch/enqueue lifecycle.  Its storage and final
+  processing drive are non-retaining offline stubs.
+
+The assertion is a growth comparison, never a machine-specific absolute RSS
+budget.  A 10x backlog at fixed page/queue/batch sizes may pay allocator noise,
+but it must not pay anything close to 10x transient memory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import importlib
+import logging
+import multiprocessing
+import os
+import sys
+import threading
+import traceback
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import MethodType, SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import psutil
+import pytest
+
+from lightrag.base import (
+    CURSOR_END,
+    CURSOR_START,
+    CursorAfter,
+    DocProcessingStatus,
+    DocSchedulingRecord,
+    DocStatus,
+    DocStatusPage,
+    SourceAbsent,
+)
+from lightrag.constants import FULL_DOCS_FORMAT_RAW
+
+pytestmark = pytest.mark.offline
+
+_PIPELINE_PAGE_SIZE = 64
+_QUEUE_SIZE = 4
+_RSS_SAMPLE_SECONDS = 0.001
+_RSS_FIXED_HEADROOM = 8 * 1024 * 1024
+_BASE_TIME = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+class _PeakRSS:
+    """Sample this process's RSS from a constant-memory helper thread."""
+
+    def __init__(self) -> None:
+        self._process = psutil.Process(os.getpid())
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.baseline = 0
+        self.peak = 0
+
+    def start(self) -> None:
+        gc.collect()
+        self.baseline = self._process.memory_info().rss
+        self.peak = self.baseline
+
+        def _sample() -> None:
+            while not self._stop.wait(_RSS_SAMPLE_SECONDS):
+                self.peak = max(self.peak, self._process.memory_info().rss)
+
+        self._thread = threading.Thread(
+            target=_sample, name="rss-acceptance-sampler", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> dict[str, int]:
+        self.peak = max(self.peak, self._process.memory_info().rss)
+        self._stop.set()
+        assert self._thread is not None
+        self._thread.join(timeout=5)
+        assert not self._thread.is_alive()
+        return {
+            "baseline": self.baseline,
+            "peak": self.peak,
+            "growth": max(0, self.peak - self.baseline),
+        }
+
+
+class _StreamingPipelineDocStatus:
+    """Generate scheduling rows by cursor and retain only one bit per document.
+
+    A JSON fake would itself keep every status row and every terminal update in
+    the worker process, making RSS correctly grow with the *storage* rather than
+    revealing whether the scheduler grows.  This fake models an external indexed
+    backend: pages are generated on demand, while a preallocated bytearray records
+    which rows reached a terminal state without allocating during the measurement.
+    """
+
+    supports_strict_point_reads = True
+
+    def __init__(self, total: int) -> None:
+        self.total = total
+        self._terminal = bytearray(total)
+        self.completed = 0
+        self.page_calls = 0
+        self.feeder_hydrations = 0
+        self.parsing_writes = 0
+        self.analyzing_writes = 0
+        self.processed_writes = 0
+
+    @staticmethod
+    def _index(doc_id: str) -> int:
+        return int(doc_id.rsplit("-", 1)[1])
+
+    @staticmethod
+    def _doc_id(index: int) -> str:
+        return f"doc-{index:09d}"
+
+    @staticmethod
+    def _created_at(index: int) -> str:
+        return (_BASE_TIME + timedelta(microseconds=index)).isoformat()
+
+    def _status_doc(self, index: int) -> DocProcessingStatus:
+        created_at = self._created_at(index)
+        return DocProcessingStatus(
+            # Match the production summary ceiling closely enough that an
+            # accidental backlog-sized accumulator has a measurable RSS slope.
+            content_summary=f"rss-{index:09d}-" + ("s" * 230),
+            content_length=32,
+            status=(
+                DocStatus.PROCESSED if self._terminal[index] else DocStatus.PENDING
+            ),
+            created_at=created_at,
+            updated_at=created_at,
+            file_path=f"file-{index:09d}.txt",
+            track_id="rss",
+            content_hash=f"hash-{index:09d}",
+            chunks_count=0,
+            chunks_list=[],
+            metadata={},
+        )
+
+    async def get_docs_by_statuses_page(
+        self,
+        statuses,
+        *,
+        limit: int,
+        position=CURSOR_START,
+        strict: bool = False,
+    ) -> DocStatusPage:
+        del strict
+        wanted = {
+            value if isinstance(value, DocStatus) else DocStatus(value)
+            for value in statuses
+        }
+        if DocStatus.PENDING not in wanted:
+            return DocStatusPage(docs={}, next_position=CURSOR_END)
+
+        index = int(position.opaque) + 1 if isinstance(position, CursorAfter) else 0
+        docs: dict[str, DocSchedulingRecord] = {}
+        # Leave exactly one slot in the first epoch for a pre-published document
+        # message. The production feeder must hydrate and admit that document,
+        # proving this is not merely a supervisor/worker test with an idle feeder.
+        page_limit = limit - 1 if self.page_calls == 0 else limit
+        while index < self.total and len(docs) < page_limit:
+            if not self._terminal[index]:
+                doc_id = self._doc_id(index)
+                created_at = self._created_at(index)
+                docs[doc_id] = DocSchedulingRecord(
+                    id=doc_id,
+                    status=DocStatus.PENDING,
+                    created_at=created_at,
+                    updated_at=created_at,
+                    file_path=f"file-{index:09d}.txt",
+                    track_id="rss",
+                    has_custom_chunk_journal=False,
+                )
+            index += 1
+        self.page_calls += 1
+        next_position = (
+            CURSOR_END if index >= self.total else CursorAfter(str(index - 1))
+        )
+        return DocStatusPage(docs=docs, next_position=next_position)
+
+    async def get_full_docs_by_ids(
+        self, doc_ids, *, strict: bool = False
+    ) -> dict[str, DocProcessingStatus]:
+        del strict
+        doc_ids = list(doc_ids)
+        feeder_doc_id = self._doc_id(_PIPELINE_PAGE_SIZE - 1)
+        if doc_ids == [feeder_doc_id]:
+            self.feeder_hydrations += 1
+        rows = {}
+        for doc_id in doc_ids:
+            index = self._index(doc_id)
+            if not self._terminal[index]:
+                rows[doc_id] = self._status_doc(index)
+        return rows
+
+    async def get_by_id(self, doc_id: str) -> dict[str, Any] | None:
+        index = self._index(doc_id)
+        if self._terminal[index]:
+            return None
+        row = self._status_doc(index)
+        return {
+            "status": row.status,
+            "content_summary": row.content_summary,
+            "content_length": row.content_length,
+            "created_at": row.created_at,
+            "updated_at": row.updated_at,
+            "file_path": row.file_path,
+            "track_id": row.track_id,
+            "content_hash": row.content_hash,
+            "chunks_count": 0,
+            "chunks_list": [],
+            "metadata": {},
+        }
+
+    async def get_doc_by_content_hash(
+        self, content_hash: str, *, exclude_doc_id: str | None = None
+    ) -> None:
+        del content_hash, exclude_doc_id
+        return None
+
+    async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
+        for doc_id, payload in data.items():
+            status = payload.get("status")
+            status = status if isinstance(status, DocStatus) else DocStatus(status)
+            if status is DocStatus.PARSING:
+                self.parsing_writes += 1
+            elif status is DocStatus.ANALYZING:
+                self.analyzing_writes += 1
+            elif status is DocStatus.PROCESSED:
+                self.processed_writes += 1
+                index = self._index(doc_id)
+                if not self._terminal[index]:
+                    self._terminal[index] = 1
+                    self.completed += 1
+
+    async def delete(self, doc_ids) -> None:
+        for doc_id in doc_ids:
+            index = self._index(doc_id)
+            if not self._terminal[index]:
+                self._terminal[index] = 1
+                self.completed += 1
+
+
+class _StreamingFullDocs:
+    """Return one small raw body at a time and retain no document rows."""
+
+    supports_strict_point_reads = True
+
+    @staticmethod
+    def _row(doc_id: str) -> dict[str, Any]:
+        index = int(doc_id.rsplit("-", 1)[1])
+        return {
+            "content": f"bounded rss body {index}",
+            "file_path": f"file-{index:09d}.txt",
+            "parse_format": FULL_DOCS_FORMAT_RAW,
+            "content_hash": f"hash-{index:09d}",
+            "process_options": "",
+        }
+
+    async def get_by_id(self, doc_id: str) -> dict[str, Any]:
+        return self._row(doc_id)
+
+    async def get_by_id_strict(self, doc_id: str) -> dict[str, Any]:
+        return self._row(doc_id)
+
+
+async def _rss_process_single_document(
+    self,
+    *,
+    doc_id: str,
+    status_doc: DocProcessingStatus,
+    parsed_data: dict[str, Any],
+    ctx,
+) -> None:
+    """Offline KG/LLM stub behind the real production process worker."""
+
+    del parsed_data
+    async with ctx.pipeline_status_lock:
+        ctx.processed_count += 1
+    await asyncio.sleep(0)
+    await self._upsert_doc_status_transition(
+        ctx=ctx,
+        doc_id=doc_id,
+        status=DocStatus.PROCESSED,
+        status_doc=status_doc,
+        file_path=status_doc.file_path,
+        extra_fields={"chunks_count": 0, "chunks_list": []},
+    )
+
+
+async def _run_pipeline_rss(total: int, working_dir: str) -> dict[str, int]:
+    import numpy as np
+
+    from lightrag import LightRAG
+    from lightrag.kg.shared_storage import (
+        finalize_share_data,
+        get_pipeline_ingress,
+        initialize_pipeline_status,
+        initialize_share_data,
+    )
+    from lightrag.kg.pipeline_ingress import PipelineIngressMessage
+    from lightrag.utils import EmbeddingFunc, Tokenizer
+
+    class _Tokenizer:
+        def encode(self, content: str) -> list[int]:
+            return [ord(ch) for ch in content]
+
+        def decode(self, tokens: list[int]) -> str:
+            return "".join(chr(token) for token in tokens)
+
+    async def _embedding(texts: list[str]) -> np.ndarray:
+        return np.ones((len(texts), 8), dtype=float)
+
+    async def _llm(*args, **kwargs) -> str:
+        return "ok"
+
+    initialize_share_data()
+    workspace = f"rss-pipeline-{uuid4().hex}"
+    await initialize_pipeline_status(workspace=workspace)
+    rag = LightRAG(
+        working_dir=working_dir,
+        workspace=workspace,
+        llm_model_func=_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_embedding
+        ),
+        tokenizer=Tokenizer("rss-tokenizer", _Tokenizer()),
+        max_parallel_insert=2,
+        max_parallel_parse_native=2,
+        max_parallel_analyze=2,
+        queue_size_parse=_QUEUE_SIZE,
+        queue_size_analyze=_QUEUE_SIZE,
+        queue_size_insert=_QUEUE_SIZE,
+        pipeline_scheduling_page_size=_PIPELINE_PAGE_SIZE,
+    )
+    doc_status = _StreamingPipelineDocStatus(total)
+    rag.doc_status = doc_status
+    rag.full_docs = _StreamingFullDocs()
+    rag.process_single_document = MethodType(_rss_process_single_document, rag)
+    ingress = await get_pipeline_ingress(workspace)
+    ingress.put_document(
+        PipelineIngressMessage(
+            kind="document",
+            doc_id=doc_status._doc_id(_PIPELINE_PAGE_SIZE - 1),
+        )
+    )
+
+    sampler = _PeakRSS()
+    sampler.start()
+    try:
+        await rag.apipeline_process_enqueue_documents()
+    finally:
+        rss = sampler.stop()
+        finalize_share_data()
+
+    if doc_status.completed != total:
+        raise AssertionError(
+            f"pipeline completed {doc_status.completed}/{total} documents"
+        )
+    if doc_status.parsing_writes < total:
+        raise AssertionError("parse workers did not process every document")
+    if doc_status.analyzing_writes < total:
+        raise AssertionError("analyze workers did not process every document")
+    if doc_status.processed_writes != total:
+        raise AssertionError("process workers did not process every document")
+    if doc_status.feeder_hydrations < 1:
+        raise AssertionError("production feeder did not hydrate/admit its document")
+    if doc_status.page_calls < max(2, total // _PIPELINE_PAGE_SIZE):
+        raise AssertionError("production supervisor did not traverse multiple pages")
+    return {
+        **rss,
+        "completed": doc_status.completed,
+        "feeder_hydrations": doc_status.feeder_hydrations,
+        "pages": doc_status.page_calls,
+    }
+
+
+class _ScanDocStatus:
+    async def resolve_doc_source_strict(self, canonical_source_key: str):
+        del canonical_source_key
+        return SourceAbsent()
+
+    async def get_full_docs_by_ids(self, doc_ids, *, strict: bool = False):
+        del doc_ids, strict
+        return {}
+
+
+class _ScanFullDocs:
+    supports_strict_point_reads = True
+
+    async def get_by_id(self, doc_id: str):
+        del doc_id
+        return None
+
+    async def get_by_id_strict(self, doc_id: str):
+        del doc_id
+        return None
+
+
+class _ScanRag:
+    """Non-retaining storage/processing edge around the production scan."""
+
+    def __init__(self) -> None:
+        self.workspace = f"rss-scan-{uuid4().hex}"
+        self.doc_status = _ScanDocStatus()
+        self.full_docs = _ScanFullDocs()
+        self.addon_params = {}
+        self.enqueued = 0
+        self.process_calls = 0
+
+    async def apipeline_enqueue_documents(self, _input: str, **kwargs):
+        del kwargs
+        self.enqueued += 1
+        return "enqueued"
+
+    async def apipeline_enqueue_error_documents(self, *args, **kwargs) -> None:
+        raise AssertionError(f"unexpected scan enqueue error: {args!r} {kwargs!r}")
+
+    async def arollback_failed_custom_chunk_patches(self, **kwargs):
+        del kwargs
+        return {"rolled_back": [], "failed": []}
+
+    async def apipeline_reset_failed_for_scan(
+        self, request_id: str, *, scan_owner_token: str | None = None
+    ) -> bool:
+        del scan_owner_token
+        from lightrag.kg.shared_storage import get_pipeline_ingress
+
+        ingress = await get_pipeline_ingress(self.workspace)
+        ingress.ack_manual_retry(request_id)
+        return True
+
+    async def apipeline_process_enqueue_documents(self) -> None:
+        self.process_calls += 1
+
+
+def _import_document_routes():
+    original_argv = sys.argv[:]
+    sys.argv = [sys.argv[0]]
+    try:
+        return importlib.import_module("lightrag.api.routers.document_routes")
+    finally:
+        sys.argv = original_argv
+
+
+async def _run_scan_rss(total: int, input_dir: str) -> dict[str, int]:
+    from lightrag.kg.shared_storage import (
+        finalize_share_data,
+        get_scan_job_store,
+        initialize_pipeline_status,
+        initialize_share_data,
+    )
+
+    routes = _import_document_routes()
+    routes.global_args = SimpleNamespace(scan_enqueue_batch_size=_PIPELINE_PAGE_SIZE)
+
+    directory = Path(input_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    # Real directory entries, created before the baseline so the test measures
+    # discovery/classification/enqueue rather than fixture construction.
+    for index in range(total):
+        (directory / f"rss-{index:09d}-{'x' * 80}.txt").touch()
+
+    rag = _ScanRag()
+    initialize_share_data()
+    await initialize_pipeline_status(workspace=rag.workspace)
+    manager = routes.DocumentManager(str(directory))
+    router = routes.create_document_routes(rag, manager)
+    scan_endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "scan_for_new_documents"
+    ][-1]
+    managed_tasks: set[asyncio.Task] = set()
+    sampler = _PeakRSS()
+    sampler.start()
+    job = None
+    try:
+        response = await scan_endpoint(managed_tasks)
+        while managed_tasks:
+            await asyncio.gather(*list(managed_tasks))
+        job = get_scan_job_store(rag.workspace).get(response.track_id)
+    finally:
+        rss = sampler.stop()
+        finalize_share_data()
+
+    if response.status != "scanning_started":
+        raise AssertionError(f"unexpected /scan response: {response!r}")
+    if job is None or job.get("status") != "completed":
+        raise AssertionError(f"/scan job did not reach completed: {job!r}")
+    if rag.enqueued != total:
+        raise AssertionError(f"scan enqueued {rag.enqueued}/{total} files")
+    if rag.process_calls != 1:
+        raise AssertionError(
+            f"scan drove processing {rag.process_calls} times instead of once"
+        )
+    return {**rss, "enqueued": rag.enqueued}
+
+
+def _child_entry(
+    kind: str,
+    total: int,
+    working_dir: str,
+    connection,
+) -> None:
+    logging.disable(logging.CRITICAL)
+    try:
+        if kind == "pipeline":
+            result = asyncio.run(_run_pipeline_rss(total, working_dir))
+        elif kind == "scan":
+            result = asyncio.run(_run_scan_rss(total, working_dir))
+        else:  # pragma: no cover - parent controls this literal
+            raise ValueError(f"unknown RSS workload {kind!r}")
+        connection.send(("ok", result))
+    except BaseException:
+        connection.send(("error", traceback.format_exc()))
+    finally:
+        connection.close()
+
+
+def _measure_in_child(kind: str, total: int, working_dir: Path) -> dict[str, int]:
+    context = multiprocessing.get_context("spawn")
+    parent, child = context.Pipe(duplex=False)
+    process = context.Process(
+        target=_child_entry,
+        args=(kind, total, str(working_dir), child),
+        name=f"lightrag-{kind}-rss-{total}",
+    )
+    process.start()
+    child.close()
+    try:
+        if not parent.poll(180):
+            process.terminate()
+            process.join(timeout=10)
+            pytest.fail(f"{kind} RSS child timed out at backlog {total}")
+        status, payload = parent.recv()
+    finally:
+        parent.close()
+    process.join(timeout=30)
+    assert not process.is_alive(), f"{kind} RSS child did not exit"
+    assert process.exitcode == 0, (
+        f"{kind} RSS child exited {process.exitcode}: {payload}"
+    )
+    assert status == "ok", payload
+    return payload
+
+
+def _assert_rss_does_not_track_backlog(
+    label: str, small: dict[str, int], large: dict[str, int]
+) -> None:
+    limit = max(
+        3 * small["growth"],
+        small["growth"] + _RSS_FIXED_HEADROOM,
+    )
+    assert large["growth"] < limit, (
+        f"{label} RSS grew with the backlog: "
+        f"{small['growth'] / 1024 / 1024:.1f} MiB transient growth at small "
+        f"vs {large['growth'] / 1024 / 1024:.1f} MiB at 10x; "
+        f"allowed {limit / 1024 / 1024:.1f} MiB"
+    )
+
+
+def test_full_worker_feeder_pipeline_rss_does_not_track_backlog(tmp_path):
+    """The production supervisor + feeder + three worker layers stay bounded."""
+
+    small = _measure_in_child("pipeline", 1_000, tmp_path / "pipeline-small")
+    large = _measure_in_child("pipeline", 10_000, tmp_path / "pipeline-large")
+
+    assert large["completed"] == 10 * small["completed"]
+    assert large["pages"] > 10
+    _assert_rss_does_not_track_backlog("full pipeline", small, large)
+
+
+def test_real_directory_scan_rss_does_not_track_file_count(tmp_path):
+    """Production discovery/classification/enqueue over a real directory is flat."""
+
+    small = _measure_in_child("scan", 1_000, tmp_path / "scan-small")
+    large = _measure_in_child("scan", 10_000, tmp_path / "scan-large")
+
+    assert large["enqueued"] == 10 * small["enqueued"]
+    _assert_rss_does_not_track_backlog("real-directory scan", small, large)

--- a/tests/pipeline/test_strict_capability_gate.py
+++ b/tests/pipeline/test_strict_capability_gate.py
@@ -1,0 +1,124 @@
+"""``PIPELINE_REQUIRE_STRICT_STORAGE_READS`` and the startup capability warning.
+
+``/health`` already publishes which strict capabilities a doc_status backend has
+(LR2 Phase 6 item 2), but a status page only helps someone who already suspects a
+problem. Every one of these capabilities fails CLOSED when absent — admission
+answers 503, the conflict endpoints answer 501, a scan keeps re-examining a stale
+stub — and from the outside each looks like a broken database rather than a
+backend that was never able to do it. The startup log is where an operator finds
+out before the first 503; ``require=True`` is for a deployment that would rather
+not run at all.
+
+Pinned here as well: the warning names the operator-facing CONSEQUENCE, not just
+the capability key (a line saying "strict_active_count: False" tells whoever reads
+the log nothing about why uploads started failing), and a failure of the probe
+ITSELF never blocks startup — refusing to boot over a broken diagnostic would be
+worse than the degradation it was looking for.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lightrag.base import DocStatusStorage
+from lightrag.exceptions import StorageCapabilityError
+from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
+from lightrag.utils_pipeline import enforce_strict_storage_capabilities
+
+pytestmark = pytest.mark.offline
+
+
+def _minimal_backend():
+    """A third-party doc_status that implements only the abstract methods and so
+    keeps every fail-closed base default."""
+
+    class _MinimalDocStatus(DocStatusStorage):
+        supports_strict_point_reads = False
+
+        async def get_docs_by_statuses_page(self, *args, **kwargs): ...
+        async def get_docs_by_ids(self, *args, **kwargs): ...
+        async def resolve_doc_source_strict(self, *args, **kwargs): ...
+        async def get_full_docs_by_ids(self, *args, **kwargs): ...
+
+    # The probe only reads the class; clearing the ABC guard beats stubbing the
+    # data-plane methods this test never touches.
+    _MinimalDocStatus.__abstractmethods__ = frozenset()
+    return _MinimalDocStatus.__new__(_MinimalDocStatus)
+
+
+def test_a_first_party_backend_warns_about_nothing(caplog):
+    with caplog.at_level(logging.WARNING, logger="lightrag"):
+        capabilities = enforce_strict_storage_capabilities(
+            JsonDocStatusStorage.__new__(JsonDocStatusStorage)
+        )
+
+    assert all(capabilities.values())
+    assert caplog.records == []
+
+
+def test_gaps_are_warned_with_their_operator_facing_consequence(caplog):
+    # lightrag's logger does not propagate, so caplog needs it turned on.
+    logger = logging.getLogger("lightrag")
+    previous = logger.propagate
+    logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="lightrag"):
+            enforce_strict_storage_capabilities(_minimal_backend())
+    finally:
+        logger.propagate = previous
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    # Every genuinely-missable capability is named...
+    for capability in (
+        "strict_active_count",
+        "source_conflict_listing",
+        "source_conflict_repair",
+        "strict_point_reads",
+    ):
+        assert capability in message
+    # ...with what it costs, not just its key.
+    assert "503" in message and "501" in message
+    assert "PIPELINE_REQUIRE_STRICT_STORAGE_READS=true" in message
+
+
+def test_require_turns_the_gaps_into_a_startup_failure():
+    with pytest.raises(StorageCapabilityError) as excinfo:
+        enforce_strict_storage_capabilities(_minimal_backend(), require=True)
+
+    assert "PIPELINE_REQUIRE_STRICT_STORAGE_READS" in str(excinfo.value)
+    assert "strict_active_count" in str(excinfo.value)
+
+
+def test_require_does_not_fail_a_backend_that_has_everything():
+    enforce_strict_storage_capabilities(
+        JsonDocStatusStorage.__new__(JsonDocStatusStorage), require=True
+    )
+
+
+def test_a_broken_probe_never_blocks_startup(monkeypatch):
+    """Refusing to boot because the diagnostic broke would be worse than the
+    degradation the diagnostic was looking for."""
+    import lightrag.utils_pipeline as utils_pipeline
+
+    def _boom(_doc_status):
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(utils_pipeline, "describe_doc_status_capabilities", _boom)
+
+    assert utils_pipeline.enforce_strict_storage_capabilities({}, require=True) == {}
+
+
+def test_the_paging_capabilities_are_not_part_of_the_gate():
+    """They are ``@abstractmethod``: a backend without them cannot be
+    instantiated, which is stronger than an opt-in check. Including them here
+    would imply the knob can be turned off for them."""
+    from lightrag.utils_pipeline import _CAPABILITY_CONSEQUENCES
+
+    assert "scheduling_pages" not in _CAPABILITY_CONSEQUENCES
+    assert "typed_source_resolution" not in _CAPABILITY_CONSEQUENCES
+
+    for name in ("get_docs_by_statuses_page", "resolve_doc_source_strict"):
+        assert getattr(DocStatusStorage, name).__isabstractmethod__

--- a/tests/tools/test_source_conflict_repair_cli.py
+++ b/tests/tools/test_source_conflict_repair_cli.py
@@ -8,6 +8,8 @@ than from a fabricated placeholder.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from lightrag.base import SourceConflict, SourceUnique
@@ -424,4 +426,87 @@ async def test_a_contentless_primary_is_refused_offline_too(tmp_path):
             full_docs=_FullDocs({"doc-1": {"content": "x"}}),
             apply=True,
         )
+    assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceConflict)
+
+
+@pytest.mark.asyncio
+async def test_an_unverifiable_primary_refuses_instead_of_committing(tmp_path):
+    """Fix-proof: a strict read that RAISED warned and committed the demotions
+    anyway. The demotions are irreversible — a repair only demotes, and a key with
+    no candidate left cannot be repaired at all — so an unverified primary must
+    fail closed as a storage-control-plane error (503 on the endpoint) and leave
+    the conflict exactly as it was, for the operator to retry."""
+    from lightrag.exceptions import StorageControlPlaneError
+
+    class _UnreachableFullDocs:
+        supports_strict_point_reads = True
+
+        async def get_by_id_strict(self, doc_id):
+            raise ConnectionError("full_docs is down")
+
+    storage = await _storage(
+        tmp_path, {"doc-1": _row("a.pdf"), "doc-2": _row("a.pdf", "failed")}
+    )
+    with pytest.raises(StorageControlPlaneError, match="doc-2"):
+        await repair_one_conflict(
+            storage,
+            "a.pdf",
+            "doc-2",
+            workspace="unverifiable-ws",
+            full_docs=_UnreachableFullDocs(),
+            apply=True,
+        )
+    assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceConflict)
+
+
+@pytest.mark.asyncio
+async def test_the_cli_refuses_to_apply_when_full_docs_cannot_be_opened(
+    tmp_path, monkeypatch, capsys
+):
+    """The CLI's own fail-open: ``full_docs.initialize()`` failing used to print a
+    warning and run the commit with the contentless-primary check disabled — the
+    same irreversible demotion on an unverified primary, one layer up. Listing and
+    dry-runs still work, since they modify nothing."""
+    import lightrag
+    from lightrag.tools import source_conflict_repair as tool
+
+    storage = await _storage(
+        tmp_path, {"doc-1": _row("a.pdf"), "doc-2": _row("a.pdf", "failed")}
+    )
+    committed: list[bool] = []
+    real_repair = storage.repair_source_conflict
+
+    async def _recording_repair(*args, **kwargs):
+        committed.append(not kwargs.get("dry_run", True))
+        return await real_repair(*args, **kwargs)
+
+    storage.repair_source_conflict = _recording_repair
+
+    class _BrokenFullDocs:
+        async def initialize(self):
+            raise ConnectionError("full_docs socket refused")
+
+    class _FakeRAG:
+        def __init__(self, **kwargs):
+            self.workspace = kwargs.get("workspace") or "cli-refuse-ws"
+            self.doc_status = storage
+            self.full_docs = _BrokenFullDocs()
+
+    async def _keep_the_storage_open():
+        """The tool finalizes doc_status on its way out; this test still has to
+        read the conflict afterwards to prove nothing was demoted."""
+
+    monkeypatch.setattr(lightrag, "LightRAG", _FakeRAG)
+    monkeypatch.setattr(storage, "finalize", _keep_the_storage_open, raising=False)
+
+    args = SimpleNamespace(
+        command="repair",
+        workspace="cli-refuse-ws",
+        source="a.pdf",
+        primary="doc-2",
+        apply=True,
+    )
+    assert await tool._async_main(args) is False
+    assert committed == []  # nothing reached the backend, not even a dry-run
+    assert "Refused" in capsys.readouterr().out
     assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceConflict)

--- a/tests/tools/test_source_conflict_repair_cli.py
+++ b/tests/tools/test_source_conflict_repair_cli.py
@@ -38,6 +38,27 @@ def _shared():
     finalize_share_data()
 
 
+class _AnyContent:
+    """full_docs double that confirms content for every id.
+
+    A COMMIT requires one: an unverified primary is refused (the demotions are
+    irreversible), so every ``apply=True`` call below passes a full_docs handle.
+    The refusals themselves have their own tests.
+    """
+
+    supports_strict_point_reads = True
+
+    def __init__(self, contents=None):
+        self.contents = contents
+        self.reads: list[str] = []
+
+    async def get_by_id_strict(self, doc_id):
+        self.reads.append(doc_id)
+        if self.contents is None:
+            return {"content": "body"}
+        return self.contents.get(doc_id)
+
+
 def _row(file_path: str, status: str = "pending") -> dict:
     return {
         "status": status,
@@ -128,7 +149,9 @@ async def test_apply_commits_with_the_token_from_its_own_dry_run(tmp_path):
 
     storage.repair_source_conflict = _recording
 
-    result = await repair_one_conflict(storage, "a.pdf", "doc-2", apply=True)
+    result = await repair_one_conflict(
+        storage, "a.pdf", "doc-2", full_docs=_AnyContent(), apply=True
+    )
 
     assert result.committed is True
     assert [call["dry_run"] for call in seen] == [True, False]
@@ -152,7 +175,9 @@ async def test_unknown_primary_is_refused_before_any_write(tmp_path):
         tmp_path, {"doc-1": _row("a.pdf"), "doc-2": _row("a.pdf", "failed")}
     )
     with pytest.raises(ValueError, match="not a current primary candidate"):
-        await repair_one_conflict(storage, "a.pdf", "doc-typo", apply=True)
+        await repair_one_conflict(
+            storage, "a.pdf", "doc-typo", full_docs=_AnyContent(), apply=True
+        )
 
     assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceConflict)
 
@@ -202,7 +227,12 @@ async def test_commit_holds_the_enqueue_serialize_lock(tmp_path):
         # The enqueue lock is held, so a correctly-locked commit cannot start.
         commit = asyncio.create_task(
             repair_one_conflict(
-                storage, "a.pdf", "doc-2", workspace=workspace, apply=True
+                storage,
+                "a.pdf",
+                "doc-2",
+                workspace=workspace,
+                full_docs=_AnyContent(),
+                apply=True,
             )
         )
         await asyncio.sleep(0.05)
@@ -263,7 +293,12 @@ async def test_the_commit_registers_itself_as_in_flight_ingress(tmp_path):
 
     storage.repair_source_conflict = _observing
     result = await repair_one_conflict(
-        storage, "a.pdf", "doc-1", workspace=workspace, apply=True
+        storage,
+        "a.pdf",
+        "doc-1",
+        workspace=workspace,
+        full_docs=_AnyContent(),
+        apply=True,
     )
     assert result.committed is True
 
@@ -298,7 +333,12 @@ async def test_a_destructive_job_in_flight_refuses_the_commit(tmp_path):
     )
     with pytest.raises(StorageControlPlaneError, match="clear/delete"):
         await repair_one_conflict(
-            storage, "a.pdf", "doc-1", workspace=workspace, apply=True
+            storage,
+            "a.pdf",
+            "doc-1",
+            workspace=workspace,
+            full_docs=_AnyContent(),
+            apply=True,
         )
     # Nothing demoted.
     assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceConflict)
@@ -334,7 +374,12 @@ async def test_scan_classification_and_a_manual_freeze_also_refuse(tmp_path):
         )
         with pytest.raises(StorageControlPlaneError, match=expected):
             await repair_one_conflict(
-                storage, "a.pdf", "doc-1", workspace=workspace, apply=True
+                storage,
+                "a.pdf",
+                "doc-1",
+                workspace=workspace,
+                full_docs=_AnyContent(),
+                apply=True,
             )
 
 
@@ -360,7 +405,12 @@ async def test_an_offline_repair_proceeds_but_says_it_is_unguarded(tmp_path, cap
     try:
         with caplog.at_level(logging.WARNING, logger=logger.name):
             result = await repair_one_conflict(
-                storage, "a.pdf", "doc-1", workspace="never-initialised-ws", apply=True
+                storage,
+                "a.pdf",
+                "doc-1",
+                workspace="never-initialised-ws",
+                full_docs=_AnyContent(),
+                apply=True,
             )
     finally:
         logger.propagate = False
@@ -393,7 +443,12 @@ async def test_a_guarded_repair_does_not_warn(tmp_path, caplog):
     try:
         with caplog.at_level(logging.WARNING, logger=logger.name):
             await repair_one_conflict(
-                storage, "a.pdf", "doc-1", workspace=workspace, apply=True
+                storage,
+                "a.pdf",
+                "doc-1",
+                workspace=workspace,
+                full_docs=_AnyContent(),
+                apply=True,
             )
     finally:
         logger.propagate = False
@@ -509,4 +564,56 @@ async def test_the_cli_refuses_to_apply_when_full_docs_cannot_be_opened(
     assert await tool._async_main(args) is False
     assert committed == []  # nothing reached the backend, not even a dry-run
     assert "Refused" in capsys.readouterr().out
+    assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceConflict)
+
+
+@pytest.mark.asyncio
+async def test_a_commit_without_full_docs_is_refused(tmp_path):
+    """Fix-proof: omitting ``full_docs`` used to skip the contentless-primary
+    check and commit anyway, so a library caller (and the CLI when full_docs
+    could not be opened) could hand a canonical source to an unprocessable stub
+    irreversibly. A commit now requires the handle; dry-runs still do not."""
+    from lightrag.exceptions import StorageControlPlaneError
+
+    storage = await _storage(
+        tmp_path, {"doc-1": _row("a.pdf"), "doc-2": _row("a.pdf", "failed")}
+    )
+
+    # Dry-run: mutates nothing, so it needs no verification.
+    assert (await repair_one_conflict(storage, "a.pdf", "doc-2")).committed is False
+
+    with pytest.raises(StorageControlPlaneError, match="no full_docs handle"):
+        await repair_one_conflict(
+            storage, "a.pdf", "doc-2", workspace="no-full-docs-ws", apply=True
+        )
+    assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceConflict)
+
+
+@pytest.mark.asyncio
+async def test_a_primary_that_duplicates_another_source_is_refused_offline_too(
+    tmp_path,
+):
+    """The processing stage holds no source-key lock, so a primary whose content
+    already lives under a different source is refused BEFORE the irreversible
+    demotions — the same shape as the contentless-stub refusal, on the CLI path."""
+    from lightrag.exceptions import SourceConflictPrimaryUnusableError
+
+    rows = {
+        "doc-1": _row("a.pdf"),
+        "doc-2": _row("a.pdf", "failed"),
+        "doc-elsewhere": _row("other.pdf", "processed"),
+    }
+    rows["doc-2"]["content_hash"] = "hash-x"
+    rows["doc-elsewhere"]["content_hash"] = "hash-x"
+    storage = await _storage(tmp_path, rows)
+
+    with pytest.raises(SourceConflictPrimaryUnusableError, match="doc-elsewhere"):
+        await repair_one_conflict(
+            storage,
+            "a.pdf",
+            "doc-2",
+            workspace="twin-ws",
+            full_docs=_AnyContent(),
+            apply=True,
+        )
     assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceConflict)

--- a/tests/tools/test_source_conflict_repair_cli.py
+++ b/tests/tools/test_source_conflict_repair_cli.py
@@ -617,3 +617,73 @@ async def test_a_primary_that_duplicates_another_source_is_refused_offline_too(
             apply=True,
         )
     assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceConflict)
+
+
+@pytest.mark.asyncio
+async def test_a_document_already_marked_duplicate_is_refused_before_any_demotion(
+    tmp_path,
+):
+    """The other linearization the source-key lock establishes (stability test —
+    this direction was already refused; what is new is that the lock guarantees
+    the two operations cannot overlap, so this is the ONLY thing the repair can
+    see once the marking has won).
+
+    Marking wins → the primary is no longer a candidate → the commit refuses
+    before demoting anything, instead of writing irreversible demotions and then
+    reporting a 503 about storage that was fine.
+    """
+    rows = {"doc-1": _row("a.pdf"), "doc-2": _row("a.pdf", "failed")}
+    # doc-2 lost its claim the way _mark_duplicate_after_parse takes it away.
+    rows["doc-2"]["metadata"] = {
+        "is_duplicate": True,
+        "duplicate_kind": "content_hash",
+        "original_doc_id": "doc-elsewhere",
+    }
+    storage = await _storage(tmp_path, rows)
+
+    with pytest.raises(ValueError, match="not a current primary candidate"):
+        await repair_one_conflict(
+            storage,
+            "a.pdf",
+            "doc-2",
+            workspace="linearized-ws",
+            full_docs=_AnyContent(),
+            apply=True,
+        )
+    # doc-1 keeps its claim: nothing was demoted on the way to the refusal.
+    assert (await storage.get_by_id("doc-1")).get("metadata") in (None, {})
+
+
+@pytest.mark.asyncio
+async def test_the_absent_recovery_hint_matches_what_actually_happened(tmp_path):
+    """Fix-proof: the hint said "delete the leftover row and re-upload to claim the
+    source again", which does not work while the content's new holder still exists
+    — a doc id is derived from the file name, so the re-upload is deduplicated
+    against that holder and the key stays Absent. The hint now reads the row and
+    names the real condition."""
+    from lightrag.exceptions import StorageControlPlaneError
+    from lightrag.tools.source_conflict_repair import verify_repair_outcome
+
+    rows = {"doc-keep": _row("a.pdf", "failed")}
+    rows["doc-keep"]["metadata"] = {
+        "is_duplicate": True,
+        "duplicate_kind": "content_hash",
+        "original_doc_id": "doc-holder",
+    }
+    storage = await _storage(tmp_path, rows)
+    result = SimpleNamespace(demoted_sample_doc_ids=("doc-lose",))
+
+    with pytest.raises(StorageControlPlaneError) as raised:
+        await verify_repair_outcome(storage, "a.pdf", "doc-keep", result)
+
+    message = str(raised.value)
+    assert "doc-holder" in message
+    assert "NOT enough" in message  # deleting the leftover row does not suffice
+    assert "cannot be re-run" in message
+
+    # The complement: a primary that simply vanished IS recoverable by re-ingest.
+    async with storage._storage_lock:
+        del storage._data["doc-keep"]
+    with pytest.raises(StorageControlPlaneError) as gone:
+        await verify_repair_outcome(storage, "a.pdf", "doc-keep", result)
+    assert "re-ingest the file" in str(gone.value)

--- a/tests/tools/test_source_conflict_repair_cli.py
+++ b/tests/tools/test_source_conflict_repair_cli.py
@@ -337,19 +337,65 @@ async def test_scan_classification_and_a_manual_freeze_also_refuse(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_an_offline_repair_needs_no_pipeline_status(tmp_path):
-    """The CLI runs against a stopped server, where pipeline_status was never
-    initialised. There is no server-side writer to exclude, so the repair
-    proceeds — the correct answer, not a concession."""
+async def test_an_offline_repair_proceeds_but_says_it_is_unguarded(tmp_path, caplog):
+    """The CLI runs with no pipeline_status of its own, so the caller-side
+    exclusion is inert. Refusing would break the stopped-server case — the CLI's
+    whole purpose — so it proceeds, but it must SAY so.
+
+    An uninitialised pipeline_status proves only that THIS process has none; a
+    server may be running in another process whose shared state this one cannot
+    see. Inferring "no server" from a local miss is the same mistake as inferring
+    "no duplicate" from a swallowed read.
+    """
+    import logging
+
+    from lightrag.utils import logger
+
     storage = await _storage(
         tmp_path, {"doc-1": _row("a.pdf"), "doc-2": _row("a.pdf", "failed")}
     )
-    result = await repair_one_conflict(
-        storage, "a.pdf", "doc-1", workspace="never-initialised-ws", apply=True
-    )
+    logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            result = await repair_one_conflict(
+                storage, "a.pdf", "doc-1", workspace="never-initialised-ws", apply=True
+            )
+    finally:
+        logger.propagate = False
+
     assert result.committed is True
     resolved = await storage.resolve_doc_source_strict("a.pdf")
     assert isinstance(resolved, SourceUnique) and resolved.doc_id == "doc-1"
+
+    assert "without pipeline exclusion" in caplog.text
+    assert "ANOTHER process" in caplog.text  # the boundary, not just "no server"
+    assert "source_conflicts/repair" in caplog.text  # names the guarded route
+
+
+@pytest.mark.asyncio
+async def test_a_guarded_repair_does_not_warn(tmp_path, caplog):
+    """The complement: with a real pipeline_status the exclusion is live, so the
+    caveat must not fire — a warning on every in-server repair would train
+    operators to ignore it."""
+    import logging
+
+    from lightrag.kg.shared_storage import initialize_pipeline_status
+    from lightrag.utils import logger
+
+    workspace = "guarded-ws"
+    await initialize_pipeline_status(workspace=workspace)
+    storage = await _storage(
+        tmp_path, {"doc-1": _row("a.pdf"), "doc-2": _row("a.pdf", "failed")}
+    )
+    logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            await repair_one_conflict(
+                storage, "a.pdf", "doc-1", workspace=workspace, apply=True
+            )
+    finally:
+        logger.propagate = False
+    assert "without pipeline exclusion" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_source_conflict_repair_cli.py
+++ b/tests/tools/test_source_conflict_repair_cli.py
@@ -216,3 +216,166 @@ async def test_commit_holds_the_enqueue_serialize_lock(tmp_path):
     assert observed_during_repair == [[]]
     resolved = await storage.resolve_doc_source_strict("a.pdf")
     assert isinstance(resolved, SourceUnique) and resolved.doc_id == "doc-2"
+
+
+@pytest.mark.asyncio
+async def test_the_commit_registers_itself_as_in_flight_ingress(tmp_path):
+    """The repair holds a weight-0 pending-enqueue reservation for its duration.
+
+    That single fact is what excludes the writers the enqueue-serialize lock
+    cannot: ``_acquire_destructive_busy`` and the scan reservation both already
+    list ``pending_enqueues`` in their own reject_when, so a clear/delete or a
+    scan cannot start while a repair is mid-commit — no new lock and no new
+    lock-order edge. Weight 0 so the repair never consumes admission capacity.
+    """
+    from lightrag.kg.shared_storage import (
+        get_namespace_data,
+        initialize_pipeline_status,
+    )
+
+    workspace = "reservation-ws"
+    await initialize_pipeline_status(workspace=workspace)
+    pipeline_status = await get_namespace_data("pipeline_status", workspace=workspace)
+
+    storage = await _storage(
+        tmp_path, {"doc-1": _row("a.pdf"), "doc-2": _row("a.pdf", "failed")}
+    )
+    seen: list[dict] = []
+    original = storage.repair_source_conflict
+
+    async def _observing(key, **kwargs):
+        # Sampled inside the backend call: the span a concurrent delete would
+        # otherwise be free to interleave with.
+        seen.append(
+            {
+                "pending": pipeline_status.get("pending_enqueues", 0),
+                "weights": [
+                    meta.get("weight")
+                    for meta in dict(
+                        pipeline_status.get("pending_enqueue_tokens", {})
+                    ).values()
+                ],
+            }
+        )
+        return await original(key, **kwargs)
+
+    storage.repair_source_conflict = _observing
+    result = await repair_one_conflict(
+        storage, "a.pdf", "doc-1", workspace=workspace, apply=True
+    )
+    assert result.committed is True
+
+    assert seen and all(sample["pending"] == 1 for sample in seen), seen
+    assert all(sample["weights"] == [0] for sample in seen), seen
+    # Released afterwards, so it cannot wedge later uploads / scans / deletes.
+    assert pipeline_status.get("pending_enqueues", 0) == 0
+    assert dict(pipeline_status.get("pending_enqueue_tokens", {})) == {}
+
+
+@pytest.mark.asyncio
+async def test_a_destructive_job_in_flight_refuses_the_commit(tmp_path):
+    """The other direction of the same fence: a clear/delete already running can
+    DELETE the primary the operator is about to keep, so the repair refuses
+    rather than committing demotions around it."""
+    from lightrag.exceptions import StorageControlPlaneError
+    from lightrag.kg.shared_storage import (
+        get_namespace_data,
+        get_namespace_lock,
+        initialize_pipeline_status,
+    )
+
+    workspace = "destructive-ws"
+    await initialize_pipeline_status(workspace=workspace)
+    pipeline_status = await get_namespace_data("pipeline_status", workspace=workspace)
+    lock = get_namespace_lock("pipeline_status", workspace=workspace)
+    async with lock:
+        pipeline_status["destructive_busy"] = True
+
+    storage = await _storage(
+        tmp_path, {"doc-1": _row("a.pdf"), "doc-2": _row("a.pdf", "failed")}
+    )
+    with pytest.raises(StorageControlPlaneError, match="clear/delete"):
+        await repair_one_conflict(
+            storage, "a.pdf", "doc-1", workspace=workspace, apply=True
+        )
+    # Nothing demoted.
+    assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceConflict)
+
+
+@pytest.mark.asyncio
+async def test_scan_classification_and_a_manual_freeze_also_refuse(tmp_path):
+    """``scanning_exclusive`` deletes stale FAILED stubs and the manual exclusive
+    reset rewrites ``file_path`` (so a placeholder row can ENTER this candidate
+    set without passing the enqueue critical section). Both are refused for the
+    repair's duration."""
+    from lightrag.exceptions import StorageControlPlaneError
+    from lightrag.kg.shared_storage import (
+        get_namespace_data,
+        get_namespace_lock,
+        initialize_pipeline_status,
+    )
+
+    for flag, expected in (
+        ("scanning_exclusive", "scan is classifying"),
+        ("manual_freeze_requested", "manual retry"),
+    ):
+        workspace = f"fence-{flag}"
+        await initialize_pipeline_status(workspace=workspace)
+        pipeline_status = await get_namespace_data(
+            "pipeline_status", workspace=workspace
+        )
+        async with get_namespace_lock("pipeline_status", workspace=workspace):
+            pipeline_status[flag] = True
+
+        storage = await _storage(
+            tmp_path / flag, {"doc-1": _row("a.pdf"), "doc-2": _row("a.pdf", "failed")}
+        )
+        with pytest.raises(StorageControlPlaneError, match=expected):
+            await repair_one_conflict(
+                storage, "a.pdf", "doc-1", workspace=workspace, apply=True
+            )
+
+
+@pytest.mark.asyncio
+async def test_an_offline_repair_needs_no_pipeline_status(tmp_path):
+    """The CLI runs against a stopped server, where pipeline_status was never
+    initialised. There is no server-side writer to exclude, so the repair
+    proceeds — the correct answer, not a concession."""
+    storage = await _storage(
+        tmp_path, {"doc-1": _row("a.pdf"), "doc-2": _row("a.pdf", "failed")}
+    )
+    result = await repair_one_conflict(
+        storage, "a.pdf", "doc-1", workspace="never-initialised-ws", apply=True
+    )
+    assert result.committed is True
+    resolved = await storage.resolve_doc_source_strict("a.pdf")
+    assert isinstance(resolved, SourceUnique) and resolved.doc_id == "doc-1"
+
+
+@pytest.mark.asyncio
+async def test_a_contentless_primary_is_refused_offline_too(tmp_path):
+    """Same refusal on the CLI path, when it is given full_docs to check with."""
+    from lightrag.exceptions import SourceConflictPrimaryUnusableError
+
+    class _FullDocs:
+        supports_strict_point_reads = True
+
+        def __init__(self, contents):
+            self.contents = contents
+
+        async def get_by_id_strict(self, doc_id):
+            return self.contents.get(doc_id)
+
+    storage = await _storage(
+        tmp_path, {"doc-1": _row("a.pdf"), "doc-2": _row("a.pdf", "failed")}
+    )
+    with pytest.raises(SourceConflictPrimaryUnusableError, match="doc-2"):
+        await repair_one_conflict(
+            storage,
+            "a.pdf",
+            "doc-2",
+            workspace="content-ws",
+            full_docs=_FullDocs({"doc-1": {"content": "x"}}),
+            apply=True,
+        )
+    assert isinstance(await storage.resolve_doc_source_strict("a.pdf"), SourceConflict)


### PR DESCRIPTION
The verification the design asks for (§13.1, §18) — and the two defects writing it exposed. This is the PR to read if you want to know whether the rest of the stack actually delivers what it claims.

## PostgreSQL was scanning the table on every page

Measured on live PostgreSQL at 60k rows, before this PR:

| query | plan | rows scanned | time |
|---|---|---:|---:|
| 1 status | Bitmap Index Scan + top-N sort | 7583 | 4.6 ms |
| 2 statuses | **Seq Scan of the whole table** + sort | 15003 | 14.8 ms |

Two statuses is the AUTO sweep's own shape, so **every page of every sweep scanned the table**. Page *memory* was bounded (a top-N heapsort keeps only `limit` rows), so the RSS claim held — but the I/O was O(table) per page, making a full sweep O(n²/page_size). The docstring asserted the opposite ("the planner combines per-status index ranges under the LIMIT"), which is why nobody looked.

Two independent causes, both required:

1. **The index could not satisfy the `ORDER BY` at all.** PostgreSQL's default for `ASC` is NULLS **LAST**, so `(workspace, status, created_at, id)` does not provide `ORDER BY created_at ASC NULLS FIRST, id ASC`. Now declared `created_at NULLS FIRST`, under a new name with the old one dropped — `CREATE INDEX IF NOT EXISTS` on the same name would have kept the wrong definition forever.
2. **`status = ANY($2)` cannot produce ordered output.** Rewritten as one parenthesised branch per status, `UNION ALL`'d, each with the same keyset predicate / `ORDER BY` / `LIMIT`, the wrapper re-sorting and re-limiting — the shape that lets the planner MergeAppend ordered index scans.

| after | plan | rows scanned | time |
|---|---|---:|---:|
| 1 status | Index Scan | 500 | 0.23 ms |
| 2 statuses | Index Scan | 501 | 0.29 ms |

The consumed-frontier rules survive: an unreturned row is either outside the top-`limit` window (above the frontier) or beyond a branch that hit its own `LIMIT`, and that branch's last fetched row is itself ≥ the frontier — otherwise all of its rows would have fitted. `returned < limit` still proves exhaustion, because the union is short only when every branch was short.

## A leaked test pool broke every later PostgreSQL test

`test_postgres_client_manager.py` reset the process-wide pool **before** each test but never after, leaving its `MagicMock` pool with a pinned vector signature in place. The next real PostgreSQL storage in the session was then refused for "incompatible vector settings".

## What is now verified

**One shared contract suite for all five backends** (§13.1) — 29 cases × 5. Five independently written per-backend files were the previous state, and that is the problem: the assertion sets drift, so a backend stays green in its own file while violating an invariant only some other file happens to check. Covers sort order and the id tiebreaker, `limit=1` paging losing and repeating nothing, multi-status merge, `CURSOR_END` as the only termination signal, `created_at` immutability, strict batch reads, the projection staying small, strict point reads, count/page agreement after a transition, typed source resolution, derived-index consistency across delete / source move / re-upsert, conflict listing, CAS repair, and the sweep under concurrent writes. Marked **per parameter**, so JSON runs in the default offline suite and the other four are `integration`.

**Plan assertions** that `EXPLAIN` the SQL the real method builds — captured, not restated, so a future rewrite is explained as-changed — plus MongoDB profile and OpenSearch `search_after` checks.

**A measured memory bound** (§18 item 6) via `tracemalloc`, asserted as a **ratio** between backlog sizes rather than a byte budget: an absolute threshold would encode this machine's interpreter and this fixture's row width. Three cases, because the obvious one is insufficient alone — 10× backlog stays flat; a larger page size *does* raise the peak (otherwise a sweep keeping nothing would pass while proving nothing); and a fix-proof case showing a backlog-sized accumulator **fails** the ratio, because a memory test that cannot fail is decoration.

**`PIPELINE_REQUIRE_STRICT_STORAGE_READS`** turns a missing strict capability into a startup failure. Default `false` logs each gap with its operator-facing consequence — "strict_active_count: False" tells nobody why uploads started 503-ing. The probe's own failure never blocks startup, even under `require=true`: refusing to boot over a broken diagnostic is worse than the degradation it was looking for. No equivalent knob for bounded paging, deliberately — those methods are `@abstractmethod`, so a backend lacking them cannot be constructed, and a knob would imply it can be turned off.

## Also corrected: two claims that were false

The base contract promised a missing `created_at` "sorts FIRST … stays reachable" — it can never be *returned*, because `DocSchedulingRecord` requires the field, so all five backends raise under strict and consume-and-skip under relaxed. And Redis's `_zset_member` docstring claimed such a member sorts first, when `'|'` (0x7C) puts it **last**. The encoding is left alone on purpose: the ZSET is rebuilt only when absent, so changing it would leave a live index holding both formats with a rewrite unable to `ZREM` the stale member — listing the row twice.

## Results

`4666 passed, 155 skipped` offline. `4556 passed` with live Redis / PostgreSQL / MongoDB / OpenSearch (the 10 remaining failures are `requires_api`, needing a running server). WebUI `tsc --noEmit`, 88 `bun test` and `bun run build` clean.

---

**Stack** (merge bottom-up; each PR is green on its own and targets the one below):
`main` ← **#3482** P0 test rig ← **#3483** P1 storage pages ← **#3484** P2 bounded sweep ← **#3485** P2.5 dedup ← **#3486** P3 manual retry ← **#3481** P4 `/scan` ← **#3487** P5 admission ← **#3488** P6 observability ← **#3489** P7 verification

Design: LR2 *pipeline memory bounding*. When merging, retarget the child PR **before** deleting a merged branch — GitHub closes the child otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
