### PR TITLE
fix(operate): partition the query answer cache by conversation_history

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -4024,6 +4024,48 @@ async def extract_entities(
     return chunk_results
 
 
+# Policy version of the query-answer cache (cache_type="query"). Bump it when the
+# meaning of an entry changes in a way the other key fields cannot express, so
+# entries written by older versions become unreachable instead of being served
+# under a key whose semantics have moved. v2 retires every entry written before
+# the _answer_cache_kv bypass below: such an entry may hold history-conditioned
+# text filed under a history-blind key, and entries record no history, so a
+# tainted entry cannot be told apart from a clean one. Only the answer cache is
+# versioned; keyword/extract/summary entries never see conversation_history.
+_ANSWER_CACHE_POLICY_VERSION = "query-answer-cache-v2"
+
+
+def _answer_cache_kv(
+    query_param: QueryParam, hashing_kv: BaseKVStorage | None
+) -> BaseKVStorage | None:
+    """Return the storage backing the query-answer cache, or None to bypass it.
+
+    The answer cache key deliberately excludes ``conversation_history``: every
+    turn of a conversation carries a different history, so keying on it would
+    make each entry unique and turn a cache that is meant to be shared across
+    callers into a per-session one. But the history *is* handed to the model as
+    ``history_messages``, so an answer generated under it is not interchangeable
+    with the history-blind key it would be filed under. Requests carrying a
+    history therefore use neither side of the cache:
+
+    - they never write, so caller-supplied history cannot decide the answer that
+      other callers will be served for the same question;
+    - they never read, so a multi-turn caller is not served an answer that was
+      generated while ignoring its history.
+
+    Keyword extraction is unaffected and keeps using ``hashing_kv`` directly: it
+    derives keywords from the query text alone and never receives the history.
+    """
+    if query_param.conversation_history:
+        logger.debug(
+            " == LLM cache == Query answer cache bypassed: conversation_history "
+            f"is set ({len(query_param.conversation_history)} message(s), "
+            f"mode:{query_param.mode})"
+        )
+        return None
+    return hashing_kv
+
+
 async def kg_query(
     query: str,
     knowledge_graph_inst: BaseGraphStorage,
@@ -4153,7 +4195,9 @@ async def kg_query(
     )
 
     # Handle cache
+    answer_cache_kv = _answer_cache_kv(query_param, hashing_kv)
     args_hash = compute_args_hash(
+        _ANSWER_CACHE_POLICY_VERSION,
         query_param.mode,
         query,
         query_param.response_type,
@@ -4172,7 +4216,7 @@ async def kg_query(
     )
 
     cached_result = await handle_cache(
-        hashing_kv, args_hash, user_query, query_param.mode, cache_type="query"
+        answer_cache_kv, args_hash, user_query, query_param.mode, cache_type="query"
     )
 
     if cached_result is not None:
@@ -4193,11 +4237,12 @@ async def kg_query(
         )
 
         if (
-            hashing_kv
-            and hashing_kv.global_config.get("enable_llm_cache")
+            answer_cache_kv
+            and answer_cache_kv.global_config.get("enable_llm_cache")
             and not is_truncated_response(response)
         ):
             queryparam_dict = {
+                "answer_cache_version": _ANSWER_CACHE_POLICY_VERSION,
                 "mode": query_param.mode,
                 "response_type": query_param.response_type,
                 "top_k": query_param.top_k,
@@ -4214,7 +4259,7 @@ async def kg_query(
                 ),
             }
             await save_to_cache(
-                hashing_kv,
+                answer_cache_kv,
                 CacheData(
                     args_hash=args_hash,
                     content=response,
@@ -6168,7 +6213,9 @@ async def naive_query(
         return QueryResult(content=prompt_content, raw_data=raw_data)
 
     # Handle cache
+    answer_cache_kv = _answer_cache_kv(query_param, hashing_kv)
     args_hash = compute_args_hash(
+        _ANSWER_CACHE_POLICY_VERSION,
         query_param.mode,
         query,
         query_param.response_type,
@@ -6184,7 +6231,7 @@ async def naive_query(
         serialize_llm_cache_identity(llm_cache_identity),
     )
     cached_result = await handle_cache(
-        hashing_kv, args_hash, user_query, query_param.mode, cache_type="query"
+        answer_cache_kv, args_hash, user_query, query_param.mode, cache_type="query"
     )
     if cached_result is not None:
         cached_response, _ = cached_result  # Extract content, ignore timestamp
@@ -6202,11 +6249,12 @@ async def naive_query(
         )
 
         if (
-            hashing_kv
-            and hashing_kv.global_config.get("enable_llm_cache")
+            answer_cache_kv
+            and answer_cache_kv.global_config.get("enable_llm_cache")
             and not is_truncated_response(response)
         ):
             queryparam_dict = {
+                "answer_cache_version": _ANSWER_CACHE_POLICY_VERSION,
                 "mode": query_param.mode,
                 "response_type": query_param.response_type,
                 "top_k": query_param.top_k,
@@ -6221,7 +6269,7 @@ async def naive_query(
                 ),
             }
             await save_to_cache(
-                hashing_kv,
+                answer_cache_kv,
                 CacheData(
                     args_hash=args_hash,
                     content=response,

--- a/lightrag/tools/clean_llm_query_cache.py
+++ b/lightrag/tools/clean_llm_query_cache.py
@@ -2,7 +2,7 @@
 """
 LLM Query Cache Cleanup Tool for LightRAG
 
-This tool cleans up LLM query cache (mix:*, hybrid:*, local:*, global:*)
+This tool cleans up LLM query cache (mix:*, hybrid:*, local:*, global:*, naive:*)
 from KV storage implementations while preserving workspace isolation.
 
 Usage:
@@ -59,8 +59,10 @@ WORKSPACE_ENV_MAP = {
     "OpenSearchKVStorage": "OPENSEARCH_WORKSPACE",
 }
 
-# Query cache modes
-QUERY_MODES = ["mix", "hybrid", "local", "global"]
+# Query cache modes. Must cover every QueryParam.mode that reaches the LLM cache,
+# i.e. all of them except "bypass", which answers straight from the LLM and writes
+# no cache entry. Entries for a mode missing here are neither counted nor deleted.
+QUERY_MODES = ["mix", "hybrid", "local", "global", "naive"]
 
 # Query cache types
 CACHE_TYPES = ["query", "keywords"]

--- a/tests/llm/test_query_cache_conversation_history.py
+++ b/tests/llm/test_query_cache_conversation_history.py
@@ -1,0 +1,443 @@
+"""conversation_history must never share the ``cache_type="query"`` answer cache.
+
+The answer cache key deliberately omits ``QueryParam.conversation_history`` so the
+cache stays shared across callers instead of degenerating into a per-session one.
+But the history *is* handed to the model as ``history_messages``, so it changes the
+generated text: a history-conditioned answer is not interchangeable with the
+history-blind key it would be filed under. ``_answer_cache_kv`` therefore takes
+history-bearing requests off both sides of the answer cache, while the keywords
+cache keeps using ``hashing_kv`` directly.
+
+The same commit bumps the answer-cache policy version, so entries written before
+the bypass existed -- which may hold history-conditioned text and record no
+history to detect it by -- can no longer be read.
+"""
+
+import pytest
+
+from lightrag.base import QueryContextResult, QueryParam
+from lightrag.operate import kg_query, naive_query
+from lightrag.utils import (
+    compute_args_hash,
+    get_llm_cache_identity,
+    serialize_llm_cache_identity,
+)
+
+
+class _FakeTokenizer:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(token) for token in tokens)
+
+
+class _FakeKVStorage:
+    def __init__(self):
+        self.global_config = {"enable_llm_cache": True}
+        self._store = {}
+
+    async def get_by_id(self, key):
+        return self._store.get(key)
+
+    async def upsert(self, entries):
+        self._store.update(entries)
+
+
+class _FakeChunksVDB:
+    cosine_better_than_threshold = 0.0
+
+    async def query(self, *_args, **_kwargs):
+        return [
+            {
+                "id": "chunk-1",
+                "content": "Conversation history cache partitioning test chunk.",
+                "file_path": "test.md",
+            }
+        ]
+
+
+class _RecordingModel:
+    """Counts calls and records the history each call received.
+
+    Returns ``f"answer-{calls}"`` rather than indexing a fixed list on purpose: a
+    cache hit that should not have happened then surfaces as a failed assert on
+    the content or the call count, never as an IndexError.
+    """
+
+    def __init__(self):
+        self.calls = 0
+        self.histories = []
+
+    async def __call__(self, *_args, **kwargs):
+        self.calls += 1
+        self.histories.append(kwargs.get("history_messages"))
+        return f"answer-{self.calls}"
+
+
+def _query_global_config(llm_func, keyword_func=None) -> dict:
+    role_llm_funcs = {"query": llm_func}
+    if keyword_func is not None:
+        role_llm_funcs["keyword"] = keyword_func
+    return {
+        "tokenizer": _FakeTokenizer(),
+        "role_llm_funcs": role_llm_funcs,
+        "addon_params": {"language": "en"},
+        "min_rerank_score": 0.0,
+        "max_total_tokens": 4096,
+    }
+
+
+QUERY = "who is Tesla?"
+STALE = "STALE-HISTORY-CONDITIONED-ANSWER"
+
+HISTORY_A = [
+    {"role": "user", "content": "we were discussing Tesla the carmaker"},
+    {"role": "assistant", "content": "Yes, the automotive company."},
+]
+HISTORY_B = [
+    {"role": "user", "content": "we were discussing Nikola Tesla the physicist"},
+    {"role": "assistant", "content": "Yes, the inventor."},
+]
+
+
+def _answer_cache_keys(cache: _FakeKVStorage) -> list[str]:
+    return [key for key in cache._store if ":query:" in key]
+
+
+def _legacy_answer_cache_key(
+    param: QueryParam,
+    cfg: dict,
+    *,
+    keywords: tuple[str, str] | None = None,
+) -> str:
+    """Frozen snapshot of the pre-v2 answer-cache key composition.
+
+    Deliberately duplicates the historical argument list instead of reusing
+    production code: these tests exist to prove that entries written under the
+    older scheme are never served again. Do NOT refresh this when new key fields
+    are added -- a miss must stay a miss.
+
+    ``keywords`` is ``(hl_keywords_str, ll_keywords_str)`` for the ``kg_query``
+    variant, which carried them in the key; ``naive_query`` did not.
+    """
+    args = [
+        param.mode,
+        QUERY,
+        param.response_type,
+        param.top_k,
+        param.chunk_top_k,
+        param.max_entity_tokens,
+        param.max_relation_tokens,
+        param.max_total_tokens,
+    ]
+    if keywords is not None:
+        args.extend(keywords)
+    args.extend(
+        [
+            param.user_prompt or "",
+            param.enable_rerank,
+            cfg.get("enable_content_headings", False),
+            "\n<llm_identity>\n",
+            serialize_llm_cache_identity(get_llm_cache_identity(cfg, "query")),
+        ]
+    )
+    return f"{param.mode}:query:{compute_args_hash(*args)}"
+
+
+# ---------------------------------------------------------------------------
+# naive_query
+# ---------------------------------------------------------------------------
+
+
+def _naive_param(**overrides) -> QueryParam:
+    return QueryParam(mode="naive", enable_rerank=False, **overrides)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_naive_history_turn_does_not_seed_cache_for_plain_turn():
+    """A history-conditioned answer must never become the shared cache entry."""
+    cache = _FakeKVStorage()
+    chunks_vdb = _FakeChunksVDB()
+    model = _RecordingModel()
+    cfg = _query_global_config(model)
+
+    first = await naive_query(
+        QUERY,
+        chunks_vdb,
+        _naive_param(conversation_history=HISTORY_A),
+        cfg,
+        hashing_kv=cache,
+    )
+    assert first.content == "answer-1"
+    # Pins the premise: the history really does reach the model.
+    assert model.histories[0] == HISTORY_A
+    assert cache._store == {}
+
+    second = await naive_query(QUERY, chunks_vdb, _naive_param(), cfg, hashing_kv=cache)
+    assert second.content == "answer-2"
+    assert model.calls == 2
+    assert model.histories[1] == []
+    # The plain answer is still cached: the bypass is not a blanket disable.
+    assert len(_answer_cache_keys(cache)) == 1
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_naive_history_turn_ignores_existing_plain_cache_entry():
+    """A multi-turn caller must not be served an answer that ignored its history."""
+    cache = _FakeKVStorage()
+    chunks_vdb = _FakeChunksVDB()
+    model = _RecordingModel()
+    cfg = _query_global_config(model)
+
+    first = await naive_query(QUERY, chunks_vdb, _naive_param(), cfg, hashing_kv=cache)
+    assert first.content == "answer-1"
+    assert len(_answer_cache_keys(cache)) == 1
+
+    second = await naive_query(
+        QUERY,
+        chunks_vdb,
+        _naive_param(conversation_history=HISTORY_A),
+        cfg,
+        hashing_kv=cache,
+    )
+    assert second.content == "answer-2"
+    assert model.calls == 2
+    assert model.histories[1] == HISTORY_A
+    # Read bypassed (calls == 2) and write bypassed (no new entry).
+    assert len(_answer_cache_keys(cache)) == 1
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_naive_distinct_histories_neither_share_nor_grow_the_cache():
+    """Distinct histories get distinct answers and add zero cache entries.
+
+    The empty-store assertion is load-bearing in two directions: without the
+    bypass the two turns share one entry and the second caller gets the first
+    caller's answer, while keying the cache on conversation_history instead
+    would leave two per-session entries here. Do not relax it.
+    """
+    cache = _FakeKVStorage()
+    chunks_vdb = _FakeChunksVDB()
+    model = _RecordingModel()
+    cfg = _query_global_config(model)
+
+    first = await naive_query(
+        QUERY,
+        chunks_vdb,
+        _naive_param(conversation_history=HISTORY_A),
+        cfg,
+        hashing_kv=cache,
+    )
+    second = await naive_query(
+        QUERY,
+        chunks_vdb,
+        _naive_param(conversation_history=HISTORY_B),
+        cfg,
+        hashing_kv=cache,
+    )
+
+    assert (first.content, second.content) == ("answer-1", "answer-2")
+    assert model.calls == 2
+    assert cache._store == {}
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "history_overrides",
+    [
+        pytest.param({}, id="unset"),
+        pytest.param({"conversation_history": []}, id="empty-list"),
+        pytest.param({"conversation_history": None}, id="none"),
+    ],
+)
+async def test_naive_single_turn_query_still_hits_cache(history_overrides):
+    """Over-fix guard: history-free turns keep sharing one cache entry.
+
+    This passes before the bypass exists too -- its job is to fail if the bypass
+    is ever widened. The ``none`` case is what distinguishes the truthiness test
+    from an ``is not None`` test, which would disable caching for SDK callers
+    that pass ``conversation_history=None`` explicitly.
+    """
+    cache = _FakeKVStorage()
+    chunks_vdb = _FakeChunksVDB()
+    model = _RecordingModel()
+    cfg = _query_global_config(model)
+
+    first = await naive_query(
+        QUERY, chunks_vdb, _naive_param(**history_overrides), cfg, hashing_kv=cache
+    )
+    second = await naive_query(
+        QUERY, chunks_vdb, _naive_param(**history_overrides), cfg, hashing_kv=cache
+    )
+
+    assert first.content == "answer-1"
+    assert second.content == "answer-1"
+    assert model.calls == 1
+    assert len(_answer_cache_keys(cache)) == 1
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_naive_pre_version_cache_entry_is_not_served():
+    """An entry written under the pre-v2 key scheme must be unreachable.
+
+    Upgrading only bypasses the cache for *new* history-bearing requests; a
+    history-conditioned answer already persisted by an older version would still
+    be served to plain callers under an unchanged key. The policy version in the
+    hash retires those entries instead.
+    """
+    cache = _FakeKVStorage()
+    chunks_vdb = _FakeChunksVDB()
+    model = _RecordingModel()
+    cfg = _query_global_config(model)
+    param = _naive_param()
+
+    legacy_key = _legacy_answer_cache_key(param, cfg)
+    cache._store[legacy_key] = {"return": STALE, "create_time": 1}
+
+    first = await naive_query(QUERY, chunks_vdb, param, cfg, hashing_kv=cache)
+    assert first.content == "answer-1"
+    assert model.calls == 1
+
+    fresh_keys = [key for key in _answer_cache_keys(cache) if key != legacy_key]
+    assert len(fresh_keys) == 1
+
+    # The freshly written entry is itself cacheable as usual.
+    second = await naive_query(QUERY, chunks_vdb, param, cfg, hashing_kv=cache)
+    assert second.content == "answer-1"
+    assert model.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# kg_query
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_query_context(monkeypatch):
+    """Skip retrieval: kg_query only forwards its storage args into this call."""
+
+    async def _fake_build_query_context(*_args, **_kwargs):
+        return QueryContextResult(context="KG CONTEXT", raw_data={})
+
+    monkeypatch.setattr(
+        "lightrag.operate._build_query_context", _fake_build_query_context
+    )
+
+
+def _kg_param(**overrides) -> QueryParam:
+    # mode="local" plus preset ll_keywords short-circuits keyword extraction
+    # without tripping the empty-hl_keywords warning that hybrid/mix would.
+    return QueryParam(
+        mode="local", enable_rerank=False, ll_keywords=["Tesla"], **overrides
+    )
+
+
+async def _run_kg_query(param, cfg, cache):
+    return await kg_query(QUERY, None, None, None, None, param, cfg, hashing_kv=cache)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_kg_history_turn_does_not_seed_cache_for_plain_turn(stub_query_context):
+    """Same guarantee as the naive case, on kg_query's own cache sites."""
+    cache = _FakeKVStorage()
+    model = _RecordingModel()
+    cfg = _query_global_config(model)
+
+    first = await _run_kg_query(_kg_param(conversation_history=HISTORY_A), cfg, cache)
+    assert first.content == "answer-1"
+    assert model.histories[0] == HISTORY_A
+    assert cache._store == {}
+
+    second = await _run_kg_query(_kg_param(), cfg, cache)
+    assert second.content == "answer-2"
+    assert model.calls == 2
+    assert len(_answer_cache_keys(cache)) == 1
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_kg_history_turn_ignores_existing_plain_cache_entry(stub_query_context):
+    """A multi-turn kg_query caller is not served a history-ignoring answer."""
+    cache = _FakeKVStorage()
+    model = _RecordingModel()
+    cfg = _query_global_config(model)
+
+    first = await _run_kg_query(_kg_param(), cfg, cache)
+    assert first.content == "answer-1"
+    assert len(_answer_cache_keys(cache)) == 1
+
+    second = await _run_kg_query(_kg_param(conversation_history=HISTORY_A), cfg, cache)
+    assert second.content == "answer-2"
+    assert model.calls == 2
+    assert len(_answer_cache_keys(cache)) == 1
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_kg_pre_version_cache_entry_is_not_served(stub_query_context):
+    """kg_query must carry the policy version too, not just naive_query."""
+    cache = _FakeKVStorage()
+    model = _RecordingModel()
+    cfg = _query_global_config(model)
+    param = _kg_param()
+
+    # kg_query hashes hl_keywords_str before ll_keywords_str; the preset
+    # ll_keywords=["Tesla"] leaves hl empty.
+    legacy_key = _legacy_answer_cache_key(param, cfg, keywords=("", "Tesla"))
+    cache._store[legacy_key] = {"return": STALE, "create_time": 1}
+
+    first = await _run_kg_query(param, cfg, cache)
+    assert first.content == "answer-1"
+    assert model.calls == 1
+
+    fresh_keys = [key for key in _answer_cache_keys(cache) if key != legacy_key]
+    assert len(fresh_keys) == 1
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_kg_keywords_cache_still_shared_across_histories(stub_query_context):
+    """The keywords cache must keep the raw hashing_kv.
+
+    Keywords are derived from the query text alone and never see the history, so
+    replacing the keyword call site's storage along with the answer cache's would
+    cost a re-extraction per turn for no benefit.
+    """
+    cache = _FakeKVStorage()
+    model = _RecordingModel()
+    keyword_calls = 0
+
+    async def keyword_model(*_args, **_kwargs):
+        nonlocal keyword_calls
+        keyword_calls += 1
+        return '{"high_level_keywords": ["physics"], "low_level_keywords": ["Tesla"]}'
+
+    cfg = _query_global_config(model, keyword_func=keyword_model)
+
+    def _param(history):
+        # No preset keywords: force real extraction so its cache is exercised.
+        return QueryParam(
+            mode="local", enable_rerank=False, conversation_history=history
+        )
+
+    await kg_query(
+        QUERY, None, None, None, None, _param(HISTORY_A), cfg, hashing_kv=cache
+    )
+    await kg_query(
+        QUERY, None, None, None, None, _param(HISTORY_B), cfg, hashing_kv=cache
+    )
+
+    keyword_keys = [key for key in cache._store if ":keywords:" in key]
+    assert keyword_calls == 1
+    assert len(keyword_keys) == 1
+    assert keyword_keys[0].startswith("local:keywords:")
+    # ...while neither history-conditioned answer was cached.
+    assert _answer_cache_keys(cache) == []
+    assert model.calls == 2

--- a/tests/tools/test_clean_llm_query_cache_modes.py
+++ b/tests/tools/test_clean_llm_query_cache_modes.py
@@ -1,0 +1,46 @@
+"""The cleanup tool's mode list must stay in sync with QueryParam.mode.
+
+Cache keys are ``{mode}:{cache_type}:{hash}``, and the tool counts and deletes
+per mode from an explicit list. A mode missing from that list is invisible to the
+tool: its entries are neither reported nor removed, so an operator who runs the
+tool believes the query cache is clean when it is not. ``naive`` was missing this
+way. Deriving the expectation from the annotation rather than restating the list
+means a newly added mode fails here instead of being silently skipped.
+"""
+
+import typing
+
+import pytest
+
+from lightrag.base import QueryParam
+from lightrag.tools.clean_llm_query_cache import QUERY_MODES
+
+pytestmark = pytest.mark.offline
+
+# "bypass" answers straight from the LLM without touching the query cache, so it
+# is the one mode that legitimately has no entries to clean.
+_MODES_WITHOUT_CACHE = {"bypass"}
+
+
+def _declared_query_modes() -> set[str]:
+    hints = typing.get_type_hints(QueryParam)
+    return set(typing.get_args(hints["mode"]))
+
+
+def test_cleanup_tool_covers_every_cache_writing_query_mode():
+    expected = _declared_query_modes() - _MODES_WITHOUT_CACHE
+    missing = expected - set(QUERY_MODES)
+    assert not missing, (
+        f"QUERY_MODES misses {sorted(missing)}; their cache entries would be "
+        "neither counted nor deleted by the cleanup tool"
+    )
+
+
+def test_cleanup_tool_declares_no_unknown_query_mode():
+    unknown = set(QUERY_MODES) - _declared_query_modes()
+    assert not unknown, f"QUERY_MODES lists non-existent modes: {sorted(unknown)}"
+
+
+def test_cleanup_tool_does_not_scan_bypass_mode():
+    """bypass writes no cache entries, so scanning for them would be dead work."""
+    assert "bypass" not in QUERY_MODES


### PR DESCRIPTION
## Summary

The query answer cache (`cache_type="query"`) keys on everything that shapes an answer *except* `QueryParam.conversation_history`, which is handed to the model as `history_messages` and does change the generated text. A turn that carried a history therefore shared a cache entry with history-free turns for the same question.

This routes the answer cache through a new `_answer_cache_kv` helper that returns `None` when a history is present, so history-bearing requests neither read nor write it, and bumps an answer-cache policy version so entries written before the bypass existed can no longer be read.

## Motivation

Two symptoms, both from the same missing key field:

- A history-conditioned answer became the canonical cached answer for that question and was returned to every later caller who asked it without a history. The most common shape is entirely accidental — a multi-turn caller asks something whose answer references an earlier turn ("regarding the order you mentioned…"), and that answer is then served to everyone.
- Conversely, an existing history-free entry was replayed to a multi-turn caller, whose history was silently ignored — multi-turn conversation quietly stopped working on any question that had already been asked once.

Sharing one answer between different callers asking the same question is intended: LightRAG is a knowledge-base query system and the cache is deliberately cross-caller. The problem is that an input which is neither the question nor the knowledge base got to decide what that shared answer contains.

## What's changed

**`lightrag/operate.py`**

- New `_ANSWER_CACHE_POLICY_VERSION` constant, hashed into the answer cache key in both `kg_query` and `naive_query`, and recorded in the stored `queryparam` dict so persisted entries are self-describing.
- New `_answer_cache_kv(query_param, hashing_kv)` helper returning `None` when `conversation_history` is non-empty. Each query function resolves it once into a local and uses it at all three answer-cache sites (read, write guard, write).
- Keyword extraction keeps using `hashing_kv` directly. It derives keywords from the query text alone, never receives the history, and uses a different LLM role, so its entries cannot be history-conditioned.

Both directions of the bypass are load-bearing: not writing is what stops one caller's history from deciding another caller's answer; not reading is what stops a multi-turn caller from being served an answer generated while ignoring its history.

`conversation_history` is deliberately **not** added to the key. Every turn carries a different history, so keying on it would make each entry unique and convert a deliberately shared cache into a per-session one.

**Why the policy version is needed.** Bypassing the cache only affects *new* requests. An entry already persisted by an earlier version sits under a key that today's single-turn requests still compute, so it would keep being served; the query cache has no TTL and the default `JsonKVStorage` persists it across restarts. Entries record no history, so a history-conditioned entry cannot be told apart from a clean one and no targeted purge is possible. Versioning the key retires the answer cache wholesale instead, leaving the keywords, extract and summary caches intact.

**Tests** — `tests/llm/test_query_cache_conversation_history.py`, 11 cases across `kg_query` and `naive_query`:

- a history-bearing turn writes nothing, and a later history-free turn still reaches the model and caches normally;
- an existing history-free entry is not replayed to a history-bearing turn;
- two different histories get two different answers and add zero cache entries (this one also fails if the cache were keyed on history instead, pinning the design decision);
- history-free turns still share a single entry — parametrized over unset / `[]` / `None` so the bypass can't be widened into `is not None`, which would disable caching for SDK callers passing `None` explicitly;
- an entry written under the pre-version key scheme is not served, and the freshly written replacement is cacheable as usual;
- the keywords cache is still shared across differing histories.

Verified fix-proof: with the `operate.py` change stashed, 8 of the 11 fail on assertions (never on exceptions) and the 3 over-fix guards stay green. The two pre-version cases fail specifically by returning the seeded stale entry, which is also what proves the test's frozen snapshot of the old key composition is faithful rather than vacuously missing.

## Second commit (separable)

`clean_llm_query_cache` counted and deleted per mode from a `QUERY_MODES` list that omitted `naive`, so `naive:query:*` and `naive:keywords:*` were invisible to the tool on all five supported KV backends — neither reported in the before/after counts nor deleted by any cleanup option. It's included here because this tool is the recommended way to reclaim the retired entries (see below). The accompanying test derives the expected modes from `QueryParam.mode`'s annotation, so a future mode fails the test instead of being silently skipped.

## Operational impact

**1. One-time answer-cache cold start.** After upgrading, the first query for each question misses; normal cross-caller sharing resumes immediately after. Old entries become unreachable garbage — harmless, and reclaiming them is optional housekeeping. To reclaim, shut the server down and run:

```
python -m lightrag.tools.clean_llm_query_cache
```

choosing **`[2] Delete query caches only (keep keywords)`**. That removes only `*:query:*` and preserves the keywords, extract, summary and analysis caches.

Do **not** use `POST /documents/clear_cache` for this: it calls `aclear_cache()`, which `drop()`s the entire `llm_response_cache` — including the entity-extraction cache, the expensive one to rebuild, since it requires re-running extraction over every chunk. That cost is out of all proportion to reclaiming some unreachable answer entries.

**2. `/api/chat` hit rate.** The Ollama-compatible chat endpoint treats every message but the last as conversation history, so every turn after the first now bypasses the answer cache. On an Open-WebUI-fronted deployment the observed answer-cache hit rate on that endpoint can fall close to zero. This is the intended trade — those are exactly the requests whose answers are not interchangeable — and the helper emits a `DEBUG` line naming the reason so a hit-rate drop is diagnosable rather than mysterious. The bundled WebUI is unaffected: it pins `history_turns` to 0 and so sends an empty history on every cached mode.

## Test results

- `tests/llm/test_query_cache_conversation_history.py`: 11 passed
- `tests/tools/test_clean_llm_query_cache_modes.py`: 3 passed
- Affected subset (`tests/llm tests/extraction tests/utils tests/tools`): 512 passed
- Full offline suite (CI's gate, `pytest tests -m offline`): 4022 passed, 2 skipped, 0 failed

No existing test needed changing: the current answer-cache tests all use a history-free `QueryParam`, start from an empty cache, and assert on entry counts and call counts rather than on specific hash values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)