### PR TITLE
fix(operate): iterate `tasks` list, not `done` set, when collecting chunk_results

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3986,21 +3986,31 @@ async def extract_entities(
     # This allows us to cancel remaining tasks if any task fails
     done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
 
-    # Check if any task raised an exception and ensure all exceptions are retrieved
+    # Check if any task raised an exception and ensure all exceptions are retrieved.
+    # NOTE ON ORDER: `done` is a SET, whose iteration order is __hash__-based and
+    # effectively random per event loop instance. Two runs of the same document
+    # (fresh cache, identical LLM) would materialise `chunk_results` in different
+    # orders, which then propagates into `merge_nodes_and_edges`' defaultdict(list)
+    # accumulation → different description-summary LLM input → different graph
+    # for the same input. We iterate `tasks` (a LIST — deterministic creation
+    # order matching `ordered_chunks`) so `chunk_results` is stable across runs.
     first_exception = None
     chunk_results = []
 
     for task in done:
         try:
             exception = task.exception()
-            if exception is not None:
-                if first_exception is None:
-                    first_exception = exception
-            else:
-                chunk_results.append(task.result())
+            if exception is not None and first_exception is None:
+                first_exception = exception
         except Exception as e:
             if first_exception is None:
                 first_exception = e
+
+    # Materialise chunk_results in the deterministic tasks-order — only when no
+    # exception occurred (otherwise we're about to raise and unwind).
+    if first_exception is None:
+        for task in tasks:
+            chunk_results.append(task.result())
 
     # If any task failed, cancel all pending tasks and raise the first exception
     if first_exception is not None:


### PR DESCRIPTION
> **Maintainer note (edited by @danielaskdd):** the fix is correct and is being
> merged. The *Problem* and *Fix* sections below were rewritten during review —
> the original text named the description-summary path as the primary
> consequence, which the code does not support (see "What the ordering actually
> reaches" below). A follow-up commit adding a fix-proof regression test and
> correcting the in-code comment is applied on top by the maintainer, since this
> PR's head branch lives in an organization-owned fork and cannot be pushed to.
> The reproduction report and the downstream notes are the author's, kept as
> written.

### Problem

`asyncio.wait(...)` in `extract_entities` returns `done` as a **set**:

```python
done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
...
for task in done:            # <- set iteration order is not stable across runs
    ...
    chunk_results.append(task.result())
```

`asyncio.Task` inherits `object.__hash__`, so the set's iteration order derives
from object identity (memory address) and the set's bucket layout. It is
therefore **neither completion order nor creation order**, and it is unstable
across processes — note that this is independent of `PYTHONHASHSEED`, which only
governs `str`/`bytes` hashing. Two ingests of the same document — identical LLM
output, cache hit or same-seed extraction — materialise `chunk_results` as
different permutations.

#### What the ordering actually reaches

`merge_nodes_and_edges` accumulates per-entity/per-relation records into a
`defaultdict(list)` in arrival order. From there:

- **`source_id` (unguarded).** `new_source_ids` is taken in `chunk_results`
  order, `merge_source_ids` is an order-preserving dedup, and the result is
  `GRAPH_FIELD_SEP.join(...)`-ed straight into the persisted node/edge. A
  different permutation persists a different string.
- **The chunk subset kept by `apply_source_ids_limit` (unguarded).** Past the
  cap, FIFO/KEEP truncation drops "the ones at the end" — so a different
  permutation keeps a *different subset of chunks*, and under KEEP a different
  set of descriptions with it. This is a semantic difference, not just a
  reordering.
- **`file_path` (unguarded).** Same order-preserving dedup, no sort.
- **Description lists (guarded).** These are sorted downstream by
  `(timestamp, -len(description))` before reaching the summary LLM, so the
  arrival order is only observable when both the timestamp *and* the length tie.
  The original version of this description named this as the main consequence;
  it is in fact the weakest of the four.
- **Edge `weight`.** `sum()` over floats is order-sensitive in principle, though
  with the near-integral weights the extractor emits this is rarely observable.

### Reproduction

*(reported by @marsch)*

We hit this while trying to make cross-workspace ingest deterministic for a
downstream user (the [Enchilada knowledge platform](https://github.com/mimagic/enchilada)).
Three fresh workspaces, same input document, `temperature=0` + `seed=42` (both
threaded through into `openai_complete_if_cache`) — we still got three different
semantic graph digests. Instrumenting the LLM cache confirmed the extracted
entity records themselves were identical across runs; the divergence started at
merge time and came from the chunk_results ordering.

Symptoms in user-visible output: varying edge weights on identical edges,
description strings shuffled between runs, and entity names occasionally
collapsing (`Christoph Voelkel` vs `ChristopVoelkel`).

> Maintainer note: the entity-name variant cannot be produced by chunk ordering —
> nothing on this path rewrites an entity name. That symptom has a separate cause
> (extraction or summary output drift) and is not addressed here.

### Fix

Split the exception check from the result materialisation:

- **Exception pass** iterates `done` (set order is fine — we only need to know
  whether ANY task raised, and to consume every exception object so none fires
  a "never retrieved" warning).
- **Result pass** iterates `tasks`, a list populated in `ordered_chunks` order at
  task creation, so `chunk_results[i]` corresponds to `ordered_chunks[i]`.
  Because `chunks` is built as an insertion-ordered dict keyed by
  `chunk_order_index`, that is the document's own reading order — not just *some*
  stable order.

Result materialisation is guarded on `first_exception is None`, so the exception
path is unchanged: pending tasks still get cancelled and the first exception is
still re-raised with the `C[...]` progress prefix.

**Why two passes and not one loop over `tasks`:** on the exception path
`asyncio.wait` returns early and `tasks` still holds pending entries. Calling
`.exception()` on a pending task raises `InvalidStateError`, which the
surrounding `except Exception` would latch as `first_exception` — masking the
real failure. The split is load-bearing; a regression test pins it.

### Scope — what this does *not* fix

This removes one source of run-to-run divergence; it does not make ingest
deterministic on its own. Still open:

- `timestamp = int(time.time())` on a cache miss (`use_llm_func_with_cache`) is
  the first key of the description sort, so on a fresh extraction the description
  order varies with wall-clock seconds regardless of this fix. This is the larger
  remaining source.
- Concurrent entity/relation merge in `merge_nodes_and_edges` (stub entities
  created from the relation pass race between edge tasks).
- LLM stochasticity itself (`seed` + pinned model snapshot).

### Non-changes

- No API change: `extract_entities` signature and return type are identical.
- No behaviour change on the exception path.
- Zero-cost in the common case: the results list is built in the same number of
  steps.
- The concurrency semantics (chunk_max_async semaphore, FIRST_EXCEPTION wait) are
  preserved.

### Tests

A fix-proof regression test is added in
`tests/extraction/test_chunk_results_ordering.py`:

- `test_chunk_results_follow_ordered_chunks` monkeypatches `asyncio.wait` so the
  completed-task container iterates in **reverse** creation order. A real set only
  guarantees *some* order, so reversing is the deterministic worst case — code
  that still returns input order cannot be passing by luck. Against the pre-fix
  code it fails with the `source_id` sequence exactly reversed
  (`chunk-charlie` first); it passes on the fix.
- `test_first_exception_survives_pending_tasks` pins the fail-fast path: the
  chunk's own exception must propagate, not an `InvalidStateError` from touching
  a still-pending task.

Both are `@pytest.mark.offline` and need no LLM. `tests/extraction/` passes in
full (165 tests).

### Related work in the downstream repo

*(reported by @marsch)*

We also shipped a monkey-patched version of the same fix in Enchilada's rag
engine (post-hoc sort by content-hash) and a docs page cataloging the remaining
sources of extraction non-determinism (`seed` + pinned model snapshot for LLM
stochasticity, `math.fsum(sorted(w))` for weight ordering, per-chunk timestamp
freeze in `use_llm_func_with_cache`). Happy to open follow-up PRs for any of
those the maintainers are interested in.
