### PR TITLE
fix(rerank): ignore out-of-bounds document indices in chunk score aggregation

### DIFF
--- a/lightrag/rerank.py
+++ b/lightrag/rerank.py
@@ -157,7 +157,8 @@ def aggregate_chunk_scores(
 
         if 0 <= chunk_idx < len(doc_indices):
             original_doc_idx = doc_indices[chunk_idx]
-            doc_scores[original_doc_idx].append(score)
+            if 0 <= original_doc_idx < num_original_docs:
+                doc_scores[original_doc_idx].append(score)
 
     # Aggregate scores
     aggregated_results = []

--- a/tests/chunker/test_rerank_chunking.py
+++ b/tests/chunker/test_rerank_chunking.py
@@ -258,6 +258,22 @@ class TestAggregateChunkScores:
         # Should fall back to max
         assert aggregated[0]["relevance_score"] == 0.8
 
+    def test_out_of_bounds_doc_index_ignored(self):
+        """Test that out-of-bounds original document indices in doc_indices do not raise KeyError."""
+        chunk_results = [
+            {"index": 0, "relevance_score": 0.9},
+            {"index": 1, "relevance_score": 0.8},
+        ]
+        doc_indices = [0, 5]
+        num_original_docs = 2
+
+        aggregated = aggregate_chunk_scores(
+            chunk_results, doc_indices, num_original_docs, aggregation="max"
+        )
+
+        assert len(aggregated) == 1
+        assert aggregated[0] == {"index": 0, "relevance_score": 0.9}
+
 
 @pytest.mark.offline
 class TestTopNWithChunking:


### PR DESCRIPTION
When doc_indices maps a chunk to a document index outside the valid range of doc_ids, aggregate_chunk_scores raises KeyError.

Safely skip document indices that fall outside the valid index map.