### PR TITLE
fix(operate): distinguish naive-mode vector search failures from genuine no-context

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -4496,6 +4496,7 @@ async def _get_vector_context(
     chunks_vdb: BaseVectorStorage,
     query_param: QueryParam,
     query_embedding: list[float] = None,
+    suppress_errors: bool = True,
 ) -> list[dict]:
     """
     Retrieve text chunks from the vector database without reranking or truncation.
@@ -4508,6 +4509,10 @@ async def _get_vector_context(
         chunks_vdb: Vector database containing document chunks
         query_param: Query parameters including chunk_top_k and ids
         query_embedding: Optional pre-computed query embedding to avoid redundant embedding calls
+        suppress_errors: If True (default), a backend failure is logged and treated
+            like a zero-match result. Callers that need to tell a genuine empty
+            result apart from an infra failure should pass False and handle the
+            exception themselves.
 
     Returns:
         List of text chunks with metadata
@@ -4545,6 +4550,8 @@ async def _get_vector_context(
 
     except Exception as e:
         logger.error(f"Error in _get_vector_context: {e}")
+        if not suppress_errors:
+            raise
         return []
 
 
@@ -6036,7 +6043,9 @@ async def naive_query(
 
     if progress_callback:
         await progress_callback(QueryProgress.RETRIEVING_CHUNKS)
-    chunks = await _get_vector_context(query, chunks_vdb, query_param, None)
+    chunks = await _get_vector_context(
+        query, chunks_vdb, query_param, None, suppress_errors=False
+    )
 
     if chunks is None or len(chunks) == 0:
         logger.info(

--- a/tests/llm/test_naive_query_vector_search_failure.py
+++ b/tests/llm/test_naive_query_vector_search_failure.py
@@ -1,0 +1,72 @@
+import pytest
+
+from lightrag.base import QueryParam
+from lightrag.operate import _get_vector_context, naive_query
+
+
+class _FakeTokenizer:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(token) for token in tokens)
+
+
+class _RaisingChunksVDB:
+    cosine_better_than_threshold = 0.0
+
+    async def query(self, *_args, **_kwargs):
+        raise TimeoutError("embedding worker timed out")
+
+
+def _query_global_config() -> dict:
+    async def query_model(*_args, **_kwargs):
+        return "unused"
+
+    return {
+        "tokenizer": _FakeTokenizer(),
+        "role_llm_funcs": {"query": query_model},
+        "min_rerank_score": 0.0,
+        "max_total_tokens": 4096,
+    }
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_get_vector_context_suppresses_by_default():
+    """Legacy callers (e.g. mix mode) keep the existing graceful-degradation behavior."""
+    param = QueryParam(mode="naive", enable_rerank=False)
+    chunks = await _get_vector_context("q", _RaisingChunksVDB(), param, None)
+    assert chunks == []
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_get_vector_context_raises_when_not_suppressed():
+    param = QueryParam(mode="naive", enable_rerank=False)
+    with pytest.raises(TimeoutError):
+        await _get_vector_context(
+            "q", _RaisingChunksVDB(), param, None, suppress_errors=False
+        )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_naive_query_propagates_vector_search_failure():
+    """A vector-search backend failure must not be reported as 'no relevant chunks'.
+
+    Before the fix, _get_vector_context swallowed every exception into an empty
+    list, so naive_query returned None exactly as it would for a genuine
+    zero-match query -- the caller (and eventually the /query API) could not
+    tell an embedding-worker timeout apart from "nothing matched".
+    """
+    param = QueryParam(mode="naive", enable_rerank=False)
+
+    with pytest.raises(TimeoutError):
+        await naive_query(
+            "same query",
+            _RaisingChunksVDB(),
+            param,
+            _query_global_config(),
+            hashing_kv=None,
+        )


### PR DESCRIPTION
`_get_vector_context` wraps `chunks_vdb.query()` in a bare `except Exception` and returns `[]` on any failure, the same shape it returns for a genuine zero-match search. `naive_query` then treats an empty list as "no relevant document chunks", so an embedding-worker timeout during retrieval reads identically to the vector store honestly finding nothing, and the caller gets back the generic no-context response with no way to tell the two apart.

Add a `suppress_errors` parameter to `_get_vector_context`, defaulting to `True` so the mix-mode caller keeps its existing graceful degradation unchanged. `naive_query`'s own call site passes `suppress_errors=False`, so a backend failure now propagates as a real exception; `aquery_llm`'s existing `except Exception` clause already converts that into a `status: failure` response carrying the actual error message instead of the generic fail response text.

Verification:
- Added `tests/llm/test_naive_query_vector_search_failure.py`: `test_naive_query_propagates_vector_search_failure` fails on main (asserts `naive_query` raises when the vector store raises, and it silently returned a no-context result instead) and passes on this branch; a companion test confirms the mix-mode call site's default behavior (swallow and return `[]`) is unchanged.
- Full offline suite (`pytest tests/ -m offline`) passes: 3314 passed, 42 skipped, no new failures.
- `pre-commit run --files lightrag/operate.py tests/llm/test_naive_query_vector_search_failure.py` is clean.
- Not verified: the `kg`/`hybrid`/`mix` query modes are unaffected by design (unchanged default), but I did not separately exercise them against a live backend; this fix is scoped to the naive-mode path described in the issue.

Fixes #3195
