### PR TITLE
fix(pipeline): keep the in-batch feeder alive while auto-rescan is dirty

### DIFF
--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -2267,9 +2267,8 @@ class _PipelineMixin:
         await self._admit_fed_document(ctx, doc_id, status_doc, full_doc)
         return True  # admitted
 
-    @staticmethod
     def _feeder_should_yield(
-        ctx: "_BatchRunContext", ingress, *, check_auto: bool
+        self, ctx: "_BatchRunContext", ingress, *, check_auto: bool
     ) -> bool:
         """True when the feeder must stop admitting and let the batch reach its
         quiescence point:
@@ -2279,13 +2278,35 @@ class _PipelineMixin:
           starve it) — both re-checked before every single admission, so the
           yield latency is one admission, not a whole drain;
         * (``check_auto``, at the top of each drain) the auto-rescan flag is
-          dirty — a document-channel overflow dropped notifications, a partial
-          upsert landed, or one of this feeder's own skips armed it. Yielding
-          hands the batch to its boundary, where the supervisor consumes the
-          flag and its strict rescan recovers those dropped/deferred PENDING
-          docs; without it a sustained stream that never lets the batch reach a
-          boundary would starve them. The feeder only PEEKS the flag (via
-          ``counts``); the supervisor remains its sole consumer.
+          dirty AND this epoch is unbounded (``PIPELINE_SCHEDULING_PAGE_SIZE=0``
+          disables ``_feeder_epoch_full``).
+
+          The flag is the coarse "only a strict rescan can find this work"
+          signal — an overflow dropped notifications, a partial upsert landed,
+          one of this feeder's own skips armed it, or a wake-up was refused
+          because this very run holds ``busy`` — and only the supervisor's
+          boundary rescan can serve it. But yielding does NOT bring that
+          boundary closer on its own: the boundary is the queue-join cascade in
+          :meth:`_run_pipeline_batch` (which then cancels this feeder), and a
+          feeder parked on ``wait_for_documents`` holds no unfinished queue
+          item, so it never delays a join. The ONLY way the feeder can postpone
+          the boundary is by admitting new work indefinitely — and with paging
+          on, ``_feeder_epoch_full`` already caps that at
+          ``PIPELINE_SCHEDULING_PAGE_SIZE`` admissions per epoch, so the flag is
+          served within one bounded epoch. Yielding on it as well buys nothing
+          and costs the accelerator: every per-file ``/upload`` calls
+          ``apipeline_process_enqueue_documents`` after its enqueue, each such
+          call is refused while a batch runs, and each refusal arms this flag
+          (see ``acquire_processing_reservation``) — so a bare-flag yield killed
+          the feeder for the rest of the batch on the SECOND uploaded file and
+          stranded every later file in the mailbox until the batch barrier.
+
+          With paging disabled there is no admission cap, so a sustained stream
+          could keep this epoch alive forever; there the dirty flag still
+          yields.
+
+          The feeder only PEEKS the flag (via ``counts``); the supervisor
+          remains its sole consumer.
 
         NOT ``has_work()`` — that would busy-loop on a pending manual/auto entry.
         """
@@ -2293,7 +2314,11 @@ class _PipelineMixin:
             return True
         if ingress.peek_next_manual_retry() is not None:
             return True
-        if check_auto and ingress.counts().get("auto_rescan_pending"):
+        if (
+            check_auto
+            and getattr(self, "pipeline_scheduling_page_size", 0) <= 0
+            and ingress.counts().get("auto_rescan_pending")
+        ):
             return True
         return False
 
@@ -2339,7 +2364,9 @@ class _PipelineMixin:
         cancellation is requested (otherwise ``/cancel_pipeline`` could never
         complete under a sustained upload stream that keeps the parse queue
         non-empty) or when a sticky manual retry request is waiting (it is only
-        consumed at the batch boundary, so an unbounded batch would starve it).
+        consumed at the batch boundary, so an unbounded batch would starve it),
+        or — only with paging disabled, where nothing else caps this epoch's
+        admissions — when the auto-rescan flag is dirty.
         This is re-checked before the drain AND before EVERY admission
         (:meth:`_feeder_should_yield`), so a signal that lands while the feeder
         is admitting a full drain is honored within one admission, not after up
