### PR TITLE
🐛 fix(api): stop serving when the gunicorn master is gone

### DIFF
--- a/lightrag/api/gunicorn_config.py
+++ b/lightrag/api/gunicorn_config.py
@@ -31,8 +31,9 @@ keyfile = None
 # Enable preload_app option
 preload_app = True
 
-# Use Uvicorn worker
-worker_class = "uvicorn.workers.UvicornWorker"
+# Use Uvicorn worker, subclassed so a worker whose master died stops serving
+# instead of holding the listening socket forever (see gunicorn_worker.py).
+worker_class = "lightrag.api.gunicorn_worker.LightRAGUvicornWorker"
 
 # Other Gunicorn configurations
 

--- a/lightrag/api/gunicorn_worker.py
+++ b/lightrag/api/gunicorn_worker.py
@@ -1,0 +1,58 @@
+"""Gunicorn worker class: uvicorn plus the orphan check uvicorn drops.
+
+gunicorn's own workers exit when their parent changes — ``sync.py`` checks
+``self.ppid != os.getppid()`` on every loop turn. ``UvicornWorker`` replaces
+``run()`` with an asyncio server and never makes that check, so a master that
+dies without signalling its children (``kill -9 <master_pid>``, which reaches
+one process only; POSIX does not cascade to children) leaves the workers
+serving forever:
+
+* nothing restarts a worker that then crashes, and ``--reload`` / SIGHUP have
+  no master to drive them;
+* the workers keep the inherited listening socket open, so the port stays bound
+  and a replacement master cannot start (gunicorn sets ``SO_REUSEADDR``, and
+  ``reuse_port`` is off by default) — the operator sees ``EADDRINUSE`` from a
+  server they believe is dead.
+
+Detection rides uvicorn's own notify tick (``callback_notify``, driven roughly
+every ``timeout / 2`` seconds — the value gunicorn's arbiter hands each worker),
+so this adds no timer of its own. Shutdown goes through SIGTERM rather than
+poking the server object: ``callback_notify`` has no handle on the ``Server``
+instance (``UvicornWorker._serve`` keeps it local), and uvicorn installs its own
+SIGTERM handler for the whole of ``serve()`` (``capture_signals`` →
+``handle_exit`` → ``should_exit``), which is the documented graceful path — it
+stops accepting, drains in-flight requests, then exits.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+
+from uvicorn.workers import UvicornWorker
+
+
+class LightRAGUvicornWorker(UvicornWorker):
+    """Uvicorn worker that stops serving once its gunicorn master is gone."""
+
+    async def callback_notify(self) -> None:
+        await super().callback_notify()
+        self.exit_if_orphaned()
+
+    def exit_if_orphaned(self) -> bool:
+        """Request a graceful shutdown when the master is gone. Returns whether
+        this worker was orphaned (kept small and separate so the condition is
+        testable without a live arbiter)."""
+        if self.ppid == os.getppid():
+            return False
+        # Logs the pids directly rather than ``%s`` on self: gunicorn's
+        # ``Worker.__str__`` reads ``self.pid``, and a shutdown path is the worst
+        # place to depend on another attribute being populated.
+        self.log.info(
+            "Parent changed (master was %s, now %s), shutting down worker %s",
+            self.ppid,
+            os.getppid(),
+            os.getpid(),
+        )
+        os.kill(os.getpid(), signal.SIGTERM)
+        return True

--- a/lightrag/api/gunicorn_worker.py
+++ b/lightrag/api/gunicorn_worker.py
@@ -22,18 +22,29 @@ instance (``UvicornWorker._serve`` keeps it local), and uvicorn installs its own
 SIGTERM handler for the whole of ``serve()`` (``capture_signals`` →
 ``handle_exit`` → ``should_exit``), which is the documented graceful path — it
 stops accepting, drains in-flight requests, then exits.
+
+``UvicornWorker`` does not forward gunicorn's ``graceful_timeout`` to
+uvicorn, whose graceful-shutdown timeout otherwise defaults to unlimited.
+Forwarding it here bounds the drain of active ASGI requests after SIGTERM.
+LightRAG's application-managed background work keeps using the lifespan
+cancellation-and-join cleanup path.
 """
 
 from __future__ import annotations
 
 import os
 import signal
