### PR TITLE
fix(pipeline): fall back to sidecar LaTeX when equation field is omitted or aliased

### DIFF
--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -6195,19 +6195,55 @@ class _PipelineMixin:
                     "description": _required_json_string(parsed, prefix, "description"),
                 }
                 if kind == "equation":
-                    # The model may return the equation under a semantically
-                    # equivalent key such as "equ", or omit it entirely. The
-                    # sidecar already holds the authoritative LaTeX, so fall
-                    # back to it rather than aborting the whole document
-                    # (#3502).
-                    equation_value = parsed.get("equation") or parsed.get("equ")
-                    if isinstance(equation_value, str) and equation_value.strip():
-                        result_obj["equation"] = equation_value.strip()
+                    # ``equation`` is the one deterministic analysis field: the
+                    # equations sidecar already carries the parser's
+                    # authoritative LaTeX.  An otherwise valid response (name +
+                    # description) must therefore not fail a whole document
+                    # just because the model renamed or dropped that one field
+                    # (#3502).  Resolution order:
+                    #   1. ``equation`` — the schema field, normalized as the
+                    #      equation_analysis prompt requires (delimiters and
+                    #      ``\tag{...}`` stripped, align→aligned, Markdown /
+                    #      Unicode math converted to LaTeX).
+                    #   2. ``equ`` — off-schema key observed in the wild, also
+                    #      model-normalized.  Kept deliberately narrow to keys
+                    #      actually seen, because any key accepted here
+                    #      shadows the sidecar fallback below.
+                    #   3. sidecar source LaTeX — NOT normalized (may still
+                    #      carry ``\tag{...}``, ``align``, Unicode math), but
+                    #      preserving it beats failing the document.
+                    equation_value = ""
+                    equation_key = ""
+                    for candidate_key in ("equation", "equ"):
+                        candidate = parsed.get(candidate_key)
+                        if isinstance(candidate, str) and candidate.strip():
+                            equation_value = candidate.strip()
+                            equation_key = candidate_key
+                            break
+                    if equation_value:
+                        if equation_key != "equation":
+                            logger.warning(
+                                f"[analyze_multimodal] {prefix}: model returned "
+                                f"the equation under off-schema key "
+                                f"'{equation_key}'; accepting it as 'equation'"
+                            )
+                        result_obj["equation"] = equation_value
                     elif equation_fallback and equation_fallback.strip():
+                        logger.warning(
+                            f"[analyze_multimodal] {prefix}: model response "
+                            f"missing valid 'equation'; using unnormalized "
+                            f"source LaTeX from the equation sidecar"
+                        )
                         result_obj["equation"] = equation_fallback.strip()
                     else:
-                        raise _MMJSONConformanceError(
-                            f"{prefix}: missing or invalid field 'equation'"
+                        # Defensive only: ``_analyze_text_modality`` rejects an
+                        # equation item with empty sidecar content before any
+                        # analysis call, so the live path always has a fallback.
+                        # Reuse the standard validator so a future caller that
+                        # omits ``equation_fallback`` still fails with the
+                        # canonical conformance error (and gets the retry).
+                        result_obj["equation"] = _required_json_string(
+                            parsed, prefix, "equation"
                         )
                 return result_obj
 

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -6184,7 +6184,10 @@ class _PipelineMixin:
                 }
 
             def _validate_text_analysis(
-                kind: str, item_id: str, parsed: dict[str, Any]
+                kind: str,
+                item_id: str,
+                parsed: dict[str, Any],
+                equation_fallback: str | None = None,
             ) -> dict[str, str]:
                 prefix = f"{kind}/{item_id}"
                 result_obj = {
@@ -6192,9 +6195,20 @@ class _PipelineMixin:
                     "description": _required_json_string(parsed, prefix, "description"),
                 }
                 if kind == "equation":
