### PR TITLE
fix(operate): guard against empty entity list indexing in cached extraction rebuild

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -1003,6 +1003,8 @@ async def rebuild_knowledge_from_chunks(
                 # Merge entities and relationships from this extraction result
                 # Compare description lengths and keep the better version for the same chunk_id
                 for entity_name, entity_list in entities.items():
+                    if not entity_list:
+                        continue
                     if entity_name not in chunk_entities[chunk_id]:
                         # New entity for this chunk_id
                         chunk_entities[chunk_id][entity_name].extend(entity_list)
@@ -1026,6 +1028,8 @@ async def rebuild_knowledge_from_chunks(
 
                 # Compare description lengths and keep the better version for the same chunk_id
                 for rel_key, rel_list in relationships.items():
+                    if not rel_list:
+                        continue
                     if rel_key not in chunk_relationships[chunk_id]:
                         # New relationship for this chunk_id
                         chunk_relationships[chunk_id][rel_key].extend(rel_list)
@@ -2138,13 +2142,18 @@ async def _merge_nodes_then_upsert(
         source_id = GRAPH_FIELD_SEP.join(source_ids)
 
         # 6.2 Finalize entity type by highest count
-        entity_type = sorted(
-            Counter(
-                [dp["entity_type"] for dp in nodes_data] + already_entity_types
-            ).items(),
-            key=lambda x: x[1],
-            reverse=True,
-        )[0][0]
+        type_counts = Counter(
+            [dp["entity_type"] for dp in nodes_data if dp.get("entity_type")]
+            + already_entity_types
+        ).items()
+        if type_counts:
+            entity_type = sorted(
+                type_counts,
+                key=lambda x: x[1],
+                reverse=True,
+            )[0][0]
+        else:
+            entity_type = "UNKNOWN"
 
         # 7. Deduplicate nodes by description, keeping first occurrence in the same document
         unique_nodes = {}
@@ -3592,16 +3601,21 @@ async def extract_entities(
             for i, (entity_name, glean_entities) in enumerate(
                 glean_nodes.items(), start=1
             ):
+                if not glean_entities:
+                    continue
                 if entity_name in maybe_nodes:
-                    # Compare description lengths and keep the better one
-                    original_desc_len = len(
-                        maybe_nodes[entity_name][0].get("description", "") or ""
-                    )
-                    glean_desc_len = len(glean_entities[0].get("description", "") or "")
-
-                    if glean_desc_len > original_desc_len:
+                    if not maybe_nodes[entity_name]:
                         maybe_nodes[entity_name] = list(glean_entities)
-                    # Otherwise keep original version
+                    else:
+                        # Compare description lengths and keep the better one
+                        original_desc_len = len(
+                            maybe_nodes[entity_name][0].get("description", "") or ""
+                        )
+                        glean_desc_len = len(glean_entities[0].get("description", "") or "")
+
+                        if glean_desc_len > original_desc_len:
+                            maybe_nodes[entity_name] = list(glean_entities)
+                        # Otherwise keep original version
                 else:
                     # New entity from gleaning stage
                     maybe_nodes[entity_name] = list(glean_entities)
@@ -3610,18 +3624,23 @@ async def extract_entities(
             for i, (edge_key, glean_edge_list) in enumerate(
                 glean_edges.items(), start=1
             ):
+                if not glean_edge_list:
+                    continue
                 if edge_key in maybe_edges:
-                    # Compare description lengths and keep the better one
-                    original_desc_len = len(
-                        maybe_edges[edge_key][0].get("description", "") or ""
-                    )
-                    glean_desc_len = len(
-                        glean_edge_list[0].get("description", "") or ""
-                    )
-
-                    if glean_desc_len > original_desc_len:
+                    if not maybe_edges[edge_key]:
                         maybe_edges[edge_key] = list(glean_edge_list)
-                    # Otherwise keep original version
+                    else:
+                        # Compare description lengths and keep the better one
+                        original_desc_len = len(
+                            maybe_edges[edge_key][0].get("description", "") or ""
+                        )
+                        glean_desc_len = len(
+                            glean_edge_list[0].get("description", "") or ""
+                        )
+
+                        if glean_desc_len > original_desc_len:
+                            maybe_edges[edge_key] = list(glean_edge_list)
+                        # Otherwise keep original version
                 else:
                     # New edge from gleaning stage
                     maybe_edges[edge_key] = list(glean_edge_list)
@@ -5136,14 +5155,14 @@ async def _build_query_context(
             truncation_result.get("filtered_relations", [])
         ),
         "merged_chunks_count": len(merged_chunks),
-        "final_chunks_count": len(raw_data.get("data", {}).get("chunks", [])),
+        "final_chunks_count": len((raw_data.get("data") or {}).get("chunks", [])),
     }
 
     logger.debug(
         f"[_build_query_context] Context length: {len(context) if context else 0}"
     )
     logger.debug(
-        f"[_build_query_context] Raw data entities: {len(raw_data.get('data', {}).get('entities', []))}, relationships: {len(raw_data.get('data', {}).get('relationships', []))}, chunks: {len(raw_data.get('data', {}).get('chunks', []))}"
+        f"[_build_query_context] Raw data entities: {len((raw_data.get('data') or {}).get('entities', []))}, relationships: {len((raw_data.get('data') or {}).get('relationships', []))}, chunks: {len((raw_data.get('data') or {}).get('chunks', []))}"
     )
 
     return QueryContextResult(context=context, raw_data=raw_data)

--- a/tests/test_cached_extraction_empty_list_index.py
+++ b/tests/test_cached_extraction_empty_list_index.py
@@ -1,0 +1,123 @@
+import pytest
+from collections import defaultdict
+from unittest.mock import AsyncMock
+
+from lightrag.operate import _build_query_context
+
+pytestmark = pytest.mark.offline
+
+
+def test_cached_entities_merge_empty_list_does_not_raise():
+    """Verify that cached entity merge handles empty entity_list gracefully without raising IndexError."""
+    chunk_entities = defaultdict(dict)
+    chunk_entities["chunk1"]["E1"] = [{"description": "desc1"}]
+    entities = {"E1": []}
+
+    # Simulate loop from lightrag/operate.py (lines 1005-1025)
+    for entity_name, entity_list in entities.items():
+        if not entity_list:
+            continue
+        if entity_name not in chunk_entities["chunk1"]:
+            chunk_entities["chunk1"][entity_name].extend(entity_list)
+        elif len(chunk_entities["chunk1"][entity_name]) == 0:
+            chunk_entities["chunk1"][entity_name].extend(entity_list)
+        else:
+            existing_desc_len = len(
+                chunk_entities["chunk1"][entity_name][0].get(
+                    "description", ""
+                )
+                or ""
+            )
+            new_desc_len = len(entity_list[0].get("description", "") or "")
+
+            if new_desc_len > existing_desc_len:
+                chunk_entities["chunk1"][entity_name] = list(entity_list)
+
+    assert chunk_entities["chunk1"]["E1"] == [{"description": "desc1"}]
+
+
+def test_cached_relationships_merge_empty_list_does_not_raise():
+    """Verify that cached relationship merge handles empty rel_list gracefully without raising IndexError."""
+    chunk_relationships = defaultdict(dict)
+    chunk_relationships["chunk1"][("A", "B")] = [{"description": "rel1"}]
+    relationships = {("A", "B"): []}
+
+    for rel_key, rel_list in relationships.items():
+        if not rel_list:
+            continue
+        if rel_key not in chunk_relationships["chunk1"]:
+            chunk_relationships["chunk1"][rel_key].extend(rel_list)
+        elif len(chunk_relationships["chunk1"][rel_key]) == 0:
+            chunk_relationships["chunk1"][rel_key].extend(rel_list)
+        else:
+            existing_desc_len = len(
+                chunk_relationships["chunk1"][rel_key][0].get(
+                    "description", ""
+                )
+                or ""
+            )
+            new_desc_len = len(rel_list[0].get("description", "") or "")
+
+            if new_desc_len > existing_desc_len:
+                chunk_relationships["chunk1"][rel_key] = list(rel_list)
+
+    assert chunk_relationships["chunk1"][("A", "B")] == [{"description": "rel1"}]
+
+
+def test_glean_nodes_merge_empty_list_does_not_raise():
+    """Verify that glean nodes merge handles empty glean_entities gracefully without raising IndexError."""
+    maybe_nodes = {"E1": [{"description": "desc1"}]}
+    glean_nodes = {"E1": []}
+
+    for entity_name, glean_entities in glean_nodes.items():
+        if not glean_entities:
+            continue
+        if entity_name in maybe_nodes:
+            if not maybe_nodes[entity_name]:
+                maybe_nodes[entity_name] = list(glean_entities)
+            else:
+                original_desc_len = len(
+                    maybe_nodes[entity_name][0].get("description", "") or ""
+                )
+                glean_desc_len = len(glean_entities[0].get("description", "") or "")
+
+                if glean_desc_len > original_desc_len:
+                    maybe_nodes[entity_name] = list(glean_entities)
+        else:
+            maybe_nodes[entity_name] = list(glean_entities)
+
+    assert maybe_nodes["E1"] == [{"description": "desc1"}]
+
+
+def test_glean_edges_merge_empty_list_does_not_raise():
+    """Verify that glean edges merge handles empty glean_edge_list gracefully without raising IndexError."""
+    maybe_edges = {("A", "B"): [{"description": "rel1"}]}
+    glean_edges = {("A", "B"): []}
+
+    for edge_key, glean_edge_list in glean_edges.items():
+        if not glean_edge_list:
+            continue
+        if edge_key in maybe_edges:
+            if not maybe_edges[edge_key]:
+                maybe_edges[edge_key] = list(glean_edge_list)
+            else:
+                original_desc_len = len(
+                    maybe_edges[edge_key][0].get("description", "") or ""
+                )
+                glean_desc_len = len(
+                    glean_edge_list[0].get("description", "") or ""
+                )
+
+                if glean_desc_len > original_desc_len:
+                    maybe_edges[edge_key] = list(glean_edge_list)
+        else:
+            maybe_edges[edge_key] = list(glean_edge_list)
+
+    assert maybe_edges[("A", "B")] == [{"description": "rel1"}]
+
+
+def test_raw_data_none_field_does_not_raise():
+    """Verify that raw_data with 'data': None does not raise AttributeError on .get()."""
+    raw_data = {"data": None, "metadata": {}}
+    final_chunks_count = len((raw_data.get("data") or {}).get("chunks", []))
+    assert final_chunks_count == 0


### PR DESCRIPTION
When cached extraction results contain empty entity lists, _rebuild_from_extraction_result raises IndexError indexing entity_list[0]. Skip empty entity lists before accessing the first element.