### PR TITLE
fix(docx): tolerate editorial drift in title-block locate-back

### DIFF
--- a/lightrag/parser/docx/smart_heading/title_block.py
+++ b/lightrag/parser/docx/smart_heading/title_block.py
@@ -7,8 +7,14 @@ synchronous judge callable; this module never touches asyncio) then confirms
 and decomposes each candidate.
 
 LLM output is STRICTLY validated: the main/sub title must be locatable in
-the window text (concatenation allowed), and paragraphs carrying a physical
-outline level are never demoted by an LLM "body" vote (invariant I2). A
+the window text, and paragraphs carrying a physical outline level are never
+demoted by an LLM "body" vote (invariant I2). Locate-back rejects INVENTED
+text, not editorial polish — beyond a literal substring it accepts a
+concatenation of consecutive paragraphs, punctuation/width/case
+normalization, and a few long window fragments reassembled in source order
+(the overlap-dedup case where two cover lines share a boundary word); see
+:func:`_locate`, whose relaxed hits are counted in the
+``title_block_locate_relaxed`` parse warning. A
 non-title verdict's headings/body partition must be well-formed; a MALFORMED
 partition (missing/null field, out-of-range index, a duplicate within a list,
 or the same index voted both heading and body) raises
@@ -28,6 +34,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import unicodedata
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -101,6 +108,82 @@ def _estimate_tokens(text: str) -> int:
 def _canon(text: str) -> str:
     """Whitespace-free canonical form for locate-back comparisons."""
     return re.sub(r"\s+", "", text or "")
+
+
+#: Locate-back tiers, tightest first — see :func:`_locate`.
+_LOCATE_EXACT = "exact"
+_LOCATE_FOLDED = "folded"
+_LOCATE_ASSEMBLED = "assembled"
+
+#: Assembled tier bounds. Few fragments, each long enough to be evidence on
+#: its own: the observed real case needs exactly two (a whole title line plus
+#: the non-overlapping tail of the next), and a third covers a title split
+#: across three cover lines. Every fragment must clear
+#: ``_LOCATE_MIN_PIECE_WEIGHTED`` en-equivalent chars (2 CJK / 4 ASCII), which
+#: is what keeps an invented title from being stitched together out of stray
+#: single characters.
+_LOCATE_MAX_PIECES = 3
+_LOCATE_MIN_PIECE_WEIGHTED = 4
+#: Backstop on the assembler's search (see :func:`_assemble_from_window`).
+_LOCATE_ASSEMBLE_STEPS = 20000
+
+
+def _fold(text: str) -> str:
+    """Punctuation/width/case-insensitive form of an already-canon string.
+
+    NFKC unifies full-width and half-width forms (``ＡＢ`` → ``AB``, ``：`` →
+    ``:``), every punctuation/symbol character is dropped so an added,
+    removed, or swapped separator cannot break the match (``2027-2028`` vs
+    ``2027—2028``, ``（2026年修订）`` vs ``(2026年修订)``), and case folds for
+    Latin text. NFKC can re-introduce whitespace (``\\u00a0`` → space), so
+    whitespace is stripped here too rather than relying on the caller.
+    """
+    folded = []
+    for ch in unicodedata.normalize("NFKC", text or ""):
+        if ch.isspace():
+            continue
+        if unicodedata.category(ch)[0] in ("P", "S"):
+            continue
+        folded.append(ch)
+    return "".join(folded).casefold()
+
+
+def _assemble_from_window(answer: str, window: str) -> bool:
+    """True when ``answer`` is a concatenation of at most
+    :data:`_LOCATE_MAX_PIECES` ``window`` fragments taken in source order.
+
+    Both arguments must already be :func:`_fold`-ed. Fragments may not
+    overlap and may not go backwards (each search resumes after the previous
+    fragment), so the answer's characters are the window's characters in the
+    window's own order — the property the hallucination guard actually
+    protects. Longest-fragment-first with backtracking, bounded by
+    :data:`_LOCATE_ASSEMBLE_STEPS` probes; exhausting the budget reports
+    "not located" (the strict, safe direction).
+    """
+    budget = [_LOCATE_ASSEMBLE_STEPS]
+
+    def walk(start: int, from_pos: int, pieces_left: int) -> bool:
+        if start == len(answer):
+            return True
+        if pieces_left == 0:
+            return False
+        # Longest first: the real split is one long fragment plus a short
+        # remainder, and a long first fragment prunes the search hardest.
+        for end in range(len(answer), start, -1):
+            piece = answer[start:end]
+            if guardrails.weighted_char_length(piece) < _LOCATE_MIN_PIECE_WEIGHTED:
+                break  # every shorter prefix is shorter still
+            pos = window.find(piece, from_pos)
+            while pos != -1:
+                if budget[0] <= 0:
+                    return False
+                budget[0] -= 1
+                if walk(end, pos + len(piece), pieces_left - 1):
+                    return True
+                pos = window.find(piece, pos + 1)
+        return False
+
+    return walk(0, 0, _LOCATE_MAX_PIECES)
 
 
 def _is_cjk_char(ch: str) -> bool:
@@ -1349,11 +1432,50 @@ def _parse_llm_json(raw: str) -> dict:
     return data
 
 
-def _locate(text: str | None, window_canon: str) -> bool:
+def _locate(text: str | None, window_canon: str) -> str | None:
+    """Locate an LLM title field back in the window; ``None`` = not located.
+
+    Returns the LOOSEST tier that matched, so the caller can audit how far the
+    answer drifted from the source text:
+
+    - ``exact`` — the whitespace-free text is a literal window substring
+      (also the answer for an absent field: nothing to locate).
+    - ``folded`` — matches once both sides drop punctuation/symbols and fold
+      case + full/half-width forms (:func:`_fold`). An LLM normalizing
+      ``（2026年修订）`` to ``(2026年修订)``, ``：`` to ``:``, or an em dash to a
+      hyphen is editorial polish, not invention.
+    - ``assembled`` — matches as at most :data:`_LOCATE_MAX_PIECES` window
+      fragments in source order, each at least
+      :data:`_LOCATE_MIN_PIECE_WEIGHTED` weighted chars
+      (:func:`_assemble_from_window`). This is the overlap-dedup case: a cover
+      splitting the title as ``…信息化运维项目`` / ``项目方案`` makes verbatim
+      concatenation read ``…运维项目项目方案``, and the LLM answers the natural
+      ``…运维项目方案`` — every character still comes from the window, in
+      order.
+
+    The guard's job is to reject INVENTED text, not to demand a byte-exact
+    echo: a hard failure fails the whole document, so a title the LLM merely
+    tidied must not be treated as a hallucination. Fragments must stay long
+    and few, so an invented title cannot be assembled character-by-character
+    out of the window.
+    """
     if text is None:
-        return True
+        return _LOCATE_EXACT
     canon = _canon(text)