@@ -2366,10 +2393,10 @@ class _PipelineMixin:
                     # Top-of-drain yield check is INSIDE the try so a transient
                     # manual-peek / counts RPC failure (multiprocess) is logged
                     # and retried, not left to silently kill the feeder. Includes
-                    # the auto-rescan flag (overflow / partial upsert / this
-                    # feeder's own skips) so a sustained stream still reaches a
-                    # boundary where the supervisor's rescan recovers the dropped
-                    # PENDING docs.
+                    # the auto-rescan flag ONLY when this epoch is unbounded —
+                    # with paging on, the epoch cap below is what bounds the
+                    # batch, and a busy-refused upload wake-up arms that flag on
+                    # every file (see _feeder_should_yield).
                     if self._feeder_should_yield(ctx, ingress, check_auto=True):
                         return
                     # Single-epoch bound (LR2 §6.4): once this batch holds

--- a/tests/pipeline/test_pipeline_ingress_feed.py
+++ b/tests/pipeline/test_pipeline_ingress_feed.py
@@ -157,6 +157,55 @@ def test_document_arriving_mid_batch_is_fed_without_waiting(tmp_path):
     asyncio.run(_run())
 
 
+def test_sequential_upload_wakeups_do_not_strand_later_files(tmp_path):
+    """End-to-end reproduction of the WebUI multi-file upload path: the dialog
+    uploads files ONE AT A TIME, and each ``/upload`` background task runs
+    ``apipeline_enqueue_documents`` followed by
+    ``apipeline_process_enqueue_documents``.  Every one of those process calls
+    after the first is refused (busy) and arms the auto-rescan flag, so the
+    feeder must keep routing anyway.
+
+    Fix-proof: with the old bare-flag yield the feeder died on file B's refused
+    wake-up and C stayed PENDING in the mailbox until A's batch finished — this
+    times out, because A is deliberately blocked."""
+
+    async def _run():
+        extract = _MarkerExtract()
+        extract.block_marker = "AAAA"
+        rag = await _build_rag(tmp_path, extract, max_parallel_insert=3)
+        try:
+            await rag.apipeline_enqueue_documents(input="AAAA body", file_paths="a.txt")
+            a_id = compute_mdhash_id("a.txt", prefix="doc-")
+
+            proc = asyncio.create_task(rag.apipeline_process_enqueue_documents())
+            await asyncio.wait_for(extract.started.wait(), timeout=5)  # A blocked
+
+            # Uploads B then C, exactly as pipeline_index_file drives them.
+            for name, body in (("b.txt", "BBBB"), ("c.txt", "CCCC")):
+                await rag.apipeline_enqueue_documents(
+                    input=f"{body} body", file_paths=name
+                )
+                await rag.apipeline_process_enqueue_documents()  # refused: busy
+
+            # Both fed into A's running batch while A is still stuck.
+            for name in ("b.txt", "c.txt"):
+                await _wait_status(
+                    rag, compute_mdhash_id(name, prefix="doc-"), "processed"
+                )
+            assert _status_text(await rag.doc_status.get_by_id(a_id)) != "processed"
+
+            extract.release.set()
+            await asyncio.wait_for(proc, timeout=10)
+            assert _status_text(await rag.doc_status.get_by_id(a_id)) == "processed"
+            assert extract.calls["BBBB"] == 1
+            assert extract.calls["CCCC"] == 1
+        finally:
+            extract.release.set()
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
 def test_feeder_deduplicates_inflight_document_message(tmp_path):
     """A document message that echoes an id already inflight (the initial batch
     doc, or one the feeder already routed) is dropped, not re-routed — the doc
@@ -341,12 +390,13 @@ def test_feeder_teardown_republishes_undrained_messages(tmp_path):
 
 
 def test_feeder_arms_auto_rescan_and_republishes_on_skip(tmp_path):
-    """Finding: a SKIP (full_docs not yet visible) must not be able to starve
-    under a sustained stream that never otherwise reaches a boundary. Skipping B
-    arms the auto-rescan recovery flag (so the supervisor's rescan will pick it
-    up) and, because the flag is now dirty, the feeder yields to the boundary;
-    the feeder-lifetime deferred set re-publishes B on the way out. The feeder
-    only PEEKS auto-rescan — it stays pending for the supervisor to consume."""
+    """Finding: a SKIP (full_docs not yet visible) must not be lost. Skipping B
+    arms the auto-rescan recovery flag (so the supervisor's boundary rescan
+    picks it up) and B goes into the feeder-lifetime deferred set, which is
+    re-published on ANY exit — here the batch teardown's cancel (see
+    ``_run_pipeline_batch``). The feeder only PEEKS auto-rescan; with paging on
+    it does NOT yield on it (the epoch cap bounds the batch instead), so the
+    skip costs nothing to the docs it can still route."""
 
     async def _run():
         rag = await _build_rag(tmp_path, _MarkerExtract(), max_parallel_insert=1)
@@ -368,9 +418,15 @@ def test_feeder_arms_auto_rescan_and_republishes_on_skip(tmp_path):
             rag.full_docs.get_by_id = not_visible
 
             ctx = _make_feeder_ctx()
-            # Returns on its own: the skip arms auto-rescan, the next top-of-drain
-            # check sees the dirty flag and yields.
-            await asyncio.wait_for(rag._pipeline_feeder(ctx, ingress), timeout=3)
+            feeder = asyncio.create_task(rag._pipeline_feeder(ctx, ingress))
+
+            async def _armed():
+                while not ingress.counts()["auto_rescan_pending"]:
+                    await asyncio.sleep(0.02)
+
+            await asyncio.wait_for(_armed(), timeout=3)  # skip armed the flag
+            feeder.cancel()  # batch teardown
+            await asyncio.gather(feeder, return_exceptions=True)
 
             assert ctx.parse_queues["native"].qsize() == 0  # nothing routed
             assert (
@@ -384,32 +440,80 @@ def test_feeder_arms_auto_rescan_and_republishes_on_skip(tmp_path):
     asyncio.run(_run())
 
 
-def test_feeder_yields_when_auto_rescan_pending(tmp_path):
-    """Finding: a document-channel overflow drops notifications and sets
-    auto_rescan_pending — the recovery signal for those dropped PENDING docs.
-    The feeder must yield on it so the batch reaches a boundary where the
-    supervisor consumes the flag and rescans; otherwise a sustained stream
-    starves the dropped docs. Fix-proof: without the auto check the feeder
-    would drain the (non-PENDING) notifications and then block forever."""
+def test_feeder_keeps_routing_while_auto_rescan_pending(tmp_path):
+    """Finding: with paging on, a dirty auto-rescan flag must NOT stop the
+    feeder. Every per-file ``/upload`` calls
+    apipeline_process_enqueue_documents after its enqueue, each such call is
+    refused while a batch runs, and each refusal arms the flag
+    (acquire_processing_reservation) — so yielding on the bare flag disabled the
+    feeder for the rest of the batch from the second uploaded file on. Yielding
+    also buys no earlier boundary: a parked feeder holds no unfinished queue
+    item, and the epoch cap is what bounds admissions.
+
+    Fix-proof: with the old bare-flag check the feeder returns at the top having
+    routed nothing, so the wait below times out."""
 
     async def _run():
         rag = await _build_rag(tmp_path, _MarkerExtract(), max_parallel_insert=1)
         try:
+            await rag.apipeline_enqueue_documents(input="BODYB", file_paths="b.txt")
+            b_id = compute_mdhash_id("b.txt", prefix="doc-")
+
             ingress = await get_pipeline_ingress(rag.workspace)
-            for i in range(10):
-                ingress.put_document(
-                    PipelineIngressMessage(kind="document", doc_id=f"doc-{i}")
-                )
-            ingress.request_auto_rescan()  # stand in for the overflow signal
+            ingress.drain_documents()
+            ingress.consume_auto_rescan()  # clear any flag from enqueue
+            ingress.request_auto_rescan()  # stand in for a busy-refused wake-up
+            ingress.put_document(PipelineIngressMessage(kind="document", doc_id=b_id))
+
+            ctx = _make_feeder_ctx()
+            feeder = asyncio.create_task(rag._pipeline_feeder(ctx, ingress))
+            try:
+
+                async def _routed():
+                    while ctx.parse_queues["native"].qsize() == 0:
+                        await asyncio.sleep(0.02)
+
+                await asyncio.wait_for(_routed(), timeout=3)
+                assert b_id in ctx.inflight_doc_ids
+                # The flag still reaches the supervisor: it is only peeked.
+                assert ingress.counts()["auto_rescan_pending"] is True
+            finally:
+                feeder.cancel()
+                await asyncio.gather(feeder, return_exceptions=True)
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+
+def test_feeder_yields_on_auto_rescan_when_paging_disabled(tmp_path):
+    """With PIPELINE_SCHEDULING_PAGE_SIZE=0 nothing caps this epoch's
+    admissions, so a sustained stream could keep the feeder admitting forever
+    and the boundary rescan would never run. There the dirty flag still yields
+    immediately, leaving the queued notification untouched for the next epoch.
+
+    Fix-proof: without the auto check the feeder parks on the document channel
+    and the wait below times out."""
+
+    async def _run():
+        rag = await _build_rag(tmp_path, _MarkerExtract(), max_parallel_insert=1)
+        try:
+            rag.pipeline_scheduling_page_size = 0  # paging disabled
+            await rag.apipeline_enqueue_documents(input="BODYB", file_paths="b.txt")
+            b_id = compute_mdhash_id("b.txt", prefix="doc-")
+
+            ingress = await get_pipeline_ingress(rag.workspace)
+            ingress.drain_documents()
+            ingress.consume_auto_rescan()
+            ingress.put_document(PipelineIngressMessage(kind="document", doc_id=b_id))
+            ingress.request_auto_rescan()
 
             ctx = _make_feeder_ctx()
             await asyncio.wait_for(rag._pipeline_feeder(ctx, ingress), timeout=3)
 
-            # Yielded at the top before draining; the flag is left for the
-            # supervisor (the feeder only peeks it).
-            assert ctx.parse_queues["native"].qsize() == 0
+            assert ctx.parse_queues["native"].qsize() == 0  # yielded at the top
             assert ingress.counts()["auto_rescan_pending"] is True
-            assert ingress.has_work()  # the notifications are untouched
+            assert {m.doc_id for m in ingress.drain_documents()} == {b_id}
         finally:
             await rag.finalize_storages()
 


### PR DESCRIPTION
## Description

Uploading multiple files from the WebUI left all but the first two documents stuck in PENDING until the running batch had finished **every** stage of the documents already in flight. Dropping the same files into the input directory and starting them with `/documents/scan` worked fine — they entered processing as soon as a slot freed.

The in-batch feeder (LR2 Phase 2) exists precisely to remove that latency: a document enqueued *during* a running batch is routed straight into that batch's parse queues instead of waiting for the batch barrier. It was being switched off for the whole batch by the second uploaded file.

**Root cause.** The WebUI upload dialog uploads files ONE AT A TIME (`for (const file of sortedFiles) { await uploadDocument(...) }`), and each `/upload` background task runs `apipeline_enqueue_documents` followed by `apipeline_process_enqueue_documents` (`pipeline_index_file`). Every one of those process calls after the first is refused because the first run holds `busy`, and `acquire_processing_reservation` arms the ingress **auto-rescan flag on every such refusal**. `_feeder_should_yield(check_auto=True)` returned as soon as that flag was dirty — and the feeder task is created once per batch, so its `return` ends in-batch feeding permanently. Net effect with 5 uploaded files: file 1 in the run's initial page, file 2 routed by the feeder in the race window before the flag was armed, files 3–5 stranded in the mailbox until the batch barrier. Exactly 2 documents processing, the rest "waiting".

`/documents/scan` is unaffected because it performs one enqueue batch plus one process call: no busy refusal, no dirty flag, and every file lands in the run's initial scheduling page.

**Why the yield can go.** Yielding on the flag does not bring the batch boundary closer on its own. The boundary is the queue-join cascade in `_run_pipeline_batch` (which *then* cancels the feeder), and a feeder parked on `wait_for_documents` holds no unfinished queue item, so it never delays a join. The only way the feeder can postpone the boundary is by admitting new work indefinitely — and with paging on, `_feeder_epoch_full` already caps that at `PIPELINE_SCHEDULING_PAGE_SIZE` admissions per epoch, so the flag is served within one bounded epoch. The yield is therefore kept only for the unbounded case (`PIPELINE_SCHEDULING_PAGE_SIZE=0`), where nothing else caps admissions.

The busy-refusal arm itself is deliberately left untouched: it is the recovery net for trigger-only callers that publish no document message. The feeder still only *peeks* the flag and the supervisor remains its sole consumer, so overflow / partial-upsert / ryw-skip recovery semantics are unchanged.

## Related Issues

N/A — reported and reproduced locally.

## Changes Made

- `lightrag/pipeline.py`
  - `_feeder_should_yield`: honor the dirty auto-rescan flag only when the epoch is unbounded (`pipeline_scheduling_page_size <= 0`). Cancellation and sticky-manual-retry yields are unchanged. The method is no longer a `staticmethod` because it now reads the instance's page-size field (both call sites already invoked it via `self`); the short-circuit order also skips the per-drain `counts()` call (one fewer Manager RPC per drain in multiprocess mode).
  - Docstrings/comments on `_feeder_should_yield` and `_pipeline_feeder` updated to record the reasoning above and the upload-path failure mode.
- `tests/pipeline/test_pipeline_ingress_feed.py`
  - `test_sequential_upload_wakeups_do_not_strand_later_files` (new): end-to-end reproduction of the per-file upload path — doc A blocked in the process stage, then B and C each enqueued + refused-process, both must reach PROCESSED while A is still stuck.
  - `test_feeder_keeps_routing_while_auto_rescan_pending` (new): feeder-level — a dirty flag plus a queued document message must still be routed.
  - `test_feeder_yields_on_auto_rescan_when_paging_disabled` (new): pins the retained guarantee for `PIPELINE_SCHEDULING_PAGE_SIZE=0`.
  - `test_feeder_arms_auto_rescan_and_republishes_on_skip` (rewritten): a ryw SKIP still arms the flag and the deferred message is still re-published, now on the batch teardown's cancel rather than a self-return.
  - `test_feeder_yields_when_auto_rescan_pending` removed — it asserted the behavior this PR intentionally changes; its recovery guarantee is now covered by the paging-disabled test above.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

**Fix-proof verification.** With `lightrag/pipeline.py` stashed (old code) and the new tests in place, `test_sequential_upload_wakeups_do_not_strand_later_files` and `test_feeder_keeps_routing_while_auto_rescan_pending` both fail behaviorally — the later documents time out in PENDING — while the other 9 tests in the file pass on both sides.

**Test runs.**

- `tests/pipeline` — 533 passed
- `tests/kg/test_pipeline_ingress.py` + `tests/api/routes` — 364 passed, 4 skipped
- `pre-commit` (incl. the repo-pinned ruff) — passed

**Real-server verification.** Reproduced against a running `lightrag-server` (single worker, `MAX_PARALLEL_INSERT=3`, default `PIPELINE_SCHEDULING_PAGE_SIZE=500`): 5 files uploaded in one WebUI batch previously showed 2 processing / 3 stuck in PENDING; after the fix the pending files are fed into the running batch and advance as slots free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
