### PR TITLE
fix(utils): return no chunks for non-positive weighted polling max

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4400,6 +4400,8 @@ def pick_by_weighted_polling(
     """
     if not entities_or_relations:
         return []
+    if max_related_chunks <= 0:
+        return []
 
     n = len(entities_or_relations)
     if n == 1:

--- a/tests/test_weighted_polling_nonpositive_max.py
+++ b/tests/test_weighted_polling_nonpositive_max.py
@@ -1,0 +1,23 @@
+"""pick_by_weighted_polling must not reverse-slice on negative max."""
+
+import pytest
+
+from lightrag.utils import pick_by_weighted_polling
+
+pytestmark = pytest.mark.offline
+
+
+def test_negative_max_does_not_reverse_slice():
+    # On buggy code, chunks[:-1] returns all-but-last instead of [].
+    chunks = [{"sorted_chunks": ["c1", "c2", "c3"]}]
+    assert pick_by_weighted_polling(chunks, -1) == []
+
+
+def test_zero_max_returns_empty():
+    chunks = [{"sorted_chunks": ["c1", "c2", "c3"]}]
+    assert pick_by_weighted_polling(chunks, 0) == []
+
+
+def test_positive_max_still_truncates():
+    chunks = [{"sorted_chunks": ["c1", "c2", "c3"]}]
+    assert pick_by_weighted_polling(chunks, 2) == ["c1", "c2"]


### PR DESCRIPTION
RELATED_CHUNK_NUMBER=-1 reached pick_by_weighted_polling and used Python reverse slicing, so trailing chunks were returned instead of an empty selection.

Return no chunks when max_related_chunks is non-positive, with a test.