+from typing import Any
 
 from uvicorn.workers import UvicornWorker
 
 
 class LightRAGUvicornWorker(UvicornWorker):
     """Uvicorn worker that stops serving once its gunicorn master is gone."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.config.timeout_graceful_shutdown = self.cfg.graceful_timeout
 
     async def callback_notify(self) -> None:
         await super().callback_notify()

--- a/tests/api/test_gunicorn_worker_orphan_exit.py
+++ b/tests/api/test_gunicorn_worker_orphan_exit.py
@@ -1,0 +1,99 @@
+"""A worker whose gunicorn master died must stop serving.
+
+gunicorn's sync worker exits when ``self.ppid != os.getppid()``; UvicornWorker
+replaces ``run()`` with an asyncio server and never checks, so ``kill -9`` on the
+master (which reaches one process only — POSIX does not cascade) left workers
+serving forever, holding the inherited listening socket so the port stayed bound
+and a replacement master could not start.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+
+import pytest
+
+from lightrag.api.gunicorn_worker import LightRAGUvicornWorker
+
+pytestmark = pytest.mark.offline
+
+
+class _Log:
+    def __init__(self):
+        self.messages: list[str] = []
+
+    def info(self, message, *args):
+        self.messages.append(message % args if args else message)
+
+
+def _worker(ppid: int) -> LightRAGUvicornWorker:
+    """A worker with only the attributes the check touches.
+
+    ``__new__`` on purpose: ``UvicornWorker.__init__`` builds a uvicorn ``Config``
+    from a live gunicorn ``cfg``, which is a whole arbiter's worth of setup for a
+    branch that reads two integers.
+    """
+    worker = LightRAGUvicornWorker.__new__(LightRAGUvicornWorker)
+    worker.ppid = ppid
+    worker.log = _Log()
+    return worker
+
+
+def test_an_orphaned_worker_requests_a_graceful_shutdown(monkeypatch):
+    """Fix-proof: nothing used to notice, and the worker kept serving."""
+    signals: list[tuple[int, int]] = []
+    monkeypatch.setattr(os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+    worker = _worker(ppid=os.getppid() + 1000)  # a master this process never had
+    assert worker.exit_if_orphaned() is True
+
+    # SIGTERM to ourselves: uvicorn installs its own handler for the whole of
+    # serve(), which stops accepting and drains in-flight requests. SIGKILL would
+    # drop them, and touching Server.should_exit is not reachable from here.
+    assert signals == [(os.getpid(), signal.SIGTERM)]
+    assert any("Parent changed" in message for message in worker.log.messages)
+
+
+def test_a_live_master_is_left_alone(monkeypatch):
+    """The check must be silent on every ordinary tick — it runs for the life of
+    the process, so a false positive would kill a healthy worker."""
+    signals: list[tuple[int, int]] = []
+    monkeypatch.setattr(os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+    worker = _worker(ppid=os.getppid())
+    assert worker.exit_if_orphaned() is False
+    assert signals == []
+    assert worker.log.messages == []
+
+
+@pytest.mark.asyncio
+async def test_the_check_rides_the_notify_tick_and_still_notifies(monkeypatch):
+    """It must hang off uvicorn's existing notify callback (no timer of its own)
+    AND keep doing what that callback was for — gunicorn murders a worker that
+    stops notifying."""
+    notified: list[bool] = []
+    monkeypatch.setattr(
+        LightRAGUvicornWorker, "notify", lambda self: notified.append(True)
+    )
+    signals: list[tuple[int, int]] = []
+    monkeypatch.setattr(os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+    worker = _worker(ppid=os.getppid() + 1000)
+    await worker.callback_notify()
+
+    assert notified == [True]
+    assert signals == [(os.getpid(), signal.SIGTERM)]
+
+
+def test_the_configured_worker_class_resolves(monkeypatch):
+    """The class is wired in by dotted path, so a rename would only surface at
+    deploy time — gunicorn resolves it here instead."""
+    from gunicorn.util import load_class
+
+    monkeypatch.setattr("sys.argv", ["pytest"])
+    from lightrag.api import gunicorn_config
+
+    assert load_class(gunicorn_config.worker_class) is LightRAGUvicornWorker, (
+        gunicorn_config.worker_class
+    )

--- a/tests/api/test_gunicorn_worker_orphan_exit.py
+++ b/tests/api/test_gunicorn_worker_orphan_exit.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import os
 import signal
+from types import SimpleNamespace
 
 import pytest
+from uvicorn.workers import UvicornWorker
 
 from lightrag.api.gunicorn_worker import LightRAGUvicornWorker
 
@@ -38,6 +40,21 @@ def _worker(ppid: int) -> LightRAGUvicornWorker:
     worker.ppid = ppid
     worker.log = _Log()
     return worker
+
+
+def test_gunicorn_graceful_timeout_is_forwarded_to_uvicorn(monkeypatch):
+    """Without this mapping uvicorn waits forever for active ASGI requests after
+    the orphan-triggered SIGTERM because its shutdown timeout defaults to None."""
+
+    def fake_init(worker, *args, **kwargs):
+        worker.cfg = SimpleNamespace(graceful_timeout=47)
+        worker.config = SimpleNamespace(timeout_graceful_shutdown=None)
+
+    monkeypatch.setattr(UvicornWorker, "__init__", fake_init)
+
+    worker = LightRAGUvicornWorker()
+
+    assert worker.config.timeout_graceful_shutdown == 47
 
 
 def test_an_orphaned_worker_requests_a_graceful_shutdown(monkeypatch):

--- a/tests/api/test_path_prefixes.py
+++ b/tests/api/test_path_prefixes.py
@@ -642,14 +642,27 @@ class TestUvicornRootPathSemantics:
             "app-level root_path only — see TestUvicornRootPathSemantics docstring."
         )
 
-    def test_gunicorn_uses_upstream_uvicorn_worker(self):
+    def test_gunicorn_worker_does_not_inject_root_path(self):
         """Symmetric guard for the multi-worker launcher.
 
-        gunicorn_config.worker_class must remain the upstream
-        ``uvicorn.workers.UvicornWorker`` — a custom subclass injecting
-        root_path via CONFIG_KWARGS would re-introduce the same
-        path-doubling regression in worker processes.
+        The regression this protects against is a worker class that injects
+        ``root_path`` through ``CONFIG_KWARGS``, re-creating the path-doubling
+        in worker processes. Asserted as that invariant rather than as an exact
+        class name: the configured class IS a subclass now
+        (``LightRAGUvicornWorker`` adds the orphan check gunicorn's own workers
+        have and uvicorn's drops), and pinning the name would have blocked it
+        while proving nothing extra — a subclass could add root_path under any
+        name.
         """
-        from lightrag.api import gunicorn_config
+        from uvicorn.workers import UvicornWorker
 
-        assert gunicorn_config.worker_class == "uvicorn.workers.UvicornWorker"
+        from lightrag.api import gunicorn_config
+        from gunicorn.util import load_class
+
+        worker_class = load_class(gunicorn_config.worker_class)
+        assert issubclass(worker_class, UvicornWorker), worker_class
+        # Covers the subclass's own kwargs and everything it inherits.
+        assert "root_path" not in worker_class.CONFIG_KWARGS, (
+            "the gunicorn worker must not inject root_path; rely on FastAPI's "
+            "app-level root_path only — see TestUvicornRootPathSemantics docstring."
+        )


### PR DESCRIPTION
## Problem

gunicorn's own workers exit when their parent changes — `gunicorn/workers/sync.py` checks `self.ppid != os.getppid()` on every loop turn. `UvicornWorker` replaces `run()` with an asyncio server and never makes that check.

So a master killed without signalling its children — `kill -9 <master_pid>` reaches **one** process; POSIX does not cascade to children — leaves the workers serving forever:

- nothing restarts a worker that then crashes, and SIGHUP / reload have no master to drive them;
- the workers keep the **inherited listening socket** open, so the port stays bound and a replacement master cannot start. gunicorn sets `SO_REUSEADDR` and leaves `reuse_port` off by default, so the operator gets `EADDRINUSE` from a server they believe is dead.

(Container and systemd deployments are unaffected: PID 1 exiting tears down the cgroup. This is the bare-process / manual-kill case.)

## Fix

`LightRAGUvicornWorker` adds the check back on uvicorn's **existing** notify tick — `callback_notify`, driven roughly every `timeout / 2` seconds, the value the arbiter hands each worker — so it introduces no timer of its own.

Shutdown goes through `SIGTERM` rather than poking the server object:

- `callback_notify` has no handle on the `Server` instance (`UvicornWorker._serve` keeps it local);
- uvicorn installs its own SIGTERM handler for the whole of `serve()` (`capture_signals` → `handle_exit` → `should_exit`), which is the documented graceful path: stop accepting, drain in-flight requests, exit;
- `SIGKILL` would drop live requests.

## Test-guard change

`test_gunicorn_uses_upstream_uvicorn_worker` pinned `worker_class` to the exact string `"uvicorn.workers.UvicornWorker"`. Its docstring says the regression it guards is a worker class that injects `root_path` through `CONFIG_KWARGS`, so it now asserts **that** — the configured class resolves, is a subclass of upstream `UvicornWorker`, and carries no `root_path` in `CONFIG_KWARGS` (inherited entries included). An exact-name check never proved that anyway: a subclass could add `root_path` under any name.

## Verification

- 4 new tests, including a fix-proof: neutering the parent comparison (method and signature kept) fails the orphan tests.
- `tests/api/` 343 passed, 14 skipped.
- Full offline suite: 3350 passed, 2 skipped.

Independent of the LR2 bounded-scheduling stack (#3483–#3489) — separate branch off `main` on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)