### PR TITLE
fix(parser): stop a heavy member from swamping an outline merge owner

### DIFF
--- a/lightrag/parser/docx/smart_heading/heading_flow.py
+++ b/lightrag/parser/docx/smart_heading/heading_flow.py
@@ -1826,9 +1826,16 @@ def anchor_outline_levels(
 
 _MERGE_MAX_LINES = 4
 
-#: How much heavier than the merge owner a member must be for the owner's own
-#: physical outline to arm the joined-text gate. Calibrated against the two
-#: measured shapes (weighted en-equivalent chars, cap 180):
+#: How much heavier than the merge owner its members must COLLECTIVELY be for
+#: the owner's own physical outline to arm the joined-text gate. Both sides of
+#: the comparison are fixed points — the owner's ORIGINAL weight and the running
+#: total of everything absorbed — never the accumulated join: comparing each
+#: member against a window that already swallowed the previous ones makes the
+#: criterion path-dependent and monotonically harder to meet, so members that
+#: individually stay under the ratio can still swamp the owner together (14 +
+#: 20 + 60 + 100 clears a 180 cap while every successive 2x check passes).
+#: Calibrated against the two measured shapes (weighted en-equivalent chars,
+#: cap 180):
 #:   - 【政策内容】 (14) absorbing a 312-char citation — ratio 22: the join reads
 #:     as body entirely because of the NEIGHBOUR, and committing it costs a real
 #:     baseline heading its identity;
@@ -1843,23 +1850,21 @@ _MERGE_MAX_LINES = 4
 _MERGE_OUTLINE_OWNER_OUTWEIGH_RATIO = 2.0
 
 
-def _outline_owner_outweighed(cur: HeadingDecision, nxt: HeadingDecision) -> bool:
-    """Does ``cur`` carry a physical outline that ``nxt`` would swamp?
+def _members_outweigh_owner(owner_weight: int, absorbed_weight: int) -> bool:
+    """Have the absorbed members collectively swamped the merge owner?
 
-    True when the owner has an ``outlineLvl`` and the candidate member weighs at
-    least :data:`_MERGE_OUTLINE_OWNER_OUTWEIGH_RATIO` times as much: whatever
-    makes the joined text read as body then comes from the MEMBER, not from the
-    owner, so the merge would trade a real heading for a body paragraph. The
-    comparison is against ``cur.text`` as accumulated so far (the window may
-    already hold earlier members), which is the text the verdict applies to.
+    ``owner_weight`` is the owner's ORIGINAL weighted length and
+    ``absorbed_weight`` the running total of every member taken so far,
+    including the one under consideration. True means whatever makes the joined
+    text read as body comes from the MEMBERS, not from the owner — so a merge
+    that the sweep would then demote trades a real heading for a body paragraph.
+
+    Monotonic in ``absorbed_weight``, hence sticky by construction: once the
+    members outweigh the owner they cannot un-outweigh it later in the window.
     """
-    if cur.outline_level is None:
-        return False
-    owner_weight = guardrails.weighted_char_length(cur.text.strip())
     if owner_weight <= 0:
         return False
-    member_weight = guardrails.weighted_char_length(nxt.text.strip())
-    return member_weight >= _MERGE_OUTLINE_OWNER_OUTWEIGH_RATIO * owner_weight
+    return absorbed_weight >= _MERGE_OUTLINE_OWNER_OUTWEIGH_RATIO * owner_weight
 
 
 def merge_split_headings(
@@ -1897,7 +1902,10 @@ def merge_split_headings(
       decision — an invariant-I2 violation that costs the WHOLE document its
       smart output (see :func:`_register_merge_members`);
     - the same gate arms when the OWNER is the one carrying the outline and the
-      member outweighs it (:func:`_outline_owner_outweighed`). This mirror image
+      members COLLECTIVELY outweigh it (:func:`_members_outweigh_owner`, fed the
+      owner's original weight and the running member total — never the
+      accumulated join, which would let members that each stay under the ratio
+      swamp the owner together). This mirror image
       fails differently and more quietly: the owner is what the sweep demotes,
       and ``strong_body_demoted`` IS whitelisted by
       :func:`guardrails.verify_baseline_heading_retention`, so I2 does NOT trip
@@ -1933,6 +1941,8 @@ def merge_split_headings(
         lines = cur.text.count("\n") + 1
         merged_members = [cur.record_index]
         absorbed_outline = False  # sticky: a baseline heading is in the window
+        owner_weight = guardrails.weighted_char_length(cur.text.strip())
+        absorbed_weight = 0  # running total of the members taken so far
         k = pos + 1
         while k < len(decisions):
             nxt = decisions[k]
@@ -1951,12 +1961,16 @@ def merge_split_headings(
             if lines + nxt_lines > _MERGE_MAX_LINES:
                 break
             joined = _join_heading_texts(cur.text, nxt.text)
+            absorbed_weight += guardrails.weighted_char_length(nxt.text.strip())
             # Outer guard: a window with no outline at stake never pays for this
             # extra NLP judgment.
             if (
                 absorbed_outline
                 or nxt.outline_level is not None
-                or _outline_owner_outweighed(cur, nxt)
+                or (
+                    cur.outline_level is not None
+                    and _members_outweigh_owner(owner_weight, absorbed_weight)
+                )
             ):
                 joined_reason, _joined_spared = _strong_body_with_outline_context(
                     joined, cur.outline_level, strong_body

--- a/lightrag/parser/docx/smart_heading/heading_flow.py
+++ b/lightrag/parser/docx/smart_heading/heading_flow.py
@@ -1826,6 +1826,41 @@ def anchor_outline_levels(
 
 _MERGE_MAX_LINES = 4
 
+#: How much heavier than the merge owner a member must be for the owner's own
+#: physical outline to arm the joined-text gate. Calibrated against the two
+#: measured shapes (weighted en-equivalent chars, cap 180):
+#:   - 【政策内容】 (14) absorbing a 312-char citation — ratio 22: the join reads
+#:     as body entirely because of the NEIGHBOUR, and committing it costs a real
+#:     baseline heading its identity;
+#:   - _Medical Graph RAG.docx's author line (96) absorbing its affiliation line
+#:     (103) — ratio 1.07: two comparably meaty lines that only cross the body
+#:     threshold TOGETHER, exactly the merge-then-demote-together case the gate
+#:     must not break (that .docx marks the author list as outlineLvl=1, so the
+#:     outline evidence itself is dirty and cannot be trusted on its own).
+#: 2.0 sits in the wide gap between them. Raising it toward 22 or lowering it
+#: toward 1.07 narrows one of those margins — do not tune without re-running the
+#: corpus A/B.
+_MERGE_OUTLINE_OWNER_OUTWEIGH_RATIO = 2.0
+
+
+def _outline_owner_outweighed(cur: HeadingDecision, nxt: HeadingDecision) -> bool:
+    """Does ``cur`` carry a physical outline that ``nxt`` would swamp?
+
+    True when the owner has an ``outlineLvl`` and the candidate member weighs at
+    least :data:`_MERGE_OUTLINE_OWNER_OUTWEIGH_RATIO` times as much: whatever
+    makes the joined text read as body then comes from the MEMBER, not from the
+    owner, so the merge would trade a real heading for a body paragraph. The
+    comparison is against ``cur.text`` as accumulated so far (the window may
+    already hold earlier members), which is the text the verdict applies to.
+    """
+    if cur.outline_level is None:
+        return False
+    owner_weight = guardrails.weighted_char_length(cur.text.strip())
+    if owner_weight <= 0:
+        return False
+    member_weight = guardrails.weighted_char_length(nxt.text.strip())
+    return member_weight >= _MERGE_OUTLINE_OWNER_OUTWEIGH_RATIO * owner_weight
+
 
 def merge_split_headings(
     decisions: list[HeadingDecision],
@@ -1860,7 +1895,17 @@ def merge_split_headings(
       finally pushes the join over the body threshold. Committing such a merge
       would let the sweep undo it and strand the outline member without a
       decision — an invariant-I2 violation that costs the WHOLE document its
-      smart output (see :func:`_register_merge_members`).
+      smart output (see :func:`_register_merge_members`);
+    - the same gate arms when the OWNER is the one carrying the outline and the
+      member outweighs it (:func:`_outline_owner_outweighed`). This mirror image
+      fails differently and more quietly: the owner is what the sweep demotes,
+      and ``strong_body_demoted`` IS whitelisted by
+      :func:`guardrails.verify_baseline_heading_retention`, so I2 does NOT trip
+      and no fallback rescues the document — a real baseline heading just
+      becomes body. Owner outline alone is NOT enough to arm it: a .docx that
+      marks a 96-char author list as ``outlineLvl=1`` is dirty evidence, and the
+      merge-then-demote-together outcome is right there. The weight ratio is
+      what separates the two.
 
     The joined-text gate is verdict-identical to the sweep's own test: same
     predicate, same ``(text, outline_level)`` arguments, and nothing mutates
@@ -1906,9 +1951,13 @@ def merge_split_headings(
             if lines + nxt_lines > _MERGE_MAX_LINES:
                 break
             joined = _join_heading_texts(cur.text, nxt.text)
-            # Outer guard: an outline-free window never pays for this extra
-            # NLP judgment.
-            if absorbed_outline or nxt.outline_level is not None:
+            # Outer guard: a window with no outline at stake never pays for this
+            # extra NLP judgment.
+            if (
+                absorbed_outline
+                or nxt.outline_level is not None
+                or _outline_owner_outweighed(cur, nxt)
+            ):
                 joined_reason, _joined_spared = _strong_body_with_outline_context(
                     joined, cur.outline_level, strong_body
                 )
@@ -1964,6 +2013,16 @@ def _register_merge_members(
     parent's subtree) and :func:`clamp_deep_levels` (level > 9); both are
     warned about so the event is diagnosable instead of mysterious.
 
+    Separately, an undone merge whose OWNER carries a physical outline is
+    counted as ``smart_merge_outline_owner_demoted``. That case does not violate
+    I2 — the owner holds a whitelisted ``strong_body_demoted`` /
+    ``clamp_gt9_demoted`` tag, so nothing trips and no fallback runs — which is
+    exactly why it needs its own counter: the heading is gone and the only other
+    trace is an aggregate ``smart_strong_body_demotions`` that cannot be
+    attributed to a merge. The weight-ratio gate in
+    :func:`merge_split_headings` closes the direct route here too; the residual
+    routes are the same cascade and clamp.
+
     A member's own decision is NOT restored as a heading: its level is the
     product of the whole per-sub-document pipeline (series alignment,
     anchoring, gap closing, nesting, clamping — all cross-paragraph set
@@ -1973,6 +2032,16 @@ def _register_merge_members(
     ``rec.text``), and restoring it would mean teaching the merge about
     downstream demotion.
     """
+    if not d.is_heading and records[d.record_index].outline_level is not None:
+        warnings["smart_merge_outline_owner_demoted"] = (
+            warnings.get("smart_merge_outline_owner_demoted", 0) + 1
+        )
+        logger.warning(
+            "[smart_heading] outline paragraph %d lost its heading identity as "
+            "the owner of an undone heading merge; I2 does not cover this case "
+            "(the demotion rule is whitelisted), so nothing else reports it",
+            d.record_index,
+        )
     for m in d.member_indices[1:]:
         if d.is_heading:
             member = HeadingDecision(record_index=m, text="", absorbed=True)

--- a/tests/parser/docx/test_smart_heading_skeleton.py
+++ b/tests/parser/docx/test_smart_heading_skeleton.py
@@ -225,6 +225,113 @@ def test_absorbed_outline_keeps_guarding_later_outline_free_joins() -> None:
     assert verify_baseline_heading_retention(records, list(decisions.values())) == []
 
 
+def _weighted_strong_body(text: str) -> str | None:
+    """Stub mirroring the real predicate's LENGTH rule only (cap 180
+    en-equivalent chars), so a test can place two lines on either side of the
+    threshold the way a real document does."""
+    from lightrag.parser.docx.smart_heading.guardrails import (
+        heading_max_chars,
+        weighted_char_length,
+    )
+
+    stripped = text.strip()
+    if weighted_char_length(stripped) > heading_max_chars():
+        return "strong_body_length"
+    return None
+
+
+def test_outline_owner_is_not_swamped_by_a_much_heavier_member() -> None:
+    """The MIRROR of 1a-ii: the outline is on the OWNER, not on the member.
+
+    This direction fails more quietly than the member one. The sweep demotes the
+    OWNER, which then carries a whitelisted ``strong_body_demoted`` tag, so I2
+    stays green (asserted below) and no fallback rescues the document — the
+    baseline heading simply becomes body. The member outweighs the owner 22:1
+    here, so the join reads as body entirely because of the member.
+    """
+    from lightrag.parser.docx.smart_heading.guardrails import (
+        verify_baseline_heading_retention,
+    )
+
+    citation = "（2）《某某部关于印发某某规定的通知》（某部联企业〔2011〕300号）等文件规定的内容在此展开叙述。"
+    records = [
+        ParagraphRecord(kind="para", text="【政策内容】", outline_level=0),
+        ParagraphRecord(kind="para", text=citation),
+    ]
+    ds = [_d("【政策内容】", 1, idx=0, outline=0), _d(citation, 1, idx=1)]
+    warnings: dict = {}
+    out = merge_split_headings(
+        ds, records, strong_body=_stub_strong_body, warnings=warnings
+    )
+    assert len(out) == 2  # no merge: the member would swamp the outline owner
+    assert "smart_heading_merges" not in warnings
+
+    demote_strong_body_headings(out, strong_body=_stub_strong_body, warnings=warnings)
+    assert out[0].is_heading  # 【政策内容】 keeps its heading identity
+    assert out[0].text == "【政策内容】"
+    # I2 is NOT the safety net in this direction — it passes either way.
+    assert verify_baseline_heading_retention(records, out) == []
+
+
+def test_comparably_weighted_outline_owner_still_merges() -> None:
+    """The owner gate is scoped by WEIGHT, not by the mere presence of an
+    outline level — seeding it from ``cur.outline_level is not None`` regresses
+    _Medical Graph RAG.docx, whose author line is marked ``outlineLvl=1``.
+
+    Two comparably heavy lines (ratio 1.07) cross the body threshold only
+    TOGETHER; blocking the merge resurrects both as spurious headings instead of
+    letting the sweep demote the join. Sizes here mirror that document: 96 and
+    103 weighted chars against a 180 cap.
+    """
+    owner_text = (
+        "Author One1, Author Two1, Author Three1, Author Four1, Author Five2,"
+        " Author Six3, Author Seven1,"
+    )
+    member_text = (
+        "1University of Somewhere, 2Institute of Something Else, 3The"
+        " University of Anotherplace, Department of Examples,"
+    )
+    records = [
+        ParagraphRecord(kind="para", text=owner_text, outline_level=1),
+        ParagraphRecord(kind="para", text=member_text),
+    ]
+    ds = [_d(owner_text, 2, idx=0, outline=1), _d(member_text, 2, idx=1)]
+    warnings: dict = {}
+    out = merge_split_headings(
+        ds, records, strong_body=_weighted_strong_body, warnings=warnings
+    )
+    assert len(out) == 1  # merged, exactly as before the owner gate
+    assert warnings["smart_heading_merges"] == 1
+    demote_strong_body_headings(out, strong_body=_weighted_strong_body, warnings={})
+    assert not out[0].is_heading  # …and demoted TOGETHER, which is the point
+
+
+def test_demoted_outline_owner_is_counted() -> None:
+    """An undone merge whose OWNER carries an outline is invisible to I2 (its
+    demotion rule is whitelisted) and indistinguishable from any other
+    strong-body demotion in the aggregate counter — so it gets its own."""
+    from lightrag.parser.docx.smart_heading.guardrails import (
+        verify_baseline_heading_retention,
+    )
+
+    records = [
+        ParagraphRecord(kind="para", text="【政策内容】", outline_level=0),
+        ParagraphRecord(kind="para", text="被吞掉的正文续句。"),
+    ]
+    owner = _d("【政策内容】被吞掉的正文续句。", 1, idx=0, outline=0)
+    owner.member_indices = (0, 1)
+    owner.is_heading = False  # the sweep undid the merge
+    owner.note("strong_body_demoted")  # …with a rule I2 whitelists
+    decisions = {0: owner}
+    warnings: dict = {}
+    _register_merge_members(decisions, owner, records, warnings)
+
+    assert warnings.get("smart_merge_outline_owner_demoted") == 1
+    assert warnings.get("smart_merge_unwound") == 1  # the non-outline member
+    # The counter exists precisely BECAUSE nothing else reports this:
+    assert verify_baseline_heading_retention(records, list(decisions.values())) == []
+
+
 def test_stranded_outline_member_keeps_the_i2_fallback() -> None:
     """1b outline branch: an undone merge must NOT silently re-classify a
     baseline heading as body. No decision is written, so I2 still trips and the

--- a/tests/parser/docx/test_smart_heading_skeleton.py
+++ b/tests/parser/docx/test_smart_heading_skeleton.py
@@ -306,6 +306,43 @@ def test_comparably_weighted_outline_owner_still_merges() -> None:
     assert not out[0].is_heading  # …and demoted TOGETHER, which is the point
 
 
+def test_outline_owner_gate_counts_members_cumulatively() -> None:
+    """The owner gate weighs the members COLLECTIVELY against the owner's
+    ORIGINAL weight, not each member against the accumulated join.
+
+    Judging against the accumulated join makes the criterion path-dependent and
+    monotonically harder to meet: 15 + 21 + 60 + 102 clears the 180 cap while
+    every successive 2x check passes (the window weighs 15, 36, then 96), so all
+    four merge, the sweep demotes the outlined owner, and — the demotion rule
+    being whitelisted — I2 stays green and the heading is silently gone.
+    """
+    from lightrag.parser.docx.smart_heading.guardrails import (
+        verify_baseline_heading_retention,
+    )
+
+    # weighted_char_length counts a CJK char as 3, so N chars weigh 3N.
+    texts = ["文" * 5, "文" * 7, "文" * 20, "文" * 34]  # 15 / 21 / 60 / 102
+    records = [ParagraphRecord(kind="para", text=texts[0], outline_level=0)] + [
+        ParagraphRecord(kind="para", text=t) for t in texts[1:]
+    ]
+    ds = [_d(texts[0], 1, idx=0, outline=0)] + [
+        _d(t, 1, idx=i) for i, t in enumerate(texts[1:], start=1)
+    ]
+    warnings: dict = {}
+    out = merge_split_headings(
+        ds, records, strong_body=_weighted_strong_body, warnings=warnings
+    )
+    # The first two members stay under the cumulative ratio and merge; the 102
+    # one takes the running total to 183 (> 2x15), arming the gate on a join
+    # that weighs 198 > 180.
+    assert out[0].member_indices == (0, 1, 2)
+    assert [d.record_index for d in out] == [0, 3]
+
+    demote_strong_body_headings(out, strong_body=_weighted_strong_body, warnings={})
+    assert out[0].is_heading  # the outlined owner keeps its heading identity
+    assert verify_baseline_heading_retention(records, out) == []
+
+
 def test_demoted_outline_owner_is_counted() -> None:
     """An undone merge whose OWNER carries an outline is invisible to I2 (its
     demotion rule is whitelisted) and indistinguishable from any other


### PR DESCRIPTION
## Description

Follow-up to #3526, from its review. The merge gates added there cover the case where the absorbed MEMBER carries `w:outlineLvl`. The mirror image — the outline is on the merge OWNER — was left open, and it fails more quietly.

When `cur` carries the outline and `nxt` does not, `absorbed_outline` starts `False` and the outer guard `absorbed_outline or nxt.outline_level is not None` never evaluates the joined-text gate. The join commits, the post-merge sweep demotes the OWNER, and the owner then carries `strong_body_demoted` — a rule `verify_baseline_heading_retention` **whitelists**. So I2 stays green, no fallback runs, and a real baseline heading simply becomes body. Nothing reports it.

Verified on `f2971405` (the commit #3526 branched from): the same input produces the same silent loss there, so this is a pre-existing gap the member-side gates did not reach, **not** a regression they introduced.

## Related Issues

None. Found while reviewing #3526.

## Changes Made

### The gate must NOT arm on outline presence

The obvious-looking fix — seed the sticky flag with `cur.outline_level is not None` — regresses `_Medical Graph RAG.docx`, measured:

| | blocks | chars | merges |
|---|---|---|---|
| as shipped | 28 | 34293 | 1 |
| seeded on outline presence | 30 | 34297 | 0 |

That document marks a 96-char author list as `outlineLvl=1`; its merge with the 103-char affiliation line is demoted **together**, which is correct. Blocking it resurrects both lines as spurious L2 headings. Outline evidence is not automatically trustworthy, so its mere presence cannot arm a gate.

### What separates the two shapes: which side makes the join read as body

| Shape | owner | member | ratio | right outcome |
|---|---|---|---|---|
| `【政策内容】` + a citation | 14 | 312 | **22** | block the merge — the member alone is what crosses the threshold |
| author list + affiliations | 96 | 103 | **1.07** | allow it — two comparably heavy lines cross it only together |

So `_members_outweigh_owner()` arms the existing joined-text gate when the owner carries an outline **and** the members COLLECTIVELY weigh at least `_MERGE_OUTLINE_OWNER_OUTWEIGH_RATIO` (2.0) times the owner — a value sitting in the wide gap between the two measurements.

Both sides of that comparison are fixed points: the owner's **original** weight and a running total of everything absorbed. Judging each member against the accumulated join instead would make the criterion path-dependent and monotonically harder to meet — the owner grows as it swallows members, so members that each stay under the ratio swamp it together (15 + 21 + 60 + 102 clears a 180 cap while every successive 2x check passes). The running total is monotonic, hence sticky by construction, with no separate flag. Caught by Codex in review; see the second commit.

A ratio, not an absolute short-owner threshold: `weighted_char_length` counts CJK as 3, so any absolute cutoff low enough to exclude the 96-weight author list protects only ~20 CJK chars and misses long outline headings entirely.

### Attribution for the case that survives

`_register_merge_members` now counts an undone merge whose owner carries an outline as `smart_merge_outline_owner_demoted` (+ a log line). Unlike the member branch this is **not** an I2 event, which is exactly why it needs its own counter — the only other trace was an aggregate `smart_strong_body_demotions` that cannot be attributed to a merge. The gate closes the direct sweep route; the residual routes remain the `subtree_demoted` cascade and `clamp_deep_levels`, as documented in #3526.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

### Corpus A/B, 19 documents, real branch code

(Re-run after the review fix; numbers below are for the final state of the branch.)

Compared block levels, headings, per-block content hashes, `doc_title` and the full warnings dict, with a deterministic stub judge.

**Output is byte-identical across all 19 documents.** The single difference anywhere is the new counter firing once — on `_Medical Graph RAG.docx`, the known dirty-outline document, whose merge is preserved. That is the intended observability: the event was already happening, silently.

### Fix-proof

Each production condition reverted on its own, all failing behaviourally:

| Reverted | Failing test | Failure |
|---|---|---|
| `_outline_owner_outweighed` clause | `test_outline_owner_is_not_swamped_by_a_much_heavier_member` | `assert 1 == 2` (merged rows) |
| gate armed on outline presence instead of weight | `test_comparably_weighted_outline_owner_still_merges` | `assert 2 == 1` |
| the counter | `test_demoted_outline_owner_is_counted` | `None != 1` |
| cumulative total → member-vs-accumulated | `test_outline_owner_gate_counts_members_cumulatively` | `assert (0, 1, 2, 3) == (0, 1, 2)` |

The middle row is the reviewer's originally proposed one-liner; the test pins it out.

### Verification

- `tests/parser/docx`: **826 passed** (rebased onto main, which now carries #3528)
- `pre-commit run --files …`: ruff format + ruff pass

### Known limits

- The 2.0 ratio has two calibration points (22 and 1.07). The constant's docstring says so and says not to tune it without re-running the corpus A/B.
- `test_comparably_weighted_outline_owner_still_merges` uses synthetic Latin text sized to match the real document (96 / 103 weighted against the 180 cap) rather than the corpus binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
