### PR TITLE
fix(utils): fall back when float env values are non-finite

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -306,9 +306,21 @@ def get_env_value(
             return default
 
     try:
-        return value_type(value)
+        converted = value_type(value)
     except (ValueError, TypeError):
         return default
+
+    # Reject non-finite floats so env-backed thresholds cannot become NaN/Inf.
+    if value_type is float and isinstance(converted, float) and not math.isfinite(
+        converted
+    ):
+        logger.warning(
+            "Environment variable %s=%r is not a finite float, using default",
+            env_key,
+            value,
+        )
+        return default
+    return converted
 
 
 # Use TYPE_CHECKING to avoid circular imports

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -311,8 +311,10 @@ def get_env_value(
         return default
 
     # Reject non-finite floats so env-backed thresholds cannot become NaN/Inf.
-    if value_type is float and isinstance(converted, float) and not math.isfinite(
-        converted
+    if (
+        value_type is float
+        and isinstance(converted, float)
+        and not math.isfinite(converted)
     ):
         logger.warning(
             "Environment variable %s=%r is not a finite float, using default",

--- a/tests/test_get_env_value_nonfinite.py
+++ b/tests/test_get_env_value_nonfinite.py
@@ -1,0 +1,27 @@
+"""get_env_value must reject non-finite float env values."""
+
+import math
+import os
+
+import pytest
+
+from lightrag.utils import get_env_value
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.mark.parametrize("raw", ["nan", "NaN", "inf", "-inf", "+inf"])
+def test_get_env_value_rejects_nonfinite_float(raw, monkeypatch):
+    monkeypatch.setenv("LIGHTRAG_TEST_FLOAT_ENV", raw)
+    assert get_env_value("LIGHTRAG_TEST_FLOAT_ENV", 1.5, float) == 1.5
+
+
+def test_get_env_value_keeps_finite_float(monkeypatch):
+    monkeypatch.setenv("LIGHTRAG_TEST_FLOAT_ENV", "0.42")
+    assert get_env_value("LIGHTRAG_TEST_FLOAT_ENV", 1.5, float) == pytest.approx(0.42)
+
+
+def test_get_env_value_missing_uses_default(monkeypatch):
+    monkeypatch.delenv("LIGHTRAG_TEST_FLOAT_ENV", raising=False)
+    assert get_env_value("LIGHTRAG_TEST_FLOAT_ENV", 1.5, float) == 1.5
+    assert math.isfinite(get_env_value("LIGHTRAG_TEST_FLOAT_ENV", 1.5, float))

--- a/tests/test_get_env_value_nonfinite.py
+++ b/tests/test_get_env_value_nonfinite.py
@@ -1,7 +1,6 @@
 """get_env_value must reject non-finite float env values."""
 
 import math
-import os
 
 import pytest
 


### PR DESCRIPTION
get_env_value accepted nan/inf for float envs such as COSINE_THRESHOLD, so threshold comparisons broke.

Fall back to the default when the parsed float is non-finite, with a test.