-    return bool(canon) and canon in window_canon
+    if not canon:
+        return None
+    if canon in window_canon:
+        return _LOCATE_EXACT
+    folded = _fold(canon)
+    folded_window = _fold(window_canon)
+    if not folded:
+        # Punctuation-only field: nothing left to anchor on — never located.
+        return None
+    if folded in folded_window:
+        return _LOCATE_FOLDED
+    if _assemble_from_window(folded, folded_window):
+        return _LOCATE_ASSEMBLED
+    return None
 
 
 def judge_title_block(
@@ -1491,16 +1613,35 @@ def judge_title_block(
             publisher = _opt_str("publisher")
             date = _opt_str("date")
             locate_scope = window_canon
+        relaxed: list[str] = []
         for label, value in (
             ("main_title", main_title),
             ("sub_title", sub_title),
             ("doc_number", doc_number),
         ):
-            if not _locate(value, locate_scope):
+            mode = _locate(value, locate_scope)
+            if mode is None:
                 raise TitleBlockLLMError(
                     f"title-block {label} {value!r} cannot be located in the "
                     "candidate window (LLM hallucination guard)"
                 )
+            if mode != _LOCATE_EXACT:
+                relaxed.append(f"{label}={mode}")
+        if relaxed:
+            # Accepted, but the answer is NOT a verbatim echo of the source —
+            # the field the document carries downstream is the LLM's edit.
+            # Audited so a drifting model is visible without reading logs.
+            if warnings is not None:
+                warnings["title_block_locate_relaxed"] = (
+                    warnings.get("title_block_locate_relaxed", 0) + 1
+                )
+            logger.info(
+                "[smart_heading] title-block field(s) located only after "
+                "relaxation in candidate [%d, %d): %s",
+                candidate.start,
+                candidate.end,
+                ", ".join(relaxed),
+            )
         return TitleBlockDecision(
             candidate=candidate,
             is_title_block=True,

--- a/tests/parser/docx/test_smart_heading_title_block.py
+++ b/tests/parser/docx/test_smart_heading_title_block.py
@@ -418,9 +418,109 @@ def test_flatten_heading_line_unicode_breaks() -> None:
     assert flatten_heading_line("\n \n") == ""
 
 
+def test_title_verdict_overlap_dedup_main_title_locates() -> None:
+    """Fix proof: a cover whose two title lines SHARE a boundary word makes
+    verbatim concatenation read ``…运维项目项目方案``, so the LLM answers the
+    natural de-duplicated ``…运维项目方案``. Every character still comes from
+    the window in window order, so locate-back accepts it (assembled tier)
+    instead of hard-failing the whole document as a hallucination."""
+    records = [
+        _para("广州市节能中心", size=24.0),
+        _para("2027-2028年信息化运维项目", size=24.0),
+        _para("项目方案", size=24.0),
+        _para("正文开始。", size=12.0),
+    ]
+    warnings: dict = {}
+    decision = _judge_with(
+        {
+            "is_title_block": True,
+            "main_title": "2027-2028年信息化运维项目方案",
+            "publisher": "广州市节能中心",
+        },
+        records=records,
+        candidate=TitleBlockCandidate(start=0, end=3, single=False, trigger="t"),
+        warnings=warnings,
+    )
+    assert decision.main_title == "2027-2028年信息化运维项目方案"
+    # Relaxation is accepted but never silent.
+    assert warnings["title_block_locate_relaxed"] == 1
+
+
+def test_title_verdict_punctuation_and_case_normalized_locates() -> None:
+    """An LLM tidying the source punctuation (full-width → half-width, em dash
+    → hyphen) or Latin case is editorial polish, not invention: locate-back
+    matches on the folded form and counts ONE relaxation for the verdict."""
+    records = [
+        _para("某某平台（2026年修订）", size=22.0),
+        _para("Q1—Q2 ROADMAP", size=16.0),
+        _para("国某发〔2026〕12号", size=12.0),
+        _para("正文开始。", size=12.0),
+    ]
+    warnings: dict = {}
+    decision = _judge_with(
+        {
+            "is_title_block": True,
+            "main_title": "某某平台(2026年修订)",
+            "sub_title": "Q1-Q2 Roadmap",
+            "doc_number": "国某发[2026]12号",
+        },
+        records=records,
+        candidate=TitleBlockCandidate(start=0, end=3, single=False, trigger="t"),
+        warnings=warnings,
+    )
+    assert decision.main_title == "某某平台(2026年修订)"
+    assert decision.sub_title == "Q1-Q2 Roadmap"
+    assert decision.doc_number == "国某发[2026]12号"
+    assert warnings["title_block_locate_relaxed"] == 1
+
+
+def test_title_verdict_exact_match_records_no_relaxation() -> None:
+    """Stability: a verbatim answer still takes the exact tier, so the audit
+    counter stays clean and a drifting model remains visible."""
+    warnings: dict = {}
+    _judge_with(
+        {"is_title_block": True, "main_title": "中华人民共和国某某管理办法"},
+        warnings=warnings,
+    )
+    assert "title_block_locate_relaxed" not in warnings
+
+
 def test_title_verdict_hallucinated_title_hard_fails() -> None:
     with pytest.raises(TitleBlockLLMError, match="cannot be located"):
         _judge_with({"is_title_block": True, "main_title": "完全虚构的标题"})
+
+
+def test_title_verdict_stitched_from_stray_chars_hard_fails() -> None:
+    """The relaxed tiers must not become a licence to invent: a title whose
+    characters all appear in the window but only as scattered SINGLE chars
+    cannot be assembled (each fragment must clear the minimum length), so it
+    is still rejected."""
+    records = [
+        _para("中某人办法某某共和国管理", size=22.0),
+        _para("正文开始。", size=12.0),
+    ]
+    with pytest.raises(TitleBlockLLMError, match="cannot be located"):
+        _judge_with(
+            {"is_title_block": True, "main_title": "中共某国某人管某某某和办"},
+            records=records,
+            candidate=TitleBlockCandidate(start=0, end=1, single=False, trigger="t"),
+        )
+
+
+def test_title_verdict_out_of_order_fragments_hard_fail() -> None:
+    """Assembly is order-preserving: the same two window fragments in REVERSE
+    source order are not the document's title."""
+    records = [
+        _para("信息化运维项目", size=22.0),
+        _para("广州市节能中心", size=22.0),
+        _para("正文开始。", size=12.0),
+    ]
+    with pytest.raises(TitleBlockLLMError, match="cannot be located"):
+        _judge_with(
+            {"is_title_block": True, "main_title": "广州市节能中心信息化运维项目"},
+            records=records,
+            candidate=TitleBlockCandidate(start=0, end=2, single=False, trigger="t"),
+        )
 
 
 def test_invalid_json_hard_fails() -> None:


### PR DESCRIPTION
## Description

The smart-heading title-block hallucination guard demanded a byte-exact echo: the LLM's `main_title` / `sub_title` / `doc_number` had to be a literal (whitespace-free) substring of the candidate window. `TitleBlockLLMError` is not caught anywhere on the judge path ([`heading_flow.py`](https://github.com/HKUDS/LightRAG/blob/main/lightrag/parser/docx/smart_heading/heading_flow.py) calls `judge_title_block` bare), so a single tidied character fails the **whole document**.

This PR keeps the guard's real job — rejecting *invented* text — while accepting an answer the model merely polished.

## Motivation

Two real project covers hit this. Their title is split across two paragraphs that **share a boundary word**:

```
[1] 广州市节能中心               24pt
[2] 2027-2028年信息化运维项目     24pt
[3] 项目方案                     24pt
```

Verbatim concatenation of [2]+[3] reads `…运维项目项目方案` (duplicated 项目), while the document's own body (`1.1 项目名称`) calls itself `广州市节能中心2027-2028年信息化运维项目方案`. The LLM answers the natural de-duplicated form, and the guard rejects it:

```
title-block main_title '2027-2028年信息化运维项目方案' cannot be located in
the candidate window (LLM hallucination guard)
```

Two aggravating factors:

- **It is not recoverable by retrying.** The verdict is cached under `cache_type="smartheading"`, keyed on the prompt alone (no doc id). Both files produce byte-identical prompts, so one bad sample freezes the failure for every file with that cover and every re-parse.
- **It is a coin flip, not a bug in the algorithm.** An earlier run of the *same* file (identical md5) succeeded with `main_title="2027-2028年信息化运维项目"` + `sub_title="项目方案"`. Same window, same code — a different sample.

Requiring a byte-exact echo makes this class of failure unavoidable in general: punctuation and case normalization are exactly the kind of edit a model makes.

## Changes Made

`_locate` now reports the **loosest tier that matched** instead of a bool:

| Tier | Rule | Covers |
|---|---|---|
| `exact` | literal window substring (unchanged) | verbatim answers |
| `folded` | NFKC width folding + drop all punctuation/symbols + case folding | `（2026年修订）`→`(2026年修订)`, `〔〕`→`[]`, `：`→`:`, em dash ↔ hyphen, Latin case |
| `assembled` | at most 3 window fragments in **source order**, each ≥ 4 weighted chars (2 CJK / 4 ASCII) | the overlap-dedup case above |

The `assembled` tier does not dismantle the guard — it preserves the property the guard actually protects: every character comes from the window, in the window's own order, in few and long fragments. Still hard-failing:

- fully invented text (existing test unchanged),
- fragments taken **out of source order**,
- titles stitched together from stray single characters (minimum fragment length).

A non-exact match is accepted but **never silent**: it counts one `title_block_locate_relaxed` parse warning (routed into `smart_audit.json` by the existing `title_block_` prefix rule) and logs the fields and tiers involved, so a drifting model stays visible without reading logs.

Files:
- `lightrag/parser/docx/smart_heading/title_block.py` — `_fold`, `_assemble_from_window`, tiered `_locate`, relaxation audit/log, module docstring.
- `tests/parser/docx/test_smart_heading_title_block.py` — 5 tests (below).

## What's broken / how it works

Nothing changes for a verbatim answer — `exact` is the first check and the old code path. Only verdicts that previously **hard-failed the document** can now succeed, so this is strictly a widening of what parses.

One behavioural note worth calling out: when a relaxed tier matches, the heading the document carries downstream is the **LLM's edited string**, not the source text. That was already true for the exact tier (the verdict's own field is stored, not the record text), and in the motivating case it is the better title — the resulting H1 is `2027-2028年信息化运维项目方案`, matching what the body calls the document, rather than the concatenated `2027-2028年信息化运维项目  项目方案`. Block *content* is untouched either way; only the heading metadata differs.

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

**Verification**

- **Real files.** Replayed the cached bad verdict through the real parser (`get_parser("native").parse(...)` with a stub extract LLM) for both documents: both raised `TitleBlockLLMError` before, both parse after, audit records `title_block_locate_relaxed: 1`.
- **Fix proof.** Stashing only `title_block.py` back to the old version makes the two tolerance tests fail with the production error (`title-block main_title '某某平台(2026年修订)' cannot be located…`); they pass with the fix. The other three are stability/guard-preservation tests and pass on both sides by design.
- **Suites.** `tests/parser` + `tests/chunker/test_paragraph_semantic_title_block.py` + `tests/pipeline/test_parse_warnings_split_persist.py` → **1379 passed**. `pre-commit` (ruff format, ruff) clean.

**Tests added**

- `test_title_verdict_overlap_dedup_main_title_locates` — fix proof for the reported failure, asserts the relaxation counter.
- `test_title_verdict_punctuation_and_case_normalized_locates` — full/half-width, bracket style, Latin case across all three located fields.
- `test_title_verdict_exact_match_records_no_relaxation` — a verbatim answer keeps the audit counter clean.
- `test_title_verdict_stitched_from_stray_chars_hard_fails` — minimum fragment length still blocks invention.
- `test_title_verdict_out_of_order_fragments_hard_fail` — assembly is order-preserving.

**Not included:** the judge path still hard-fails the document when locate-back genuinely finds nothing. Making a locate failure degrade to "this candidate is not a title block" (the module already does exactly that for an under-specified non-title partition) is a reasonable follow-up, but it is a separate decision from tolerating editorial drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