-                    result_obj["equation"] = _required_json_string(
-                        parsed, prefix, "equation"
-                    )
+                    # The model may return the equation under a semantically
+                    # equivalent key such as "equ", or omit it entirely. The
+                    # sidecar already holds the authoritative LaTeX, so fall
+                    # back to it rather than aborting the whole document
+                    # (#3502).
+                    equation_value = parsed.get("equation") or parsed.get("equ")
+                    if isinstance(equation_value, str) and equation_value.strip():
+                        result_obj["equation"] = equation_value.strip()
+                    elif equation_fallback and equation_fallback.strip():
+                        result_obj["equation"] = equation_fallback.strip()
+                    else:
+                        raise _MMJSONConformanceError(
+                            f"{prefix}: missing or invalid field 'equation'"
+                        )
                 return result_obj
 
             async def _run_json_conformance_retry(
@@ -6669,7 +6683,12 @@ class _PipelineMixin:
                     f"{kind}/{item_id}",
                     cached,
                     _call_extract_once,
-                    lambda parsed: _validate_text_analysis(kind, item_id, parsed),
+                    lambda parsed: _validate_text_analysis(
+                        kind,
+                        item_id,
+                        parsed,
+                        equation_fallback=content_text if kind == "equation" else None,
+                    ),
                 )
                 result_obj: dict[str, Any] = {
                     "name": analysis_fields["name"],

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -833,6 +833,131 @@ async def test_table_routes_to_extract_role_not_vlm(tmp_path):
         await rag.finalize_storages()
 
 
+def _write_equation_fixture(tmp_path: Path, latex: str) -> tuple[str, dict, Path]:
+    """Write a minimal equation sidecar fixture and return (doc_id, parsed_data, path)."""
+    parsed_dir = tmp_path / "parsed"
+    parsed_dir.mkdir()
+    blocks_path = parsed_dir / "doc.blocks.jsonl"
+    blocks_path.write_text(
+        json.dumps({"type": "meta", "doc_id": "doc-1"}) + "\n",
+        encoding="utf-8",
+    )
+    equations_path = parsed_dir / "doc.equations.json"
+    equations_path.write_text(
+        json.dumps(
+            {
+                "equations": {
+                    "eq-001": {
+                        "id": "eq-001",
+                        "blockid": "blk-1",
+                        "heading": "",
+                        "parent_headings": [],
+                        "format": "latex",
+                        "content": latex,
+                        "caption": "",
+                        "footnotes": [],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return "doc-1", {"blocks_path": str(blocks_path)}, equations_path
+
+
+@pytest.mark.asyncio
+async def test_equation_omitted_field_falls_back_to_sidecar_latex(tmp_path):
+    """Regression #3502: when the model omits the `equation` field entirely,
+    the analysis must fall back to the sidecar's authoritative LaTeX instead
+    of aborting the whole document."""
+    extract_log: list[dict] = []
+
+    async def extract_func(prompt, **kwargs):
+        extract_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
+        # Model returns valid name/description but omits `equation` entirely.
+        return json.dumps(
+            {
+                "name": "sample-quantile",
+                "description": "Defines the p-th sample quantile.",
+            }
+        )
+
+    rag = _build_rag(
+        tmp_path,
+        vlm_process_enable=True,
+        vlm_func=_make_vlm_mock([]),
+        extract_func=extract_func,
+    )
+    await rag.initialize_storages()
+    try:
+        sidecar_latex = r"x_p = \left\{ \begin{array}{ll} x_{(k)} & \text{if } p = k \end{array} \right."
+        doc_id, parsed_data, equations_path = _write_equation_fixture(
+            tmp_path, sidecar_latex
+        )
+
+        await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="e",
+        )
+        assert len(extract_log) == 1
+        payload = json.loads(equations_path.read_text(encoding="utf-8"))
+        result = payload["equations"]["eq-001"]["llm_analyze_result"]
+        assert result["status"] == "success"
+        assert result["name"] == "sample-quantile"
+        # The equation field must be recovered from the sidecar LaTeX.
+        assert result["equation"] == sidecar_latex
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_equation_equ_alias_accepted(tmp_path):
+    """Regression #3502: when the model returns the equation under a
+    semantically equivalent key such as `equ`, it must be accepted."""
+    extract_log: list[dict] = []
+
+    async def extract_func(prompt, **kwargs):
+        extract_log.append({"prompt": prompt, "kwargs": dict(kwargs)})
+        # Model returns the equation under the alias key `equ`.
+        return json.dumps(
+            {
+                "name": "sample-quantile",
+                "description": "Defines the p-th sample quantile.",
+                "equ": r"x_p = x_{(k)}",
+            }
+        )
+
+    rag = _build_rag(
+        tmp_path,
+        vlm_process_enable=True,
+        vlm_func=_make_vlm_mock([]),
+        extract_func=extract_func,
+    )
+    await rag.initialize_storages()
+    try:
+        sidecar_latex = r"x_p = \left\{ \begin{array}{ll} x_{(k)} \end{array} \right."
+        doc_id, parsed_data, equations_path = _write_equation_fixture(
+            tmp_path, sidecar_latex
+        )
+
+        await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="e",
+        )
+        assert len(extract_log) == 1
+        payload = json.loads(equations_path.read_text(encoding="utf-8"))
+        result = payload["equations"]["eq-001"]["llm_analyze_result"]
+        assert result["status"] == "success"
+        # The `equ` alias value is used (preferred over the sidecar fallback).
+        assert result["equation"] == r"x_p = x_{(k)}"
+    finally:
+        await rag.finalize_storages()
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "response",

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -866,10 +866,14 @@ def _write_equation_fixture(tmp_path: Path, latex: str) -> tuple[str, dict, Path
 
 
 @pytest.mark.asyncio
-async def test_equation_omitted_field_falls_back_to_sidecar_latex(tmp_path):
+async def test_equation_omitted_field_falls_back_to_sidecar_latex(
+    tmp_path, caplog, _propagate_lightrag_logger
+):
     """Regression #3502: when the model omits the `equation` field entirely,
     the analysis must fall back to the sidecar's authoritative LaTeX instead
-    of aborting the whole document."""
+    of aborting the whole document — and must say so in the log, since the
+    fallback silently trades the prompt-mandated normalization for source
+    LaTeX and no conformance retry fires any more."""
     extract_log: list[dict] = []
 
     async def extract_func(prompt, **kwargs):
@@ -895,12 +899,14 @@ async def test_equation_omitted_field_falls_back_to_sidecar_latex(tmp_path):
             tmp_path, sidecar_latex
         )
 
-        await rag.analyze_multimodal(
-            doc_id=doc_id,
-            file_path="fixture.pdf",
-            parsed_data=parsed_data,
-            process_options="e",
-        )
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="lightrag"):
+            await rag.analyze_multimodal(
+                doc_id=doc_id,
+                file_path="fixture.pdf",
+                parsed_data=parsed_data,
+                process_options="e",
+            )
         assert len(extract_log) == 1
         payload = json.loads(equations_path.read_text(encoding="utf-8"))
         result = payload["equations"]["eq-001"]["llm_analyze_result"]
@@ -908,14 +914,26 @@ async def test_equation_omitted_field_falls_back_to_sidecar_latex(tmp_path):
         assert result["name"] == "sample-quantile"
         # The equation field must be recovered from the sidecar LaTeX.
         assert result["equation"] == sidecar_latex
+        # Operators must be able to see that their model returns off-schema
+        # JSON: the fallback is the only remaining signal (the JSON
+        # conformance retry no longer fires for this response).
+        assert [
+            r
+            for r in caplog.records
+            if "equation/eq-001" in r.getMessage()
+            and "unnormalized source LaTeX" in r.getMessage()
+        ]
     finally:
         await rag.finalize_storages()
 
 
 @pytest.mark.asyncio
-async def test_equation_equ_alias_accepted(tmp_path):
+async def test_equation_equ_alias_accepted(
+    tmp_path, caplog, _propagate_lightrag_logger
+):
     """Regression #3502: when the model returns the equation under a
-    semantically equivalent key such as `equ`, it must be accepted."""
+    semantically equivalent key such as `equ`, it must be accepted (and
+    logged — an accepted alias shadows the sidecar's authoritative LaTeX)."""
     extract_log: list[dict] = []
 
     async def extract_func(prompt, **kwargs):
@@ -942,18 +960,31 @@ async def test_equation_equ_alias_accepted(tmp_path):
             tmp_path, sidecar_latex
         )
 
-        await rag.analyze_multimodal(
-            doc_id=doc_id,
-            file_path="fixture.pdf",
-            parsed_data=parsed_data,
-            process_options="e",
-        )
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="lightrag"):
+            await rag.analyze_multimodal(
+                doc_id=doc_id,
+                file_path="fixture.pdf",
+                parsed_data=parsed_data,
+                process_options="e",
+            )
         assert len(extract_log) == 1
         payload = json.loads(equations_path.read_text(encoding="utf-8"))
         result = payload["equations"]["eq-001"]["llm_analyze_result"]
         assert result["status"] == "success"
         # The `equ` alias value is used (preferred over the sidecar fallback).
         assert result["equation"] == r"x_p = x_{(k)}"
+        assert [
+            r
+            for r in caplog.records
+            if "equation/eq-001" in r.getMessage()
+            and "off-schema key 'equ'" in r.getMessage()
+        ]
+        # The sidecar fallback must NOT be reported when the alias supplied a
+        # usable body.
+        assert not [
+            r for r in caplog.records if "unnormalized source LaTeX" in r.getMessage()
+        ]
     finally:
         await rag.finalize_storages()
 


### PR DESCRIPTION
## Summary

Fixes #3502

When ingesting a PDF through MinerU with equation analysis enabled, the Extract model may return valid `name`/`description` fields but omit the expected `equation` field, or return it under an off-schema key such as `equ`. Previously this raised `_MMJSONConformanceError` (`missing or invalid field 'equation'`) and — after the single conformance retry also failed — **aborted the entire document ingestion**, even though MinerU had already extracted valid LaTeX into the equation sidecar. In the reported case a 400+ page textbook failed on one equation on page 142.

## Root cause

`_validate_text_analysis` treated `equation` as a hard-required field via `_required_json_string`, with no tolerance for off-schema keys and no fallback to the sidecar's authoritative LaTeX.

Unlike `name`/`description`, `equation` is a *deterministic* field: the equations sidecar already holds the parser's LaTeX for that item, so the model response is not the only source of truth for it.

## Fix

`_validate_text_analysis` now resolves the equation body in this order:

1. **`equation`** — the schema field. Normalized as the `equation_analysis` prompt requires (delimiters and `\tag{...}` stripped, `align`/`align*` → `aligned`, Markdown/Unicode math converted to LaTeX).
2. **`equ`** — off-schema key observed in the wild (#3502), also model-normalized. Deliberately narrow to keys actually observed rather than an open-ended synonym list, because any key accepted here shadows the sidecar fallback below.
3. **Sidecar source LaTeX** (`content_text`) — the parser's authoritative body.

`name` and `description` remain hard-required: only the deterministic field is backfilled. The terminal `_required_json_string` branch is retained as a defensive path only — `_analyze_text_modality` already rejects an equation item with empty sidecar content before any analysis call, so the live path always has a fallback available.

Because the fallback lives in the `validate_result` callback passed to `_run_json_conformance_retry`, it applies identically to cached and fresh responses, so re-ingestion is idempotent.

## Observability

Both non-schema paths log a warning, because the fallback makes the first validation attempt succeed and therefore suppresses the previous `invalid JSON schema from model; retrying once` warning:

- sidecar fallback used → `model response missing valid 'equation'; using unnormalized source LaTeX from the equation sidecar`
- alias accepted → `model returned the equation under off-schema key 'equ'; accepting it as 'equation'`

Without these, an operator whose model consistently returns off-schema JSON would have no signal at all.

## Trade-offs / notes

- **The fallback LaTeX is not normalized.** The `equation` field the model is asked to produce goes through the prompt's normalization rules (see above); the sidecar `content` does not. For MinerU output — already LaTeX, with `$$`/`$` wrappers stripped by `_strip_latex_dollar_wrappers` in the sidecar writer — the practical difference is small, and preserving source LaTeX is strictly better than failing the document. But the fallback body may still carry `\tag{...}`, `align`, or Unicode math. This is a deliberate trade, not an equivalence.
- **The fallback uses the untrimmed sidecar content.** The prompt may have been built from a `trim_content_to_budget`-trimmed copy; the fallback is the full body. For a pathologically long equation this can shift the failure to the multimodal-chunk assembly cap (`multimodal chunk exceeds max_tokens`, which truncates only `description`, never `equation`). Same exposure already exists when the model echoes a long equation, so no new class of failure — just noting where it would surface.

## Relationship to #3503

The equation-fallback approach comes from the equation slice of #3503 (closed unmerged) by @cyysky2, who also reported #3502. This PR ships only that slice, standalone: it does not include #3503's MinerU content-mapping, `MINERU_DROP_TYPES`, or poll-retry changes, whose chart-retrievability question on the default `process_options="F"` ingestion path was still unresolved.

## Tests

Two regression tests in `tests/pipeline/test_pipeline_analyze_multimodal.py`, both driving the real `analyze_multimodal` path and asserting the warning lines:

- `test_equation_omitted_field_falls_back_to_sidecar_latex` — model omits `equation`, sidecar LaTeX is recovered, fallback is logged
- `test_equation_equ_alias_accepted` — `equ` alias is accepted and logged, and the sidecar-fallback warning is *not* emitted

```
$ pytest tests/pipeline/test_pipeline_analyze_multimodal.py -q
43 passed

$ pytest tests/pipeline -q
522 passed

$ pre-commit run --files lightrag/pipeline.py tests/pipeline/test_pipeline_analyze_multimodal.py
all hooks passed
```

Verified both tests fail on `main` (pre-fix) and pass with the fix; the log assertions were also verified to fail against the first commit of this PR, so they lock the new behavior rather than riding on the original fix.
