### PR TITLE
fix(api): migrate to standalone uvicorn worker

### DIFF
--- a/lightrag/api/gunicorn_worker.py
+++ b/lightrag/api/gunicorn_worker.py
@@ -36,7 +36,7 @@ import os
 import signal
 from typing import Any
 
-from uvicorn.workers import UvicornWorker
+from uvicorn_worker import UvicornWorker
 
 
 class LightRAGUvicornWorker(UvicornWorker):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ api = [
     "starlette>=1.3.1,<2",         # security floor: CVE-2026-54283 / CVE-2026-48818 (transitive via fastapi)
     "pytz",
     "uvicorn",
+    "uvicorn-worker",
     "gunicorn",
     # Document processing dependencies (required for API document upload functionality)
     "openpyxl>=3.0.0,<4.0.0",      # XLSX processing

--- a/tests/api/test_gunicorn_worker_orphan_exit.py
+++ b/tests/api/test_gunicorn_worker_orphan_exit.py
@@ -14,7 +14,7 @@ import signal
 from types import SimpleNamespace
 
 import pytest
-from uvicorn.workers import UvicornWorker
+from uvicorn_worker import UvicornWorker
 
 from lightrag.api.gunicorn_worker import LightRAGUvicornWorker
 

--- a/tests/api/test_path_prefixes.py
+++ b/tests/api/test_path_prefixes.py
@@ -654,7 +654,7 @@ class TestUvicornRootPathSemantics:
         while proving nothing extra — a subclass could add root_path under any
         name.
         """
-        from uvicorn.workers import UvicornWorker
+        from uvicorn_worker import UvicornWorker
 
         from lightrag.api import gunicorn_config
         from gunicorn.util import load_class

--- a/uv.lock
+++ b/uv.lock
@@ -2305,6 +2305,7 @@ api = [
     { name = "tenacity" },
     { name = "tiktoken" },
     { name = "uvicorn" },
+    { name = "uvicorn-worker" },
     { name = "xlsxwriter" },
 ]
 evaluation = [
@@ -2357,6 +2358,7 @@ evaluation = [
     { name = "tenacity" },
     { name = "tiktoken" },
     { name = "uvicorn" },
+    { name = "uvicorn-worker" },
     { name = "xlsxwriter" },
 ]
 observability = [
@@ -2424,6 +2426,7 @@ offline = [
     { name = "tenacity" },
     { name = "tiktoken" },
     { name = "uvicorn" },
+    { name = "uvicorn-worker" },
     { name = "voyageai" },
     { name = "xlsxwriter" },
     { name = "zhipuai" },
@@ -2511,6 +2514,7 @@ test = [
     { name = "tenacity" },
     { name = "tiktoken" },
     { name = "uvicorn" },
+    { name = "uvicorn-worker" },
     { name = "xlsxwriter" },
 ]
 
@@ -2612,6 +2616,7 @@ requires-dist = [
     { name = "tiktoken" },
     { name = "tiktoken", marker = "extra == 'api'" },
     { name = "uvicorn", marker = "extra == 'api'" },
+    { name = "uvicorn-worker", marker = "extra == 'api'" },
     { name = "voyageai", marker = "extra == 'offline-llm'", specifier = ">=0.2.0,<1.0.0" },
     { name = "xlsxwriter", specifier = ">=3.1.0" },
     { name = "xlsxwriter", marker = "extra == 'api'", specifier = ">=3.1.0" },
@@ -5984,6 +5989,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[[package]]
+name = "uvicorn-worker"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gunicorn" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/59/9101b9c0680fd80e9d26c07deb822a5d18a324339fcf9cd017885ee808ad/uvicorn_worker-0.4.0.tar.gz", hash = "sha256:8ee5306070d8f38dce124adce488c3c0b50f20cf0c0222b12c66188da7214493", size = 9361, upload-time = "2025-09-20T10:47:01.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/25/09cd7a90c8bb7fb693be0d6704fccd5f9778d5513214b7a01cc4a94ff314/uvicorn_worker-0.4.0-py3-none-any.whl", hash = "sha256:e2ed952cef976f5e9e429d7269640bbcafbd36c80aa80f1003c8c77a6797abde", size = 5364, upload-time = "2025-09-20T10:46:59.776Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Migrate LightRAG's custom Gunicorn worker from the deprecated `uvicorn.workers` module to the standalone `uvicorn-worker` package. This removes the deprecation warning emitted during test collection and keeps the worker compatible with future Uvicorn releases that remove the legacy module.

## Related Issues

N/A — maintenance fix prompted by the upstream Uvicorn deprecation.

## Changes Made

- Add `uvicorn-worker` to the API optional dependencies and refresh `uv.lock`.
- Import `UvicornWorker` from `uvicorn_worker` in the custom LightRAG worker.
- Update worker inheritance assertions and unit tests to use the current package.
- Preserve the existing orphan detection and graceful shutdown behavior.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Validation completed:

- `./scripts/test.sh tests/api/test_gunicorn_worker_orphan_exit.py tests/api/test_path_prefixes.py -q` — 31 passed
- Focused worker inheritance regression tests — 6 passed
- Strict import check with `DeprecationWarning` promoted to an error
- Ruff format and lint checks
- `git diff --check`
- `uv pip check` — all 241 installed packages are compatible
