### PR TITLE
fix(rerank): guard malformed provider results

### DIFF
--- a/lightrag/rerank.py
+++ b/lightrag/rerank.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import Counter
+from math import isfinite
 import os
 import aiohttp
 from typing import Any, List, Dict, Optional, Tuple
@@ -29,6 +31,35 @@ DEFAULT_RERANK_MAX_TOKENS_PER_DOC = 4096
 # payload and the number of scores to aggregate. Configured values below this are
 # accepted but warned about at startup rather than silently degrading query latency.
 MIN_PRACTICAL_RERANK_MAX_TOKENS = 64
+
+
+def _normalize_rerank_result(
+    result: Any, max_index: int
+) -> tuple[dict[str, int | float] | None, str | None]:
+    """Validate one provider result and return the public rerank shape.
+
+    Providers and compatible proxies occasionally return mixed ``results`` lists.
+    Keeping the validation here lets the HTTP boundary and chunk aggregation reject
+    the same malformed entries without leaking invalid indices or non-finite scores
+    into callers.
+    """
+    if not isinstance(result, dict):
+        return None, "not an object"
+
+    index = result.get("index")
+    if isinstance(index, bool) or not isinstance(index, int):
+        return None, "invalid index"
+    if not 0 <= index < max_index:
+        return None, "index out of range"
+
+    try:
+        score = float(result.get("relevance_score"))
+    except (TypeError, ValueError):
+        return None, "invalid relevance score"
+    if not isfinite(score):
+        return None, "non-finite relevance score"
+
+    return {"index": index, "relevance_score": score}, None
 
 
 def chunk_documents_for_rerank(
@@ -148,29 +179,26 @@ def aggregate_chunk_scores(
     Returns:
         List of results for original documents [{"index": doc_idx, "relevance_score": score}, ...]
     """
+    if not chunk_results or not doc_indices:
+        return []
+
     # Group scores by original document index
     doc_scores: Dict[int, List[float]] = {i: [] for i in range(num_original_docs)}
 
     for result in chunk_results:
-        chunk_idx = result.get("index")
-        score = result.get("relevance_score")
+        normalized_result, _ = _normalize_rerank_result(result, len(doc_indices))
+        if normalized_result is None:
+            continue
 
+        chunk_idx = normalized_result["index"]
+        score = normalized_result["relevance_score"]
+
+        original_doc_idx = doc_indices[chunk_idx]
         if (
-            chunk_idx is not None
-            and isinstance(chunk_idx, int)
-            and 0 <= chunk_idx < len(doc_indices)
+            isinstance(original_doc_idx, int)
+            and 0 <= original_doc_idx < num_original_docs
         ):
-            original_doc_idx = doc_indices[chunk_idx]
-            if (
-                isinstance(original_doc_idx, int)
-                and 0 <= original_doc_idx < num_original_docs
-                and score is not None
-            ):
-                try:
-                    score_val = float(score)
-                    doc_scores[original_doc_idx].append(score_val)
-                except (TypeError, ValueError):
-                    pass
+            doc_scores[original_doc_idx].append(score)
     # Aggregate scores
     aggregated_results = []
     for doc_idx, scores in doc_scores.items():
@@ -369,11 +397,33 @@ async def generic_rerank_api(
                 logger.warning("Rerank API returned empty results")
                 return []
 
-            # Standardize return format
-            standardized_results = [
-                {"index": result["index"], "relevance_score": result["relevance_score"]}
-                for result in results
-            ]
+            # Standardize valid provider results and report malformed entries as one
+            # bounded summary rather than failing the entire user query.
+            invalid_results = Counter()
+            standardized_results = []
+            for result in results:
+                normalized_result, invalid_reason = _normalize_rerank_result(
+                    result, len(documents)
+                )
+                if normalized_result is None:
+                    invalid_results[invalid_reason] += 1
+                    continue
+                standardized_results.append(normalized_result)
+
+            if invalid_results:
+                invalid_summary = ", ".join(
+                    f"{reason}={count}"
+                    for reason, count in sorted(invalid_results.items())
+                )
+                logger.warning(
+                    "Discarded %s malformed rerank result(s): %s",
+                    sum(invalid_results.values()),
+                    invalid_summary,
+                )
+
+            if not standardized_results:
+                logger.warning("Rerank API returned no usable results")
+                return []
 
             # Aggregate chunk scores back to original documents if chunking was enabled
             if enable_chunking and doc_indices:

--- a/lightrag/rerank.py
+++ b/lightrag/rerank.py
@@ -52,8 +52,12 @@ def _normalize_rerank_result(
     if not 0 <= index < max_index:
         return None, "index out of range"
 
+    score_value = result.get("relevance_score")
+    if isinstance(score_value, bool):
+        return None, "invalid relevance score"
+
     try:
-        score = float(result.get("relevance_score"))
+        score = float(score_value)
     except (TypeError, ValueError, OverflowError):
         return None, "invalid relevance score"
     if not isfinite(score):

--- a/lightrag/rerank.py
+++ b/lightrag/rerank.py
@@ -54,7 +54,7 @@ def _normalize_rerank_result(
 
     try:
         score = float(result.get("relevance_score"))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None, "invalid relevance score"
     if not isfinite(score):
         return None, "non-finite relevance score"

--- a/tests/chunker/test_rerank_chunking.py
+++ b/tests/chunker/test_rerank_chunking.py
@@ -324,6 +324,7 @@ class TestMalformedProviderResults:
                     {"index": True, "relevance_score": 0.9},
                     {"index": 3, "relevance_score": 0.9},
                     {"index": 0, "relevance_score": 10**10000},
+                    {"index": 0, "relevance_score": True},
                     {"index": 0, "relevance_score": "0.8"},
                     {"index": 1, "relevance_score": 0.6},
                 ]

--- a/tests/chunker/test_rerank_chunking.py
+++ b/tests/chunker/test_rerank_chunking.py
@@ -323,6 +323,7 @@ class TestMalformedProviderResults:
                     {"index": 0},
                     {"index": True, "relevance_score": 0.9},
                     {"index": 3, "relevance_score": 0.9},
+                    {"index": 0, "relevance_score": 10**10000},
                     {"index": 0, "relevance_score": "0.8"},
                     {"index": 1, "relevance_score": 0.6},
                 ]

--- a/tests/chunker/test_rerank_chunking.py
+++ b/tests/chunker/test_rerank_chunking.py
@@ -11,6 +11,7 @@ from lightrag.rerank import (
     chunk_documents_for_rerank,
     aggregate_chunk_scores,
     cohere_rerank,
+    generic_rerank_api,
 )
 
 
@@ -224,6 +225,22 @@ class TestAggregateChunkScores:
         aggregated = aggregate_chunk_scores([], [], 3, aggregation="max")
         assert aggregated == []
 
+    def test_malformed_results_are_ignored(self):
+        """Mixed provider items must not prevent valid chunk score aggregation."""
+        aggregated = aggregate_chunk_scores(
+            [
+                None,
+                "invalid",
+                {"index": True, "relevance_score": 0.9},
+                {"index": 0, "relevance_score": "not-a-score"},
+                {"index": 0, "relevance_score": "0.8"},
+            ],
+            [0],
+            1,
+        )
+
+        assert aggregated == [{"index": 0, "relevance_score": 0.8}]
+
     def test_documents_with_no_scores(self):
         """Test when some documents have no chunks/scores"""
         chunk_results = [
@@ -273,6 +290,116 @@ class TestAggregateChunkScores:
 
         assert len(aggregated) == 1
         assert aggregated[0] == {"index": 0, "relevance_score": 0.9}
+
+
+class TestMalformedProviderResults:
+    """HTTP-boundary regressions for malformed rerank provider result items."""
+
+    @staticmethod
+    def _mock_session(response_json):
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=response_json)
+        mock_response.request_info = None
+        mock_response.history = None
+        mock_response.headers = {}
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = Mock()
+        mock_session.post = Mock(return_value=mock_response)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        return mock_session
+
+    @pytest.mark.asyncio
+    async def test_generic_rerank_discards_malformed_items(self):
+        """Valid results survive a mixed provider response without raising."""
+        mock_session = self._mock_session(
+            {
+                "results": [
+                    None,
+                    "invalid",
+                    {"index": 0},
+                    {"index": True, "relevance_score": 0.9},
+                    {"index": 3, "relevance_score": 0.9},
+                    {"index": 0, "relevance_score": "0.8"},
+                    {"index": 1, "relevance_score": 0.6},
+                ]
+            }
+        )
+
+        with (
+            patch("lightrag.rerank.aiohttp.ClientSession", return_value=mock_session),
+            patch("lightrag.rerank.logger.warning") as mock_warning,
+        ):
+            result = await generic_rerank_api(
+                query="test",
+                documents=["first", "second"],
+                model="test-model",
+                base_url="http://test.com/rerank",
+                api_key="test-key",
+            )
+
+        assert result == [
+            {"index": 0, "relevance_score": 0.8},
+            {"index": 1, "relevance_score": 0.6},
+        ]
+        mock_warning.assert_called_once()
+        assert mock_warning.call_args.args[0].startswith("Discarded")
+
+    @pytest.mark.asyncio
+    async def test_generic_rerank_returns_empty_for_all_invalid_items(self):
+        """An entirely malformed response preserves the established empty result."""
+        mock_session = self._mock_session(
+            {
+                "results": [
+                    None,
+                    {"index": -1, "relevance_score": 0.9},
+                    {"index": 0, "relevance_score": "NaN"},
+                ]
+            }
+        )
+
+        with patch("lightrag.rerank.aiohttp.ClientSession", return_value=mock_session):
+            result = await generic_rerank_api(
+                query="test",
+                documents=["only document"],
+                model="test-model",
+                base_url="http://test.com/rerank",
+                api_key="test-key",
+            )
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_generic_rerank_aggregates_valid_chunk_results(self):
+        """Malformed items do not block aggregation of valid chunk scores."""
+        mock_session = self._mock_session(
+            {
+                "results": [
+                    None,
+                    {"index": 0, "relevance_score": 0.8},
+                    {"index": 1, "relevance_score": 0.6},
+                ]
+            }
+        )
+
+        with patch("lightrag.rerank.aiohttp.ClientSession", return_value=mock_session):
+            result = await generic_rerank_api(
+                query="test",
+                documents=["first", "second"],
+                model="test-model",
+                base_url="http://test.com/rerank",
+                api_key="test-key",
+                enable_chunking=True,
+                max_tokens_per_doc=8,
+            )
+
+        assert result == [
+            {"index": 0, "relevance_score": 0.8},
+            {"index": 1, "relevance_score": 0.6},
+        ]
 
 
 @pytest.mark.offline


### PR DESCRIPTION
## Description

Harden rerank response handling so malformed items from providers or compatible proxies do not fail the entire query.

## Related Issues

Follow-up to #3519, which was closed to keep the unrelated storage and extraction changes out of this focused fix.

## Changes Made

- Centralized rerank result validation for the HTTP response boundary and chunk-score aggregation.
- Discarded non-object, invalid or out-of-range index, and non-finite relevance-score entries with a bounded warning summary.
- Added mocked provider-response regressions for mixed, all-invalid, and chunked responses.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

PR #3518 already handles `None` values in otherwise valid aggregation result dictionaries. This change additionally protects non-dictionary and malformed provider result items.
