### PR TITLE
fix(api): require string content on query conversation_history messages

### DIFF
--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -141,6 +141,10 @@ class QueryRequest(BaseModel):
                 raise ValueError("Each message must have a 'role' key.")
             if not isinstance(msg["role"], str) or not msg["role"].strip():
                 raise ValueError("Each message 'role' must be a non-empty string.")
+            if "content" not in msg:
+                raise ValueError("Each message must have a 'content' key.")
+            if not isinstance(msg["content"], str):
+                raise ValueError("Each message 'content' must be a string.")
         return conversation_history
 
     def to_query_params(self, is_stream: bool) -> "QueryParam":

--- a/tests/api/routes/test_query_history_content_type.py
+++ b/tests/api/routes/test_query_history_content_type.py
@@ -1,0 +1,40 @@
+"""QueryRequest conversation_history content must be a string."""
+
+import importlib
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_qr = importlib.import_module("lightrag.api.routers.query_routes")
+sys.argv = _original_argv
+
+QueryRequest = _qr.QueryRequest
+
+pytestmark = pytest.mark.offline
+
+
+def test_conversation_history_rejects_non_string_content():
+    with pytest.raises(ValidationError):
+        QueryRequest(
+            query="hello world",
+            conversation_history=[{"role": "user", "content": 123}],
+        )
+
+
+def test_conversation_history_rejects_missing_content():
+    with pytest.raises(ValidationError):
+        QueryRequest(
+            query="hello world",
+            conversation_history=[{"role": "user"}],
+        )
+
+
+def test_conversation_history_accepts_string_content():
+    req = QueryRequest(
+        query="hello world",
+        conversation_history=[{"role": "user", "content": "hi"}],
+    )
+    assert req.conversation_history == [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
conversation_history entries with non-string or missing content passed QueryRequest validation and then crashed in LLM text sanitization (int has no strip).

Require string content at request validation, with a test.