### PR TITLE
Implement fail-closed recovery proof for whole-document purge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,26 @@ The contract permits **concurrent enqueue + processing**: a freshly-uploaded doc
 
 For the rest — write ordering of `full_docs` vs `doc_status`, the workspace-scoped `enqueue_serialize` lock around dedup-and-upsert, and the `from_scan=True` bypass — see the docstrings on `apipeline_enqueue_documents` and `apipeline_process_enqueue_documents` in `lightrag/pipeline.py`.
 
+### Purge recovery contract
+
+The KG is shared across documents, so "what did this document contribute?" can only be answered from the per-document **write-ahead recovery anchors** (`full_entities` / `full_relations`, written and flushed in `merge_nodes_and_edges` Phase 0 *before* the first graph mutation). The reverse lookup — graph `source_id` → `text_chunks` → `full_doc_id` — is not a fallback, because purge deletes those chunks.
+
+`_purge_kg_contributions` therefore **fails closed** (`RecoveryAnchorMissingError`, surfaced as HTTP 409, nothing deleted) unless one of three proofs holds. Treating absent anchors as an empty candidate list was issue #3400's silent-skip defect: graph cleanup was skipped while the chunks went anyway, stranding unattributable entities that `audit_kg_integrity` can only report as unrecoverable orphans.
+
+| Proof | Established by |
+|---|---|
+| `anchors` | Both anchor ROWS present and structurally usable. **Row presence is the test, never list truthiness** — an empty row is a document that extracted no entities, and conflating the two is the original bug. |
+| `pre_graph` | `doc_status.metadata.kg_write_state`. Stamped `pre_graph` at enqueue so every pre-merge failure state inherits it by carry-over; advanced to `graph_mutation_started` only by `merge_nodes_and_edges`' `on_anchors_durable` hook. **Monotonic** — nothing writes it back, because re-stamping `pre_graph` on reprocess would let the resume purge skip and orphan the previous run's contributions. Absent means UNKNOWN (pre-#3416), which fails closed. |
+| `journal` | `doc_status.metadata.kg_purge` at a phase past `prepared`, i.e. a previous attempt got far enough to have deleted the anchors itself. |
+
+Anchor-driven whole-document purge is **journaled and resumable** through four ordered phases — `prepared` → `derived_committed` → `anchors_pending` → `completed` — keyed by an operation id over the document key plus its chunk SET. The journal is *required by* fail-closed rather than an optimisation: purge's last step deletes the anchors, so without it any later failure would make every retry refuse forever. A resumed purge skips exactly the phases already persisted (so it never re-runs the LLM-cache-backed rebuild); an in-flight journal for a different operation is refused (`KGPurgeOperationConflictError`), while a stale `completed` one is ignored as dead bookkeeping.
+
+Both metadata keys are in the `_DOC_STATUS_METADATA_CARRY_OVER_KEYS` **and** `_DOC_STATUS_METADATA_DIRECTIVE_KEYS` whitelists in `lightrag/utils_pipeline.py`; dropping either at a transition or a FAILED→PENDING reset turns a resumable purge into a permanent refusal. Retiring one requires `doc_status_transition_metadata(..., drop=...)` — passing it via `extra` would persist the value, and omitting it lets carry-over restore it.
+
+Callers: `adelete_by_doc_id` (delegates wholly to the primitive; the chunk-less branch runs it too), and the pipeline's resume path `_purge_stale_extraction_if_resuming` (which retires the journal and persists `chunks_list=[]` in one targeted write). Explicit-candidate mode — custom-chunk patch rollback — is neither journaled nor proof-checked, because its own operation journal already names the complete candidate superset; the primitive reads that journal to union in candidates no anchor row can name yet.
+
+The offline remedy for a document with no proof is `audit_kg_integrity(..., apply=True)` (`lightrag/tools/kg_integrity_repair.py`), which rebuilds the anchors from surviving chunk provenance.
+
 ### Query Modes
 
 - **local**: Context-dependent retrieval focused on specific entities

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,9 @@ Both metadata keys are in the `_DOC_STATUS_METADATA_CARRY_OVER_KEYS` **and** `_D
 
 Callers: `adelete_by_doc_id` (delegates wholly to the primitive; the chunk-less branch runs it too), and the pipeline's resume path `_purge_stale_extraction_if_resuming` (which retires the journal and persists `chunks_list=[]` in one targeted write). Explicit-candidate mode — custom-chunk patch rollback — is neither journaled nor proof-checked, because its own operation journal already names the complete candidate superset; the primitive reads that journal to union in candidates no anchor row can name yet.
 
-The offline remedy for a document with no proof is `audit_kg_integrity(..., apply=True)` (`lightrag/tools/kg_integrity_repair.py`), which rebuilds the anchors from surviving chunk provenance.
+A document can legitimately own nothing: `skip_kg` (`process_options` `'!'`) skips extraction and the merge, so no anchor rows are ever written. Post-change those documents carry `pre_graph` and delete normally; older ones have neither proof, and anchor repair has nothing to rebuild from.
+
+The offline remedy for a document with no proof is `audit_kg_integrity(..., apply=True)` (`lightrag/tools/kg_integrity_repair.py`): it rebuilds anchors from surviving chunk provenance, and — because it enumerates the **whole** graph, which the hot paths never do — it can additionally certify that a document appearing nowhere in that scan owns nothing, writing it the empty anchor rows that are the normal proof for such a document (`anchorless_docs` in the report). Absence is only ever concluded from the completed scan; a document that does own graph objects is repaired with its real names, never blanked.
 
 ### Query Modes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,13 +87,20 @@ For the rest — write ordering of `full_docs` vs `doc_status`, the workspace-sc
 
 The KG is shared across documents, so "what did this document contribute?" can only be answered from the per-document **write-ahead recovery anchors** (`full_entities` / `full_relations`, written and flushed in `merge_nodes_and_edges` Phase 0 *before* the first graph mutation). The reverse lookup — graph `source_id` → `text_chunks` → `full_doc_id` — is not a fallback, because purge deletes those chunks.
 
-`_purge_kg_contributions` therefore **fails closed** (`RecoveryAnchorMissingError`, surfaced as HTTP 409, nothing deleted) unless one of three proofs holds. Treating absent anchors as an empty candidate list was issue #3400's silent-skip defect: graph cleanup was skipped while the chunks went anyway, stranding unattributable entities that `audit_kg_integrity` can only report as unrecoverable orphans.
+The governing invariant is narrower than "every purge needs a proof":
+
+> **A purge must never delete something that CARRIES attribution — a chunk row or an anchor row that names objects — and leave those objects behind.** An operation that removes no such carrier cannot strand anything and needs no proof.
+
+`_purge_kg_contributions` therefore **fails closed** (`RecoveryAnchorMissingError`, surfaced as HTTP 409, nothing deleted) when it would remove a carrier without one of these proofs. Treating absent anchors as an empty candidate list was issue #3400's silent-skip defect: graph cleanup was skipped while the chunks went anyway, stranding unattributable entities that `audit_kg_integrity` can only report as unrecoverable orphans.
 
 | Proof | Established by |
 |---|---|
 | `anchors` | Both anchor ROWS present and structurally usable. **Row presence is the test, never list truthiness** — an empty row is a document that extracted no entities, and conflating the two is the original bug. |
 | `pre_graph` | `doc_status.metadata.kg_write_state`. Stamped `pre_graph` at enqueue so every pre-merge failure state inherits it by carry-over; advanced to `graph_mutation_started` only by `merge_nodes_and_edges`' `on_anchors_durable` hook. **Monotonic** — nothing writes it back, because re-stamping `pre_graph` on reprocess would let the resume purge skip and orphan the previous run's contributions. Absent means UNKNOWN (pre-#3416), which fails closed. |
 | `journal` | `doc_status.metadata.kg_purge` at a phase past `prepared`, i.e. a previous attempt got far enough to have deleted the anchors itself. |
+| `empty_scope` | No chunks AND no anchor row that names anything — so the delete removes no carrier at all and the invariant is satisfied outright. This is what lets a row enqueued before the marker existed, still holding no chunks, be deleted directly (no scan, no audit). |
+
+**`kg_write_state` must never be inferred.** `pre_graph` asserts "this document never touched the graph", which licenses deleting its chunks while *skipping the graph* — sound only because the marker is written once, at enqueue, when it is necessarily true and the document has no history to misread. A backfill keying off a momentarily-empty `chunks_list` would stamp a document that does own graph objects, and because the stamp is durable the damage lands later, when the chunks reappear: chunks deleted, graph skipped, issue #3400 reproduced exactly. `empty_scope` is safe where such a backfill is not, because it is re-evaluated against live state on every call and grants nothing beyond that call. `tests/pipeline/test_purge_fail_closed.py::test_a_false_pre_graph_marker_would_reproduce_the_original_defect` pins the cost.
 
 Anchor-driven whole-document purge is **journaled and resumable** through four ordered phases — `prepared` → `derived_committed` → `anchors_pending` → `completed` — keyed by an operation id over the document key plus its chunk SET. The journal is *required by* fail-closed rather than an optimisation: purge's last step deletes the anchors, so without it any later failure would make every retry refuse forever. A resumed purge skips exactly the phases already persisted (so it never re-runs the LLM-cache-backed rebuild); an in-flight journal for a different operation is refused (`KGPurgeOperationConflictError`), while a stale `completed` one is ignored as dead bookkeeping.
 

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -286,8 +286,9 @@ CUSTOM_CHUNK_PATCH_METADATA_KEY = "custom_chunk_patch"
 # "could this document have touched the graph?" without reading the graph.
 # ``pre_graph`` is therefore a valid RECOVERY PROOF on its own: a purge may
 # clean up staged chunks even with no anchor rows, because no graph mutation
-# can have happened yet. Cleared at PROCESSED (the anchors take over as the
-# proof). Absent means UNKNOWN — a pre-#3416 document, which fails closed.
+# can have happened yet. MONOTONIC and never cleared: a PROCESSED document
+# keeps ``graph_mutation_started`` (its anchors serve as the proof from then
+# on). Absent means UNKNOWN — a pre-#3416 document, which fails closed.
 KG_WRITE_STATE_METADATA_KEY = "kg_write_state"
 KG_WRITE_STATE_PRE_GRAPH = "pre_graph"
 KG_WRITE_STATE_GRAPH_MUTATION_STARTED = "graph_mutation_started"

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -279,6 +279,33 @@ PARSED_DIR_NAME = "__parsed__"  # Dir for parsed files (renamed from __enqueued_
 # include its staged chunk IDs. Lives here (not utils_pipeline) so that
 # base.py can derive the scheduling projection without an import cycle.
 CUSTOM_CHUNK_PATCH_METADATA_KEY = "custom_chunk_patch"
+# Reserved doc_status.metadata key recording how far this document's KG write
+# has progressed (issue #3400 fail-closed purge). Stamped ``pre_graph`` when the
+# document enters PROCESSING and promoted to ``graph_mutation_started`` only
+# once the write-ahead recovery anchors are durable — i.e. the value answers
+# "could this document have touched the graph?" without reading the graph.
+# ``pre_graph`` is therefore a valid RECOVERY PROOF on its own: a purge may
+# clean up staged chunks even with no anchor rows, because no graph mutation
+# can have happened yet. Cleared at PROCESSED (the anchors take over as the
+# proof). Absent means UNKNOWN — a pre-#3416 document, which fails closed.
+KG_WRITE_STATE_METADATA_KEY = "kg_write_state"
+KG_WRITE_STATE_PRE_GRAPH = "pre_graph"
+KG_WRITE_STATE_GRAPH_MUTATION_STARTED = "graph_mutation_started"
+# Reserved doc_status.metadata key holding the whole-document purge journal
+# (issue #3400 fail-closed purge). Required BY fail-closed, not merely nice to
+# have: purge's last step deletes the recovery anchors, so without a journal a
+# failure in any later step (LLM cache, full_docs) would make the retry see
+# "anchors missing" and refuse forever. The journal distinguishes "anchors were
+# legitimately deleted by a purge that got this far" from "anchors were never
+# there". Phases are ordered — each is written only after the work it names has
+# been persisted, so a crash resumes at the recorded phase instead of redoing
+# the expensive candidate re-analysis and LLM-cache-backed rebuild.
+KG_PURGE_METADATA_KEY = "kg_purge"
+KG_PURGE_PHASE_PREPARED = "prepared"  # proof verified; nothing deleted yet
+KG_PURGE_PHASE_DERIVED_COMMITTED = "derived_committed"  # graph/vdb/tracking clean
+KG_PURGE_PHASE_ANCHORS_PENDING = "anchors_pending"  # chunks gone; anchors may go
+KG_PURGE_PHASE_COMPLETED = "completed"  # anchors gone; caller finalizes
+KG_PURGE_SCHEMA_VERSION = 1
 # doc_status.metadata keys that record a DEMOTION: this row is not the primary
 # claimant of its canonical source. ``is_duplicate`` is what every backend's
 # primary-candidate predicate keys off (``_basename_of`` returns None for it),

--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -256,6 +256,99 @@ class SourceConflictPrimaryUnusableError(ValueError):
         self.holder_doc_id = holder_doc_id
 
 
+class RecoveryAnchorMissingError(RuntimeError):
+    """A destructive KG purge has no recovery proof, so it refused to start.
+
+    Issue #3400: a whole-document purge discovers what a document contributed
+    to the shared knowledge graph from its write-ahead recovery anchors
+    (``full_entities`` / ``full_relations``). Without them the reverse lookup
+    is impossible — it runs graph ``source_id`` → ``text_chunks`` →
+    ``full_doc_id``, and purge deletes those chunks. Treating absent anchors as
+    "no contributions" silently skipped graph cleanup while still deleting the
+    chunks, stranding live-but-unattributable entities that no tool can ever
+    reclaim (``audit_kg_integrity`` can only report them as unrecoverable
+    orphans).
+
+    So purge fails closed instead, and this exception guarantees **nothing was
+    deleted**: it is raised before the first write. Two distinct reasons, and a
+    caller that renders one message for both tells the operator something false
+    about their data — so the reason travels as :attr:`reason` rather than only
+    inside the message text:
+
+    * ``REASON_MISSING_ANCHOR_ROWS`` — one or both anchor rows are absent (see
+      :attr:`missing_namespaces`) or structurally unusable, and no other proof
+      applies. Note that a row that EXISTS and holds an empty list is a valid
+      proof: a document that extracted no entities is a normal outcome, which
+      is why the check is row presence, never list truthiness;
+    * ``REASON_CHUNKLESS_CONTRIBUTIONS`` — the anchors exist and name KG
+      objects, but the document owns no chunks to attribute them to. Purge
+      classifies candidates by subtracting the document's chunk ids from each
+      object's sources, so an empty chunk set would classify every object as
+      "keep" and then delete the anchors anyway — the same orphan outcome.
+
+    Remedy in both cases: run ``audit_kg_integrity(..., apply=True)``
+    (``lightrag.tools.kg_integrity_repair``), which rebuilds anchor rows from
+    the still-present ``text_chunks`` provenance, then retry the operation.
+    Callers surface this as a conflict (HTTP 409), never a 500: the request was
+    refused on a precondition, and retrying it unchanged will refuse again.
+    """
+
+    REASON_MISSING_ANCHOR_ROWS = "missing_anchor_rows"
+    REASON_CHUNKLESS_CONTRIBUTIONS = "chunkless_contributions"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        doc_id: str,
+        reason: str,
+        missing_namespaces: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__(message)
+        self.doc_id = doc_id
+        self.reason = reason
+        # Set for REASON_MISSING_ANCHOR_ROWS: which anchor rows were absent,
+        # so the operator can tell a half-deleted purge from a never-anchored
+        # document without querying storage themselves.
+        self.missing_namespaces = missing_namespaces
+
+
+class KGPurgeOperationConflictError(RuntimeError):
+    """A resumed purge does not match the journal already on the document.
+
+    Issue #3400: a whole-document purge journals its progress in
+    ``doc_status.metadata.kg_purge`` so a retry can resume instead of redoing
+    the expensive candidate re-analysis and rebuild — and so it can tell
+    "anchors were legitimately deleted by a purge that got that far" from
+    "anchors were never there".
+
+    Resuming is only sound when the retry targets the SAME logical operation.
+    The journal therefore carries an operation id derived from the document key
+    plus its chunk-id set (:func:`~lightrag.utils_pipeline.make_kg_purge_operation_id`),
+    and a mismatch means the document's chunk set changed since the journal was
+    written — so the journal's recorded phase describes work on a different set
+    and resuming from it would skip cleanup for the chunks that differ.
+
+    Raised before the first write, so nothing was deleted. Callers surface it
+    as a conflict (HTTP 409). Remedy: run ``audit_kg_integrity`` to establish
+    the document's true state; the stale journal is cleared when the document's
+    purge completes or its ``doc_status`` row is deleted.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        doc_id: str,
+        journal_operation_id: str,
+        requested_operation_id: str,
+    ) -> None:
+        super().__init__(message)
+        self.doc_id = doc_id
+        self.journal_operation_id = journal_operation_id
+        self.requested_operation_id = requested_operation_id
+
+
 class StorageRecordNotFoundError(KeyError):
     """A targeted doc_status field update referenced a non-existent record.
 

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -8597,15 +8597,22 @@ class PGGraphStorage(BaseGraphStorage):
             if result.get("properties"):
                 node_dict = result["properties"]
 
-                # Process string result, parse it to JSON dictionary
+                # Process string result, parse it to JSON dictionary.
+                # Complete-or-raise: enumeration feeds whole-graph consumers
+                # (storage migration, VDB rebuild, KG integrity audit) that
+                # treat the result as the full graph. Silently dropping an
+                # unparsable node would let the audit certify its owning
+                # document as contribution-free — a false recovery proof.
                 if isinstance(node_dict, str):
                     try:
                         node_dict = json.loads(node_dict)
-                    except json.JSONDecodeError:
-                        logger.warning(
-                            f"[{self.workspace}] Failed to parse node string: {node_dict}"
-                        )
-                        continue
+                    except json.JSONDecodeError as e:
+                        raise PGGraphQueryException(
+                            {
+                                "message": f"Corrupt node properties in graph {self.graph_name}: {e}",
+                                "details": node_dict[:200],
+                            }
+                        ) from e
 
                 # Add node id (entity_id) to the dictionary for easier access
                 node_dict["id"] = node_dict.get("entity_id")
@@ -8638,15 +8645,21 @@ class PGGraphStorage(BaseGraphStorage):
         for result in results:
             edge_properties = result["properties"]
 
-            # Process string result, parse it to JSON dictionary
+            # Process string result, parse it to JSON dictionary.
+            # Complete-or-raise, same as get_all_nodes: blanking the
+            # properties would keep the edge row but silently drop its
+            # source_id attribution, which whole-graph consumers (KG
+            # integrity audit) rely on to attribute the edge to a document.
             if isinstance(edge_properties, str):
                 try:
                     edge_properties = json.loads(edge_properties)
-                except json.JSONDecodeError:
-                    logger.warning(
-                        f"[{self.workspace}] Failed to parse edge properties string: {edge_properties}"
-                    )
-                    edge_properties = {}
+                except json.JSONDecodeError as e:
+                    raise PGGraphQueryException(
+                        {
+                            "message": f"Corrupt edge properties in graph {self.graph_name}: {e}",
+                            "details": edge_properties[:200],
+                        }
+                    ) from e
 
             edge_properties["source"] = result["source"]
             edge_properties["target"] = result["target"]

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -91,7 +91,6 @@ from lightrag.constants import (
     KG_PURGE_PHASE_DERIVED_COMMITTED,
     KG_PURGE_PHASE_PREPARED,
     KG_PURGE_SCHEMA_VERSION,
-    KG_WRITE_STATE_METADATA_KEY,
     KG_WRITE_STATE_PRE_GRAPH,
 )
 from lightrag.utils import get_env_value
@@ -4373,10 +4372,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         self,
         doc_id: str,
         *,
-        write_state: str | None = None,
         extra_fields: dict[str, Any] | None = None,
     ) -> None:
-        """Retire a completed purge journal, optionally resetting write state.
+        """Retire a completed purge journal.
 
         Used by callers that KEEP the ``doc_status`` row after a purge (the
         pipeline's stale-extraction reset). A caller that deletes the row
@@ -4388,6 +4386,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         ``chunks_list`` / ``chunks_count`` and the journal retirement land
         atomically — a crash between them would leave the document pointing at
         chunks this purge already deleted.
+
+        Deliberately does NOT touch ``kg_write_state``. That marker is
+        monotonic, and ``_mark_graph_mutation_started`` is its only writer, so
+        neither direction is safe to guess here: forcing
+        ``graph_mutation_started`` would make a document that provably never
+        merged start demanding anchors it will never have (a false refusal that
+        leaves it neither reprocessable nor deletable), while clearing it would
+        discard the proof a still-pre-graph document depends on.
         """
         status_doc = await self.doc_status.get_by_id(doc_id)
         if status_doc is None:
@@ -4395,10 +4401,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         metadata = doc_status_field(status_doc, "metadata", {})
         metadata = dict(metadata) if isinstance(metadata, dict) else {}
         metadata.pop(KG_PURGE_METADATA_KEY, None)
-        if write_state is None:
-            metadata.pop(KG_WRITE_STATE_METADATA_KEY, None)
-        else:
-            metadata[KG_WRITE_STATE_METADATA_KEY] = write_state
         fields: dict[str, Any] = {"metadata": metadata}
         if extra_fields:
             fields.update(extra_fields)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -226,6 +226,25 @@ _KG_PURGE_PHASE_ORDER: tuple[str, ...] = (
 _KG_PURGE_RESUMABLE_PHASES: frozenset[str] = frozenset(_KG_PURGE_PHASE_ORDER)
 
 
+class _PurgeStageError(Exception):
+    """A purge step failed, tagged with which step it was.
+
+    ``adelete_by_doc_id`` records the failing step in
+    ``doc_status.metadata.deletion_failure_stage`` so an operator can see how
+    far a failed deletion got. Now that the delete path delegates its KG
+    cleanup to the purge primitive, the stage has to travel with the exception
+    instead of being tracked by the caller — carried as an attribute rather
+    than parsed back out of the message, which callers must not depend on.
+
+    Subclasses ``Exception`` and keeps the historical ``Failed to ...`` message
+    text, so existing callers and tests that match on either are unaffected.
+    """
+
+    def __init__(self, message: str, *, stage: str) -> None:
+        super().__init__(message)
+        self.purge_stage = stage
+
+
 @dataclass(frozen=True)
 class _PurgeRecoveryProof:
     """Why a whole-document purge is (or is not) allowed to delete anything.
@@ -242,6 +261,15 @@ class _PurgeRecoveryProof:
     write_state: str | None = None
     missing_namespaces: tuple[str, ...] = ()
     missing_reason: str | None = None
+    # Candidates anchored ONLY in an unfinished custom-chunk patch journal.
+    # Patch-mode merges deliberately skip the write-ahead anchor prewrite (the
+    # journal is that operation's anchor) and union into the base document's
+    # anchor rows only at commit — so until then these graph objects exist
+    # while no anchor row names them. Whole-document purge must union them in,
+    # or deleting the document removes the staged chunks and leaves those
+    # objects orphaned.
+    patch_candidate_entities: tuple[str, ...] = ()
+    patch_candidate_relations: tuple[tuple[str, str], ...] = ()
 
     def phase_at_least(self, phase: str) -> bool:
         """True when the journal records ``phase`` or a later one."""
@@ -3854,8 +3882,19 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         error_message: str | None = None,
         failed: bool,
     ) -> dict[str, Any]:
-        """Persist deletion retry metadata and return the updated status record."""
-        metadata = doc_status_data.get("metadata", {})
+        """Persist deletion retry metadata and return the updated status record.
+
+        Re-reads the record first, and writes only the fields it changes. The
+        caller's ``doc_status_data`` is a snapshot taken before deletion began,
+        and the purge that runs in between writes its journal into
+        ``metadata`` through a targeted update — so upserting the whole stale
+        snapshot would silently clobber that journal, which is precisely what
+        keeps the retry from being refused for missing recovery anchors
+        (issue #3400).
+        """
+        current = await self.doc_status.get_by_id(doc_id)
+        base_record = current if isinstance(current, dict) else doc_status_data
+        metadata = base_record.get("metadata", {})
         if not isinstance(metadata, dict):
             metadata = {}
 
@@ -3879,15 +3918,18 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             updated_metadata.pop("deletion_failed", None)
             updated_metadata.pop("deletion_failure_stage", None)
 
-        updated_status_data = {
-            **doc_status_data,
+        changed_fields = {
             "updated_at": datetime.now(timezone.utc).isoformat(),
             "metadata": updated_metadata,
             "error_msg": error_message if failed else "",
         }
 
-        await self.doc_status.upsert({doc_id: updated_status_data})
-        return updated_status_data
+        # Targeted update, and ``missing_ok`` so a record a concurrent delete
+        # already removed is not resurrected as a zombie by this write.
+        await self.doc_status.update_doc_status_fields(
+            doc_id, changed_fields, missing_ok=True
+        )
+        return {**base_record, **changed_fields}
 
     async def _get_existing_llm_cache_ids(self, cache_ids: list[str]) -> list[str]:
         """Return cache IDs that still exist in cache storage.
@@ -4055,6 +4097,37 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             pipeline_status_lock=pipeline_status_lock,
         )
 
+    @staticmethod
+    def _patch_journal_candidates(
+        status_doc: Any,
+    ) -> tuple[tuple[str, ...], tuple[tuple[str, str], ...]]:
+        """Candidates anchored only in an in-flight custom-chunk patch journal.
+
+        A patch-mode merge passes no anchor storages — the journal IS that
+        operation's recovery anchor — and its candidates are unioned into the
+        base document's ``full_entities`` / ``full_relations`` rows only at
+        commit. So between a failed patch and its rollback, these graph objects
+        exist while no anchor row names them, and a whole-document purge that
+        consulted the anchors alone would delete the staged chunks and leave
+        the objects behind.
+        """
+        journal = doc_status_custom_chunk_patch(status_doc)
+        if journal is None:
+            return (), ()
+        entities = tuple(
+            name
+            for name in (journal.get("entity_names") or [])
+            if isinstance(name, str) and name
+        )
+        relations = tuple(
+            (pair[0], pair[1])
+            for pair in (journal.get("relation_pairs") or [])
+            if isinstance(pair, (list, tuple))
+            and len(pair) == 2
+            and all(isinstance(end, str) and end for end in pair)
+        )
+        return entities, relations
+
     async def _resolve_purge_recovery_proof(
         self,
         doc_id: str,
@@ -4093,14 +4166,29 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         journal = doc_status_kg_purge_journal(status_doc)
         write_state = doc_status_kg_write_state(status_doc)
         operation_id = make_kg_purge_operation_id(doc_id, chunk_ids)
+        patch_entities, patch_relations = self._patch_journal_candidates(status_doc)
 
         journal_phase: str | None = None
         if journal is not None:
             journal_operation_id = journal.get("operation_id")
-            if (
+            mismatched = (
                 not isinstance(journal_operation_id, str)
                 or journal_operation_id != operation_id
-            ):
+            )
+            if mismatched and journal.get("phase") == KG_PURGE_PHASE_COMPLETED:
+                # A ``completed`` journal describes a FINISHED purge, so it
+                # holds no resume information worth protecting — and its
+                # retirement is a separate write that a crash can skip. Treat a
+                # stale one as ignorable rather than a conflict, or a document
+                # re-purged with a different chunk set would be refused forever
+                # over bookkeeping that no longer means anything.
+                logger.info(
+                    f"[purge] {doc_id}: ignoring a stale completed purge journal "
+                    f"for operation {journal_operation_id!r} (now purging "
+                    f"{operation_id!r})"
+                )
+                journal = None
+            elif mismatched:
                 raise KGPurgeOperationConflictError(
                     f"Document {doc_id} carries a KG purge journal for a different "
                     f"operation (journal={journal_operation_id!r}, "
@@ -4115,9 +4203,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     ),
                     requested_operation_id=operation_id,
                 )
-            phase = journal.get("phase")
-            if phase in _KG_PURGE_RESUMABLE_PHASES:
-                journal_phase = phase
+            if journal is not None:
+                phase = journal.get("phase")
+                if phase in _KG_PURGE_RESUMABLE_PHASES:
+                    journal_phase = phase
 
         # A journal past ``prepared`` is itself the proof: the anchors may
         # already be gone precisely BECAUSE a previous attempt got that far.
@@ -4127,6 +4216,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 operation_id=operation_id,
                 journal_phase=journal_phase,
                 write_state=write_state,
+                patch_candidate_entities=patch_entities,
+                patch_candidate_relations=patch_relations,
             )
 
         missing_namespaces: list[str] = []
@@ -4157,12 +4248,16 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     journal_phase=journal_phase,
                     write_state=write_state,
                     missing_reason=RecoveryAnchorMissingError.REASON_CHUNKLESS_CONTRIBUTIONS,
+                    patch_candidate_entities=patch_entities,
+                    patch_candidate_relations=patch_relations,
                 )
             return _PurgeRecoveryProof(
                 proof_kind="anchors",
                 operation_id=operation_id,
                 journal_phase=journal_phase,
                 write_state=write_state,
+                patch_candidate_entities=patch_entities,
+                patch_candidate_relations=patch_relations,
             )
 
         if write_state == KG_WRITE_STATE_PRE_GRAPH:
@@ -4172,6 +4267,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 journal_phase=journal_phase,
                 write_state=write_state,
                 missing_namespaces=tuple(missing_namespaces),
+                patch_candidate_entities=patch_entities,
+                patch_candidate_relations=patch_relations,
             )
 
         return _PurgeRecoveryProof(
@@ -4181,6 +4278,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             write_state=write_state,
             missing_namespaces=tuple(missing_namespaces),
             missing_reason=RecoveryAnchorMissingError.REASON_MISSING_ANCHOR_ROWS,
+            patch_candidate_entities=patch_entities,
+            patch_candidate_relations=patch_relations,
         )
 
     @staticmethod
@@ -4403,15 +4502,23 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             if proof.proof_kind is None:
                 self._raise_missing_recovery_proof(doc_id, proof)
             if proof.proof_kind == "pre_graph":
-                # Provably nothing in the graph to find, so force an EXPLICIT
-                # empty candidate set: the derived pass then performs no graph
-                # reads or writes at all, instead of inferring "no candidates"
-                # from anchors it could not read (the original bug).
+                # The document's OWN merge provably never ran, so force an
+                # EXPLICIT empty candidate set rather than inferring "no
+                # candidates" from anchors that could not be read (the original
+                # bug). The patch-journal extras still apply below: a patch-mode
+                # merge mutates the graph without writing anchors, so those are
+                # the one kind of contribution a pre-graph document can have.
                 logger.warning(
                     f"[purge] {doc_id}: recovery anchor row(s) missing "
                     f"({', '.join(proof.missing_namespaces)}), but kg_write_state "
-                    f"proves no graph mutation started; cleaning up staged "
-                    f"chunks only"
+                    f"proves the document's own merge never started; cleaning up "
+                    f"staged chunks"
+                    + (
+                        f" and {len(proof.patch_candidate_entities)} journal-anchored "
+                        f"candidate(s)"
+                        if proof.patch_candidate_entities
+                        else " only"
+                    )
                 )
                 candidate_entities = []
                 candidate_relations = []
@@ -4437,6 +4544,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 chunk_ids,
                 candidate_entities=candidate_entities,
                 candidate_relations=candidate_relations,
+                extra_candidate_entities=(
+                    proof.patch_candidate_entities if proof is not None else ()
+                ),
+                extra_candidate_relations=(
+                    proof.patch_candidate_relations if proof is not None else ()
+                ),
                 rebuild_policy=rebuild_policy,
                 pipeline_status=pipeline_status,
                 pipeline_status_lock=pipeline_status_lock,
@@ -4473,7 +4586,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     append_pipeline_history(pipeline_status, log_message)
             except Exception as e:
                 logger.error(f"[purge] Failed to delete chunks for {doc_id}: {e}")
-                raise Exception(f"Failed to delete document chunks: {e}") from e
+                raise _PurgeStageError(
+                    f"Failed to delete document chunks: {e}", stage="delete_chunks"
+                ) from e
 
         # Chunk deletion is confirmed durable: the anchors may now go. This
         # phase is the one that keeps step 8 retryable — without it, a failure
@@ -4505,8 +4620,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 logger.error(
                     f"[purge] Failed to delete full_entities/full_relations rows for {doc_id}: {e}"
                 )
-                raise Exception(
-                    f"Failed to delete from full_entities/full_relations: {e}"
+                raise _PurgeStageError(
+                    f"Failed to delete from full_entities/full_relations: {e}",
+                    stage="delete_doc_graph_metadata",
                 ) from e
 
         if journaled and proof is not None:
@@ -4531,6 +4647,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         *,
         candidate_entities: list[str] | None,
         candidate_relations: list[tuple[str, str]] | None,
+        extra_candidate_entities: tuple[str, ...] = (),
+        extra_candidate_relations: tuple[tuple[str, str], ...] = (),
         rebuild_policy: Literal["best_effort", "rollback"],
         pipeline_status: dict,
         pipeline_status_lock: Any,
@@ -4549,6 +4667,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         "resolve from this document's anchor rows". The caller is responsible
         for having proven that the anchors are readable — passing ``None`` with
         absent anchors is exactly the silent-skip bug of issue #3400.
+
+        ``extra_candidate_*`` are unioned in after that resolution, for objects
+        the anchor rows cannot name yet (an in-flight custom-chunk patch
+        journal). They are additive only, so they can never mask a missing
+        anchor: an empty union with absent anchors still resolves to nothing.
         """
         rebuild_report = KGRebuildReport()
 
@@ -4578,6 +4701,24 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     if doc_relations_data and "relation_pairs" in doc_relations_data
                     else []
                 )
+
+            # Union the anchor-independent extras (order-preserving dedup).
+            if extra_candidate_entities:
+                merged_entities = list(candidate_entities)
+                seen_names = set(merged_entities)
+                for name in extra_candidate_entities:
+                    if name not in seen_names:
+                        seen_names.add(name)
+                        merged_entities.append(name)
+                candidate_entities = merged_entities
+            if extra_candidate_relations:
+                merged_relations = list(candidate_relations)
+                seen_pairs = {tuple(pair) for pair in merged_relations}
+                for pair in extra_candidate_relations:
+                    if tuple(pair) not in seen_pairs:
+                        seen_pairs.add(tuple(pair))
+                        merged_relations.append(pair)
+                candidate_relations = merged_relations
 
             affected_nodes: list[dict[str, Any]] = []
             affected_edges: list[dict[str, Any]] = []
@@ -4616,7 +4757,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             logger.error(
                 f"[purge] Failed to analyze affected graph elements for {doc_id}: {e}"
             )
-            raise Exception(f"Failed to analyze graph dependencies: {e}") from e
+            raise _PurgeStageError(
+                f"Failed to analyze graph dependencies: {e}",
+                stage="analyze_graph_dependencies",
+            ) from e
 
         # ---- 2. Classify entities/relations into delete vs rebuild ----
         try:
@@ -4773,7 +4917,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             logger.error(
                 f"[purge] Failed to process graph analysis results for {doc_id}: {e}"
             )
-            raise Exception(f"Failed to process graph dependencies: {e}") from e
+            raise _PurgeStageError(
+                f"Failed to process graph dependencies: {e}",
+                stage="update_chunk_tracking",
+            ) from e
 
         # ---- 3. Delete relationships with no remaining sources ----
         if relationships_to_delete:
@@ -4808,7 +4955,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 logger.error(
                     f"[purge] Failed to delete relationships for {doc_id}: {e}"
                 )
-                raise Exception(f"Failed to delete relationships: {e}") from e
+                raise _PurgeStageError(
+                    f"Failed to delete relationships: {e}",
+                    stage="delete_relationships",
+                ) from e
 
         # ---- 4. Delete entities with no remaining sources ----
         if entities_to_delete:
@@ -4869,7 +5019,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     append_pipeline_history(pipeline_status, log_message)
             except Exception as e:
                 logger.error(f"[purge] Failed to delete entities for {doc_id}: {e}")
-                raise Exception(f"Failed to delete entities: {e}") from e
+                raise _PurgeStageError(
+                    f"Failed to delete entities: {e}", stage="delete_entities"
+                ) from e
 
         # ---- 5. Persist pre-rebuild changes ----
         # Use plain _insert_done (no discard-on-failure): the pending buffer
@@ -4880,7 +5032,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             await self._insert_done()
         except Exception as e:
             logger.error(f"[purge] Failed to persist pre-rebuild changes: {e}")
-            raise Exception(f"Failed to persist pre-rebuild changes: {e}") from e
+            raise _PurgeStageError(
+                f"Failed to persist pre-rebuild changes: {e}",
+                stage="persist_pre_rebuild_changes",
+            ) from e
 
         # ---- 6. Rebuild entities/relations that still have remaining sources ----
         if entities_to_rebuild or relationships_to_rebuild:
@@ -4902,7 +5057,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 )
             except Exception as e:
                 logger.error(f"[purge] Failed to rebuild knowledge from chunks: {e}")
-                raise Exception(f"Failed to rebuild knowledge graph: {e}") from e
+                raise _PurgeStageError(
+                    f"Failed to rebuild knowledge graph: {e}",
+                    stage="rebuild_knowledge_graph",
+                ) from e
 
             # Persist the rebuilt graph/vector/tracking state before the
             # source chunks disappear — a crash after this flush leaves a
@@ -4912,7 +5070,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 await self._insert_done()
             except Exception as e:
                 logger.error(f"[purge] Failed to persist rebuilt knowledge: {e}")
-                raise Exception(f"Failed to persist rebuilt knowledge: {e}") from e
+                raise _PurgeStageError(
+                    f"Failed to persist rebuilt knowledge: {e}",
+                    stage="persist_rebuilt_knowledge",
+                ) from e
 
         return rebuild_report
 
@@ -5152,10 +5313,34 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     + journal_chunk_ids
                 )
             )
-            chunk_ids_set = set(chunk_ids)
 
             if not chunk_ids:
                 logger.warning(f"No chunks found for document {doc_id}")
+
+                # Fail closed before touching anything (issue #3400). This
+                # branch used to delete doc_status + full_docs and report
+                # success WITHOUT looking at the graph at all — so a document
+                # whose anchors still named live entities was reported deleted
+                # while those entities stayed behind, now unattributable
+                # (removing doc_status is what breaks the provenance chain).
+                #
+                # Run the same primitive as the chunk-backed path: with an
+                # empty chunk set it refuses exactly that case, and otherwise
+                # cleans up a genuinely empty stub — including its two empty
+                # anchor rows, which this branch used to leave behind keyed to
+                # a document that no longer exists.
+                try:
+                    deletion_stage = "validate_recovery_anchors"
+                    await self._purge_kg_contributions(
+                        doc_id,
+                        chunk_ids,
+                        pipeline_status=pipeline_status,
+                        pipeline_status_lock=pipeline_status_lock,
+                    )
+                except _PurgeStageError as purge_error:
+                    deletion_stage = purge_error.purge_stage
+                    raise
+
                 # Mark that deletion operations have started
                 deletion_operations_started = True
 
@@ -5302,459 +5487,40 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 else:
                     logger.info("No LLM cache entries found for document %s", doc_id)
 
-            # 4. Analyze entities and relationships that will be affected
-            entities_to_delete = set()
-            entities_to_rebuild = {}  # entity_name -> remaining chunk id list
-            relationships_to_delete = set()
-            relationships_to_rebuild = {}  # (src, tgt) -> remaining chunk id list
-            entity_chunk_updates: dict[str, list[str]] = {}
-            relation_chunk_updates: dict[tuple[str, str], list[str]] = {}
-
+            # 4. Purge every KG contribution of this document, then its chunks.
+            #
+            # Delegated to the shared primitive rather than reimplemented here
+            # (issue #3400). Two things follow from that:
+            #
+            #  * The primitive refuses to start without a recovery proof, so a
+            #    document whose anchors were lost fails closed with a 409
+            #    instead of silently skipping graph cleanup and orphaning its
+            #    entities. Candidates anchored ONLY in an unfinished
+            #    custom-chunk patch journal are covered too — the primitive
+            #    reads that journal itself and unions them in, since a
+            #    patch-mode merge writes no anchor rows of its own — and this
+            #    path already merged the journal's staged chunk ids into
+            #    ``chunk_ids`` above.
+            #  * Destructive ordering is the primitive's (correct) one. The
+            #    inline implementation this replaces deleted the chunks BEFORE
+            #    repairing the graph, which is the window where a mid-delete
+            #    failure left graph objects pointing at chunks that no longer
+            #    existed.
+            #
+            # The failing step travels on the exception as ``purge_stage`` so
+            # ``deletion_failure_stage`` keeps reporting the same granularity
+            # it always did.
             try:
-                deletion_stage = "analyze_graph_dependencies"
-                # Get affected entities and relations from full_entities and full_relations storage
-                doc_entities_data = await self.full_entities.get_by_id(doc_id)
-                doc_relations_data = await self.full_relations.get_by_id(doc_id)
-
-                # Candidate discovery must also cover journal-only candidates
-                # (issue #3400 Phase 3): a failed custom-chunk patch may have
-                # written graph/vector/tracking objects whose anchors live
-                # ONLY in the doc's custom_chunk_patch journal — patch mode
-                # unions them into full_entities/full_relations at commit.
-                # Without this union, deleting the document would remove the
-                # staged chunks (added to chunk_ids above) while never
-                # visiting those graph objects, leaving orphans behind.
-                entity_names = list((doc_entities_data or {}).get("entity_names") or [])
-                relation_pairs = [
-                    list(pair)
-                    for pair in ((doc_relations_data or {}).get("relation_pairs") or [])
-                ]
-                if isinstance(journal, dict):
-                    seen_names = set(entity_names)
-                    for name in journal.get("entity_names") or []:
-                        if isinstance(name, str) and name and name not in seen_names:
-                            seen_names.add(name)
-                            entity_names.append(name)
-                    seen_pairs = {tuple(pair) for pair in relation_pairs}
-                    for pair in journal.get("relation_pairs") or []:
-                        if (
-                            isinstance(pair, (list, tuple))
-                            and len(pair) == 2
-                            and tuple(pair) not in seen_pairs
-                        ):
-                            seen_pairs.add(tuple(pair))
-                            relation_pairs.append(list(pair))
-
-                affected_nodes = []
-                affected_edges = []
-
-                # Get entity data from graph storage (candidates are a
-                # recovery superset; absent nodes are skipped below)
-                if entity_names:
-                    # get_nodes_batch returns dict[str, dict], need to convert to list[dict]
-                    nodes_dict = await self.chunk_entity_relation_graph.get_nodes_batch(
-                        entity_names
-                    )
-                    for entity_name in entity_names:
-                        node_data = nodes_dict.get(entity_name)
-                        if node_data:
-                            # Ensure compatibility with existing logic that expects "id" field
-                            if "id" not in node_data:
-                                node_data["id"] = entity_name
-                            affected_nodes.append(node_data)
-
-                # Get relation data from graph storage using the candidate pairs
-                if relation_pairs:
-                    edge_pairs_dicts = [
-                        {"src": pair[0], "tgt": pair[1]} for pair in relation_pairs
-                    ]
-                    # get_edges_batch returns dict[tuple[str, str], dict], need to convert to list[dict]
-                    edges_dict = await self.chunk_entity_relation_graph.get_edges_batch(
-                        edge_pairs_dicts
-                    )
-
-                    for pair in relation_pairs:
-                        src, tgt = pair[0], pair[1]
-                        edge_key = (src, tgt)
-                        edge_data = edges_dict.get(edge_key)
-                        if edge_data:
-                            # Ensure compatibility with existing logic that expects "source" and "target" fields
-                            if "source" not in edge_data:
-                                edge_data["source"] = src
-                            if "target" not in edge_data:
-                                edge_data["target"] = tgt
-                            affected_edges.append(edge_data)
-
-            except Exception as e:
-                logger.error(f"Failed to analyze affected graph elements: {e}")
-                raise Exception(f"Failed to analyze graph dependencies: {e}") from e
-
-            try:
-                # Process entities
-                for node_data in affected_nodes:
-                    node_label = node_data.get("entity_id")
-                    if not node_label:
-                        continue
-
-                    existing_sources: list[str] = []
-                    graph_sources: list[str] = []
-                    if self.entity_chunks:
-                        stored_chunks = await self.entity_chunks.get_by_id(node_label)
-                        if stored_chunks and isinstance(stored_chunks, dict):
-                            existing_sources = [
-                                chunk_id
-                                for chunk_id in stored_chunks.get("chunk_ids", [])
-                                if chunk_id
-                            ]
-
-                    if node_data.get("source_id"):
-                        graph_sources = [
-                            chunk_id
-                            for chunk_id in node_data["source_id"].split(
-                                GRAPH_FIELD_SEP
-                            )
-                            if chunk_id
-                        ]
-
-                    if not existing_sources:
-                        existing_sources = graph_sources
-
-                    if not existing_sources:
-                        # No chunk references means this entity should be deleted
-                        entities_to_delete.add(node_label)
-                        entity_chunk_updates[node_label] = []
-                        continue
-
-                    remaining_sources = subtract_source_ids(existing_sources, chunk_ids)
-                    # `existing_sources` comes from chunk-tracking storage when available, but
-                    # graph `source_id` can still be stale after a failed prior delete. If the
-                    # graph still references any chunk being deleted in this attempt, force a
-                    # rebuild/delete so the graph metadata gets synchronized instead of being
-                    # left untouched with orphaned source references.
-                    graph_references_deleted_chunks = bool(
-                        graph_sources and set(graph_sources) & chunk_ids_set
-                    )
-
-                    if not remaining_sources:
-                        entities_to_delete.add(node_label)
-                        entity_chunk_updates[node_label] = []
-                    elif (
-                        remaining_sources != existing_sources
-                        or graph_references_deleted_chunks
-                    ):
-                        entities_to_rebuild[node_label] = remaining_sources
-                        entity_chunk_updates[node_label] = remaining_sources
-                    else:
-                        logger.info(f"Untouch entity: {node_label}")
-
-                async with pipeline_status_lock:
-                    log_message = f"Found {len(entities_to_rebuild)} affected entities"
-                    logger.info(log_message)
-                    pipeline_status["latest_message"] = log_message
-                    append_pipeline_history(pipeline_status, log_message)
-
-                # Process relationships
-                for edge_data in affected_edges:
-                    # source target is not in normalize order in graph db property
-                    src = edge_data.get("source")
-                    tgt = edge_data.get("target")
-
-                    if not src or not tgt or "source_id" not in edge_data:
-                        continue
-
-                    edge_tuple = tuple(sorted((src, tgt)))
-                    if (
-                        edge_tuple in relationships_to_delete
-                        or edge_tuple in relationships_to_rebuild
-                    ):
-                        continue
-
-                    existing_sources: list[str] = []
-                    graph_sources: list[str] = []
-                    if self.relation_chunks:
-                        storage_key = make_relation_chunk_key(src, tgt)
-                        stored_chunks = await self.relation_chunks.get_by_id(
-                            storage_key
-                        )
-                        if stored_chunks and isinstance(stored_chunks, dict):
-                            existing_sources = [
-                                chunk_id
-                                for chunk_id in stored_chunks.get("chunk_ids", [])
-                                if chunk_id
-                            ]
-
-                    if edge_data.get("source_id"):
-                        graph_sources = [
-                            chunk_id
-                            for chunk_id in edge_data["source_id"].split(
-                                GRAPH_FIELD_SEP
-                            )
-                            if chunk_id
-                        ]
-
-                    if not existing_sources:
-                        existing_sources = graph_sources
-
-                    if not existing_sources:
-                        # No chunk references means this relationship should be deleted
-                        relationships_to_delete.add(edge_tuple)
-                        relation_chunk_updates[edge_tuple] = []
-                        continue
-
-                    remaining_sources = subtract_source_ids(existing_sources, chunk_ids)
-                    # Same as the entity path above: even when relation chunk-tracking is already
-                    # correct, the graph edge may still carry a stale `source_id` that mentions a
-                    # chunk deleted in this attempt. Treat that as an affected relation so retry
-                    # deletion can repair the graph metadata rather than skipping it as "untouched".
-                    graph_references_deleted_chunks = bool(
-                        graph_sources and set(graph_sources) & chunk_ids_set
-                    )
-
-                    if not remaining_sources:
-                        relationships_to_delete.add(edge_tuple)
-                        relation_chunk_updates[edge_tuple] = []
-                    elif (
-                        remaining_sources != existing_sources
-                        or graph_references_deleted_chunks
-                    ):
-                        relationships_to_rebuild[edge_tuple] = remaining_sources
-                        relation_chunk_updates[edge_tuple] = remaining_sources
-                    else:
-                        logger.info(f"Untouch relation: {edge_tuple}")
-
-                async with pipeline_status_lock:
-                    log_message = (
-                        f"Found {len(relationships_to_rebuild)} affected relations"
-                    )
-                    logger.info(log_message)
-                    pipeline_status["latest_message"] = log_message
-                    append_pipeline_history(pipeline_status, log_message)
-
-                current_time = int(time.time())
-                deletion_stage = "update_chunk_tracking"
-
-                if entity_chunk_updates and self.entity_chunks:
-                    entity_upsert_payload = {}
-                    for entity_name, remaining in entity_chunk_updates.items():
-                        if not remaining:
-                            # Empty entities are deleted alongside graph nodes later
-                            continue
-                        entity_upsert_payload[entity_name] = {
-                            "chunk_ids": remaining,
-                            "count": len(remaining),
-                            "updated_at": current_time,
-                        }
-                    if entity_upsert_payload:
-                        await self.entity_chunks.upsert(entity_upsert_payload)
-
-                if relation_chunk_updates and self.relation_chunks:
-                    relation_upsert_payload = {}
-                    for edge_tuple, remaining in relation_chunk_updates.items():
-                        if not remaining:
-                            # Empty relations are deleted alongside graph edges later
-                            continue
-                        storage_key = make_relation_chunk_key(*edge_tuple)
-                        relation_upsert_payload[storage_key] = {
-                            "chunk_ids": remaining,
-                            "count": len(remaining),
-                            "updated_at": current_time,
-                        }
-
-                    if relation_upsert_payload:
-                        await self.relation_chunks.upsert(relation_upsert_payload)
-
-            except Exception as e:
-                logger.error(f"Failed to process graph analysis results: {e}")
-                raise Exception(f"Failed to process graph dependencies: {e}") from e
-
-            # Data integrity is ensured by allowing only one process to hold pipeline at a time（no graph db lock is needed anymore)
-
-            # 5. Delete chunks from storage
-            if chunk_ids:
-                try:
-                    deletion_stage = "delete_chunks"
-                    await self.chunks_vdb.delete(chunk_ids)
-                    await self.text_chunks.delete(chunk_ids)
-
-                    async with pipeline_status_lock:
-                        log_message = (
-                            f"Successfully deleted {len(chunk_ids)} chunks from storage"
-                        )
-                        logger.info(log_message)
-                        pipeline_status["latest_message"] = log_message
-                        append_pipeline_history(pipeline_status, log_message)
-
-                except Exception as e:
-                    logger.error(f"Failed to delete chunks: {e}")
-                    raise Exception(f"Failed to delete document chunks: {e}") from e
-
-            # 6. Delete relationships that have no remaining sources
-            if relationships_to_delete:
-                try:
-                    deletion_stage = "delete_relationships"
-                    # Delete from relation vdb
-                    rel_ids_to_delete = []
-                    for src, tgt in relationships_to_delete:
-                        rel_ids_to_delete.extend(
-                            [
-                                compute_mdhash_id(src + tgt, prefix="rel-"),
-                                compute_mdhash_id(tgt + src, prefix="rel-"),
-                            ]
-                        )
-                    await self.relationships_vdb.delete(rel_ids_to_delete)
-
-                    # Delete from graph
-                    await self.chunk_entity_relation_graph.remove_edges(
-                        list(relationships_to_delete)
-                    )
-
-                    # Delete from relation_chunks storage
-                    if self.relation_chunks:
-                        relation_storage_keys = [
-                            make_relation_chunk_key(src, tgt)
-                            for src, tgt in relationships_to_delete
-                        ]
-                        await self.relation_chunks.delete(relation_storage_keys)
-
-                    async with pipeline_status_lock:
-                        log_message = f"Successfully deleted {len(relationships_to_delete)} relations"
-                        logger.info(log_message)
-                        pipeline_status["latest_message"] = log_message
-                        append_pipeline_history(pipeline_status, log_message)
-
-                except Exception as e:
-                    logger.error(f"Failed to delete relationships: {e}")
-                    raise Exception(f"Failed to delete relationships: {e}") from e
-
-            # 7. Delete entities that have no remaining sources
-            if entities_to_delete:
-                try:
-                    deletion_stage = "delete_entities"
-                    # Batch get all edges for entities to avoid N+1 query problem
-                    nodes_edges_dict = (
-                        await self.chunk_entity_relation_graph.get_nodes_edges_batch(
-                            list(entities_to_delete)
-                        )
-                    )
-
-                    # Debug: Check and log all edges before deleting nodes
-                    edges_to_delete = set()
-                    edges_still_exist = 0
-
-                    for entity, edges in nodes_edges_dict.items():
-                        if edges:
-                            for src, tgt in edges:
-                                # Normalize edge representation (sorted for consistency)
-                                edge_tuple = tuple(sorted((src, tgt)))
-                                edges_to_delete.add(edge_tuple)
-
-                                if (
-                                    src in entities_to_delete
-                                    and tgt in entities_to_delete
-                                ):
-                                    logger.warning(
-                                        f"Edge still exists: {src} <-> {tgt}"
-                                    )
-                                elif src in entities_to_delete:
-                                    logger.warning(
-                                        f"Edge still exists: {src} --> {tgt}"
-                                    )
-                                else:
-                                    logger.warning(
-                                        f"Edge still exists: {src} <-- {tgt}"
-                                    )
-                            edges_still_exist += 1
-
-                    if edges_still_exist:
-                        logger.warning(
-                            f"⚠️ {edges_still_exist} entities still has edges before deletion"
-                        )
-
-                    # Clean residual edges from VDB and storage before deleting nodes
-                    if edges_to_delete:
-                        # Delete from relationships_vdb
-                        rel_ids_to_delete = []
-                        for src, tgt in edges_to_delete:
-                            rel_ids_to_delete.extend(
-                                [
-                                    compute_mdhash_id(src + tgt, prefix="rel-"),
-                                    compute_mdhash_id(tgt + src, prefix="rel-"),
-                                ]
-                            )
-                        await self.relationships_vdb.delete(rel_ids_to_delete)
-
-                        # Delete from relation_chunks storage
-                        if self.relation_chunks:
-                            relation_storage_keys = [
-                                make_relation_chunk_key(src, tgt)
-                                for src, tgt in edges_to_delete
-                            ]
-                            await self.relation_chunks.delete(relation_storage_keys)
-
-                        logger.info(
-                            f"Cleaned {len(edges_to_delete)} residual edges from VDB and chunk-tracking storage"
-                        )
-
-                    # Delete from graph (edges will be auto-deleted with nodes)
-                    await self.chunk_entity_relation_graph.remove_nodes(
-                        list(entities_to_delete)
-                    )
-
-                    # Delete from vector vdb
-                    entity_vdb_ids = [
-                        compute_mdhash_id(entity, prefix="ent-")
-                        for entity in entities_to_delete
-                    ]
-                    await self.entities_vdb.delete(entity_vdb_ids)
-
-                    # Delete from entity_chunks storage
-                    if self.entity_chunks:
-                        await self.entity_chunks.delete(list(entities_to_delete))
-
-                    async with pipeline_status_lock:
-                        log_message = (
-                            f"Successfully deleted {len(entities_to_delete)} entities"
-                        )
-                        logger.info(log_message)
-                        pipeline_status["latest_message"] = log_message
-                        append_pipeline_history(pipeline_status, log_message)
-
-                except Exception as e:
-                    logger.error(f"Failed to delete entities: {e}")
-                    raise Exception(f"Failed to delete entities: {e}") from e
-
-            # Persist changes to graph database before entity and relationship rebuild
-            # Plain _insert_done: pending DELETES must be retained for retry on
-            # failure, not discarded (see _insert_done_with_cleanup docstring).
-            try:
-                deletion_stage = "persist_pre_rebuild_changes"
-                await self._insert_done()
-            except Exception as e:
-                logger.error(f"Failed to persist pre-rebuild changes: {e}")
-                raise Exception(f"Failed to persist pre-rebuild changes: {e}") from e
-
-            # 8. Rebuild entities and relationships from remaining chunks
-            if entities_to_rebuild or relationships_to_rebuild:
-                try:
-                    deletion_stage = "rebuild_knowledge_graph"
-                    await rebuild_knowledge_from_chunks(
-                        entities_to_rebuild=entities_to_rebuild,
-                        relationships_to_rebuild=relationships_to_rebuild,
-                        knowledge_graph_inst=self.chunk_entity_relation_graph,
-                        entities_vdb=self.entities_vdb,
-                        relationships_vdb=self.relationships_vdb,
-                        text_chunks_storage=self.text_chunks,
-                        llm_response_cache=self.llm_response_cache,
-                        global_config=self._build_global_config(),
-                        pipeline_status=pipeline_status,
-                        pipeline_status_lock=pipeline_status_lock,
-                        entity_chunks_storage=self.entity_chunks,
-                        relation_chunks_storage=self.relation_chunks,
-                    )
-
-                except Exception as e:
-                    logger.error(f"Failed to rebuild knowledge from chunks: {e}")
-                    raise Exception(f"Failed to rebuild knowledge graph: {e}") from e
+                deletion_stage = "validate_recovery_anchors"
+                await self._purge_kg_contributions(
+                    doc_id,
+                    chunk_ids,
+                    pipeline_status=pipeline_status,
+                    pipeline_status_lock=pipeline_status_lock,
+                )
+            except _PurgeStageError as purge_error:
+                deletion_stage = purge_error.purge_stage
+                raise
 
             # 9. Delete LLM cache while the document status still exists so a failure
             # remains retryable via the same doc_id.
@@ -5802,16 +5568,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         append_pipeline_history(pipeline_status, log_message)
                     raise Exception(log_message) from cache_delete_error
 
-            # 10. Delete from full_entities and full_relations storage
-            try:
-                deletion_stage = "delete_doc_graph_metadata"
-                await self.full_entities.delete([doc_id])
-                await self.full_relations.delete([doc_id])
-            except Exception as e:
-                logger.error(f"Failed to delete from full_entities/full_relations: {e}")
-                raise Exception(
-                    f"Failed to delete from full_entities/full_relations: {e}"
-                ) from e
+            # 10. (The recovery anchor rows were deleted by the purge above —
+            # LAST within that operation, and only once its journal recorded
+            # that the chunks were gone. Deleting them again here would be
+            # redundant, and doing it BEFORE the LLM cache step, as this
+            # function used to, removed the retry's recovery proof while work
+            # remained.)
 
             # 11. Delete original document and status.
             # doc_status is deleted first so that if full_docs.delete fails, a retry
@@ -5832,6 +5594,40 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 doc_id=doc_id,
                 message=log_message,
                 status_code=200,
+                file_path=file_path,
+            )
+
+        except (RecoveryAnchorMissingError, KGPurgeOperationConflictError) as e:
+            # A refused PRECONDITION, not a failed deletion: the purge raised
+            # before its first write, so nothing was deleted and the document
+            # is exactly as it was. Surfaced as 409 rather than 500 because
+            # retrying unchanged will refuse again — the operator has to run
+            # the integrity audit first. The message is written to be
+            # client-safe and names that remedy.
+            original_exception = e
+            error_message = str(e)
+            logger.error(f"Refusing to delete document {doc_id}: {e}")
+            try:
+                if doc_status_data is not None:
+                    doc_status_data = await self._update_delete_retry_state(
+                        doc_id,
+                        doc_status_data,
+                        deletion_stage="validate_recovery_anchors",
+                        doc_llm_cache_ids=doc_llm_cache_ids,
+                        error_message=error_message,
+                        failed=True,
+                    )
+            except Exception as status_update_error:
+                logger.error(
+                    "Failed to record recovery-anchor refusal for document %s: %s",
+                    doc_id,
+                    status_update_error,
+                )
+            return DeletionResult(
+                status="fail",
+                doc_id=doc_id,
+                message=error_message,
+                status_code=409,
                 file_path=file_path,
             )
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -4192,8 +4192,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     f"Document {doc_id} carries a KG purge journal for a different "
                     f"operation (journal={journal_operation_id!r}, "
                     f"requested={operation_id!r}); the document's chunk set changed "
-                    f"since that purge started. Resolve with "
-                    f"audit_kg_integrity(..., apply=True) before retrying.",
+                    f"since that purge started. Retry the operation that wrote the "
+                    f"journal (its chunk set is unchanged, so its purge resumes), "
+                    f"or resolve with audit_kg_integrity(..., apply=True) before "
+                    f"retrying this one.",
                     doc_id=doc_id,
                     journal_operation_id=(
                         journal_operation_id

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -254,7 +254,7 @@ class _PurgeRecoveryProof:
     to raise with.
     """
 
-    proof_kind: Literal["anchors", "pre_graph", "journal"] | None
+    proof_kind: Literal["anchors", "pre_graph", "journal", "empty_scope"] | None
     operation_id: str
     journal_phase: str | None = None
     write_state: str | None = None
@@ -4270,6 +4270,43 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 patch_candidate_relations=patch_relations,
             )
 
+        # Nothing that CARRIES attribution would be deleted, so there is no
+        # damage for a proof to guard against. Fail-closed exists to stop a
+        # purge from destroying the chunk rows and anchor rows that are the
+        # only record of what a document contributed; an operation that
+        # removes neither cannot strand anything, whatever the document's
+        # history. Reached only when at least one anchor row is absent (the
+        # both-present case returned above), so this covers exactly the
+        # documents no proof can be produced for: a legacy row enqueued before
+        # ``kg_write_state`` existed, still holding no chunks.
+        #
+        # Deliberately NOT generalised into a persisted marker. A stored
+        # ``pre_graph`` says "this document never touched the graph", which
+        # licenses deleting its chunks while skipping the graph — so inferring
+        # one from observable state would turn a transient inconsistency (a
+        # chunks_list that is momentarily empty) into a durable licence to
+        # reproduce issue #3400 the moment the chunks reappear. This decision
+        # is re-evaluated against live state on every call and grants nothing
+        # beyond the call, which is why it is safe where a backfill is not.
+        if (
+            not chunk_ids
+            and not (
+                isinstance(entities_row, dict) and entities_row.get("entity_names")
+            )
+            and not (
+                isinstance(relations_row, dict) and relations_row.get("relation_pairs")
+            )
+        ):
+            return _PurgeRecoveryProof(
+                proof_kind="empty_scope",
+                operation_id=operation_id,
+                journal_phase=journal_phase,
+                write_state=write_state,
+                missing_namespaces=tuple(missing_namespaces),
+                patch_candidate_entities=patch_entities,
+                patch_candidate_relations=patch_relations,
+            )
+
         return _PurgeRecoveryProof(
             proof_kind=None,
             operation_id=operation_id,
@@ -4521,6 +4558,17 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         if proof.patch_candidate_entities
                         else " only"
                     )
+                )
+                candidate_entities = []
+                candidate_relations = []
+            elif proof.proof_kind == "empty_scope":
+                # Nothing attribution-bearing is being deleted (no chunks, no
+                # anchor row that names anything), so there is nothing for the
+                # derived pass to do and no reason to read the graph.
+                logger.info(
+                    f"[purge] {doc_id}: no chunks and no populated recovery "
+                    f"anchors, so nothing that carries attribution would be "
+                    f"deleted; removing the empty record"
                 )
                 candidate_entities = []
                 candidate_relations = []

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -156,6 +156,7 @@ from lightrag.utils_pipeline import (
     make_custom_chunk_operation_id,
     make_kg_purge_operation_id,
     normalize_document_file_path,
+    require_doc_status_record,
 )
 from lightrag.constants import GRAPH_FIELD_SEP
 from lightrag.exceptions import (
@@ -3890,9 +3891,32 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         snapshot would silently clobber that journal, which is precisely what
         keeps the retry from being refused for missing recovery anchors
         (issue #3400).
+
+        For the same reason the re-read must never silently fall back to that
+        snapshot. Strict where the backend supports it, so a read failure
+        raises (every caller wraps this in its own try/except and settles for
+        logging). A ``None`` — confirmed absent under strict reads, ambiguous
+        otherwise — skips the write entirely: rebuilding ``metadata`` from the
+        pre-deletion snapshot when the row is actually alive (a masked read
+        failure) would erase the journal, and an unrecorded retry state is
+        recoverable while a clobbered journal is a permanent 409. Retry-state
+        metadata is diagnostics; the journal is load-bearing.
         """
-        current = await self.doc_status.get_by_id(doc_id)
-        base_record = current if isinstance(current, dict) else doc_status_data
+        strict_reads = getattr(self.doc_status, "supports_strict_point_reads", False)
+        current = await (
+            self.doc_status.get_by_id_strict(doc_id)
+            if strict_reads
+            else self.doc_status.get_by_id(doc_id)
+        )
+        if not isinstance(current, dict):
+            logger.warning(
+                "Skipping deletion retry-state write for document %s: its "
+                "doc_status row is %s",
+                doc_id,
+                "confirmed absent" if strict_reads else "absent or unreadable",
+            )
+            return doc_status_data
+        base_record = current
         metadata = base_record.get("metadata", {})
         if not isinstance(metadata, dict):
             metadata = {}
@@ -4161,7 +4185,21 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         failure DOES propagate: an unknown state must not be read as an absent
         journal (that would re-run a purge whose anchors are already gone).
         """
-        status_doc = await self.doc_status.get_by_id(doc_id)
+        # Strict-where-supported, honoring the docstring's "a read failure
+        # DOES propagate": a plain get_by_id may present backend trouble as
+        # None, which would silently discard an in-flight journal — the one
+        # record distinguishing "anchors legitimately deleted" from "never
+        # written". A None from the strict read is CONFIRMED absence, which
+        # stays a legal input: every derived proof reads as unknown and the
+        # resolution below fails closed with the actionable 409.
+        strict_status_reads = getattr(
+            self.doc_status, "supports_strict_point_reads", False
+        )
+        status_doc = await (
+            self.doc_status.get_by_id_strict(doc_id)
+            if strict_status_reads
+            else self.doc_status.get_by_id(doc_id)
+        )
         journal = doc_status_kg_purge_journal(status_doc)
         write_state = doc_status_kg_write_state(status_doc)
         operation_id = make_kg_purge_operation_id(doc_id, chunk_ids)
@@ -4382,17 +4420,20 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         Flushed before returning: a journal that is only in memory proves
         nothing about what is already deleted on disk.
+
+        Raises when the row cannot be read (strict where the backend supports
+        it) or has vanished. Every call site runs while the row is guaranteed
+        to exist — ``adelete_by_doc_id`` read it before starting, and the
+        caller's finalization (which deletes it) comes only after the purge —
+        so an unreadable row must abort the purge rather than skip the
+        journal: a destructive purge that runs unjournaled loses the only
+        record that lets a retry survive its own anchor deletion (step 8), and
+        the failure mode it creates — anchors gone, journal absent — is a
+        permanent fail-closed refusal.
         """
-        status_doc = await self.doc_status.get_by_id(doc_id)
-        if status_doc is None:
-            # No doc_status row: nothing to journal against, and the caller's
-            # finalization (which deletes that row) is what the journal exists
-            # to protect. Purge remains correct — it just cannot resume.
-            logger.warning(
-                f"[purge] {doc_id}: no doc_status record; skipping purge journal "
-                f"phase '{phase}' (this purge will not be resumable)"
-            )
-            return
+        status_doc = await require_doc_status_record(
+            self.doc_status, doc_id, purpose=f"journal purge phase '{phase}'"
+        )
         metadata = doc_status_field(status_doc, "metadata", {})
         metadata = dict(metadata) if isinstance(metadata, dict) else {}
         metadata[KG_PURGE_METADATA_KEY] = {
@@ -4402,9 +4443,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             "chunk_count": chunk_count,
             "updated_at": int(time.time()),
         }
-        await self.doc_status.update_doc_status_fields(
-            doc_id, {"metadata": metadata}, missing_ok=True
-        )
+        # missing_ok=False: the row vanishing between the read above and this
+        # write is the same unjournaled-purge hazard, not a tolerable race.
+        await self.doc_status.update_doc_status_fields(doc_id, {"metadata": metadata})
         await self._flush_storages([self.doc_status])
 
     async def _clear_kg_purge_journal(
@@ -4433,17 +4474,22 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         merged start demanding anchors it will never have (a false refusal that
         leaves it neither reprocessable nor deletable), while clearing it would
         discard the proof a still-pre-graph document depends on.
+
+        Raises when the row cannot be read or has vanished, same as
+        :py:meth:`_write_kg_purge_phase`: the one caller runs mid-pipeline
+        with the row guaranteed present, and skipping silently would leave
+        the stored ``chunks_list`` pointing at chunks the purge just deleted.
         """
-        status_doc = await self.doc_status.get_by_id(doc_id)
-        if status_doc is None:
-            return
+        status_doc = await require_doc_status_record(
+            self.doc_status, doc_id, purpose="retire the purge journal"
+        )
         metadata = doc_status_field(status_doc, "metadata", {})
         metadata = dict(metadata) if isinstance(metadata, dict) else {}
         metadata.pop(KG_PURGE_METADATA_KEY, None)
         fields: dict[str, Any] = {"metadata": metadata}
         if extra_fields:
             fields.update(extra_fields)
-        await self.doc_status.update_doc_status_fields(doc_id, fields, missing_ok=True)
+        await self.doc_status.update_doc_status_fields(doc_id, fields)
         await self._flush_storages([self.doc_status])
 
     async def _purge_kg_contributions(

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -24,6 +24,7 @@ from typing import (
     Callable,
     Coroutine,
     Iterator,
+    NoReturn,
     TypeVar,
     cast,
     final,
@@ -84,6 +85,14 @@ from lightrag.constants import (
     DEFAULT_PIPELINE_REQUIRE_STRICT_STORAGE_READS,
     DEFAULT_MAX_PENDING_DOCUMENTS,
     DEFAULT_FILE_PATH_MORE_PLACEHOLDER,
+    KG_PURGE_METADATA_KEY,
+    KG_PURGE_PHASE_ANCHORS_PENDING,
+    KG_PURGE_PHASE_COMPLETED,
+    KG_PURGE_PHASE_DERIVED_COMMITTED,
+    KG_PURGE_PHASE_PREPARED,
+    KG_PURGE_SCHEMA_VERSION,
+    KG_WRITE_STATE_METADATA_KEY,
+    KG_WRITE_STATE_PRE_GRAPH,
 )
 from lightrag.utils import get_env_value
 from lightrag.parser.routing import _chunk_env_int
@@ -140,13 +149,21 @@ from lightrag.utils_pipeline import (
     KG_RECOVERY_WARNINGS_METADATA_KEY,
     compute_text_content_hash,
     doc_status_custom_chunk_patch,
+    doc_status_field,
+    doc_status_kg_purge_journal,
+    doc_status_kg_write_state,
     enforce_strict_storage_capabilities,
     make_custom_chunk_id,
     make_custom_chunk_operation_id,
+    make_kg_purge_operation_id,
     normalize_document_file_path,
 )
 from lightrag.constants import GRAPH_FIELD_SEP
-from lightrag.exceptions import IndexFlushError
+from lightrag.exceptions import (
+    IndexFlushError,
+    KGPurgeOperationConflictError,
+    RecoveryAnchorMissingError,
+)
 from lightrag.utils import (
     Tokenizer,
     TiktokenTokenizer,
@@ -191,6 +208,48 @@ from lightrag.storage_migrations import _StorageMigrationMixin
 load_dotenv(dotenv_path=".env", override=False)
 
 _SyncResultT = TypeVar("_SyncResultT")
+
+# Ordered purge journal phases (issue #3400). Index = how much destructive work
+# is already persisted, so a resumed purge can skip exactly that much:
+#   prepared          — proof verified, journal durable, NOTHING deleted yet
+#   derived_committed — graph/vector/tracking contributions repaired or removed
+#   anchors_pending   — chunks deleted too; only the anchor rows remain
+#   completed         — anchors deleted; the caller's finalization is all that's left
+# Only phases at/after ``derived_committed`` are proof in their own right: they
+# are the ones that may legitimately have removed the anchors.
+_KG_PURGE_PHASE_ORDER: tuple[str, ...] = (
+    KG_PURGE_PHASE_PREPARED,
+    KG_PURGE_PHASE_DERIVED_COMMITTED,
+    KG_PURGE_PHASE_ANCHORS_PENDING,
+    KG_PURGE_PHASE_COMPLETED,
+)
+_KG_PURGE_RESUMABLE_PHASES: frozenset[str] = frozenset(_KG_PURGE_PHASE_ORDER)
+
+
+@dataclass(frozen=True)
+class _PurgeRecoveryProof:
+    """Why a whole-document purge is (or is not) allowed to delete anything.
+
+    See :py:meth:`LightRAG._resolve_purge_recovery_proof`. ``proof_kind`` is
+    ``None`` exactly when no proof applies, in which case ``missing_reason``
+    carries the :class:`~lightrag.exceptions.RecoveryAnchorMissingError` reason
+    to raise with.
+    """
+
+    proof_kind: Literal["anchors", "pre_graph", "journal"] | None
+    operation_id: str
+    journal_phase: str | None = None
+    write_state: str | None = None
+    missing_namespaces: tuple[str, ...] = ()
+    missing_reason: str | None = None
+
+    def phase_at_least(self, phase: str) -> bool:
+        """True when the journal records ``phase`` or a later one."""
+        if self.journal_phase is None:
+            return False
+        return _KG_PURGE_PHASE_ORDER.index(
+            self.journal_phase
+        ) >= _KG_PURGE_PHASE_ORDER.index(phase)
 
 
 def _run_sync(
@@ -3996,6 +4055,257 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             pipeline_status_lock=pipeline_status_lock,
         )
 
+    async def _resolve_purge_recovery_proof(
+        self,
+        doc_id: str,
+        chunk_ids: list[str],
+    ) -> _PurgeRecoveryProof:
+        """Decide whether a whole-document purge is allowed to delete anything.
+
+        Fail-closed precondition for issue #3400. A purge discovers what a
+        document contributed to the shared graph from its write-ahead anchors;
+        without them the reverse lookup (graph ``source_id`` → ``text_chunks``
+        → ``full_doc_id``) is impossible once the chunks are gone. So rather
+        than treating absent anchors as "no contributions" — which silently
+        skipped graph cleanup and stranded unattributable entities — this
+        resolves one of three PROOFS, or reports that none applies:
+
+        * ``anchors`` — both anchor rows are present and structurally usable.
+          Presence is the test, never list truthiness: a row holding an empty
+          list is a valid proof (a document that extracted no entities), and
+          conflating the two is the original bug.
+        * ``pre_graph`` — persisted ``kg_write_state`` says the document never
+          reached its first graph mutation, so there is provably nothing in the
+          graph to find. The caller may clean up staged chunks with an
+          explicitly empty candidate set.
+        * ``journal`` — a ``kg_purge`` journal from a previous attempt records a
+          phase past the point where the anchors were legitimately deleted.
+          Without this, purge's own last step (deleting the anchors) would make
+          every subsequent retry refuse forever.
+
+        Never raises for a missing proof — returns it as
+        :attr:`_PurgeRecoveryProof.missing_reason` so the caller raises after
+        it has assembled a full, actionable message. A ``doc_status`` read
+        failure DOES propagate: an unknown state must not be read as an absent
+        journal (that would re-run a purge whose anchors are already gone).
+        """
+        status_doc = await self.doc_status.get_by_id(doc_id)
+        journal = doc_status_kg_purge_journal(status_doc)
+        write_state = doc_status_kg_write_state(status_doc)
+        operation_id = make_kg_purge_operation_id(doc_id, chunk_ids)
+
+        journal_phase: str | None = None
+        if journal is not None:
+            journal_operation_id = journal.get("operation_id")
+            if (
+                not isinstance(journal_operation_id, str)
+                or journal_operation_id != operation_id
+            ):
+                raise KGPurgeOperationConflictError(
+                    f"Document {doc_id} carries a KG purge journal for a different "
+                    f"operation (journal={journal_operation_id!r}, "
+                    f"requested={operation_id!r}); the document's chunk set changed "
+                    f"since that purge started. Resolve with "
+                    f"audit_kg_integrity(..., apply=True) before retrying.",
+                    doc_id=doc_id,
+                    journal_operation_id=(
+                        journal_operation_id
+                        if isinstance(journal_operation_id, str)
+                        else ""
+                    ),
+                    requested_operation_id=operation_id,
+                )
+            phase = journal.get("phase")
+            if phase in _KG_PURGE_RESUMABLE_PHASES:
+                journal_phase = phase
+
+        # A journal past ``prepared`` is itself the proof: the anchors may
+        # already be gone precisely BECAUSE a previous attempt got that far.
+        if journal_phase is not None and journal_phase != KG_PURGE_PHASE_PREPARED:
+            return _PurgeRecoveryProof(
+                proof_kind="journal",
+                operation_id=operation_id,
+                journal_phase=journal_phase,
+                write_state=write_state,
+            )
+
+        missing_namespaces: list[str] = []
+        entities_row = await self.full_entities.get_by_id(doc_id)
+        if not isinstance(entities_row, dict) or not isinstance(
+            entities_row.get("entity_names"), list
+        ):
+            missing_namespaces.append("full_entities")
+        relations_row = await self.full_relations.get_by_id(doc_id)
+        if not isinstance(relations_row, dict) or not isinstance(
+            relations_row.get("relation_pairs"), list
+        ):
+            missing_namespaces.append("full_relations")
+
+        if not missing_namespaces:
+            # Anchors name KG objects but the document owns no chunks to
+            # attribute them to. Classification subtracts this document's
+            # chunk ids from each object's sources, so an empty chunk set
+            # classifies every object as "keep" and then the anchors are
+            # deleted anyway — the same orphan outcome fail-closed exists to
+            # prevent. Empty anchors with no chunks is fine: nothing to strand.
+            if not chunk_ids and (
+                entities_row["entity_names"] or relations_row["relation_pairs"]
+            ):
+                return _PurgeRecoveryProof(
+                    proof_kind=None,
+                    operation_id=operation_id,
+                    journal_phase=journal_phase,
+                    write_state=write_state,
+                    missing_reason=RecoveryAnchorMissingError.REASON_CHUNKLESS_CONTRIBUTIONS,
+                )
+            return _PurgeRecoveryProof(
+                proof_kind="anchors",
+                operation_id=operation_id,
+                journal_phase=journal_phase,
+                write_state=write_state,
+            )
+
+        if write_state == KG_WRITE_STATE_PRE_GRAPH:
+            return _PurgeRecoveryProof(
+                proof_kind="pre_graph",
+                operation_id=operation_id,
+                journal_phase=journal_phase,
+                write_state=write_state,
+                missing_namespaces=tuple(missing_namespaces),
+            )
+
+        return _PurgeRecoveryProof(
+            proof_kind=None,
+            operation_id=operation_id,
+            journal_phase=journal_phase,
+            write_state=write_state,
+            missing_namespaces=tuple(missing_namespaces),
+            missing_reason=RecoveryAnchorMissingError.REASON_MISSING_ANCHOR_ROWS,
+        )
+
+    @staticmethod
+    def _raise_missing_recovery_proof(
+        doc_id: str, proof: _PurgeRecoveryProof
+    ) -> NoReturn:
+        """Turn an unproven purge into an actionable, client-safe refusal.
+
+        Split out so the purge primitive and the delete path raise identical
+        messages, and so the remedy (the offline audit tool) is named exactly
+        once.
+        """
+        remedy = (
+            "Nothing was deleted. Rebuild the recovery anchors with "
+            "audit_kg_integrity(..., apply=True) "
+            "(python -m lightrag.tools.kg_integrity_repair), then retry."
+        )
+        if (
+            proof.missing_reason
+            == RecoveryAnchorMissingError.REASON_CHUNKLESS_CONTRIBUTIONS
+        ):
+            message = (
+                f"Refusing to purge document {doc_id}: its recovery anchors name "
+                f"knowledge-graph objects, but the document owns no chunks to "
+                f"attribute them to, so those objects cannot be classified and "
+                f"would be orphaned. {remedy}"
+            )
+        else:
+            missing = (
+                ", ".join(proof.missing_namespaces) or "full_entities, full_relations"
+            )
+            message = (
+                f"Refusing to purge document {doc_id}: recovery anchor row(s) "
+                f"missing or unusable ({missing}) and the document may already "
+                f"have written to the knowledge graph "
+                f"(kg_write_state={proof.write_state or 'unknown'}). Purging now "
+                f"would delete its chunks while leaving unattributable graph "
+                f"objects behind. {remedy}"
+            )
+        raise RecoveryAnchorMissingError(
+            message,
+            doc_id=doc_id,
+            reason=proof.missing_reason
+            or RecoveryAnchorMissingError.REASON_MISSING_ANCHOR_ROWS,
+            missing_namespaces=proof.missing_namespaces,
+        )
+
+    async def _write_kg_purge_phase(
+        self,
+        doc_id: str,
+        phase: str,
+        *,
+        operation_id: str,
+        chunk_count: int,
+    ) -> None:
+        """Persist (and flush) the purge journal's phase for ``doc_id``.
+
+        ``metadata`` is an opaque replace-on-write blob in every backend, so
+        this is a read-modify-write of that one field via the targeted
+        ``update_doc_status_fields`` primitive — never a whole-record upsert,
+        which would drag ``chunks_list`` through memory.
+
+        Flushed before returning: a journal that is only in memory proves
+        nothing about what is already deleted on disk.
+        """
+        status_doc = await self.doc_status.get_by_id(doc_id)
+        if status_doc is None:
+            # No doc_status row: nothing to journal against, and the caller's
+            # finalization (which deletes that row) is what the journal exists
+            # to protect. Purge remains correct — it just cannot resume.
+            logger.warning(
+                f"[purge] {doc_id}: no doc_status record; skipping purge journal "
+                f"phase '{phase}' (this purge will not be resumable)"
+            )
+            return
+        metadata = doc_status_field(status_doc, "metadata", {})
+        metadata = dict(metadata) if isinstance(metadata, dict) else {}
+        metadata[KG_PURGE_METADATA_KEY] = {
+            "schema_version": KG_PURGE_SCHEMA_VERSION,
+            "operation_id": operation_id,
+            "phase": phase,
+            "chunk_count": chunk_count,
+            "updated_at": int(time.time()),
+        }
+        await self.doc_status.update_doc_status_fields(
+            doc_id, {"metadata": metadata}, missing_ok=True
+        )
+        await self._flush_storages([self.doc_status])
+
+    async def _clear_kg_purge_journal(
+        self,
+        doc_id: str,
+        *,
+        write_state: str | None = None,
+        extra_fields: dict[str, Any] | None = None,
+    ) -> None:
+        """Retire a completed purge journal, optionally resetting write state.
+
+        Used by callers that KEEP the ``doc_status`` row after a purge (the
+        pipeline's stale-extraction reset). A caller that deletes the row
+        instead — ``adelete_by_doc_id`` — must NOT call this: the ``completed``
+        journal is what keeps its own post-purge finalization retryable, and it
+        disappears with the row.
+
+        ``extra_fields`` rides in the same targeted write so the reset of
+        ``chunks_list`` / ``chunks_count`` and the journal retirement land
+        atomically — a crash between them would leave the document pointing at
+        chunks this purge already deleted.
+        """
+        status_doc = await self.doc_status.get_by_id(doc_id)
+        if status_doc is None:
+            return
+        metadata = doc_status_field(status_doc, "metadata", {})
+        metadata = dict(metadata) if isinstance(metadata, dict) else {}
+        metadata.pop(KG_PURGE_METADATA_KEY, None)
+        if write_state is None:
+            metadata.pop(KG_WRITE_STATE_METADATA_KEY, None)
+        else:
+            metadata[KG_WRITE_STATE_METADATA_KEY] = write_state
+        fields: dict[str, Any] = {"metadata": metadata}
+        if extra_fields:
+            fields.update(extra_fields)
+        await self.doc_status.update_doc_status_fields(doc_id, fields, missing_ok=True)
+        await self._flush_storages([self.doc_status])
+
     async def _purge_kg_contributions(
         self,
         doc_id: str,
@@ -4056,19 +4366,195 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             - Pipeline busy-flag — assumes the caller already holds the
               pipeline (i.e. this runs inside a pipeline run).
 
-        Idempotent: passing an empty ``chunk_ids`` returns immediately
-        without touching storage; repeating a partially-failed purge
-        converges (absent objects are skipped, remaining ones are cleaned).
+        Idempotent and RESUMABLE. In whole-document (anchor-driven) mode this
+        additionally journals its progress to
+        ``doc_status.metadata.kg_purge`` and refuses to start without a
+        recovery proof — see :py:meth:`_resolve_purge_recovery_proof`. The
+        journal is what makes fail-closed safe to combine with step 8: once
+        the anchors are gone, only the journal can tell a retry that they were
+        deleted legitimately rather than never written. A resumed purge skips
+        exactly the phases already persisted, so it never re-runs the
+        LLM-cache-backed rebuild. Repeating a partially-failed purge converges
+        (absent objects are skipped, remaining ones are cleaned).
+
+        Explicit-candidate mode (custom-chunk patch rollback) is NOT journaled
+        and skips the proof: its caller's own operation journal already names
+        the complete candidate superset, and an empty ``chunk_ids`` returns
+        immediately without touching storage.
         """
-        if not chunk_ids:
+        # Anchor-driven whole-document purge: the only mode that both needs a
+        # recovery proof (it discovers candidates FROM the anchors) and deletes
+        # the anchors at the end (so it needs a journal to stay retryable).
+        journaled = (
+            candidate_entities is None
+            and candidate_relations is None
+            and not patch_only
+        )
+
+        proof: _PurgeRecoveryProof | None = None
+        if journaled:
+            proof = await self._resolve_purge_recovery_proof(doc_id, chunk_ids)
+            if proof.phase_at_least(KG_PURGE_PHASE_COMPLETED):
+                logger.info(
+                    f"[purge] {doc_id}: journal reports this purge already "
+                    f"completed; nothing left to delete"
+                )
+                return KGRebuildReport()
+            if proof.proof_kind is None:
+                self._raise_missing_recovery_proof(doc_id, proof)
+            if proof.proof_kind == "pre_graph":
+                # Provably nothing in the graph to find, so force an EXPLICIT
+                # empty candidate set: the derived pass then performs no graph
+                # reads or writes at all, instead of inferring "no candidates"
+                # from anchors it could not read (the original bug).
+                logger.warning(
+                    f"[purge] {doc_id}: recovery anchor row(s) missing "
+                    f"({', '.join(proof.missing_namespaces)}), but kg_write_state "
+                    f"proves no graph mutation started; cleaning up staged "
+                    f"chunks only"
+                )
+                candidate_entities = []
+                candidate_relations = []
+            if proof.journal_phase is None:
+                # Journal BEFORE the first destructive write. A crash between
+                # here and step 8 is then distinguishable from a document that
+                # never had anchors at all.
+                await self._write_kg_purge_phase(
+                    doc_id,
+                    KG_PURGE_PHASE_PREPARED,
+                    operation_id=proof.operation_id,
+                    chunk_count=len(chunk_ids),
+                )
+        elif not chunk_ids:
             return KGRebuildReport()
 
+        rebuild_report = KGRebuildReport()
+
+        # ---- Steps 1-6: repair or remove every derived contribution ----
+        if proof is None or not proof.phase_at_least(KG_PURGE_PHASE_DERIVED_COMMITTED):
+            rebuild_report = await self._purge_derived_kg_contributions(
+                doc_id,
+                chunk_ids,
+                candidate_entities=candidate_entities,
+                candidate_relations=candidate_relations,
+                rebuild_policy=rebuild_policy,
+                pipeline_status=pipeline_status,
+                pipeline_status_lock=pipeline_status_lock,
+            )
+            if journaled and proof is not None:
+                await self._write_kg_purge_phase(
+                    doc_id,
+                    KG_PURGE_PHASE_DERIVED_COMMITTED,
+                    operation_id=proof.operation_id,
+                    chunk_count=len(chunk_ids),
+                )
+        else:
+            logger.info(
+                f"[purge] {doc_id}: resuming at phase "
+                f"'{proof.journal_phase}'; derived contributions already clean"
+            )
+
+        # ---- 7. Delete chunks themselves ----
+        if chunk_ids and (
+            proof is None or not proof.phase_at_least(KG_PURGE_PHASE_ANCHORS_PENDING)
+        ):
+            # Deleted only AFTER every derived graph/vector/tracking contribution
+            # has been repaired or removed AND flushed (issue #3400: unsafe
+            # destructive ordering). A failure before this point leaves the
+            # chunks in place, so graph objects never reference deleted chunks.
+            try:
+                await self.chunks_vdb.delete(chunk_ids)
+                await self.text_chunks.delete(chunk_ids)
+                await self._flush_storages([self.chunks_vdb, self.text_chunks])
+                async with pipeline_status_lock:
+                    log_message = f"[purge] {doc_id}: deleted {len(chunk_ids)} chunk(s) from storage"
+                    logger.info(log_message)
+                    pipeline_status["latest_message"] = log_message
+                    append_pipeline_history(pipeline_status, log_message)
+            except Exception as e:
+                logger.error(f"[purge] Failed to delete chunks for {doc_id}: {e}")
+                raise Exception(f"Failed to delete document chunks: {e}") from e
+
+        # Chunk deletion is confirmed durable: the anchors may now go. This
+        # phase is the one that keeps step 8 retryable — without it, a failure
+        # after the first anchor delete would make every retry see "anchors
+        # missing" and refuse forever.
+        if (
+            journaled
+            and proof is not None
+            and not proof.phase_at_least(KG_PURGE_PHASE_ANCHORS_PENDING)
+        ):
+            await self._write_kg_purge_phase(
+                doc_id,
+                KG_PURGE_PHASE_ANCHORS_PENDING,
+                operation_id=proof.operation_id,
+                chunk_count=len(chunk_ids),
+            )
+
+        # ---- 8. Delete per-doc full_entities / full_relations index rows ----
+        # LAST, so every intermediate purge failure keeps the recovery
+        # anchors and stays retryable. Patch-only rollback keeps the base
+        # document's recovery rows: the document still owns its previously
+        # committed contributions.
+        if not patch_only:
+            try:
+                await self.full_entities.delete([doc_id])
+                await self.full_relations.delete([doc_id])
+                await self._flush_storages([self.full_entities, self.full_relations])
+            except Exception as e:
+                logger.error(
+                    f"[purge] Failed to delete full_entities/full_relations rows for {doc_id}: {e}"
+                )
+                raise Exception(
+                    f"Failed to delete from full_entities/full_relations: {e}"
+                ) from e
+
+        if journaled and proof is not None:
+            # The caller finalizes from here (doc_status / full_docs / LLM
+            # cache). The journal stays until the caller either retires it
+            # (_clear_kg_purge_journal) or deletes the doc_status row, so a
+            # finalization failure retries as a no-op purge instead of
+            # tripping the missing-anchor refusal.
+            await self._write_kg_purge_phase(
+                doc_id,
+                KG_PURGE_PHASE_COMPLETED,
+                operation_id=proof.operation_id,
+                chunk_count=len(chunk_ids),
+            )
+
+        return rebuild_report
+
+    async def _purge_derived_kg_contributions(
+        self,
+        doc_id: str,
+        chunk_ids: list[str],
+        *,
+        candidate_entities: list[str] | None,
+        candidate_relations: list[tuple[str, str]] | None,
+        rebuild_policy: Literal["best_effort", "rollback"],
+        pipeline_status: dict,
+        pipeline_status_lock: Any,
+    ) -> KGRebuildReport:
+        """Steps 1-6 of :py:meth:`_purge_kg_contributions`.
+
+        Repairs or removes every DERIVED contribution of ``chunk_ids`` —
+        graph nodes/edges, entity/relation vectors, chunk tracking — and
+        flushes, leaving the chunks themselves and the recovery anchors in
+        place. Split out so a resumed purge whose journal already records
+        ``derived_committed`` can skip it wholesale: it is the expensive part
+        (candidate re-analysis plus an LLM-cache-backed rebuild).
+
+        Candidates are a recovery SUPERSET: an explicit ``[]`` means "provably
+        nothing to clean" (the caller established that), while ``None`` means
+        "resolve from this document's anchor rows". The caller is responsible
+        for having proven that the anchors are readable — passing ``None`` with
+        absent anchors is exactly the silent-skip bug of issue #3400.
+        """
         rebuild_report = KGRebuildReport()
 
         # Set view for membership/intersection checks below (chunk_ids stays a list
         # so it satisfies the storage delete contract: ``delete(ids: list[str])``).
         chunk_ids_set = set(chunk_ids)
-
         # ---- 1. Analyze affected entities/relations from the candidate set ----
         entities_to_delete: set[str] = set()
         entities_to_rebuild: dict[str, list[str]] = {}
@@ -4427,44 +4913,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             except Exception as e:
                 logger.error(f"[purge] Failed to persist rebuilt knowledge: {e}")
                 raise Exception(f"Failed to persist rebuilt knowledge: {e}") from e
-
-        # ---- 7. Delete chunks themselves ----
-        # Deleted only AFTER every derived graph/vector/tracking contribution
-        # has been repaired or removed AND flushed (issue #3400: unsafe
-        # destructive ordering). A failure before this point leaves the
-        # chunks in place, so graph objects never reference deleted chunks.
-        try:
-            await self.chunks_vdb.delete(chunk_ids)
-            await self.text_chunks.delete(chunk_ids)
-            await self._flush_storages([self.chunks_vdb, self.text_chunks])
-            async with pipeline_status_lock:
-                log_message = (
-                    f"[purge] {doc_id}: deleted {len(chunk_ids)} chunk(s) from storage"
-                )
-                logger.info(log_message)
-                pipeline_status["latest_message"] = log_message
-                append_pipeline_history(pipeline_status, log_message)
-        except Exception as e:
-            logger.error(f"[purge] Failed to delete chunks for {doc_id}: {e}")
-            raise Exception(f"Failed to delete document chunks: {e}") from e
-
-        # ---- 8. Delete per-doc full_entities / full_relations index rows ----
-        # LAST, so every intermediate purge failure keeps the recovery
-        # anchors and stays retryable. Patch-only rollback keeps the base
-        # document's recovery rows: the document still owns its previously
-        # committed contributions.
-        if not patch_only:
-            try:
-                await self.full_entities.delete([doc_id])
-                await self.full_relations.delete([doc_id])
-                await self._flush_storages([self.full_entities, self.full_relations])
-            except Exception as e:
-                logger.error(
-                    f"[purge] Failed to delete full_entities/full_relations rows for {doc_id}: {e}"
-                )
-                raise Exception(
-                    f"Failed to delete from full_entities/full_relations: {e}"
-                ) from e
 
         return rebuild_report
 

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3236,6 +3236,7 @@ async def merge_nodes_and_edges(
     current_file_number: int = 0,
     total_files: int = 0,
     file_path: str = "unknown_source",
+    on_anchors_durable: Callable[[], Awaitable[None]] | None = None,
 ) -> None:
     """Merge extracted entities/relations into the KG behind write-ahead anchors.
 
@@ -3265,6 +3266,16 @@ async def merge_nodes_and_edges(
         current_file_number: Current file number for logging
         total_files: Total files for logging
         file_path: File path for logging
+        on_anchors_durable: Optional async hook awaited exactly once, after
+            both Phase 0 anchors are flushed and before the first graph
+            mutation. Lets the caller persist "this document may have touched
+            the graph from here on" (``doc_status.metadata.kg_write_state``)
+            in the one window where that statement flips, so a fail-closed
+            purge can distinguish a document that never reached the graph from
+            one whose anchors were lost. A raise propagates and aborts the
+            merge before any mutation. Not called when the anchor storages or
+            ``doc_id`` are absent (patch-mode merges, which carry their own
+            operation journal as the recovery proof).
     """
 
     # Check for cancellation at the start of merge
@@ -3351,6 +3362,12 @@ async def merge_nodes_and_edges(
                     storage_inst, "namespace", ""
                 )
                 raise IndexFlushError(type(storage_inst).__name__, namespace, e) from e
+
+        # Anchors are durable: this is the last instant at which "no graph
+        # mutation has happened" is still true. A raise here aborts the merge
+        # with the anchors already in place — the safe direction.
+        if on_anchors_durable is not None:
+            await on_anchors_durable()
 
     # Get max async tasks limit from global_config for semaphore control
     graph_max_async = global_config.get("llm_model_max_async", 4) * 2

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -5425,12 +5425,11 @@ class _PipelineMixin:
         # so a crash here left the row advertising them. Retiring the journal
         # in the SAME write is what keeps the two consistent — a surviving
         # ``completed`` journal would later collide with the next purge's
-        # operation id. kg_write_state is deliberately left alone: this
-        # document HAS written to the graph, and re-stamping ``pre_graph``
-        # would let a future purge skip the graph entirely.
+        # operation id. kg_write_state is deliberately left untouched: it is
+        # monotonic, and this run's own merge will advance it if it gets that
+        # far.
         await self._clear_kg_purge_journal(
             doc_id,
-            write_state=KG_WRITE_STATE_GRAPH_MUTATION_STARTED,
             extra_fields={"chunks_list": [], "chunks_count": 0},
         )
         status_doc.chunks_list = []

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -134,6 +134,7 @@ from lightrag.utils_pipeline import (
     doc_status_metadata_has_attempt_fields,
     doc_status_reset_metadata,
     read_source_file_basename,
+    require_doc_status_record,
     resolve_existing_doc_source,
     resolve_doc_file_path,
     resolve_doc_status_parse_engine,
@@ -5458,16 +5459,25 @@ class _PipelineMixin:
         and silently revert this marker. A PROCESSED document would then claim
         it never touched the graph — reinstating exactly the silent-skip the
         marker exists to prevent.
+
+        Raises when the row cannot be read (strict where the backend supports
+        it), has vanished, or the update fails. The document is mid-merge
+        under the pipeline reservation, so the row is guaranteed to exist —
+        an unreadable row is the read failing, not the document being gone.
+        Returning silently instead would let the merge proceed with the
+        stored marker still ``pre_graph``: the graph gets written, and if the
+        anchors are later lost, that stale marker is a false proof licensing
+        a purge to skip graph cleanup — the exact defect of issue #3400.
         """
-        stored = await self.doc_status.get_by_id(doc_id)
-        if stored is None:
-            return
+        stored = await require_doc_status_record(
+            self.doc_status, doc_id, purpose="advance kg_write_state"
+        )
         raw_metadata = doc_status_field(stored, "metadata", {})
         metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
         metadata[KG_WRITE_STATE_METADATA_KEY] = KG_WRITE_STATE_GRAPH_MUTATION_STARTED
-        await self.doc_status.update_doc_status_fields(
-            doc_id, {"metadata": metadata}, missing_ok=True
-        )
+        # missing_ok=False: the row vanishing between the read above and this
+        # write must abort the merge too, not silently skip the marker.
+        await self.doc_status.update_doc_status_fields(doc_id, {"metadata": metadata})
         await self._flush_storages([self.doc_status])
         if status_doc is not None:
             in_memory = getattr(status_doc, "metadata", None)

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -5221,7 +5221,7 @@ class _PipelineMixin:
                             total_files=ctx.total_files,
                             file_path=file_path,
                             on_anchors_durable=partial(
-                                self._mark_graph_mutation_started, doc_id
+                                self._mark_graph_mutation_started, doc_id, status_doc
                             ),
                         )
 
@@ -5436,7 +5436,9 @@ class _PipelineMixin:
         status_doc.chunks_list = []
         status_doc.chunks_count = 0
 
-    async def _mark_graph_mutation_started(self, doc_id: str) -> None:
+    async def _mark_graph_mutation_started(
+        self, doc_id: str, status_doc: DocProcessingStatus | None = None
+    ) -> None:
         """Advance ``kg_write_state`` past the point of no return.
 
         Awaited by ``merge_nodes_and_edges`` in the single window where "this
@@ -5449,17 +5451,33 @@ class _PipelineMixin:
         ``graph_mutation_started``, and no path writes ``pre_graph`` back.
         Raising aborts the merge before any mutation, which is the safe
         direction: the anchors are already durable.
+
+        ``status_doc`` is the caller's in-memory snapshot, and updating it is
+        NOT optional bookkeeping: every later transition upsert rebuilds
+        ``metadata`` from that object via ``doc_status_transition_metadata``, so
+        leaving it stale makes the PROCESSED write carry ``pre_graph`` forward
+        and silently revert this marker. A PROCESSED document would then claim
+        it never touched the graph — reinstating exactly the silent-skip the
+        marker exists to prevent.
         """
-        status_doc = await self.doc_status.get_by_id(doc_id)
-        if status_doc is None:
+        stored = await self.doc_status.get_by_id(doc_id)
+        if stored is None:
             return
-        raw_metadata = doc_status_field(status_doc, "metadata", {})
+        raw_metadata = doc_status_field(stored, "metadata", {})
         metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
         metadata[KG_WRITE_STATE_METADATA_KEY] = KG_WRITE_STATE_GRAPH_MUTATION_STARTED
         await self.doc_status.update_doc_status_fields(
             doc_id, {"metadata": metadata}, missing_ok=True
         )
         await self._flush_storages([self.doc_status])
+        if status_doc is not None:
+            in_memory = getattr(status_doc, "metadata", None)
+            if isinstance(in_memory, dict):
+                in_memory[KG_WRITE_STATE_METADATA_KEY] = (
+                    KG_WRITE_STATE_GRAPH_MUTATION_STARTED
+                )
+            else:
+                status_doc.metadata = dict(metadata)
 
     # ============================================================
     # doc_status state-machine helpers (shared by all layers)

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -25,7 +25,7 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from functools import lru_cache
+from functools import lru_cache, partial
 from pathlib import Path
 from typing import Any
 
@@ -43,6 +43,10 @@ from lightrag.constants import (
     FULL_DOCS_FORMAT_LIGHTRAG,
     FULL_DOCS_FORMAT_PENDING_PARSE,
     FULL_DOCS_FORMAT_RAW,
+    KG_PURGE_METADATA_KEY,
+    KG_WRITE_STATE_GRAPH_MUTATION_STARTED,
+    KG_WRITE_STATE_METADATA_KEY,
+    KG_WRITE_STATE_PRE_GRAPH,
     PARSED_DIR_NAME,
 )
 from lightrag.exceptions import (
@@ -1038,7 +1042,22 @@ class _PipelineMixin:
             }
             if content_data.get("content_hash"):
                 base["content_hash"] = content_data["content_hash"]
-            metadata: dict[str, Any] = {}
+            # Stamp the KG write-progress marker at BIRTH (issue #3400
+            # fail-closed purge). A brand-new row provably owns nothing in the
+            # graph, and every pre-merge state a document can fail in —
+            # PENDING, PARSING, ANALYZING, PROCESSING-before-merge — inherits
+            # that fact by carry-over. This is what lets deletion clean up a
+            # parse-stage failure that never got as far as writing recovery
+            # anchors, instead of refusing it for lack of proof.
+            #
+            # The marker is MONOTONIC: only ``on_anchors_durable`` advances it
+            # to ``graph_mutation_started``, and nothing ever writes it back.
+            # Re-stamping ``pre_graph`` at the start of a reprocess would be a
+            # lie about the PREVIOUS run's contributions — the resume purge
+            # would then skip the graph and orphan them.
+            metadata: dict[str, Any] = {
+                KG_WRITE_STATE_METADATA_KEY: KG_WRITE_STATE_PRE_GRAPH,
+            }
             options_str = content_data.get("process_options") or ""
             if options_str:
                 # Mirror process_options into doc_status.metadata so admin UIs
@@ -5201,6 +5220,9 @@ class _PipelineMixin:
                             current_file_number=current_file_number,
                             total_files=ctx.total_files,
                             file_path=file_path,
+                            on_anchors_durable=partial(
+                                self._mark_graph_mutation_started, doc_id
+                            ),
                         )
 
                     # If another in-flight document already triggered an abort
@@ -5245,6 +5267,16 @@ class _PipelineMixin:
                             "process_end_time": process_end_time,
                             **extraction_meta,
                         },
+                        # A PROCESSED document has no purge in flight by
+                        # definition, so retire any journal that a resume purge
+                        # left behind. Belt-and-braces next to
+                        # _clear_kg_purge_journal: a surviving ``completed``
+                        # journal would name a stale operation id and collide
+                        # with the next purge of this document.
+                        # kg_write_state is deliberately NOT dropped — it is
+                        # monotonic history, and the anchors written during this
+                        # run are the proof from here on.
+                        metadata_drop=(KG_PURGE_METADATA_KEY,),
                     )
 
                     async with ctx.pipeline_status_lock:
@@ -5386,8 +5418,48 @@ class _PipelineMixin:
         # The status_doc carries chunks_list / chunks_count from the prior
         # run; clear them so subsequent state-machine upserts don't write
         # back stale IDs.
+        #
+        # Persist that reset together with retiring the purge journal, in one
+        # targeted write (issue #3400). In-memory-only was not enough: the
+        # stored chunks_list kept pointing at chunks this purge just deleted,
+        # so a crash here left the row advertising them. Retiring the journal
+        # in the SAME write is what keeps the two consistent — a surviving
+        # ``completed`` journal would later collide with the next purge's
+        # operation id. kg_write_state is deliberately left alone: this
+        # document HAS written to the graph, and re-stamping ``pre_graph``
+        # would let a future purge skip the graph entirely.
+        await self._clear_kg_purge_journal(
+            doc_id,
+            write_state=KG_WRITE_STATE_GRAPH_MUTATION_STARTED,
+            extra_fields={"chunks_list": [], "chunks_count": 0},
+        )
         status_doc.chunks_list = []
         status_doc.chunks_count = 0
+
+    async def _mark_graph_mutation_started(self, doc_id: str) -> None:
+        """Advance ``kg_write_state`` past the point of no return.
+
+        Awaited by ``merge_nodes_and_edges`` in the single window where "this
+        document has never touched the graph" stops being true: after both
+        recovery anchors are flushed, before the first mutation. From here on a
+        purge may no longer assume there is nothing in the graph to find, so it
+        demands the anchors (or a purge journal) as proof.
+
+        Monotonic by construction — this is the only writer that sets
+        ``graph_mutation_started``, and no path writes ``pre_graph`` back.
+        Raising aborts the merge before any mutation, which is the safe
+        direction: the anchors are already durable.
+        """
+        status_doc = await self.doc_status.get_by_id(doc_id)
+        if status_doc is None:
+            return
+        raw_metadata = doc_status_field(status_doc, "metadata", {})
+        metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
+        metadata[KG_WRITE_STATE_METADATA_KEY] = KG_WRITE_STATE_GRAPH_MUTATION_STARTED
+        await self.doc_status.update_doc_status_fields(
+            doc_id, {"metadata": metadata}, missing_ok=True
+        )
+        await self._flush_storages([self.doc_status])
 
     # ============================================================
     # doc_status state-machine helpers (shared by all layers)
@@ -5403,6 +5475,7 @@ class _PipelineMixin:
         ctx: "_BatchRunContext",
         extra_fields: dict[str, Any] | None = None,
         metadata_extra: dict[str, Any] | None = None,
+        metadata_drop: tuple[str, ...] = (),
     ) -> None:
         """Single source of truth for doc_status state-transition upserts.
 
@@ -5411,6 +5484,8 @@ class _PipelineMixin:
         ``chunks_count`` / ``chunks_list`` / ``error_msg``; ``metadata_extra``
         is forwarded to ``doc_status_transition_metadata`` so carry-over
         fields (e.g. ``process_options``) survive every state change.
+        ``metadata_drop`` is forwarded as its ``drop`` argument — the only way
+        to retire a carried-over metadata key at a transition.
 
         Owner-checked (LR2 §7.7 items 3/4/7): every worker status write verifies
         its run still owns ``busy`` immediately before writing, and a run whose
@@ -5440,7 +5515,7 @@ class _PipelineMixin:
             "track_id": status_doc.track_id,
             "content_hash": status_doc.content_hash,
             "metadata": doc_status_transition_metadata(
-                status_doc, extra=metadata_extra
+                status_doc, extra=metadata_extra, drop=metadata_drop
             ),
         }
         if extra_fields:

--- a/lightrag/storage_migrations.py
+++ b/lightrag/storage_migrations.py
@@ -224,8 +224,12 @@ class _StorageMigrationMixin:
             try:
                 nodes = await self.chunk_entity_relation_graph.get_all_nodes()
             except Exception as exc:
+                # Complete-or-raise, matching _migrate_entity_relation_data:
+                # degrading to an empty list would record a "completed"
+                # backfill built from nothing, and chunk-tracking would then
+                # silently miss every entity until manually repaired.
                 logger.error(f"Failed to fetch nodes for chunk migration: {exc}")
-                nodes = []
+                raise
 
             logger.info(f"Starting chunk_tracking data migration: {len(nodes)} nodes")
 
@@ -277,8 +281,9 @@ class _StorageMigrationMixin:
             try:
                 edges = await self.chunk_entity_relation_graph.get_all_edges()
             except Exception as exc:
+                # Same contract as the nodes read above.
                 logger.error(f"Failed to fetch edges for chunk migration: {exc}")
-                edges = []
+                raise
 
             logger.info(f"Starting chunk_tracking data migration: {len(edges)} edges")
 

--- a/lightrag/tools/README_KG_INTEGRITY_REPAIR.md
+++ b/lightrag/tools/README_KG_INTEGRITY_REPAIR.md
@@ -44,3 +44,43 @@ python -m lightrag.tools.kg_integrity_repair --verbose   # per-doc details
 
 Run it while the server is stopped (or the workspace is otherwise idle):
 the audit reads a moving target if ingestion runs concurrently.
+
+## This tool is now the required remedy, not just a diagnostic
+
+Purge and deletion **fail closed** when a document has no recovery proof.
+Previously, absent anchor rows were read as "this document contributed
+nothing", so graph cleanup was silently skipped while the chunks were deleted
+anyway — which destroyed the provenance chain (`source_id` → `text_chunks` →
+`full_doc_id`) that this tool needs, turning repairable data into permanent
+orphans. So instead, the operation now refuses before deleting anything:
+
+```
+RecoveryAnchorMissingError: Refusing to purge document doc-…: recovery anchor
+row(s) missing or unusable (full_entities, full_relations) …
+```
+
+Over the API this surfaces as **HTTP 409** with no data removed. Retrying
+unchanged will refuse again — run `--apply` first, then retry.
+
+A purge is allowed to proceed when any one of these holds:
+
+| Proof | Meaning |
+| --- | --- |
+| Both anchor rows present | The normal case. Presence is the test, **not** whether the lists are non-empty: a row holding an empty list is a document that extracted no entities, and is a perfectly good proof. |
+| `doc_status.metadata.kg_write_state == pre_graph` | Stamped at enqueue and advanced only once the anchors are durable, so it proves the document never reached its first graph mutation. Staged chunks are cleaned up with no graph access at all. |
+| `doc_status.metadata.kg_purge` past `prepared` | A previous purge attempt got far enough to have deleted the anchors itself. Without this, purge's own last step would make every retry refuse forever. |
+
+Two states therefore need this tool:
+
+- documents ingested **before** #3416 landed the write-ahead anchors;
+- documents written through direct KG paths such as `ainsert_custom_kg`,
+  which are documented as sitting outside the document-level guarantee.
+
+Note that `--apply` reports what it found under `missing_entity_anchors` /
+`missing_relation_anchors` (the diagnosis) and what it rebuilt under
+`repaired_docs` (the action) — the first two are not emptied by a repair.
+
+Anything listed under `orphan_entities` / `orphan_relations` cannot be
+repaired by this tool: its source chunks are already gone, so no owning
+document is determinable. Those need external provenance, a re-ingest, or
+manual deletion.

--- a/lightrag/tools/README_KG_INTEGRITY_REPAIR.md
+++ b/lightrag/tools/README_KG_INTEGRITY_REPAIR.md
@@ -62,13 +62,18 @@ row(s) missing or unusable (full_entities, full_relations) …
 Over the API this surfaces as **HTTP 409** with no data removed. Retrying
 unchanged will refuse again — run `--apply` first, then retry.
 
-A purge is allowed to proceed when any one of these holds:
+The rule is narrower than "every purge needs a proof". What must never happen
+is deleting something that *carries* attribution — a chunk row, or an anchor
+row that names objects — while leaving those objects in the graph. A purge that
+removes no such carrier cannot strand anything, so it needs no proof. Otherwise
+one of these must hold:
 
 | Proof | Meaning |
 | --- | --- |
 | Both anchor rows present | The normal case. Presence is the test, **not** whether the lists are non-empty: a row holding an empty list is a document that extracted no entities, and is a perfectly good proof. |
 | `doc_status.metadata.kg_write_state == pre_graph` | Stamped at enqueue and advanced only once the anchors are durable, so it proves the document never reached its first graph mutation. Staged chunks are cleaned up with no graph access at all. |
 | `doc_status.metadata.kg_purge` past `prepared` | A previous purge attempt got far enough to have deleted the anchors itself. Without this, purge's own last step would make every retry refuse forever. |
+| No chunks and no populated anchor row | Nothing that carries attribution would be deleted. This is what lets a document that was queued before the `kg_write_state` marker existed, and never processed, be deleted directly — no scan, no audit. |
 
 Three states therefore need this tool:
 

--- a/lightrag/tools/README_KG_INTEGRITY_REPAIR.md
+++ b/lightrag/tools/README_KG_INTEGRITY_REPAIR.md
@@ -102,6 +102,28 @@ Absence is only ever concluded from the completed scan. A document that does
 own graph objects is repaired with its real names instead; blanking it would
 manufacture a false proof and license the exact deletion this work prevents.
 
+### What the certification assumes of the storage backends
+
+"Proven empty" is only as strong as the enumeration it is concluded from, so
+both reads are held to a complete-or-raise contract and the audit **fails
+loudly instead of certifying on a partial view**:
+
+- the `doc_status` enumeration uses `strict=True`, so a transport or
+  deserialization failure raises rather than silently narrowing the set of
+  documents being certified;
+- the graph scan relies on `get_all_nodes()` / `get_all_edges()` never
+  silently truncating. All shipped graph backends satisfy this (errors
+  propagate; there is no result cap). Corrupt AGE properties raise a
+  `PGGraphQueryException` rather than dropping the node or blanking the
+  edge's `source_id` — a dropped node is an attribution the scan never sees,
+  which is exactly how a contributing document could be falsely certified.
+
+One sharp edge remains: a graph backend whose indices/collections are missing
+(e.g. deleted out-of-band) reads as an **empty graph**, not as an error. The
+audit cannot distinguish that from a workspace that truly owns no graph data —
+one more reason to run it only while the server is stopped and the workspace
+is healthy, as stated at the top.
+
 Note that `--apply` reports what it found under `missing_entity_anchors` /
 `missing_relation_anchors` (the diagnosis) and what it wrote under
 `repaired_docs` (the action) — the first two are not emptied by a repair.

--- a/lightrag/tools/README_KG_INTEGRITY_REPAIR.md
+++ b/lightrag/tools/README_KG_INTEGRITY_REPAIR.md
@@ -70,14 +70,35 @@ A purge is allowed to proceed when any one of these holds:
 | `doc_status.metadata.kg_write_state == pre_graph` | Stamped at enqueue and advanced only once the anchors are durable, so it proves the document never reached its first graph mutation. Staged chunks are cleaned up with no graph access at all. |
 | `doc_status.metadata.kg_purge` past `prepared` | A previous purge attempt got far enough to have deleted the anchors itself. Without this, purge's own last step would make every retry refuse forever. |
 
-Two states therefore need this tool:
+Three states therefore need this tool:
 
 - documents ingested **before** #3416 landed the write-ahead anchors;
 - documents written through direct KG paths such as `ainsert_custom_kg`,
-  which are documented as sitting outside the document-level guarantee.
+  which are documented as sitting outside the document-level guarantee;
+- documents ingested with `skip_kg` (`process_options` `'!'`) **before** the
+  `kg_write_state` marker existed — see below.
+
+### Documents that legitimately own nothing
+
+`skip_kg` skips extraction and the merge entirely, so no anchor rows are ever
+written. Documents ingested that way *after* this change carry
+`kg_write_state=pre_graph` from enqueue and delete normally. Older ones have
+neither anchors nor a marker, and anchor repair has nothing to rebuild from —
+they never appear in the graph scan, because they own nothing in it.
+
+The audit settles that case, and it is the only thing that can: it enumerates
+the **whole** graph, which the hot paths deliberately never do, so a document
+absent from that scan is not merely unproven but *proven empty*. Such
+documents are listed under `anchorless_docs`, and `--apply` gives them empty
+anchor rows — the present-and-empty pair that is the normal proof for a
+document with no contributions.
+
+Absence is only ever concluded from the completed scan. A document that does
+own graph objects is repaired with its real names instead; blanking it would
+manufacture a false proof and license the exact deletion this work prevents.
 
 Note that `--apply` reports what it found under `missing_entity_anchors` /
-`missing_relation_anchors` (the diagnosis) and what it rebuilt under
+`missing_relation_anchors` (the diagnosis) and what it wrote under
 `repaired_docs` (the action) — the first two are not emptied by a repair.
 
 Anything listed under `orphan_entities` / `orphan_relations` cannot be

--- a/lightrag/tools/kg_integrity_repair.py
+++ b/lightrag/tools/kg_integrity_repair.py
@@ -42,6 +42,7 @@ import asyncio
 import os
 from typing import Any
 
+from lightrag.base import DocStatus
 from lightrag.constants import GRAPH_FIELD_SEP
 from lightrag.utils import logger
 
@@ -82,7 +83,24 @@ async def audit_kg_integrity(
       the document's anchor row;
     - ``orphan_entities`` / ``orphan_relations``: contributions with no
       resolvable source chunk (reported, never modified);
+    - ``anchorless_docs``: documents with no anchor rows that own nothing in
+      the graph — see below;
     - ``repaired_docs``: doc ids whose anchors were updated (``apply=True``).
+
+    **Certifying absence.** A document can legitimately own nothing in the
+    graph — ``skip_kg`` (``process_options`` ``'!'``) skips extraction and the
+    merge entirely, so no anchor rows are ever written. Since #3400 a purge
+    needs a positive recovery proof, and for such a document written before
+    the ``kg_write_state`` marker existed there is none: it has no anchors, and
+    it never appears in the graph scan above, so anchor repair has nothing to
+    rebuild from and the document would be permanently undeletable.
+
+    This audit is the one place that CAN settle it. It enumerates the whole
+    graph — something the hot paths deliberately never do — so a document
+    absent from both ``doc_entities`` and ``doc_relations`` is not merely
+    unproven but *proven empty*. With ``apply=True`` those documents get
+    written empty anchor rows, which is simply the truth about them and
+    restores the normal ``anchors`` proof.
     """
     graph = rag.chunk_entity_relation_graph
 
@@ -151,6 +169,12 @@ async def audit_kg_integrity(
         if missing:
             missing_relation_anchors[doc_id] = [list(p) for p in missing]
 
+    # Documents that own nothing in the graph AND carry no anchor rows. The
+    # completed scan above is what makes this a positive statement rather than
+    # an absence of evidence: every graph object was visited and none was
+    # attributed to these documents.
+    anchorless_docs = await _find_anchorless_docs(rag, doc_entities, doc_relations)
+
     repaired_docs: list[str] = []
     if apply and (missing_entity_anchors or missing_relation_anchors):
         for doc_id in sorted(
@@ -166,6 +190,18 @@ async def audit_kg_integrity(
             f"[kg-integrity] Repaired recovery anchors for {len(repaired_docs)} document(s)"
         )
 
+    if apply and anchorless_docs:
+        # Empty rows, written through the same union helper: it upserts both
+        # namespaces, so a document with no contributions ends up with the
+        # present-and-empty pair that IS the normal proof for one.
+        for doc_id in anchorless_docs:
+            await rag._union_doc_recovery_anchors(doc_id, [], [])
+            repaired_docs.append(doc_id)
+        logger.info(
+            f"[kg-integrity] Wrote empty recovery anchors for "
+            f"{len(anchorless_docs)} document(s) with no graph contributions"
+        )
+
     return {
         "entities_total": len(node_sources),
         "relations_total": len(edge_sources),
@@ -173,8 +209,47 @@ async def audit_kg_integrity(
         "missing_relation_anchors": missing_relation_anchors,
         "orphan_entities": sorted(orphan_entities),
         "orphan_relations": sorted(orphan_relations),
-        "repaired_docs": repaired_docs,
+        "anchorless_docs": anchorless_docs,
+        "repaired_docs": sorted(set(repaired_docs)),
     }
+
+
+async def _find_anchorless_docs(
+    rag,
+    doc_entities: dict[str, set[str]],
+    doc_relations: dict[str, set[tuple[str, str]]],
+) -> list[str]:
+    """Documents proven to own nothing in the graph and holding no anchor rows.
+
+    Only documents in a TERMINAL state are considered. A document still moving
+    through the pipeline may be about to write its anchors, and while writing
+    empty rows for it would be harmless in itself (merge Phase 0 overwrites
+    them unconditionally), reporting it as anchorless would be misleading — it
+    is unfinished, not empty.
+    """
+    try:
+        rows = await rag.doc_status.get_docs_by_statuses(
+            [DocStatus.PROCESSED, DocStatus.FAILED]
+        )
+    except Exception as e:  # pragma: no cover - backend/transport dependent
+        logger.warning(
+            f"[kg-integrity] Could not enumerate doc_status to certify "
+            f"anchorless documents: {e}"
+        )
+        return []
+
+    anchorless: list[str] = []
+    for doc_id in sorted(rows):
+        if doc_id in doc_entities or doc_id in doc_relations:
+            continue
+        entities_row = await rag.full_entities.get_by_id(doc_id)
+        relations_row = await rag.full_relations.get_by_id(doc_id)
+        # Row PRESENCE is the test, matching the purge contract: a present but
+        # empty row already is a valid proof and needs no repair.
+        if isinstance(entities_row, dict) and isinstance(relations_row, dict):
+            continue
+        anchorless.append(doc_id)
+    return anchorless
 
 
 def _print_report(report: dict[str, Any], verbose: bool) -> None:

--- a/lightrag/tools/kg_integrity_repair.py
+++ b/lightrag/tools/kg_integrity_repair.py
@@ -173,7 +173,9 @@ async def audit_kg_integrity(
     # completed scan above is what makes this a positive statement rather than
     # an absence of evidence: every graph object was visited and none was
     # attributed to these documents.
-    anchorless_docs = await _find_anchorless_docs(rag, doc_entities, doc_relations)
+    anchorless_docs = await _find_anchorless_docs(
+        rag, doc_entities, doc_relations, batch_size
+    )
 
     repaired_docs: list[str] = []
     if apply and (missing_entity_anchors or missing_relation_anchors):
@@ -218,6 +220,7 @@ async def _find_anchorless_docs(
     rag,
     doc_entities: dict[str, set[str]],
     doc_relations: dict[str, set[tuple[str, str]]],
+    batch_size: int,
 ) -> list[str]:
     """Documents proven to own nothing in the graph and holding no anchor rows.
 
@@ -226,29 +229,38 @@ async def _find_anchorless_docs(
     empty rows for it would be harmless in itself (merge Phase 0 overwrites
     them unconditionally), reporting it as anchorless would be misleading — it
     is unfinished, not empty.
+
+    The doc_status enumeration is strict (complete-or-raise) and failures
+    propagate. This function's answer is a PROOF of absence, and a
+    best-effort read that silently dropped rows would narrow it: every
+    dropped row is a document the audit was asked to certify and quietly
+    did not. An empty result must mean "no such documents", never "the scan
+    did not run" — so the audit fails loudly rather than reporting a
+    certainty it does not have.
     """
-    try:
-        rows = await rag.doc_status.get_docs_by_statuses(
-            [DocStatus.PROCESSED, DocStatus.FAILED]
-        )
-    except Exception as e:  # pragma: no cover - backend/transport dependent
-        logger.warning(
-            f"[kg-integrity] Could not enumerate doc_status to certify "
-            f"anchorless documents: {e}"
-        )
-        return []
+    rows = await rag.doc_status.get_docs_by_statuses(
+        [DocStatus.PROCESSED, DocStatus.FAILED], strict=True
+    )
+
+    candidates = [
+        doc_id
+        for doc_id in sorted(rows)
+        if doc_id not in doc_entities and doc_id not in doc_relations
+    ]
 
     anchorless: list[str] = []
-    for doc_id in sorted(rows):
-        if doc_id in doc_entities or doc_id in doc_relations:
-            continue
-        entities_row = await rag.full_entities.get_by_id(doc_id)
-        relations_row = await rag.full_relations.get_by_id(doc_id)
-        # Row PRESENCE is the test, matching the purge contract: a present but
-        # empty row already is a valid proof and needs no repair.
-        if isinstance(entities_row, dict) and isinstance(relations_row, dict):
-            continue
-        anchorless.append(doc_id)
+    for start in range(0, len(candidates), batch_size):
+        batch = candidates[start : start + batch_size]
+        entity_rows = await rag.full_entities.get_by_ids(batch)
+        relation_rows = await rag.full_relations.get_by_ids(batch)
+        for doc_id, entities_row, relations_row in zip(
+            batch, entity_rows, relation_rows
+        ):
+            # Row PRESENCE is the test, matching the purge contract: a present
+            # but empty row already is a valid proof and needs no repair.
+            if isinstance(entities_row, dict) and isinstance(relations_row, dict):
+                continue
+            anchorless.append(doc_id)
     return anchorless
 
 

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -515,9 +515,7 @@ async def require_doc_status_record(
     """
     strict = getattr(doc_status, "supports_strict_point_reads", False)
     record = await (
-        doc_status.get_by_id_strict(doc_id)
-        if strict
-        else doc_status.get_by_id(doc_id)
+        doc_status.get_by_id_strict(doc_id) if strict else doc_status.get_by_id(doc_id)
     )
     if record is None:
         raise StorageRecordNotFoundError(

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -31,6 +31,8 @@ from lightrag.constants import (
     DUPLICATE_DEMOTION_METADATA_KEYS,
     FILE_EXTRACTION_SUMMARY_PREFIX,
     FULL_DOCS_FORMAT_LIGHTRAG,
+    KG_PURGE_METADATA_KEY,
+    KG_WRITE_STATE_METADATA_KEY,
     LIGHTRAG_DOC_CONTENT_PREFIX,
     PARSED_DIR_NAME,
     PARSER_ENGINE_LEGACY,
@@ -379,6 +381,15 @@ _DOC_STATUS_METADATA_CARRY_OVER_KEYS: tuple[str, ...] = (
     # in-flight/failed ainsert_custom_chunks operation. Must survive every
     # status transition until the operation commits or is rolled back.
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    # KG write-progress marker and whole-document purge journal (issue #3400
+    # fail-closed purge). Both are load-bearing recovery state, not display
+    # fields: ``kg_write_state`` is the proof that lets a purge clean up an
+    # anchor-less document that never reached the graph, and ``kg_purge`` is
+    # what distinguishes "anchors already deleted by a purge that got that far"
+    # from "anchors were never there". Dropping either on a transition turns a
+    # resumable purge into a permanent fail-closed refusal.
+    KG_WRITE_STATE_METADATA_KEY,
+    KG_PURGE_METADATA_KEY,
     # Duplicate demotion. ``metadata.is_duplicate`` is not a display field: it is
     # the ONLY thing that makes a row ineligible as a primary candidate for its
     # canonical source (``_basename_of`` returns None for it), so an operator's
@@ -431,6 +442,54 @@ def doc_status_custom_chunk_patch(status_doc: Any) -> dict[str, Any] | None:
     return journal if isinstance(journal, dict) else None
 
 
+def make_kg_purge_operation_id(doc_key: str, chunk_ids: list[str]) -> str:
+    """Deterministic operation id for one whole-document purge (issue #3400).
+
+    Identifies "the same logical purge" across retries so a resumed run can
+    trust the journaled phase. Derived from the document key plus its chunk-id
+    SET (sorted and de-duplicated, unlike
+    :func:`make_custom_chunk_operation_id` which pins an ordered list): a purge
+    assembles ``chunk_ids`` from ``chunks_list`` unioned with a custom-chunk
+    journal, so the order is an assembly artifact while the set is the thing
+    that determines what gets deleted. Length-prefixed like
+    :func:`make_custom_chunk_id` so a caller-supplied ``doc_id`` cannot collide
+    with another document's chunk-id list.
+    """
+    joined = "|".join(sorted(set(chunk_ids)))
+    return compute_mdhash_id(f"{len(doc_key)}:{doc_key}:{joined}", prefix="purge-")
+
+
+def doc_status_kg_write_state(status_doc: Any) -> str | None:
+    """Return how far this document's KG write progressed, if recorded.
+
+    ``None`` means UNKNOWN — either a pre-#3416 document or one already
+    PROCESSED (which clears the marker because its anchors are the proof).
+    A fail-closed purge treats UNKNOWN as "may have touched the graph".
+    """
+    if status_doc is None:
+        return None
+    raw_metadata = doc_status_field(status_doc, "metadata", {})
+    if not isinstance(raw_metadata, dict):
+        return None
+    state = raw_metadata.get(KG_WRITE_STATE_METADATA_KEY)
+    return state if isinstance(state, str) and state else None
+
+
+def doc_status_kg_purge_journal(status_doc: Any) -> dict[str, Any] | None:
+    """Return the whole-document purge journal from a doc-status record, if any.
+
+    Accepts either a ``DocProcessingStatus`` object or a raw storage dict.
+    Returns ``None`` when no purge is in flight (the normal case).
+    """
+    if status_doc is None:
+        return None
+    raw_metadata = doc_status_field(status_doc, "metadata", {})
+    if not isinstance(raw_metadata, dict):
+        return None
+    journal = raw_metadata.get(KG_PURGE_METADATA_KEY)
+    return journal if isinstance(journal, dict) else None
+
+
 def doc_status_metadata_carry_over(status_doc: Any) -> dict[str, Any]:
     """Return the subset of ``status_doc.metadata`` to preserve across upserts.
 
@@ -457,16 +516,26 @@ def doc_status_transition_metadata(
     status_doc: Any,
     *,
     extra: dict[str, Any] | None = None,
+    drop: tuple[str, ...] = (),
 ) -> dict[str, Any]:
     """Build a doc_status ``metadata`` payload that preserves carry-over fields.
 
     Use at every state-transition upsert site so the user's
     ``process_options`` (and any future long-lived metadata fields) survive
     PENDING → PARSING → ANALYZING → PROCESSING → PROCESSED / FAILED.
+
+    ``drop`` removes keys AFTER carry-over and ``extra`` are applied, which is
+    the only way to retire a carried-over key: passing it in ``extra`` with a
+    ``None``/empty value would persist that value rather than remove the key,
+    and omitting it just lets carry-over put it back. Used to clear the
+    ``kg_write_state`` / ``kg_purge`` recovery markers at PROCESSED, where the
+    document's recovery anchors take over as the proof.
     """
     payload = doc_status_metadata_carry_over(status_doc)
     if extra:
         payload.update(extra)
+    for key in drop:
+        payload.pop(key, None)
     return payload
 
 
@@ -485,6 +554,14 @@ _DOC_STATUS_METADATA_DIRECTIVE_KEYS: tuple[str, ...] = (
     # journal must survive — stripping it would orphan the operation's staged
     # data with no recovery anchor (issue #3400).
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    # A FAILED→PENDING reset is exactly the case that must not strip these: the
+    # retry re-runs extraction, and if a previous attempt's purge is half-done
+    # (anchors deleted, journal at ``anchors_pending``) the journal is the only
+    # thing keeping that purge resumable rather than permanently refused. The
+    # write-state marker rides along for the same reason — the reset leaves the
+    # document PENDING, i.e. still pre-graph.
+    KG_WRITE_STATE_METADATA_KEY,
+    KG_PURGE_METADATA_KEY,
     # A demotion is an operator decision, not a per-attempt result: the manual
     # FAILED→PENDING retry must not undo it. A demoted row keeps its content and
     # its FAILED status, so it is reset like any other failed document — and

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -39,7 +39,7 @@ from lightrag.constants import (
     PARSER_ENGINE_NATIVE,
 )
 from lightrag import pipeline_metrics
-from lightrag.exceptions import StorageCapabilityError
+from lightrag.exceptions import StorageCapabilityError, StorageRecordNotFoundError
 from lightrag.parser.routing import (
     canonicalize_parser_hinted_basename,
     default_chunker_config,
@@ -489,6 +489,43 @@ def doc_status_kg_purge_journal(status_doc: Any) -> dict[str, Any] | None:
         return None
     journal = raw_metadata.get(KG_PURGE_METADATA_KEY)
     return journal if isinstance(journal, dict) else None
+
+
+async def require_doc_status_record(
+    doc_status: Any, doc_id: str, *, purpose: str
+) -> dict[str, Any]:
+    """Point-read a doc_status row that a load-bearing metadata write needs.
+
+    For writers of KG recovery state (``kg_write_state``, ``kg_purge``): they
+    read the row only to rebuild the opaque ``metadata`` blob around the key
+    they change, and every one of them runs while the row is guaranteed to
+    exist (mid-merge under the pipeline reservation, mid-purge before the
+    caller's finalization). ``None`` is therefore never a state to proceed
+    past — it is the read failing to prove the state the write depends on.
+
+    Strict where the backend supports it, so a transport/index failure raises
+    with its real cause instead of masquerading as an absent row (a plain
+    ``get_by_id`` may treat backend trouble as a best-effort miss). Whatever
+    the read path, ``None`` raises ``StorageRecordNotFoundError``: proceeding
+    silently is how the marker stays ``pre_graph`` while the graph is written,
+    or how a destructive purge runs unjournaled — both of which manufacture
+    exactly the unprovable states issue #3400's fail-closed contract exists to
+    prevent. Callers abort instead: an aborted merge (anchors already durable)
+    or an aborted purge (nothing deleted yet) is always the safe direction.
+    """
+    strict = getattr(doc_status, "supports_strict_point_reads", False)
+    record = await (
+        doc_status.get_by_id_strict(doc_id)
+        if strict
+        else doc_status.get_by_id(doc_id)
+    )
+    if record is None:
+        raise StorageRecordNotFoundError(
+            f"doc_status record for {doc_id} is "
+            f"{'confirmed absent' if strict else 'absent or unreadable'} "
+            f"while trying to {purpose}; refusing to proceed without it"
+        )
+    return record
 
 
 def doc_status_metadata_carry_over(status_doc: Any) -> dict[str, Any]:

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -462,9 +462,10 @@ def make_kg_purge_operation_id(doc_key: str, chunk_ids: list[str]) -> str:
 def doc_status_kg_write_state(status_doc: Any) -> str | None:
     """Return how far this document's KG write progressed, if recorded.
 
-    ``None`` means UNKNOWN — either a pre-#3416 document or one already
-    PROCESSED (which clears the marker because its anchors are the proof).
-    A fail-closed purge treats UNKNOWN as "may have touched the graph".
+    ``None`` means UNKNOWN — a pre-#3416 document. The marker is monotonic
+    and never cleared: a PROCESSED document keeps ``graph_mutation_started``
+    (its anchors serve as the proof from then on). A fail-closed purge
+    treats UNKNOWN as "may have touched the graph".
     """
     if status_doc is None:
         return None

--- a/tests/extraction/test_write_ahead_indexes.py
+++ b/tests/extraction/test_write_ahead_indexes.py
@@ -161,13 +161,18 @@ async def _merge(chunk_results, order: _OrderLog, **overrides):
         _MemVdb(),
         _MemVdb(),
         _cfg(),
-        full_entities_storage=stores["full_entities"],
-        full_relations_storage=stores["full_relations"],
+        full_entities_storage=(
+            None if overrides.get("no_anchor_storage") else stores["full_entities"]
+        ),
+        full_relations_storage=(
+            None if overrides.get("no_anchor_storage") else stores["full_relations"]
+        ),
         doc_id="d1",
         pipeline_status={"history_messages": []},
         pipeline_status_lock=asyncio.Lock(),
         entity_chunks_storage=stores["entity_chunks"],
         relation_chunks_storage=stores["relation_chunks"],
+        on_anchors_durable=overrides.get("on_anchors_durable"),
     )
     return graph, stores
 
@@ -277,3 +282,88 @@ async def test_anchor_flush_failure_aborts_merge_before_mutation():
             graph=graph,
         )
     assert graph.nodes == {} and graph.edges == {}
+
+
+# ---------------------------------------------------------------------------
+# on_anchors_durable: the hook the fail-closed purge contract depends on
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_on_anchors_durable_runs_after_flush_before_first_mutation():
+    """The hook fires in the one instant where "this document has never
+    touched the graph" stops being true — after both anchors are durable, and
+    before anything is merged. The pipeline persists ``kg_write_state`` there,
+    which is what lets a purge distinguish a document that never reached the
+    graph from one whose anchors were lost.
+    """
+    order = _OrderLog()
+
+    async def hook():
+        order.add("hook")
+
+    graph, _ = await _merge(_chunk_results(), order, on_anchors_durable=hook)
+
+    hook_idx = order.first("hook")
+    assert hook_idx >= 0, "hook never ran"
+    for prefix in ("full_entities.flush", "full_relations.flush"):
+        assert 0 <= order.first(prefix) < hook_idx, (
+            f"{prefix} must be durable before the hook: {order.events}"
+        )
+    first_mutation = min(
+        i
+        for i in (order.first("graph.upsert_node"), order.first("graph.upsert_edge"))
+        if i >= 0
+    )
+    assert hook_idx < first_mutation, (
+        f"hook (at {hook_idx}) must precede the first graph mutation "
+        f"(at {first_mutation}): {order.events}"
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_on_anchors_durable_failure_aborts_merge_before_mutation():
+    """If the marker cannot be persisted the merge must not proceed.
+
+    Merging anyway would leave a document that HAS graph contributions while
+    still claiming ``pre_graph``, and a later purge would trust that claim and
+    skip the graph — the silent-skip this whole mechanism exists to prevent.
+    """
+    order = _OrderLog()
+
+    async def boom():
+        order.add("hook")
+        raise RuntimeError("write-state boom")
+
+    graph = _MemGraph(order)
+    with pytest.raises(RuntimeError, match="write-state boom"):
+        await _merge(_chunk_results(), order, graph=graph, on_anchors_durable=boom)
+
+    assert graph.nodes == {} and graph.edges == {}
+    # The anchors stay: aborting with them in place is the safe direction, and
+    # keeps the document discoverable for a retry.
+    assert order.first("full_entities.upsert") >= 0
+    assert order.first("full_relations.flush") >= 0
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_on_anchors_durable_skipped_without_anchor_storages():
+    """Patch-mode merges pass no anchor storages — their operation journal is
+    the recovery proof — so there is no anchors-durable moment to report."""
+    order = _OrderLog()
+    calls: list[str] = []
+
+    async def hook():
+        calls.append("hook")
+
+    await _merge(
+        _chunk_results(),
+        order,
+        no_anchor_storage=True,
+        on_anchors_durable=hook,
+    )
+
+    assert calls == []

--- a/tests/kg/postgres_impl/test_postgres_get_all_complete_or_raise.py
+++ b/tests/kg/postgres_impl/test_postgres_get_all_complete_or_raise.py
@@ -1,0 +1,109 @@
+"""``get_all_nodes`` / ``get_all_edges`` must be complete-or-raise.
+
+These two methods feed whole-graph consumers — storage migration, VDB rebuild,
+and the KG integrity audit — that treat the returned list as the entire graph.
+The audit in particular concludes "this document owns nothing" from a document
+being absent from the scan, so a silently dropped node (or an edge whose
+properties, including ``source_id``, were silently blanked) is not a cosmetic
+loss: it is a missing attribution that can get a contributing document falsely
+certified as contribution-free, licensing a purge that leaves its graph
+objects stranded (issue #3400).
+
+Historically both methods degraded on a JSON parse failure of the AGE
+``properties`` payload: ``get_all_nodes`` skipped the row with a warning and
+``get_all_edges`` kept the row but blanked its properties. Corrupt properties
+are data corruption; the methods now raise ``PGGraphQueryException`` instead.
+"""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from lightrag.kg.postgres_impl import PGGraphQueryException, PGGraphStorage
+
+pytestmark = pytest.mark.offline
+
+
+def make_graph_storage() -> PGGraphStorage:
+    storage = PGGraphStorage.__new__(PGGraphStorage)
+    storage.workspace = "test_ws"
+    storage.namespace = "test_graph"
+    storage.graph_name = "test_graph"
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_get_all_nodes_raises_on_corrupt_properties():
+    storage = make_graph_storage()
+    storage._query = AsyncMock(
+        return_value=[
+            {"properties": '{"entity_id": "ALICE", "source_id": "chunk-1"}'},
+            {"properties": '{"entity_id": "ACME", not-json'},
+        ]
+    )
+
+    with pytest.raises(PGGraphQueryException) as excinfo:
+        await storage.get_all_nodes()
+
+    assert "Corrupt node properties" in excinfo.value.get_message()
+
+
+@pytest.mark.asyncio
+async def test_get_all_nodes_returns_every_parsable_row():
+    storage = make_graph_storage()
+    storage._query = AsyncMock(
+        return_value=[
+            {"properties": '{"entity_id": "ALICE", "source_id": "chunk-1"}'},
+            {"properties": {"entity_id": "ACME", "source_id": "chunk-2"}},
+        ]
+    )
+
+    nodes = await storage.get_all_nodes()
+
+    assert [n["id"] for n in nodes] == ["ALICE", "ACME"]
+
+
+@pytest.mark.asyncio
+async def test_get_all_edges_raises_on_corrupt_properties():
+    storage = make_graph_storage()
+    storage._query = AsyncMock(
+        return_value=[
+            {
+                "source": '"ACME"',
+                "target": '"ALICE"',
+                "properties": '{"source_id": "chunk-1"',
+            },
+        ]
+    )
+
+    with pytest.raises(PGGraphQueryException) as excinfo:
+        await storage.get_all_edges()
+
+    assert "Corrupt edge properties" in excinfo.value.get_message()
+
+
+@pytest.mark.asyncio
+async def test_get_all_edges_keeps_source_id_attribution():
+    storage = make_graph_storage()
+    storage._query = AsyncMock(
+        return_value=[
+            {
+                "source": '"ACME"',
+                "target": '"ALICE"',
+                "properties": '{"source_id": "chunk-1", "weight": 1.0}',
+            },
+            {
+                "source": '"ACME"',
+                "target": '"BOB"',
+                "properties": {"source_id": "chunk-2", "weight": 1.0},
+            },
+        ]
+    )
+
+    edges = await storage.get_all_edges()
+
+    assert edges[0]["source_id"] == "chunk-1"
+    assert edges[0]["source"] == '"ACME"'
+    assert edges[0]["target"] == '"ALICE"'
+    # Already-parsed dict properties pass through unchanged.
+    assert edges[1]["source_id"] == "chunk-2"
+    assert edges[1]["target"] == '"BOB"'

--- a/tests/pipeline/test_delete_fail_closed.py
+++ b/tests/pipeline/test_delete_fail_closed.py
@@ -534,6 +534,101 @@ async def test_pending_document_deletes_directly_without_a_scan(tmp_path, legacy
         await rag.finalize_storages()
 
 
+def _wire_empty_extraction(rag: LightRAG, per_chunk: bool) -> None:
+    """Extraction runs normally but yields nothing — no entities, no relations.
+
+    Distinct from ``skip_kg``: the merge IS called here, so Phase 0 runs and
+    writes both anchor rows (empty). ``per_chunk`` picks between the two shapes
+    a driver can return — one empty result per chunk, or no results at all.
+    """
+
+    async def fake_extract(chunks, *args, **kwargs):
+        return [({}, {}) for _ in chunks] if per_chunk else []
+
+    rag._process_extract_entities = fake_extract
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "per_chunk", [True, False], ids=["per_chunk_empty", "no_results"]
+)
+async def test_zero_entity_extraction_deletes_normally(tmp_path, per_chunk):
+    """A document the extractor found nothing in deletes like any other.
+
+    This is the case the whole fix turns on. Extraction ran, so merge ran, so
+    Phase 0 wrote both anchor rows — holding empty lists. Row PRESENCE is the
+    proof; the emptiness of the lists is a fact about the document, not a
+    missing anchor. Conflating the two is precisely the defect: the old code
+    resolved both to ``[]`` and could not tell "extracted nothing" from
+    "anchors lost", so it skipped graph cleanup for both.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        _wire_empty_extraction(rag, per_chunk)
+        doc_id = compute_mdhash_id("e.txt", prefix="doc-")
+        await rag.apipeline_enqueue_documents(
+            "nothing extractable here", ids=[doc_id], file_paths=["e.txt"]
+        )
+        await rag.apipeline_process_enqueue_documents()
+
+        row = await rag.doc_status.get_by_id(doc_id)
+        assert row["status"] == DocStatus.PROCESSED
+        chunk_ids = list(row.get("chunks_list") or [])
+        assert chunk_ids, "the document still has chunks for naive/mix retrieval"
+        # Both rows present and empty, and the merge did run.
+        assert (await rag.full_entities.get_by_id(doc_id))["entity_names"] == []
+        assert (await rag.full_relations.get_by_id(doc_id))["relation_pairs"] == []
+        assert row["metadata"][KG_WRITE_STATE_METADATA_KEY] == (
+            KG_WRITE_STATE_GRAPH_MUTATION_STARTED
+        )
+
+        result = await rag.adelete_by_doc_id(doc_id)
+
+        assert result.status == "success", result.message
+        assert await rag.doc_status.get_by_id(doc_id) is None
+        assert await rag.full_docs.get_by_id(doc_id) is None
+        assert all(
+            chunk is None for chunk in await rag.text_chunks.get_by_ids(chunk_ids)
+        )
+        assert await rag.full_entities.get_by_id(doc_id) is None
+        assert await rag.full_relations.get_by_id(doc_id) is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_legacy_zero_entity_document_is_recoverable_via_audit(tmp_path):
+    """The same document from before the anchors existed.
+
+    It has chunks, so the empty-scope rule does not reach it, and no marker, so
+    it fails closed — correctly, because nothing in the hot path can tell it
+    apart from a document whose anchors were lost. The audit settles it the
+    same way it settles ``skip_kg``: the completed graph scan proves it owns
+    nothing.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        _wire_empty_extraction(rag, per_chunk=True)
+        doc_id = compute_mdhash_id("e.txt", prefix="doc-")
+        await rag.apipeline_enqueue_documents(
+            "nothing extractable here", ids=[doc_id], file_paths=["e.txt"]
+        )
+        await rag.apipeline_process_enqueue_documents()
+        await _drop_anchors(rag, doc_id)
+        await _strip_write_state(rag, doc_id)
+
+        assert (await rag.adelete_by_doc_id(doc_id)).status_code == 409
+
+        report = await audit_kg_integrity(rag, apply=True)
+        assert report["anchorless_docs"] == [doc_id]
+
+        result = await rag.adelete_by_doc_id(doc_id)
+        assert result.status == "success", result.message
+        assert await rag.doc_status.get_by_id(doc_id) is None
+    finally:
+        await rag.finalize_storages()
+
+
 @pytest.mark.asyncio
 async def test_skip_kg_document_deletes_without_anchors(tmp_path):
     """``skip_kg`` produces a document with legitimately NO anchor rows.

--- a/tests/pipeline/test_delete_fail_closed.py
+++ b/tests/pipeline/test_delete_fail_closed.py
@@ -843,3 +843,40 @@ async def test_reprocess_clears_stale_chunk_list_after_purge(tmp_path):
         assert first_chunks
     finally:
         await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_anchorless_certification_reads_doc_status_strictly(tmp_path):
+    """The certification is a proof of absence, so its enumeration must be
+    complete-or-raise.
+
+    A best-effort read that dropped rows would silently narrow what was
+    certified, and a failure swallowed into an empty list would be
+    indistinguishable from "no anchorless documents exist" — the audit would
+    report a certainty it does not have. So the read passes ``strict=True``
+    and an enumeration failure propagates out of the audit instead of being
+    absorbed.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        await _ingest_skip_kg(rag)
+
+        seen_strict: list[bool] = []
+        original = rag.doc_status.get_docs_by_statuses
+
+        async def spy(statuses, strict=False):
+            seen_strict.append(strict)
+            return await original(statuses, strict=strict)
+
+        rag.doc_status.get_docs_by_statuses = spy
+        await audit_kg_integrity(rag)
+        assert seen_strict == [True]
+
+        async def broken(statuses, strict=False):
+            raise RuntimeError("doc_status backend unavailable")
+
+        rag.doc_status.get_docs_by_statuses = broken
+        with pytest.raises(RuntimeError, match="doc_status backend unavailable"):
+            await audit_kg_integrity(rag)
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_delete_fail_closed.py
+++ b/tests/pipeline/test_delete_fail_closed.py
@@ -918,9 +918,7 @@ async def test_unreadable_doc_status_aborts_merge_before_mutation(tmp_path):
         # Aborted BEFORE the first mutation: nothing reached the graph.
         assert await rag.chunk_entity_relation_graph.get_node("ALICE") is None
         # The stored marker still tells the truth about that.
-        assert (
-            row["metadata"][KG_WRITE_STATE_METADATA_KEY] == KG_WRITE_STATE_PRE_GRAPH
-        )
+        assert row["metadata"][KG_WRITE_STATE_METADATA_KEY] == KG_WRITE_STATE_PRE_GRAPH
         # And the anchors were already durable when the merge aborted.
         assert await rag.full_entities.get_by_id(doc_id) is not None
     finally:

--- a/tests/pipeline/test_delete_fail_closed.py
+++ b/tests/pipeline/test_delete_fail_closed.py
@@ -500,6 +500,41 @@ async def test_reprocess_refuses_when_anchors_lost(tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "legacy", [False, True], ids=["with_marker", "legacy_no_marker"]
+)
+async def test_pending_document_deletes_directly_without_a_scan(tmp_path, legacy):
+    """Deleting a queued document must not require a scan, an audit, or a run.
+
+    A new PENDING row carries ``kg_write_state=pre_graph`` from enqueue. One
+    that was already queued when this change was deployed has no marker at all,
+    and is covered instead by the empty-scope rule: with no chunks and no
+    populated anchors, the delete removes nothing that carries attribution, so
+    there is no damage for a proof to guard against.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = compute_mdhash_id("p.txt", prefix="doc-")
+        await rag.apipeline_enqueue_documents(
+            "pending body", ids=[doc_id], file_paths=["p.txt"]
+        )
+        if legacy:
+            await _strip_write_state(rag, doc_id)
+
+        row = await rag.doc_status.get_by_id(doc_id)
+        assert row["status"] == DocStatus.PENDING
+        assert not row.get("chunks_list")
+
+        result = await rag.adelete_by_doc_id(doc_id)
+
+        assert result.status == "success", result.message
+        assert await rag.doc_status.get_by_id(doc_id) is None
+        assert await rag.full_docs.get_by_id(doc_id) is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
 async def test_skip_kg_document_deletes_without_anchors(tmp_path):
     """``skip_kg`` produces a document with legitimately NO anchor rows.
 

--- a/tests/pipeline/test_delete_fail_closed.py
+++ b/tests/pipeline/test_delete_fail_closed.py
@@ -1,0 +1,505 @@
+"""End-to-end fail-closed deletion over real JSON/NetworkX storages (issue #3400).
+
+Reproduces the differential scenario from the issue report: ingest a document,
+delete its two recovery anchor rows (simulating pre-#3416 data or an
+``ainsert_custom_kg`` document, both of which are documented to have none), then
+try to delete or reprocess it.
+
+Before this change, that deleted the chunks and reported success while the
+entities and relations stayed in the graph — permanently unattributable, because
+the reverse lookup runs graph ``source_id`` -> ``text_chunks`` -> ``full_doc_id``
+and the chunks were just removed. ``audit_kg_integrity`` could then only report
+them as unrecoverable orphans.
+
+The suite asserts the operator-visible loop is now closed:
+
+    refuse (409, nothing deleted) -> audit_kg_integrity(apply=True) -> retry works
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import DocStatus
+from lightrag.constants import (
+    KG_PURGE_METADATA_KEY,
+    KG_PURGE_PHASE_COMPLETED,
+)
+from lightrag.tools.kg_integrity_repair import audit_kg_integrity
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _deterministic_chunking(
+    tokenizer,
+    content: str,
+    split_by_character,
+    split_by_character_only: bool,
+    chunk_overlap_token_size: int,
+    chunk_token_size: int,
+) -> list[dict]:
+    return [{"tokens": 1, "content": f"{content}::chunk1", "chunk_order_index": 0}]
+
+
+def _wire_fake_extraction(rag: LightRAG) -> None:
+    """One ALICE--ACME relation per chunk, so the graph has a node AND an edge."""
+
+    async def fake_extract(chunks, *args, **kwargs):
+        results = []
+        for chunk_id in chunks:
+            nodes = {
+                name: [
+                    {
+                        "entity_name": name,
+                        "entity_type": "person",
+                        "description": f"{name} description",
+                        "source_id": chunk_id,
+                        "file_path": "d.txt",
+                        "timestamp": 1,
+                    }
+                ]
+                for name in ("ALICE", "ACME")
+            }
+            edges = {
+                ("ACME", "ALICE"): [
+                    {
+                        "src_id": "ACME",
+                        "tgt_id": "ALICE",
+                        "description": "works at",
+                        "keywords": "employment",
+                        "weight": 1.0,
+                        "source_id": chunk_id,
+                        "file_path": "d.txt",
+                        "timestamp": 1,
+                    }
+                ]
+            }
+            results.append((nodes, edges))
+        return results
+
+    rag._process_extract_entities = fake_extract
+
+
+async def _build_rag(tmp_path, workspace: str) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=workspace,
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_deterministic_chunking,
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    _wire_fake_extraction(rag)
+    return rag
+
+
+async def _ingest(rag: LightRAG, file_path: str = "d.txt") -> str:
+    doc_id = compute_mdhash_id(file_path, prefix="doc-")
+    await rag.apipeline_enqueue_documents(
+        "alice works at acme", ids=[doc_id], file_paths=[file_path]
+    )
+    await rag.apipeline_process_enqueue_documents()
+    row = await rag.doc_status.get_by_id(doc_id)
+    status = row.get("status")
+    status_text = status.value if isinstance(status, DocStatus) else str(status)
+    assert status_text == DocStatus.PROCESSED.value, row
+    return doc_id
+
+
+async def _drop_anchors(rag: LightRAG, doc_id: str) -> None:
+    """Simulate the pre-#3416 / ainsert_custom_kg state: no recovery anchors."""
+    await rag.full_entities.delete([doc_id])
+    await rag.full_relations.delete([doc_id])
+    await rag.full_entities.index_done_callback()
+    await rag.full_relations.index_done_callback()
+    assert await rag.full_entities.get_by_id(doc_id) is None
+    assert await rag.full_relations.get_by_id(doc_id) is None
+
+
+async def _kg_snapshot(rag: LightRAG, chunk_ids: list[str]) -> dict:
+    return {
+        "alice": await rag.chunk_entity_relation_graph.get_node("ALICE"),
+        "acme": await rag.chunk_entity_relation_graph.get_node("ACME"),
+        "edge": await rag.chunk_entity_relation_graph.get_edge("ACME", "ALICE"),
+        "chunks": await rag.text_chunks.get_by_ids(chunk_ids),
+        "entity_tracking": await rag.entity_chunks.get_by_id("ALICE"),
+    }
+
+
+async def _chunk_ids(rag: LightRAG, doc_id: str) -> list[str]:
+    row = await rag.doc_status.get_by_id(doc_id)
+    return list(row.get("chunks_list") or [])
+
+
+@pytest.mark.asyncio
+async def test_delete_refuses_and_preserves_everything_when_anchors_lost(tmp_path):
+    """The core scenario: refuse with 409 and leave the document untouched."""
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest(rag)
+        chunk_ids = await _chunk_ids(rag, doc_id)
+        assert chunk_ids
+        await _drop_anchors(rag, doc_id)
+        before = await _kg_snapshot(rag, chunk_ids)
+        assert before["alice"] is not None and before["edge"] is not None
+
+        result = await rag.adelete_by_doc_id(doc_id)
+
+        assert result.status == "fail"
+        assert result.status_code == 409
+        assert "recovery anchor row(s) missing" in result.message
+        assert "audit_kg_integrity" in result.message
+
+        # Nothing at all was deleted.
+        assert await _kg_snapshot(rag, chunk_ids) == before
+        assert await rag.full_docs.get_by_id(doc_id) is not None
+        row = await rag.doc_status.get_by_id(doc_id)
+        assert row is not None
+        assert row["metadata"]["deletion_failure_stage"] == "validate_recovery_anchors"
+        # Refused on a precondition, so no purge was ever journaled.
+        assert KG_PURGE_METADATA_KEY not in row["metadata"]
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_audit_repair_unblocks_the_refused_delete(tmp_path):
+    """The documented remedy must actually close the loop.
+
+    This is the whole point of failing closed rather than proceeding: while the
+    chunks survive, ``audit_kg_integrity`` can still rebuild the anchors from
+    their provenance. Deleting first destroys that option forever.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest(rag)
+        await _drop_anchors(rag, doc_id)
+
+        assert (await rag.adelete_by_doc_id(doc_id)).status_code == 409
+
+        # The report is the DIAGNOSIS (what was missing); repaired_docs is what
+        # apply=True actually rebuilt from the surviving chunk provenance.
+        report = await audit_kg_integrity(rag, apply=True)
+        assert doc_id in report["missing_entity_anchors"]
+        assert doc_id in report["repaired_docs"]
+        assert await rag.full_entities.get_by_id(doc_id) is not None
+        assert await rag.full_relations.get_by_id(doc_id) is not None
+
+        result = await rag.adelete_by_doc_id(doc_id)
+
+        assert result.status == "success", result.message
+        assert await rag.doc_status.get_by_id(doc_id) is None
+        assert await rag.full_docs.get_by_id(doc_id) is None
+        # And the KG is clean: no orphans left behind by the deletion.
+        final_report = await audit_kg_integrity(rag)
+        assert final_report["orphan_entities"] == []
+        assert final_report["orphan_relations"] == []
+        assert await rag.chunk_entity_relation_graph.get_node("ALICE") is None
+        assert await rag.chunk_entity_relation_graph.get_edge("ACME", "ALICE") is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_delete_without_anchors_used_to_orphan_the_graph(tmp_path):
+    """Differential guard for the exact regression in the issue report.
+
+    Pins the two facts that together made the old behaviour unrecoverable: the
+    graph objects survive a purge that skipped them, and their chunks do not.
+    If a future change reintroduces the permissive path, this fails.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest(rag)
+        chunk_ids = await _chunk_ids(rag, doc_id)
+        await _drop_anchors(rag, doc_id)
+
+        result = await rag.adelete_by_doc_id(doc_id)
+        assert result.status == "fail"
+
+        # The chunks are what make the survivors attributable — they must still
+        # be here, and the audit must still see the graph as anchored-repairable
+        # rather than orphaned.
+        assert all(
+            chunk is not None for chunk in await rag.text_chunks.get_by_ids(chunk_ids)
+        )
+        report = await audit_kg_integrity(rag)
+        assert report["orphan_entities"] == []
+        assert report["orphan_relations"] == []
+        assert set(report["missing_entity_anchors"]) == {doc_id}
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_chunkless_document_with_populated_anchors_is_refused(tmp_path):
+    """The second route to the same orphan state.
+
+    A document with an empty ``chunks_list`` used to skip the graph entirely and
+    report success, and removing its ``doc_status`` row is what destroyed the
+    provenance of everything its anchors named.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest(rag)
+        chunk_ids = await _chunk_ids(rag, doc_id)
+        # Anchors intact, but the document no longer claims any chunks.
+        await rag.doc_status.update_doc_status_fields(
+            doc_id, {"chunks_list": [], "chunks_count": 0}
+        )
+        await rag.doc_status.index_done_callback()
+
+        result = await rag.adelete_by_doc_id(doc_id)
+
+        assert result.status == "fail"
+        assert result.status_code == 409
+        assert "no chunks to attribute them to" in result.message
+        assert await rag.doc_status.get_by_id(doc_id) is not None
+        assert await rag.chunk_entity_relation_graph.get_node("ALICE") is not None
+        assert all(
+            chunk is not None for chunk in await rag.text_chunks.get_by_ids(chunk_ids)
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_chunkless_stub_with_empty_anchors_still_deletes(tmp_path):
+    """Fail-closed must not block genuinely empty rows.
+
+    A PROCESSED document that extracted nothing has both anchor rows present and
+    empty — a valid proof — so it deletes, and its anchor rows go with it rather
+    than being left keyed to a document that no longer exists.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest(rag)
+        chunk_ids = await _chunk_ids(rag, doc_id)
+        # First delete the KG contributions the normal way, leaving an empty
+        # but PRESENT pair of anchors and no chunks.
+        await rag.text_chunks.delete(chunk_ids)
+        await rag.chunks_vdb.delete(chunk_ids)
+        await rag.full_entities.upsert({doc_id: {"entity_names": [], "count": 0}})
+        await rag.full_relations.upsert({doc_id: {"relation_pairs": [], "count": 0}})
+        await rag.doc_status.update_doc_status_fields(
+            doc_id, {"chunks_list": [], "chunks_count": 0}
+        )
+        for store in (
+            rag.text_chunks,
+            rag.chunks_vdb,
+            rag.full_entities,
+            rag.full_relations,
+            rag.doc_status,
+        ):
+            await store.index_done_callback()
+
+        result = await rag.adelete_by_doc_id(doc_id)
+
+        assert result.status == "success", result.message
+        assert await rag.doc_status.get_by_id(doc_id) is None
+        assert await rag.full_entities.get_by_id(doc_id) is None
+        assert await rag.full_relations.get_by_id(doc_id) is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_delete_repairs_graph_before_removing_chunks(tmp_path):
+    """Safe destructive ordering, asserted through the public delete API.
+
+    The inline implementation this replaced deleted the chunks first, so a
+    failure in between left graph objects pointing at chunks that were gone.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest(rag)
+        chunk_ids = await _chunk_ids(rag, doc_id)
+        order: list[str] = []
+
+        original_remove_nodes = rag.chunk_entity_relation_graph.remove_nodes
+        original_chunk_delete = rag.text_chunks.delete
+
+        async def spy_remove_nodes(names):
+            order.append("graph.remove_nodes")
+            return await original_remove_nodes(names)
+
+        async def spy_chunk_delete(ids):
+            order.append("text_chunks.delete")
+            return await original_chunk_delete(ids)
+
+        rag.chunk_entity_relation_graph.remove_nodes = spy_remove_nodes
+        rag.text_chunks.delete = spy_chunk_delete
+
+        assert (await rag.adelete_by_doc_id(doc_id)).status == "success"
+
+        assert order.index("graph.remove_nodes") < order.index("text_chunks.delete")
+        assert all(
+            chunk is None for chunk in await rag.text_chunks.get_by_ids(chunk_ids)
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_finalization_failure_retries_without_tripping_fail_closed(tmp_path):
+    """The deadlock the journal exists to prevent, end to end.
+
+    Purge deletes the anchors LAST, so a failure in the caller's post-purge
+    finalization leaves a document with no anchors and no chunks. Without the
+    ``completed`` journal the retry would then see "anchors missing" and refuse
+    forever — the document would be permanently undeletable.
+
+    The LLM-cache step is the right failure point to exercise: it runs after the
+    purge but while ``doc_status`` is still intact, so the retry genuinely
+    re-enters the purge rather than short-circuiting on a missing record.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest(rag)
+        # Deterministic fake extraction never populates the LLM cache, so seed a
+        # chunk-referenced entry to give the cache step something to fail on.
+        chunk_ids = await _chunk_ids(rag, doc_id)
+        cache_id = "llm-cache-dfc"
+        await rag.llm_response_cache.upsert({cache_id: {"return": "cached"}})
+        chunk_row = await rag.text_chunks.get_by_id(chunk_ids[0])
+        await rag.text_chunks.upsert(
+            {chunk_ids[0]: {**chunk_row, "llm_cache_list": [cache_id]}}
+        )
+        await rag.llm_response_cache.index_done_callback()
+        await rag.text_chunks.index_done_callback()
+
+        original_delete = rag.llm_response_cache.delete
+        calls = {"n": 0}
+
+        async def fail_first(ids):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("llm cache delete boom")
+            return await original_delete(ids)
+
+        rag.llm_response_cache.delete = fail_first
+
+        first = await rag.adelete_by_doc_id(doc_id, delete_llm_cache=True)
+        assert first.status == "fail"
+        assert "llm cache delete boom" in first.message
+        # The purge itself completed: anchors gone, chunks gone, and the journal
+        # records that this is why — not that they were never there.
+        assert await rag.full_entities.get_by_id(doc_id) is None
+        assert await rag.full_relations.get_by_id(doc_id) is None
+        row = await rag.doc_status.get_by_id(doc_id)
+        assert row is not None
+        assert (
+            row["metadata"][KG_PURGE_METADATA_KEY]["phase"] == KG_PURGE_PHASE_COMPLETED
+        )
+
+        second = await rag.adelete_by_doc_id(doc_id, delete_llm_cache=True)
+
+        assert second.status == "success", second.message
+        assert second.status_code != 409
+        assert await rag.doc_status.get_by_id(doc_id) is None
+        assert await rag.full_docs.get_by_id(doc_id) is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_reprocess_refuses_when_anchors_lost(tmp_path):
+    """The resume purge is the third caller, and fails closed the same way.
+
+    Re-processing a document whose content is already extracted purges the
+    previous run's chunks and KG contributions first. With the anchors gone that
+    purge cannot account for the graph, so the document must fail rather than
+    silently shed its old contributions.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest(rag)
+        chunk_ids = await _chunk_ids(rag, doc_id)
+        await _drop_anchors(rag, doc_id)
+
+        # Send it back through the pipeline as a resume.
+        await rag.doc_status.update_doc_status_fields(
+            doc_id, {"status": DocStatus.PENDING}
+        )
+        await rag.doc_status.index_done_callback()
+        await rag.apipeline_process_enqueue_documents()
+
+        row = await rag.doc_status.get_by_id(doc_id)
+        status = row.get("status")
+        status_text = status.value if isinstance(status, DocStatus) else str(status)
+        assert status_text == DocStatus.FAILED.value
+        assert "recovery anchor" in (row.get("error_msg") or "")
+        # The previous run's data is intact and still repairable.
+        assert await rag.chunk_entity_relation_graph.get_node("ALICE") is not None
+        assert all(
+            chunk is not None for chunk in await rag.text_chunks.get_by_ids(chunk_ids)
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_reprocess_clears_stale_chunk_list_after_purge(tmp_path):
+    """A successful resume purge must persist the emptied chunk list.
+
+    Leaving the stored ``chunks_list`` pointing at chunks the purge just deleted
+    made the row advertise data that no longer existed, and a crash before the
+    next write left it that way.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest(rag)
+        first_chunks = await _chunk_ids(rag, doc_id)
+        observed: dict = {}
+
+        original_resume_purge = rag._purge_stale_extraction_if_resuming
+
+        async def spy_resume_purge(**kwargs):
+            await original_resume_purge(**kwargs)
+            # Read straight after the resume purge returns and BEFORE the new
+            # run writes any chunks: the reset must already be persisted, not
+            # merely applied to the in-memory status object.
+            row = await rag.doc_status.get_by_id(kwargs["doc_id"])
+            observed["chunks_list"] = list(row.get("chunks_list") or [])
+            observed["journal"] = row.get("metadata", {}).get(KG_PURGE_METADATA_KEY)
+
+        rag._purge_stale_extraction_if_resuming = spy_resume_purge
+
+        await rag.doc_status.update_doc_status_fields(
+            doc_id, {"status": DocStatus.PENDING}
+        )
+        await rag.doc_status.index_done_callback()
+        await rag.apipeline_process_enqueue_documents()
+
+        assert observed["chunks_list"] == []
+        # Journal retired in the same write, so it cannot collide with the next
+        # purge's operation id.
+        assert observed["journal"] is None
+        assert first_chunks
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_delete_fail_closed.py
+++ b/tests/pipeline/test_delete_fail_closed.py
@@ -880,3 +880,151 @@ async def test_anchorless_certification_reads_doc_status_strictly(tmp_path):
             await audit_kg_integrity(rag)
     finally:
         await rag.finalize_storages()
+
+
+def _returns_none(*_args, **_kwargs):
+    async def _none(*_a, **_k):
+        return None
+
+    return _none
+
+
+@pytest.mark.asyncio
+async def test_unreadable_doc_status_aborts_merge_before_mutation(tmp_path):
+    """A masked doc_status read must abort the merge, not skip the marker.
+
+    Some backends can present backend trouble as ``None`` on a plain point
+    read (OpenSearch reads a not-ready index as a best-effort miss). If the
+    ``kg_write_state`` writer treats that as "nothing to update" and returns,
+    the merge proceeds and writes the graph while the STORED marker still
+    says ``pre_graph`` — a false proof that later licenses a purge to skip
+    graph cleanup if the anchors are lost (the exact #3400 defect). The safe
+    direction is to abort: the anchors are already durable at that point.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        rag.doc_status.get_by_id_strict = _returns_none()
+
+        doc_id = compute_mdhash_id("d.txt", prefix="doc-")
+        await rag.apipeline_enqueue_documents(
+            "alice works at acme", ids=[doc_id], file_paths=["d.txt"]
+        )
+        await rag.apipeline_process_enqueue_documents()
+
+        row = await rag.doc_status.get_by_id(doc_id)
+        status = row.get("status")
+        status_text = status.value if isinstance(status, DocStatus) else str(status)
+        assert status_text == DocStatus.FAILED.value, row
+        # Aborted BEFORE the first mutation: nothing reached the graph.
+        assert await rag.chunk_entity_relation_graph.get_node("ALICE") is None
+        # The stored marker still tells the truth about that.
+        assert (
+            row["metadata"][KG_WRITE_STATE_METADATA_KEY] == KG_WRITE_STATE_PRE_GRAPH
+        )
+        # And the anchors were already durable when the merge aborted.
+        assert await rag.full_entities.get_by_id(doc_id) is not None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_purge_read_failure_refuses_before_deleting_anything(tmp_path):
+    """A doc_status read error during purge must propagate, not delete on.
+
+    The proof resolution promises that a read failure propagates; on a
+    backend with strict point reads a transport error must therefore surface
+    as a refused deletion with nothing removed — never as "no journal, no
+    write state" silently resolved from a failed read.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest(rag)
+        chunks = (await rag.doc_status.get_by_id(doc_id))["chunks_list"]
+
+        async def broken(*_a, **_k):
+            raise RuntimeError("simulated doc_status transport error")
+
+        rag.doc_status.get_by_id_strict = broken
+
+        result = await rag.adelete_by_doc_id(doc_id)
+
+        assert result.status == "fail"
+        assert await rag.text_chunks.get_by_id(chunks[0]) is not None
+        assert await rag.chunk_entity_relation_graph.get_node("ALICE") is not None
+        assert await rag.full_entities.get_by_id(doc_id) is not None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_unjournalable_purge_refuses_before_deleting_anything(tmp_path):
+    """If the journal cannot be anchored to the row, the purge must not run.
+
+    A ``None`` that slips past the proof resolution (confirmed-absent is a
+    legal input there) must still stop the purge at the journal write: a
+    destructive purge that runs unjournaled loses the one record that lets a
+    retry survive its own anchor deletion, stranding the document in a
+    permanent missing-anchor refusal.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest(rag)
+        chunks = (await rag.doc_status.get_by_id(doc_id))["chunks_list"]
+
+        rag.doc_status.get_by_id_strict = _returns_none()
+
+        result = await rag.adelete_by_doc_id(doc_id)
+
+        assert result.status == "fail"
+        # The refusal happened before the first destructive write.
+        assert await rag.text_chunks.get_by_id(chunks[0]) is not None
+        assert await rag.chunk_entity_relation_graph.get_node("ALICE") is not None
+        assert await rag.full_entities.get_by_id(doc_id) is not None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_retry_state_write_never_clobbers_the_journal(tmp_path):
+    """An unreadable re-read must skip the retry-state write, not fall back.
+
+    The caller's snapshot predates the purge, so rebuilding ``metadata`` from
+    it when the fresh read comes back ``None`` (a masked read failure on the
+    OpenSearch-style best-effort path) erases the purge journal the row has
+    since acquired — turning a retryable half-done purge into a permanent
+    missing-anchor 409. Retry-state metadata is diagnostics and may go
+    unrecorded; the journal is load-bearing and may not be lost.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest(rag)
+
+        # Snapshot taken BEFORE the journal exists (what adelete holds).
+        snapshot = dict(await rag.doc_status.get_by_id(doc_id))
+
+        journal = {"operation_id": "purge-test", "phase": "anchors_pending"}
+        row = await rag.doc_status.get_by_id(doc_id)
+        await rag.doc_status.update_doc_status_fields(
+            doc_id,
+            {"metadata": {**row["metadata"], KG_PURGE_METADATA_KEY: journal}},
+        )
+
+        # Both read paths go dark; the native field update still works.
+        rag.doc_status.get_by_id = _returns_none()
+        rag.doc_status.get_by_id_strict = _returns_none()
+
+        returned = await rag._update_delete_retry_state(
+            doc_id,
+            snapshot,
+            deletion_stage="delete_llm_cache",
+            doc_llm_cache_ids=[],
+            error_message="boom",
+            failed=True,
+        )
+
+        del rag.doc_status.get_by_id, rag.doc_status.get_by_id_strict
+        stored = await rag.doc_status.get_by_id(doc_id)
+        assert stored["metadata"][KG_PURGE_METADATA_KEY] == journal
+        assert returned is snapshot
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_delete_fail_closed.py
+++ b/tests/pipeline/test_delete_fail_closed.py
@@ -23,14 +23,20 @@ from uuid import uuid4
 import numpy as np
 import pytest
 
+import lightrag.pipeline as pipeline_module
 from lightrag import LightRAG
 from lightrag.base import DocStatus
 from lightrag.constants import (
     KG_PURGE_METADATA_KEY,
     KG_PURGE_PHASE_COMPLETED,
+    KG_WRITE_STATE_GRAPH_MUTATION_STARTED,
+    KG_WRITE_STATE_METADATA_KEY,
+    KG_WRITE_STATE_PRE_GRAPH,
 )
 from lightrag.tools.kg_integrity_repair import audit_kg_integrity
 from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+
+from .conftest import request_failed_retry
 
 pytestmark = pytest.mark.offline
 
@@ -459,6 +465,57 @@ async def test_reprocess_refuses_when_anchors_lost(tmp_path):
         assert all(
             chunk is not None for chunk in await rag.text_chunks.get_by_ids(chunk_ids)
         )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_resume_purge_does_not_falsely_mark_a_pre_graph_document(tmp_path):
+    """The resume purge must not advance ``kg_write_state``.
+
+    A document that failed before merge is ``pre_graph`` and owns chunks but no
+    graph objects. Its resume purge is allowed precisely BY that marker, so if
+    retiring the journal also stamped ``graph_mutation_started``, a second
+    pre-merge failure would leave a document demanding anchors it can never
+    have — neither reprocessable nor deletable. The marker is monotonic and
+    only the anchor-durable hook advances it.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = compute_mdhash_id("pg.txt", prefix="doc-")
+        await rag.apipeline_enqueue_documents(
+            "pre graph doc", ids=[doc_id], file_paths=["pg.txt"]
+        )
+
+        # Fail during merge so chunks are written but the marker is still
+        # pre_graph (Phase 0's anchor-durable hook never runs).
+        async def boom(**kwargs):
+            raise RuntimeError("merge boom")
+
+        original_merge = pipeline_module.merge_nodes_and_edges
+        pipeline_module.merge_nodes_and_edges = boom
+        try:
+            await rag.apipeline_process_enqueue_documents()
+        finally:
+            pipeline_module.merge_nodes_and_edges = original_merge
+
+        row = await rag.doc_status.get_by_id(doc_id)
+        assert row["metadata"][KG_WRITE_STATE_METADATA_KEY] == KG_WRITE_STATE_PRE_GRAPH
+        assert await rag.full_entities.get_by_id(doc_id) is None
+
+        # The resume purge is permitted by the marker, and must leave it alone.
+        await request_failed_retry(rag)
+        await rag.apipeline_process_enqueue_documents()
+
+        row = await rag.doc_status.get_by_id(doc_id)
+        assert KG_PURGE_METADATA_KEY not in row["metadata"]
+        # A completed run advanced it legitimately; what must never happen is
+        # the marker moving on while the anchors are still absent.
+        if row["metadata"].get(KG_WRITE_STATE_METADATA_KEY) == (
+            KG_WRITE_STATE_GRAPH_MUTATION_STARTED
+        ):
+            assert await rag.full_entities.get_by_id(doc_id) is not None
+            assert await rag.full_relations.get_by_id(doc_id) is not None
     finally:
         await rag.finalize_storages()
 

--- a/tests/pipeline/test_delete_fail_closed.py
+++ b/tests/pipeline/test_delete_fail_closed.py
@@ -137,6 +137,36 @@ async def _ingest(rag: LightRAG, file_path: str = "d.txt") -> str:
     return doc_id
 
 
+async def _ingest_skip_kg(rag: LightRAG, file_path: str = "nokg.txt") -> str:
+    """Ingest with ``process_options='!'`` — extraction and merge are skipped.
+
+    This is a supported mode, and it is the case that produces a document with
+    legitimately NO anchor rows: merge never runs, so Phase 0 never writes them.
+    """
+    doc_id = compute_mdhash_id(file_path, prefix="doc-")
+    await rag.apipeline_enqueue_documents(
+        "text with no kg", ids=[doc_id], file_paths=[file_path], process_options="!"
+    )
+    await rag.apipeline_process_enqueue_documents()
+    row = await rag.doc_status.get_by_id(doc_id)
+    status = row.get("status")
+    status_text = status.value if isinstance(status, DocStatus) else str(status)
+    assert status_text == DocStatus.PROCESSED.value, row
+    assert row["metadata"]["skip_kg"] is True
+    assert await rag.full_entities.get_by_id(doc_id) is None
+    assert await rag.full_relations.get_by_id(doc_id) is None
+    return doc_id
+
+
+async def _strip_write_state(rag: LightRAG, doc_id: str) -> None:
+    """Simulate a document written before the ``kg_write_state`` marker existed."""
+    row = await rag.doc_status.get_by_id(doc_id)
+    metadata = dict(row.get("metadata") or {})
+    metadata.pop(KG_WRITE_STATE_METADATA_KEY, None)
+    await rag.doc_status.update_doc_status_fields(doc_id, {"metadata": metadata})
+    await rag.doc_status.index_done_callback()
+
+
 async def _drop_anchors(rag: LightRAG, doc_id: str) -> None:
     """Simulate the pre-#3416 / ainsert_custom_kg state: no recovery anchors."""
     await rag.full_entities.delete([doc_id])
@@ -465,6 +495,129 @@ async def test_reprocess_refuses_when_anchors_lost(tmp_path):
         assert all(
             chunk is not None for chunk in await rag.text_chunks.get_by_ids(chunk_ids)
         )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_skip_kg_document_deletes_without_anchors(tmp_path):
+    """``skip_kg`` produces a document with legitimately NO anchor rows.
+
+    Extraction and merge are skipped entirely, so Phase 0 never runs. The
+    enqueue-time ``kg_write_state=pre_graph`` marker is what carries the proof
+    instead — and it must survive to PROCESSED, which is why the PROCESSED
+    transition retires only the purge journal and not the marker.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest_skip_kg(rag)
+        row = await rag.doc_status.get_by_id(doc_id)
+        assert row["metadata"][KG_WRITE_STATE_METADATA_KEY] == KG_WRITE_STATE_PRE_GRAPH
+        chunk_ids = await _chunk_ids(rag, doc_id)
+        assert chunk_ids, "skip_kg still produces chunks for naive/mix retrieval"
+
+        result = await rag.adelete_by_doc_id(doc_id)
+
+        assert result.status == "success", result.message
+        assert await rag.doc_status.get_by_id(doc_id) is None
+        assert all(
+            chunk is None for chunk in await rag.text_chunks.get_by_ids(chunk_ids)
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_legacy_skip_kg_document_is_recoverable_via_audit(tmp_path):
+    """A ``skip_kg`` document predating the marker must not be undeletable.
+
+    It has no anchors (merge never ran) and no marker (it did not exist yet),
+    so it fails closed — correctly, since nothing in the hot path can tell it
+    apart from a document whose anchors were lost. The audit is the one place
+    that CAN: it enumerates the entire graph, so a document appearing nowhere
+    in that scan is proven to own nothing, and empty anchor rows are simply the
+    truth about it.
+
+    Without this, the remedy the refusal message names would be a dead end for
+    this whole class of document: anchor repair has nothing to rebuild from, so
+    ``repaired_docs`` would come back empty and the retry would refuse again.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest_skip_kg(rag)
+        await _strip_write_state(rag, doc_id)
+
+        refused = await rag.adelete_by_doc_id(doc_id)
+        assert refused.status_code == 409
+
+        report = await audit_kg_integrity(rag, apply=True)
+        assert report["anchorless_docs"] == [doc_id]
+        assert doc_id in report["repaired_docs"]
+        # Present-and-empty: the normal `anchors` proof for a document that
+        # contributed nothing.
+        assert (await rag.full_entities.get_by_id(doc_id))["entity_names"] == []
+        assert (await rag.full_relations.get_by_id(doc_id))["relation_pairs"] == []
+
+        result = await rag.adelete_by_doc_id(doc_id)
+        assert result.status == "success", result.message
+        assert await rag.doc_status.get_by_id(doc_id) is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_audit_never_certifies_a_document_that_owns_graph_objects(tmp_path):
+    """The safety property of the anchorless certification.
+
+    Writing empty anchors for a document that DOES own graph objects would
+    manufacture a false proof and hand purge a licence to delete the chunks
+    while skipping the graph — precisely the bug this work removes. Absence
+    must be established from the completed scan, never assumed from a missing
+    anchor row.
+    """
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        contributing = await _ingest(rag)  # owns ALICE, ACME and an edge
+        empty = await _ingest_skip_kg(rag)
+        await _drop_anchors(rag, contributing)
+        await _strip_write_state(rag, contributing)
+        await _strip_write_state(rag, empty)
+
+        report = await audit_kg_integrity(rag, apply=True)
+
+        # Only the genuinely empty one is certified empty.
+        assert report["anchorless_docs"] == [empty]
+        # The contributing one is repaired with its REAL names, not blanked.
+        assert set(report["missing_entity_anchors"][contributing]) == {"ALICE", "ACME"}
+        assert sorted(
+            (await rag.full_entities.get_by_id(contributing))["entity_names"]
+        ) == ["ACME", "ALICE"]
+        assert (await rag.full_relations.get_by_id(contributing))["relation_pairs"] == [
+            ["ACME", "ALICE"]
+        ]
+
+        # And deleting it now really does clean the graph.
+        assert (await rag.adelete_by_doc_id(contributing)).status == "success"
+        assert await rag.chunk_entity_relation_graph.get_node("ALICE") is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_audit_leaves_present_but_empty_anchor_rows_alone(tmp_path):
+    """Row presence is the test, so an already-empty pair needs no repair."""
+    rag = await _build_rag(tmp_path, f"dfc-{uuid4().hex[:8]}")
+    try:
+        doc_id = await _ingest_skip_kg(rag)
+        await rag.full_entities.upsert({doc_id: {"entity_names": [], "count": 0}})
+        await rag.full_relations.upsert({doc_id: {"relation_pairs": [], "count": 0}})
+        await rag.full_entities.index_done_callback()
+        await rag.full_relations.index_done_callback()
+
+        report = await audit_kg_integrity(rag, apply=True)
+
+        assert report["anchorless_docs"] == []
+        assert report["repaired_docs"] == []
     finally:
         await rag.finalize_storages()
 

--- a/tests/pipeline/test_doc_status_chunk_preservation.py
+++ b/tests/pipeline/test_doc_status_chunk_preservation.py
@@ -9,7 +9,11 @@ import pytest
 import lightrag.lightrag as lightrag_module
 import lightrag.pipeline as pipeline_module
 from lightrag.base import DocStatus
-from lightrag.constants import GRAPH_FIELD_SEP
+from lightrag.constants import (
+    GRAPH_FIELD_SEP,
+    KG_WRITE_STATE_METADATA_KEY,
+    KG_WRITE_STATE_PRE_GRAPH,
+)
 from lightrag.kg.shared_storage import get_namespace_data, get_namespace_lock
 from lightrag.lightrag import LightRAG
 
@@ -393,7 +397,15 @@ async def test_extract_failure_before_chunking_clears_stale_chunk_snapshot(
                     "file_path": existing["file_path"],
                     "track_id": existing["track_id"],
                     "error_msg": "previous failure",
-                    "metadata": {"source": "test"},
+                    # kg_write_state is carried across every real status
+                    # transition (it is in the carry-over whitelist), and this
+                    # document failed before merge — so a real FAILED row still
+                    # proves it never reached the graph. The resume purge needs
+                    # that proof to clean up the stale chunk snapshot.
+                    "metadata": {
+                        "source": "test",
+                        KG_WRITE_STATE_METADATA_KEY: KG_WRITE_STATE_PRE_GRAPH,
+                    },
                 }
             }
         )
@@ -498,7 +510,12 @@ async def test_delete_rebuild_failure_prunes_chunk_tracking_before_abort(
 
         assert result.status == "fail"
         assert "rebuild fail sentinel" in result.message
-        assert await rag.text_chunks.get_by_id(drop_chunk_id) is None
+        # Safe destructive ordering: the chunks are deleted only AFTER every
+        # derived contribution is repaired or removed, so a rebuild failure
+        # leaves them in place and the retry can still rebuild from them.
+        # This used to assert the chunk was already gone — the window where
+        # graph objects pointed at chunks that no longer existed (issue #3400).
+        assert await rag.text_chunks.get_by_id(drop_chunk_id) is not None
         assert await rag.text_chunks.get_by_id(keep_chunk_id) is not None
         assert failed_status is not None
         assert failed_status["chunks_list"] == [drop_chunk_id]
@@ -623,7 +640,12 @@ async def test_delete_retry_cleans_llm_cache_after_rebuild_failure(
         failed_status = await rag.doc_status.get_by_id(doc_id)
         assert failed_status is not None
         assert failed_status["metadata"]["deletion_llm_cache_ids"] == cache_ids
-        assert await rag.text_chunks.get_by_id(drop_chunk_id) is None
+        # Safe destructive ordering: the chunks are deleted only AFTER every
+        # derived contribution is repaired or removed, so a rebuild failure
+        # leaves them in place and the retry can still rebuild from them.
+        # This used to assert the chunk was already gone — the window where
+        # graph objects pointed at chunks that no longer existed (issue #3400).
+        assert await rag.text_chunks.get_by_id(drop_chunk_id) is not None
 
         monkeypatch.setattr(
             lightrag_module,
@@ -678,7 +700,12 @@ async def test_delete_retry_cleans_llm_cache_when_enabled_on_retry(
         failed_status = await rag.doc_status.get_by_id(doc_id)
         assert failed_status is not None
         assert failed_status["metadata"]["deletion_llm_cache_ids"] == cache_ids
-        assert await rag.text_chunks.get_by_id(drop_chunk_id) is None
+        # Safe destructive ordering: the chunks are deleted only AFTER every
+        # derived contribution is repaired or removed, so a rebuild failure
+        # leaves them in place and the retry can still rebuild from them.
+        # This used to assert the chunk was already gone — the window where
+        # graph objects pointed at chunks that no longer existed (issue #3400).
+        assert await rag.text_chunks.get_by_id(drop_chunk_id) is not None
 
         monkeypatch.setattr(
             lightrag_module,
@@ -736,7 +763,12 @@ async def test_delete_retry_collects_cache_ids_without_cache_storage(
         failed_status = await rag.doc_status.get_by_id(doc_id)
         assert failed_status is not None
         assert failed_status["metadata"]["deletion_llm_cache_ids"] == cache_ids
-        assert await rag.text_chunks.get_by_id(drop_chunk_id) is None
+        # Safe destructive ordering: the chunks are deleted only AFTER every
+        # derived contribution is repaired or removed, so a rebuild failure
+        # leaves them in place and the retry can still rebuild from them.
+        # This used to assert the chunk was already gone — the window where
+        # graph objects pointed at chunks that no longer existed (issue #3400).
+        assert await rag.text_chunks.get_by_id(drop_chunk_id) is not None
 
         rag.llm_response_cache = cache_storage
         monkeypatch.setattr(
@@ -902,7 +934,21 @@ async def test_delete_retry_preserves_cache_cleanup_state_when_cache_storage_una
 
 
 @pytest.mark.asyncio
-async def test_delete_succeeds_when_chunks_list_missing(tmp_path):
+async def test_delete_refuses_when_chunks_list_missing_but_anchors_name_kg(tmp_path):
+    """A chunk-less document whose anchors still name KG objects must be refused.
+
+    Regression for issue #3400. This path used to delete doc_status + full_docs
+    and report success without looking at the graph at all, so the entities and
+    relations the anchors named survived — and removing doc_status destroyed the
+    provenance chain (graph source_id -> text_chunks -> full_doc_id) that was
+    the only remaining way to attribute them. The integrity audit could then
+    only report them as unrecoverable orphans.
+
+    With no chunk ids there is also nothing to subtract from those objects'
+    source lists, so purge cannot classify them: every one would be kept while
+    the anchors were dropped anyway. Hence the dedicated refusal reason rather
+    than a best-effort attempt.
+    """
     rag = await _build_rag(
         tmp_path, "delete_missing_chunks_list_rejected", _deterministic_chunking
     )
@@ -922,10 +968,19 @@ async def test_delete_succeeds_when_chunks_list_missing(tmp_path):
 
         result = await rag.adelete_by_doc_id(doc_id)
 
-        assert result.status == "success"
-        assert "without associated chunks" in result.message
-        assert await rag.doc_status.get_by_id(doc_id) is None
-        assert await rag.full_docs.get_by_id(doc_id) is None
+        assert result.status == "fail"
+        assert result.status_code == 409
+        assert "no chunks to attribute them to" in result.message
+        assert "audit_kg_integrity" in result.message
+        # Nothing was deleted: the document is exactly as it was, so an
+        # operator can repair the anchors and retry.
+        failed_status = await rag.doc_status.get_by_id(doc_id)
+        assert failed_status is not None
+        assert (
+            failed_status["metadata"]["deletion_failure_stage"]
+            == "validate_recovery_anchors"
+        )
+        assert await rag.full_docs.get_by_id(doc_id) is not None
         assert await rag.full_entities.get_by_id(doc_id) is not None
         assert await rag.full_relations.get_by_id(doc_id) is not None
         assert await rag.text_chunks.get_by_id(drop_chunk_id) is not None
@@ -1571,6 +1626,12 @@ async def test_deletion_fully_completed_prevents_success_override_in_finally(
                         }
                     }
                 )
+                # A real PROCESSED document always has both anchor rows, even
+                # with zero chunks: merge writes them in Phase 0 before any
+                # mutation. Present-and-empty is a valid recovery proof — the
+                # distinction fail-closed purge turns on.
+                await rag.full_entities.upsert({doc_id: {"entity_names": []}})
+                await rag.full_relations.upsert({doc_id: {"relation_pairs": []}})
             else:
                 drop_chunk_id = "chunk-drop-fc"
                 await _seed_delete_retry_state(
@@ -1587,9 +1648,13 @@ async def test_deletion_fully_completed_prevents_success_override_in_finally(
             async def fail_later_insert_done():
                 nonlocal insert_done_calls
                 insert_done_calls += 1
-                # Let the first call (persist_pre_rebuild_changes) succeed for the
-                # full path; only fail the finally-block call.
-                if insert_done_calls <= (1 if scenario == "full" else 0):
+                # Let the purge's own persist_pre_rebuild_changes flush succeed
+                # in BOTH scenarios and fail only the finally-block call. The
+                # no-chunk path now runs the same purge primitive as the
+                # chunk-backed one (it has to, in order to fail closed when the
+                # document's KG contributions are unaccounted for), so it makes
+                # that flush too.
+                if insert_done_calls <= 1:
                     await original_insert_done()
                 else:
                     raise RuntimeError("finally insert_done fail sentinel")
@@ -1633,7 +1698,13 @@ async def _seed_no_chunk_smartheading_doc(
                 "file_path": "sh.docx",
                 "track_id": f"track-{doc_id}",
                 "error_msg": "parse-stage failure",
-                "metadata": {"smartheading_llm_cache_ids": cache_ids},
+                # No recovery anchors, because the run never reached merge —
+                # the enqueue-time kg_write_state marker is what proves that
+                # and lets deletion clean the row up instead of failing closed.
+                "metadata": {
+                    "smartheading_llm_cache_ids": cache_ids,
+                    KG_WRITE_STATE_METADATA_KEY: KG_WRITE_STATE_PRE_GRAPH,
+                },
             }
         }
     )

--- a/tests/pipeline/test_doc_status_reset_metadata.py
+++ b/tests/pipeline/test_doc_status_reset_metadata.py
@@ -22,9 +22,16 @@ import pytest
 from lightrag.base import DocProcessingStatus, DocStatus
 from lightrag.lightrag import LightRAG
 from lightrag.utils import EmbeddingFunc, Tokenizer
+from lightrag.constants import (
+    KG_PURGE_METADATA_KEY,
+    KG_PURGE_PHASE_ANCHORS_PENDING,
+    KG_WRITE_STATE_GRAPH_MUTATION_STARTED,
+    KG_WRITE_STATE_METADATA_KEY,
+)
 from lightrag.utils_pipeline import (
     doc_status_metadata_has_attempt_fields,
     doc_status_reset_metadata,
+    doc_status_transition_metadata,
 )
 
 pytestmark = pytest.mark.offline
@@ -142,6 +149,73 @@ def test_reset_metadata_handles_empty_or_invalid_metadata():
         )
         == {}
     )
+
+
+def test_reset_metadata_keeps_kg_recovery_state():
+    """The KG write marker and purge journal must survive a FAILED->PENDING
+    reset (issue #3400 fail-closed purge).
+
+    A reset is exactly the case that must not strip them: the retry re-runs
+    extraction, and if the previous attempt's purge is half-done (anchors
+    already deleted, journal at ``anchors_pending``) the journal is the only
+    thing left that can tell the resumed purge those anchors were removed
+    deliberately. Dropping it turns a resumable purge into a permanent
+    fail-closed refusal — a document that can neither be reprocessed nor
+    deleted.
+    """
+    journal = {
+        "schema_version": 1,
+        "operation_id": "purge-abc",
+        "phase": KG_PURGE_PHASE_ANCHORS_PENDING,
+        "chunk_count": 2,
+    }
+    result = doc_status_reset_metadata(
+        {
+            "metadata": {
+                **_FULL_ATTEMPT_METADATA,
+                KG_WRITE_STATE_METADATA_KEY: KG_WRITE_STATE_GRAPH_MUTATION_STARTED,
+                KG_PURGE_METADATA_KEY: journal,
+            }
+        }
+    )
+
+    assert result == {
+        "process_options": "iF",
+        "source_file": "report.pdf",
+        KG_WRITE_STATE_METADATA_KEY: KG_WRITE_STATE_GRAPH_MUTATION_STARTED,
+        KG_PURGE_METADATA_KEY: journal,
+    }
+
+
+def test_transition_metadata_carries_kg_recovery_state_and_drop_retires_it():
+    """Carry-over keeps both keys across every status transition, and ``drop``
+    is the only way to retire one (passing it in ``extra`` would persist the
+    value; omitting it lets carry-over put it straight back)."""
+    status_doc = {
+        "metadata": {
+            "process_options": "iF",
+            KG_WRITE_STATE_METADATA_KEY: KG_WRITE_STATE_GRAPH_MUTATION_STARTED,
+            KG_PURGE_METADATA_KEY: {"phase": KG_PURGE_PHASE_ANCHORS_PENDING},
+        }
+    }
+
+    carried = doc_status_transition_metadata(status_doc)
+    assert carried[KG_WRITE_STATE_METADATA_KEY] == (
+        KG_WRITE_STATE_GRAPH_MUTATION_STARTED
+    )
+    assert KG_PURGE_METADATA_KEY in carried
+
+    # What the PROCESSED transition does: retire the journal, keep the marker
+    # (it is monotonic history, and the anchors are the proof from here on).
+    retired = doc_status_transition_metadata(status_doc, drop=(KG_PURGE_METADATA_KEY,))
+    assert KG_PURGE_METADATA_KEY not in retired
+    assert retired[KG_WRITE_STATE_METADATA_KEY] == (
+        KG_WRITE_STATE_GRAPH_MUTATION_STARTED
+    )
+    assert retired["process_options"] == "iF"
+
+    # The source metadata must not be mutated in place.
+    assert KG_PURGE_METADATA_KEY in status_doc["metadata"]
 
 
 def test_reset_metadata_drops_degraded_recovery_warnings():

--- a/tests/pipeline/test_fault_injection_matrix.py
+++ b/tests/pipeline/test_fault_injection_matrix.py
@@ -15,7 +15,6 @@ matrix; immediate-write backends are covered by the mock-based unit suites.
 
 from __future__ import annotations
 
-import asyncio
 from uuid import uuid4
 
 import numpy as np
@@ -227,6 +226,110 @@ async def test_pipeline_failure_then_restart_converges(
         await rag2.finalize_storages()
 
 
+# Injection points inside the DELETION saga (issue #3400 fail-closed purge).
+# Each is a persistence boundary the journal has to make resumable: purge
+# deletes the recovery anchors last, so any failure at or after that point
+# leaves a document whose anchors are gone, and only the journal can tell the
+# retry that they were removed deliberately rather than never written.
+_DELETE_INJECTION_POINTS = {
+    # Journal write itself: must abort before deleting anything.
+    "purge_journal_write": lambda rag, mp: _fail_once(
+        mp, rag.doc_status, "update_doc_status_fields", "journal write boom"
+    ),
+    "graph_node_removal": lambda rag, mp: _fail_once(
+        mp, rag.chunk_entity_relation_graph, "remove_nodes", "node removal boom"
+    ),
+    "pre_rebuild_flush": lambda rag, mp: _fail_once(
+        mp, rag.entities_vdb, "index_done_callback", "pre-rebuild flush boom"
+    ),
+    "chunk_delete": lambda rag, mp: _fail_once(
+        mp, rag.text_chunks, "delete", "chunk delete boom"
+    ),
+    "chunk_flush": lambda rag, mp: _fail_once(
+        mp, rag.chunks_vdb, "index_done_callback", "chunk flush boom"
+    ),
+    # The window fail-closed would otherwise deadlock on: the first anchor row
+    # is gone, the second delete fails, and a retry must NOT read that as
+    # "this document never had anchors".
+    "second_anchor_delete": lambda rag, mp: _fail_once(
+        mp, rag.full_relations, "delete", "relations anchor delete boom"
+    ),
+    "anchor_flush": lambda rag, mp: _fail_once(
+        mp, rag.full_relations, "index_done_callback", "anchor flush boom"
+    ),
+    # After the purge is fully done, while the caller still has work left.
+    "full_docs_delete": lambda rag, mp: _fail_once(
+        mp, rag.full_docs, "delete", "full_docs delete boom"
+    ),
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("injection_point", sorted(_DELETE_INJECTION_POINTS))
+async def test_delete_failure_then_retry_converges(
+    tmp_path, monkeypatch, injection_point
+):
+    """Every deletion boundary must converge on retry, never wedge.
+
+    The failure mode this guards against is specific to failing closed: once
+    purge has removed the anchors, a naive retry sees "anchors missing" and
+    refuses forever, making the document permanently undeletable. Each point
+    below is injected once, then the same delete is retried, and the document
+    must end up either gone or still deletable — but never stuck behind a 409.
+    """
+    workspace = f"fim-del-{uuid4().hex[:8]}"
+    doc_id = compute_mdhash_id("del.txt", prefix="doc-")
+
+    rag = await _build_rag(tmp_path, workspace)
+    try:
+        await rag.apipeline_enqueue_documents(input="delete doc", file_paths="del.txt")
+        await rag.apipeline_process_enqueue_documents()
+        assert _status_text(await rag.doc_status.get_by_id(doc_id)) == (
+            DocStatus.PROCESSED.value
+        )
+
+        _DELETE_INJECTION_POINTS[injection_point](rag, monkeypatch)
+        first = await rag.adelete_by_doc_id(doc_id)
+        assert first.status == "fail", (
+            f"{injection_point}: injected failure did not surface"
+        )
+        # Never a recovery-proof refusal on the FIRST attempt: the anchors were
+        # intact when it started.
+        assert first.status_code != 409, f"{injection_point}: {first.message}"
+
+        monkeypatch.undo()
+        second = await rag.adelete_by_doc_id(doc_id)
+
+        assert second.status_code != 409, (
+            f"{injection_point}: retry refused for want of a recovery proof, "
+            f"so the document is permanently undeletable: {second.message}"
+        )
+        if injection_point == "full_docs_delete":
+            # This is the one point PAST the doc_status deletion, so the retry
+            # finds no status record and reports the document already gone.
+            # That ordering is deliberate and predates this work (see the
+            # comment on the delete_doc_entries step): doc_status goes first
+            # precisely so a full_docs failure cannot leave a status row
+            # pointing at missing content. What matters here is that the retry
+            # is not blocked by a missing-anchor refusal.
+            assert second.status == "not_found", f"{second.message}"
+        else:
+            assert second.status == "success", f"{injection_point}: {second.message}"
+            assert await rag.full_docs.get_by_id(doc_id) is None
+        assert await rag.doc_status.get_by_id(doc_id) is None
+
+        # Converged clean: no orphaned contributions, no dangling anchors.
+        report = await audit_kg_integrity(rag)
+        assert report["orphan_entities"] == []
+        assert report["orphan_relations"] == []
+        assert report["missing_entity_anchors"] == {}
+        assert report["missing_relation_anchors"] == {}
+        assert await rag.full_entities.get_by_id(doc_id) is None
+        assert await rag.full_relations.get_by_id(doc_id) is None
+    finally:
+        await rag.finalize_storages()
+
+
 @pytest.mark.asyncio
 async def test_custom_chunk_failure_then_restart_resume_converges(
     tmp_path, monkeypatch
@@ -428,29 +531,22 @@ async def test_audit_tool_detects_true_orphan_after_anchor_loss_and_purge(tmp_pa
     (``_wire_fake_extraction_with_relation``) that produces ALICE, BOB, and
     an edge between them per chunk — unlike the shared
     ``_wire_fake_extraction`` default (ALICE only, no relations) every other
-    test in this file uses. After an ordinary ingest, BOTH the
-    ``full_entities`` AND ``full_relations`` anchor rows are deleted out
-    from under the already-ingested document, then the ordinary
-    whole-document purge runs. With both anchors gone,
-    ``_purge_kg_contributions``'s candidate discovery
-    (``full_entities.get_by_id(doc_id)`` / ``full_relations.get_by_id(doc_id)``)
-    resolves to an empty candidate set on both sides, so neither entity-node
-    removal nor edge removal happens — but chunk deletion proceeds
-    regardless, leaving ALICE, BOB, and the edge between them all pointing
-    at a chunk id that no longer resolves to any document.
+    test in this file uses. After an ordinary ingest, BOTH anchor rows AND
+    the source chunks are removed directly, leaving ALICE, BOB, and the edge
+    between them all pointing at a chunk id that no longer resolves to any
+    document — which is what makes them orphans rather than merely unanchored.
 
-    IMPORTANT: this test asserts the AUDIT TOOL detects the orphans it was
-    built to find — it does NOT assert that purge leaving the nodes/edge
-    behind is correct or desired behavior. It is a known, documented gap
-    (see the module docstring of ``kg_integrity_repair.py``), and this test
-    merely exploits that documented gap to get real orphans on the board so
-    both detection paths are exercised. If a future change closes the gap
-    (e.g. ``_purge_kg_contributions`` learns to discover entities/relations
-    from the graph itself when the anchor row is missing, rather than only
-    from the anchor), ALICE/BOB/their edge would stop being orphaned and
-    this test's ``orphan_entities`` / ``orphan_relations`` assertions would
-    need to be deliberately updated — that is an intentional signal this
-    test is designed to raise, not a regression to work around.
+    NOTE: this construction deliberately does NOT go through purge. It used
+    to: with both anchors gone, candidate discovery resolved to an empty set
+    on both sides, so purge skipped the graph while deleting the chunks
+    anyway, and that was the cheapest way to manufacture real orphans. That
+    was the documented gap this test's previous docstring flagged as an
+    intentional signal — "if a future change closes the gap ... these
+    assertions would need to be deliberately updated". The gap is now closed:
+    purge fails closed with ``RecoveryAnchorMissingError`` instead of
+    silently skipping (see ``test_purge_fail_closed`` /
+    ``test_delete_fail_closed``), so the orphan state has to be constructed
+    by hand. Both detection branches are still exercised exactly as before.
     """
     workspace = f"fim-true-orphan-{uuid4().hex[:8]}"
     doc_id = compute_mdhash_id("orphan.txt", prefix="doc-")
@@ -476,15 +572,16 @@ async def test_audit_tool_detects_true_orphan_after_anchor_loss_and_purge(tmp_pa
         await rag.full_entities.delete([doc_id])
         await rag.full_relations.delete([doc_id])
 
-        status = {"latest_message": "", "history_messages": []}
-        lock = asyncio.Lock()
-        await rag._purge_doc_chunks_and_kg(
-            doc_id, chunk_ids, pipeline_status=status, pipeline_status_lock=lock
-        )
+        # And remove the source chunks, which is what turns the surviving
+        # graph objects from "unanchored but repairable" into true orphans:
+        # their source_id now resolves to nothing, so no owning document can
+        # be determined at all.
+        await rag.text_chunks.delete(chunk_ids)
+        await rag.chunks_vdb.delete(chunk_ids)
+        await rag.text_chunks.index_done_callback()
+        await rag.chunks_vdb.index_done_callback()
 
-        # The purge "succeeded" (no exception, chunk gone) but never
-        # discovered ALICE, BOB, or their edge as delete candidates: both
-        # nodes and the edge survive, now pointing at a chunk id that no
+        # Both nodes and the edge survive, now pointing at a chunk id that no
         # longer resolves to any document.
         assert await rag.chunk_entity_relation_graph.get_node("ALICE") is not None
         assert await rag.chunk_entity_relation_graph.get_node("BOB") is not None

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
@@ -10,6 +11,8 @@ from lightrag import LightRAG, ROLES, RoleLLMConfig
 from lightrag.base import DocStatus
 from lightrag.constants import (
     FULL_DOCS_FORMAT_PENDING_PARSE,
+    KG_WRITE_STATE_METADATA_KEY,
+    KG_WRITE_STATE_PRE_GRAPH,
     PARSED_DIR_NAME,
     PARSER_ENGINE_MINERU,
     PARSER_ENGINE_NATIVE,
@@ -388,6 +391,15 @@ def test_carry_over_keys_grouped_by_stage():
         # operation; must survive every status transition until commit or
         # rollback.
         "custom_chunk_patch",
+        # KG write-progress marker and whole-document purge journal (issue
+        # #3400) — also NOT stage fields, so they join the non-stage tail.
+        # ``kg_write_state`` is the proof that lets a purge clean up a document
+        # that never reached the graph; ``kg_purge`` is what distinguishes
+        # anchors deleted by a purge that got that far from anchors that were
+        # never written. Dropping either at a transition turns a resumable
+        # purge into a permanent fail-closed refusal.
+        "kg_write_state",
+        "kg_purge",
         # Duplicate demotion — NOT stage fields, so they sit after the stage
         # groups and do not disturb the dialog's timeline. ``is_duplicate`` is
         # the predicate every backend uses to exclude a row from its canonical
@@ -732,11 +744,46 @@ def test_apipeline_enqueue_persists_process_options(tmp_path):
     asyncio.run(_run())
 
 
+async def _seed_pre_graph_doc_status(rag: LightRAG, doc_id: str) -> None:
+    """Seed a doc_status row that proves the document never reached the graph.
+
+    Mirrors what enqueue stamps on every new row (``kg_write_state=pre_graph``)
+    and what carry-over preserves until the anchors are written. Whole-document
+    purge needs one of its recovery proofs before it will delete anything
+    (issue #3400), and this is the proof a pre-merge document has.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    await rag.doc_status.upsert(
+        {
+            doc_id: {
+                "status": DocStatus.PROCESSING,
+                "content_summary": "pre-graph doc",
+                "content_length": 13,
+                "chunks_count": 0,
+                "chunks_list": [],
+                "created_at": now,
+                "updated_at": now,
+                "file_path": f"{doc_id}.txt",
+                "track_id": f"track-{doc_id}",
+                "error_msg": "",
+                "metadata": {
+                    KG_WRITE_STATE_METADATA_KEY: KG_WRITE_STATE_PRE_GRAPH,
+                },
+            }
+        }
+    )
+
+
 @pytest.mark.offline
 def test_purge_doc_chunks_and_kg_is_noop_for_empty_chunks(tmp_path):
     """``_purge_doc_chunks_and_kg`` with an empty chunk_ids list must be a
     no-op so callers (including the resume branch) can invoke it
     unconditionally without first checking for non-empty chunks_list.
+
+    Whole-document purge still resolves a recovery proof first (issue #3400),
+    so the document carries the ``kg_write_state`` marker every enqueued
+    document is born with. That proves it never reached a graph mutation, which
+    is what makes the call safe rather than merely quiet.
     """
 
     async def _run():
@@ -748,6 +795,7 @@ def test_purge_doc_chunks_and_kg_is_noop_for_empty_chunks(tmp_path):
         rag = _new_rag(tmp_path)
         await rag.initialize_storages()
         try:
+            await _seed_pre_graph_doc_status(rag, "doc-empty")
             pipeline_status = await get_namespace_data(
                 "pipeline_status", workspace=rag.workspace
             )
@@ -782,6 +830,12 @@ def test_purge_doc_chunks_and_kg_clears_chunks_for_unknown_doc(tmp_path):
     the chunks from chunks_vdb / text_chunks without raising.  This
     exercises the resume path for documents whose previous run was
     interrupted between chunking and entity extraction.
+
+    That interruption window is exactly what ``kg_write_state=pre_graph``
+    records (issue #3400): no anchors exist because merge never ran, and the
+    marker is the proof that lets purge clean up the staged chunks instead of
+    refusing for want of anchors. Without it, absent anchors are
+    indistinguishable from anchors that were lost.
     """
 
     async def _run():
@@ -793,6 +847,7 @@ def test_purge_doc_chunks_and_kg_clears_chunks_for_unknown_doc(tmp_path):
         rag = _new_rag(tmp_path)
         await rag.initialize_storages()
         try:
+            await _seed_pre_graph_doc_status(rag, "doc-X")
             # Seed text_chunks + chunks_vdb with two stale chunks.
             await rag.text_chunks.upsert(
                 {

--- a/tests/pipeline/test_purge_fail_closed.py
+++ b/tests/pipeline/test_purge_fail_closed.py
@@ -470,6 +470,113 @@ async def test_no_chunks_with_empty_anchors_cleans_up_the_stub():
 
 
 # --------------------------------------------------------------------------
+# Proof: nothing attribution-bearing would be deleted
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_scope_needs_no_proof():
+    """No chunks and no populated anchors: nothing to prove.
+
+    Fail-closed exists to stop a purge destroying the chunk rows and anchor
+    rows that are the only record of what a document contributed. An operation
+    that removes neither cannot strand anything, whatever the document's
+    history — so a legacy row enqueued before ``kg_write_state`` existed, still
+    holding no chunks, deletes without a scan or an audit.
+    """
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1"])})
+    rag = _make_rag(
+        graph=graph,
+        full_entities=_KV({}),
+        full_relations=_KV({}),
+        doc_status=_DocStatus({DOC: _status_row()}),  # no marker, no journal
+    )
+
+    await _purge(rag, [])
+
+    # Nothing was destroyed, and the unrelated graph node is untouched.
+    assert graph.reads == []
+    assert graph.removed_nodes == []
+    assert rag.chunks_vdb.deleted == []
+    assert rag.text_chunks.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_empty_scope_does_not_extend_to_a_document_with_chunks():
+    """The moment there are chunks to delete, the proof is required again.
+
+    This is the original defect's exact shape: chunks would go while the graph
+    was skipped, destroying the provenance that makes the survivors
+    attributable.
+    """
+    rag = _make_rag(
+        graph=_Graph(nodes={"ALICE": _node("ALICE", ["c1"])}),
+        full_entities=_KV({}),
+        full_relations=_KV({}),
+        entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1"]}}),
+    )
+
+    with pytest.raises(RecoveryAnchorMissingError):
+        await _purge(rag, ["c1"])
+
+    _assert_nothing_deleted(rag)
+
+
+@pytest.mark.asyncio
+async def test_empty_scope_does_not_extend_to_a_populated_surviving_anchor():
+    """One anchor row missing, the other naming objects, and no chunks.
+
+    Deleting the surviving row would destroy the only record of what those
+    objects belong to, so this is a destructive operation and still needs a
+    proof — the empty-scope reasoning does not reach it.
+    """
+    rag = _make_rag(
+        graph=_Graph(nodes={"ALICE": _node("ALICE", ["c1"])}),
+        full_entities=_KV({DOC: {"entity_names": ["ALICE"], "count": 1}}),
+        full_relations=_KV({}),  # missing
+    )
+
+    with pytest.raises(RecoveryAnchorMissingError) as excinfo:
+        await _purge(rag, [])
+
+    assert excinfo.value.missing_namespaces == ("full_relations",)
+    _assert_nothing_deleted(rag)
+
+
+@pytest.mark.asyncio
+async def test_a_false_pre_graph_marker_would_reproduce_the_original_defect():
+    """Why ``kg_write_state`` must never be inferred from observable state.
+
+    ``pre_graph`` asserts "this document never touched the graph", which
+    licenses deleting its chunks while skipping the graph entirely. That is
+    sound only because the marker is written ONCE, at enqueue, when it is
+    necessarily true — never derived from a document that already has history.
+
+    This test pins what an inferred marker would cost: a backfill keying off a
+    momentarily-empty ``chunks_list`` would stamp a document that does own
+    graph objects, and the stamp is durable, so the damage lands later when the
+    chunks reappear. The empty-scope proof above is safe precisely because it
+    is re-evaluated against live state on every call and grants nothing beyond
+    it.
+    """
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1"])})
+    rag = _make_rag(
+        graph=graph,
+        full_entities=_KV({}),
+        full_relations=_KV({}),
+        entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1"]}}),
+        doc_status=_DocStatus({DOC: _status_row(write_state=KG_WRITE_STATE_PRE_GRAPH)}),
+    )
+
+    await _purge(rag, ["c1"])
+
+    # Chunks gone, entity still there: an orphan nothing can attribute.
+    assert rag.chunks_vdb.deleted == ["c1"]
+    assert graph.removed_nodes == []
+    assert graph.nodes["ALICE"] is not None
+
+
+# --------------------------------------------------------------------------
 # Explicit candidates bypass the proof entirely
 # --------------------------------------------------------------------------
 

--- a/tests/pipeline/test_purge_fail_closed.py
+++ b/tests/pipeline/test_purge_fail_closed.py
@@ -1,0 +1,711 @@
+"""Fail-closed recovery-proof contract for whole-document purge (issue #3400).
+
+A purge learns what a document contributed to the shared knowledge graph from
+its write-ahead recovery anchors (``full_entities`` / ``full_relations``). When
+those rows were absent, candidate resolution collapsed them to an empty list —
+indistinguishable from a legitimately empty anchor — so graph/vector/tracking
+cleanup was skipped while the chunks were still deleted. That strands live
+entities whose provenance can no longer be reconstructed, because the reverse
+lookup runs graph ``source_id`` -> ``text_chunks`` -> ``full_doc_id`` and purge
+just removed those chunks.
+
+These tests pin the replacement contract:
+
+- presence of the anchor ROWS is the proof, never the truthiness of the lists
+  they hold (an empty row is a document that extracted no entities);
+- ``kg_write_state=pre_graph`` is proof on its own, and spends no graph access;
+- with no proof, purge raises before its FIRST write — asserted by checking
+  every storage double recorded nothing;
+- the phase journal makes a partially-failed purge resumable, which is what
+  keeps fail-closed from deadlocking on purge's own anchor deletion;
+- a journal for a different operation is refused rather than resumed, except a
+  ``completed`` one, which is stale bookkeeping rather than a conflict.
+
+In-memory doubles are shared with ``test_purge_primitive`` in spirit but kept
+local so each file states the state it depends on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+
+import pytest
+import lightrag.operate as operate_module
+
+from lightrag import LightRAG
+from lightrag.constants import (
+    GRAPH_FIELD_SEP,
+    KG_PURGE_METADATA_KEY,
+    KG_PURGE_PHASE_ANCHORS_PENDING,
+    KG_PURGE_PHASE_COMPLETED,
+    KG_PURGE_PHASE_DERIVED_COMMITTED,
+    KG_PURGE_PHASE_PREPARED,
+    KG_WRITE_STATE_GRAPH_MUTATION_STARTED,
+    KG_WRITE_STATE_METADATA_KEY,
+    KG_WRITE_STATE_PRE_GRAPH,
+)
+from lightrag.exceptions import (
+    KGPurgeOperationConflictError,
+    RecoveryAnchorMissingError,
+    StorageRecordNotFoundError,
+)
+from lightrag.utils_pipeline import make_kg_purge_operation_id
+
+pytestmark = pytest.mark.offline
+
+DOC = "d1"
+
+
+@pytest.fixture(autouse=True)
+def _storage_keyed_lock_noop(monkeypatch):
+    @asynccontextmanager
+    async def _noop_lock(*args, **kwargs):
+        yield
+
+    monkeypatch.setattr(operate_module, "get_storage_keyed_lock", _noop_lock)
+
+
+class _KV:
+    def __init__(self, data: dict | None = None):
+        self.data = dict(data or {})
+        self.deleted: list[str] = []
+        self.upserted: list[dict] = []
+
+    async def get_by_id(self, key):
+        return self.data.get(key)
+
+    async def get_by_ids(self, keys):
+        return [self.data.get(k) for k in keys]
+
+    async def upsert(self, data):
+        self.upserted.append(dict(data))
+        self.data.update(data)
+
+    async def delete(self, ids):
+        self.deleted.extend(ids)
+        for k in ids:
+            self.data.pop(k, None)
+
+    async def index_done_callback(self):
+        pass
+
+
+class _DocStatus(_KV):
+    async def update_doc_status_fields(self, doc_id, fields, *, missing_ok=False):
+        existing = self.data.get(doc_id)
+        if existing is None:
+            if missing_ok:
+                return
+            raise StorageRecordNotFoundError(doc_id)
+        self.data[doc_id] = {**existing, **fields}
+
+    def journal(self, doc_id: str = DOC) -> dict | None:
+        return (
+            (self.data.get(doc_id) or {}).get("metadata", {}).get(KG_PURGE_METADATA_KEY)
+        )
+
+
+class _Vdb:
+    def __init__(self):
+        self.deleted: list[str] = []
+        self.data: dict = {}
+
+    async def delete(self, ids):
+        self.deleted.extend(ids)
+        for key in ids:
+            self.data.pop(key, None)
+
+    async def upsert(self, data):
+        self.data.update(data)
+
+    async def index_done_callback(self):
+        pass
+
+
+class _Graph:
+    def __init__(self, nodes: dict | None = None, edges: dict | None = None):
+        self.nodes = dict(nodes or {})
+        self.edges = dict(edges or {})
+        self.removed_nodes: list[str] = []
+        self.removed_edges: list[tuple[str, str]] = []
+        self.reads: list[str] = []
+
+    async def get_nodes_batch(self, names):
+        self.reads.append("get_nodes_batch")
+        return {n: dict(self.nodes[n]) if n in self.nodes else None for n in names}
+
+    async def get_edges_batch(self, pairs):
+        self.reads.append("get_edges_batch")
+        out = {}
+        for p in pairs:
+            s, t = p["src"], p["tgt"]
+            edge = self.edges.get((s, t)) or self.edges.get((t, s))
+            out[(s, t)] = dict(edge) if edge else None
+        return out
+
+    async def get_nodes_edges_batch(self, names):
+        self.reads.append("get_nodes_edges_batch")
+        return {n: [] for n in names}
+
+    async def remove_nodes(self, names):
+        self.removed_nodes.extend(names)
+        for n in names:
+            self.nodes.pop(n, None)
+
+    async def remove_edges(self, pairs):
+        self.removed_edges.extend(pairs)
+        for s, t in pairs:
+            self.edges.pop((s, t), None)
+            self.edges.pop((t, s), None)
+
+
+def _node(name: str, sources: list[str]) -> dict:
+    return {
+        "entity_id": name,
+        "description": name,
+        "source_id": GRAPH_FIELD_SEP.join(sources),
+        "entity_type": "X",
+        "file_path": "f",
+    }
+
+
+def _status_row(
+    *,
+    write_state: str | None = None,
+    purge_journal: dict | None = None,
+    patch_journal: dict | None = None,
+) -> dict:
+    metadata: dict = {}
+    if write_state is not None:
+        metadata[KG_WRITE_STATE_METADATA_KEY] = write_state
+    if purge_journal is not None:
+        metadata[KG_PURGE_METADATA_KEY] = purge_journal
+    if patch_journal is not None:
+        metadata["custom_chunk_patch"] = patch_journal
+    return {"status": "processed", "chunks_list": [], "metadata": metadata}
+
+
+def _journal(phase: str, chunk_ids: list[str], *, doc_id: str = DOC) -> dict:
+    return {
+        "schema_version": 1,
+        "operation_id": make_kg_purge_operation_id(doc_id, chunk_ids),
+        "phase": phase,
+        "chunk_count": len(chunk_ids),
+        "updated_at": 0,
+    }
+
+
+def _make_rag(
+    *,
+    graph: _Graph | None = None,
+    full_entities: _KV | None = None,
+    full_relations: _KV | None = None,
+    entity_chunks: _KV | None = None,
+    doc_status: _DocStatus | None = None,
+) -> LightRAG:
+    rag = LightRAG.__new__(LightRAG)
+    rag.chunk_entity_relation_graph = graph if graph is not None else _Graph()
+    rag.full_entities = full_entities if full_entities is not None else _KV()
+    rag.full_relations = full_relations if full_relations is not None else _KV()
+    rag.entity_chunks = entity_chunks if entity_chunks is not None else _KV()
+    rag.relation_chunks = _KV()
+    rag.chunks_vdb = _Vdb()
+    rag.entities_vdb = _Vdb()
+    rag.relationships_vdb = _Vdb()
+    rag.text_chunks = _KV()
+    rag.llm_response_cache = _KV()
+    rag.doc_status = (
+        doc_status if doc_status is not None else _DocStatus({DOC: _status_row()})
+    )
+
+    async def _noop_insert_done(*args, **kwargs):
+        return None
+
+    rag._insert_done = _noop_insert_done
+    rag._build_global_config = lambda: {
+        "llm_model_max_async": 1,
+        "max_source_ids_per_entity": 100,
+        "max_source_ids_per_relation": 100,
+        "source_ids_limit_method": "KEEP",
+        "max_file_paths": 100,
+        "file_path_more_placeholder": "more",
+    }
+    return rag
+
+
+def _status():
+    return {"latest_message": "", "history_messages": []}, asyncio.Lock()
+
+
+def _assert_nothing_deleted(rag: LightRAG) -> None:
+    """Fail-closed means the raise happened BEFORE the first write."""
+    graph = rag.chunk_entity_relation_graph
+    assert graph.removed_nodes == []
+    assert graph.removed_edges == []
+    assert rag.chunks_vdb.deleted == []
+    assert rag.entities_vdb.deleted == []
+    assert rag.relationships_vdb.deleted == []
+    assert rag.text_chunks.deleted == []
+    assert rag.entity_chunks.deleted == []
+    assert rag.relation_chunks.deleted == []
+    assert rag.full_entities.deleted == []
+    assert rag.full_relations.deleted == []
+
+
+async def _purge(rag: LightRAG, chunk_ids: list[str], doc_id: str = DOC):
+    status, lock = _status()
+    return await rag._purge_kg_contributions(
+        doc_id, chunk_ids, pipeline_status=status, pipeline_status_lock=lock
+    )
+
+
+# --------------------------------------------------------------------------
+# Proof: the anchor rows
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_anchor_rows_are_a_valid_proof():
+    """Present-but-empty anchors mean "extracted nothing", not "unknown".
+
+    Collapsing the two is the original defect, so this is the single most
+    important distinction in the contract.
+    """
+    rag = _make_rag(
+        full_entities=_KV({DOC: {"entity_names": [], "count": 0}}),
+        full_relations=_KV({DOC: {"relation_pairs": [], "count": 0}}),
+    )
+
+    await _purge(rag, ["c1"])
+
+    assert rag.chunks_vdb.deleted == ["c1"]
+    assert rag.text_chunks.deleted == ["c1"]
+    # Whole-document mode still retires the anchors at the end.
+    assert rag.full_entities.deleted == [DOC]
+    assert rag.full_relations.deleted == [DOC]
+
+
+@pytest.mark.parametrize(
+    "seed_entities, seed_relations, expected_missing",
+    [
+        (False, True, ("full_entities",)),
+        (True, False, ("full_relations",)),
+        (False, False, ("full_entities", "full_relations")),
+    ],
+    ids=["entities_row_gone", "relations_row_gone", "both_rows_gone"],
+)
+@pytest.mark.asyncio
+async def test_missing_anchor_row_refuses_without_deleting(
+    seed_entities, seed_relations, expected_missing
+):
+    """Either row missing is enough to refuse: both are needed to account for
+    a document's contributions, and a half-present pair is not a proof."""
+    rag = _make_rag(
+        graph=_Graph(nodes={"ALICE": _node("ALICE", ["c1"])}),
+        full_entities=_KV(
+            {DOC: {"entity_names": ["ALICE"], "count": 1}} if seed_entities else {}
+        ),
+        full_relations=_KV(
+            {DOC: {"relation_pairs": [], "count": 0}} if seed_relations else {}
+        ),
+        entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1"]}}),
+    )
+
+    with pytest.raises(RecoveryAnchorMissingError) as excinfo:
+        await _purge(rag, ["c1"])
+
+    assert excinfo.value.reason == RecoveryAnchorMissingError.REASON_MISSING_ANCHOR_ROWS
+    assert excinfo.value.doc_id == DOC
+    assert excinfo.value.missing_namespaces == expected_missing
+    assert "audit_kg_integrity" in str(excinfo.value)
+    _assert_nothing_deleted(rag)
+
+
+@pytest.mark.asyncio
+async def test_structurally_broken_anchor_row_is_not_a_proof():
+    """A row whose payload is the wrong shape cannot be trusted as a candidate
+    list, so it is treated as missing rather than silently read as empty."""
+    rag = _make_rag(
+        full_entities=_KV({DOC: {"entity_names": "ALICE"}}),  # str, not list
+        full_relations=_KV({DOC: {"relation_pairs": [], "count": 0}}),
+    )
+
+    with pytest.raises(RecoveryAnchorMissingError) as excinfo:
+        await _purge(rag, ["c1"])
+
+    assert excinfo.value.missing_namespaces == ("full_entities",)
+    _assert_nothing_deleted(rag)
+
+
+@pytest.mark.asyncio
+async def test_graph_mutation_started_does_not_excuse_missing_anchors():
+    """The marker only helps while it still says ``pre_graph``."""
+    rag = _make_rag(
+        doc_status=_DocStatus(
+            {DOC: _status_row(write_state=KG_WRITE_STATE_GRAPH_MUTATION_STARTED)}
+        ),
+    )
+
+    with pytest.raises(RecoveryAnchorMissingError):
+        await _purge(rag, ["c1"])
+
+    _assert_nothing_deleted(rag)
+
+
+@pytest.mark.asyncio
+async def test_unknown_write_state_refuses():
+    """A pre-#3416 document has no marker at all; unknown must fail closed."""
+    rag = _make_rag(doc_status=_DocStatus({DOC: _status_row()}))
+
+    with pytest.raises(RecoveryAnchorMissingError) as excinfo:
+        await _purge(rag, ["c1"])
+
+    assert "kg_write_state=unknown" in str(excinfo.value)
+    _assert_nothing_deleted(rag)
+
+
+@pytest.mark.asyncio
+async def test_absent_doc_status_row_refuses():
+    """No doc_status row means no marker and no journal — still fail closed."""
+    rag = _make_rag(doc_status=_DocStatus({}))
+
+    with pytest.raises(RecoveryAnchorMissingError):
+        await _purge(rag, ["c1"])
+
+    _assert_nothing_deleted(rag)
+
+
+# --------------------------------------------------------------------------
+# Proof: kg_write_state=pre_graph
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_graph_cleans_staged_chunks_without_touching_the_graph():
+    """Proven never to have merged, so the staged chunks can go and the graph
+    is not read at all — the candidate set is explicitly empty rather than
+    inferred from unreadable anchors."""
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1"])})
+    rag = _make_rag(
+        graph=graph,
+        doc_status=_DocStatus({DOC: _status_row(write_state=KG_WRITE_STATE_PRE_GRAPH)}),
+    )
+
+    await _purge(rag, ["c1"])
+
+    assert rag.chunks_vdb.deleted == ["c1"]
+    assert rag.text_chunks.deleted == ["c1"]
+    # No graph access whatsoever, and the unrelated node survives.
+    assert graph.reads == []
+    assert graph.removed_nodes == []
+    assert graph.nodes["ALICE"] is not None
+
+
+@pytest.mark.asyncio
+async def test_pre_graph_still_purges_patch_journal_candidates():
+    """A patch-mode merge mutates the graph without writing anchors, so a
+    ``pre_graph`` document CAN own graph objects — exactly the ones its
+    custom-chunk journal names. Those must still be cleaned."""
+    graph = _Graph(nodes={"BOB": _node("BOB", ["c1"])})
+    rag = _make_rag(
+        graph=graph,
+        entity_chunks=_KV({"BOB": {"chunk_ids": ["c1"]}}),
+        doc_status=_DocStatus(
+            {
+                DOC: _status_row(
+                    write_state=KG_WRITE_STATE_PRE_GRAPH,
+                    patch_journal={"entity_names": ["BOB"], "relation_pairs": []},
+                )
+            }
+        ),
+    )
+
+    await _purge(rag, ["c1"])
+
+    assert graph.removed_nodes == ["BOB"]
+    assert rag.chunks_vdb.deleted == ["c1"]
+
+
+# --------------------------------------------------------------------------
+# Anchors that name objects the purge cannot classify
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_chunks_but_populated_anchors_refuses():
+    """With no chunk ids there is nothing to subtract from those objects'
+    source lists, so every one would be kept while the anchors were dropped
+    anyway — the same orphan outcome, hence its own refusal reason."""
+    rag = _make_rag(
+        graph=_Graph(nodes={"ALICE": _node("ALICE", ["c1"])}),
+        full_entities=_KV({DOC: {"entity_names": ["ALICE"], "count": 1}}),
+        full_relations=_KV({DOC: {"relation_pairs": [], "count": 0}}),
+    )
+
+    with pytest.raises(RecoveryAnchorMissingError) as excinfo:
+        await _purge(rag, [])
+
+    assert (
+        excinfo.value.reason
+        == RecoveryAnchorMissingError.REASON_CHUNKLESS_CONTRIBUTIONS
+    )
+    assert "no chunks to attribute them to" in str(excinfo.value)
+    _assert_nothing_deleted(rag)
+
+
+@pytest.mark.asyncio
+async def test_no_chunks_with_empty_anchors_cleans_up_the_stub():
+    """Nothing to strand, so the two empty rows are removed rather than left
+    keyed to a document that is about to disappear."""
+    rag = _make_rag(
+        full_entities=_KV({DOC: {"entity_names": [], "count": 0}}),
+        full_relations=_KV({DOC: {"relation_pairs": [], "count": 0}}),
+    )
+
+    await _purge(rag, [])
+
+    assert rag.full_entities.deleted == [DOC]
+    assert rag.full_relations.deleted == [DOC]
+
+
+# --------------------------------------------------------------------------
+# Explicit candidates bypass the proof entirely
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explicit_candidates_need_no_proof_and_write_no_journal():
+    """Custom-chunk rollback carries its own operation journal naming the
+    complete candidate superset, so it neither consults the anchors nor
+    journals a purge phase."""
+
+    class _ExplodingKV(_KV):
+        async def get_by_id(self, key):
+            raise AssertionError("anchor row must not be read")
+
+    doc_status = _DocStatus({DOC: _status_row()})
+    rag = _make_rag(
+        graph=_Graph(nodes={"ALICE": _node("ALICE", ["c1"])}),
+        full_entities=_ExplodingKV(),
+        full_relations=_ExplodingKV(),
+        entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1"]}}),
+        doc_status=doc_status,
+    )
+    status, lock = _status()
+
+    await rag._purge_kg_contributions(
+        DOC,
+        ["c1"],
+        candidate_entities=["ALICE"],
+        candidate_relations=[],
+        patch_only=True,
+        pipeline_status=status,
+        pipeline_status_lock=lock,
+    )
+
+    assert rag.chunk_entity_relation_graph.removed_nodes == ["ALICE"]
+    assert doc_status.journal() is None
+
+
+# --------------------------------------------------------------------------
+# The phase journal: resume, and the deadlock it prevents
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_successful_purge_walks_every_phase_in_order():
+    doc_status = _DocStatus({DOC: _status_row()})
+    phases: list[str] = []
+    rag = _make_rag(
+        full_entities=_KV({DOC: {"entity_names": [], "count": 0}}),
+        full_relations=_KV({DOC: {"relation_pairs": [], "count": 0}}),
+        doc_status=doc_status,
+    )
+    original = rag._write_kg_purge_phase
+
+    async def spy(doc_id, phase, **kwargs):
+        phases.append(phase)
+        await original(doc_id, phase, **kwargs)
+
+    rag._write_kg_purge_phase = spy
+
+    await _purge(rag, ["c1"])
+
+    assert phases == [
+        KG_PURGE_PHASE_PREPARED,
+        KG_PURGE_PHASE_DERIVED_COMMITTED,
+        KG_PURGE_PHASE_ANCHORS_PENDING,
+        KG_PURGE_PHASE_COMPLETED,
+    ]
+    assert doc_status.journal()["phase"] == KG_PURGE_PHASE_COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_anchors_pending_journal_survives_anchor_loss():
+    """The deadlock fail-closed would otherwise create.
+
+    Purge's last step deletes the anchors. A failure after the FIRST anchor
+    delete leaves them half-gone, and without the journal every retry would
+    see "anchors missing" and refuse forever.
+    """
+    doc_status = _DocStatus(
+        {
+            DOC: _status_row(
+                purge_journal=_journal(KG_PURGE_PHASE_ANCHORS_PENDING, ["c1"])
+            )
+        }
+    )
+    # full_entities already deleted by the failed attempt; only relations left.
+    rag = _make_rag(
+        full_entities=_KV({}),
+        full_relations=_KV({DOC: {"relation_pairs": [], "count": 0}}),
+        doc_status=doc_status,
+    )
+
+    await _purge(rag, ["c1"])
+
+    assert rag.full_relations.deleted == [DOC]
+    assert doc_status.journal()["phase"] == KG_PURGE_PHASE_COMPLETED
+    # Chunks were already deleted by the failed attempt; not deleted twice.
+    assert rag.chunks_vdb.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_derived_committed_journal_skips_the_expensive_pass():
+    """Resume must not re-run candidate analysis or the LLM-cache-backed
+    rebuild — it jumps straight to deleting the chunks."""
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1"])})
+    rag = _make_rag(
+        graph=graph,
+        full_entities=_KV({}),
+        full_relations=_KV({}),
+        doc_status=_DocStatus(
+            {
+                DOC: _status_row(
+                    purge_journal=_journal(KG_PURGE_PHASE_DERIVED_COMMITTED, ["c1"])
+                )
+            }
+        ),
+    )
+
+    await _purge(rag, ["c1"])
+
+    assert graph.reads == []
+    assert graph.removed_nodes == []
+    assert rag.chunks_vdb.deleted == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_prepared_journal_reruns_the_derived_pass():
+    """``prepared`` means nothing was deleted yet, so it is NOT a proof on its
+    own — the anchors must still be readable."""
+    doc_status = _DocStatus(
+        {DOC: _status_row(purge_journal=_journal(KG_PURGE_PHASE_PREPARED, ["c1"]))}
+    )
+    rag = _make_rag(
+        full_entities=_KV({}), full_relations=_KV({}), doc_status=doc_status
+    )
+
+    with pytest.raises(RecoveryAnchorMissingError):
+        await _purge(rag, ["c1"])
+
+    _assert_nothing_deleted(rag)
+
+
+@pytest.mark.asyncio
+async def test_completed_journal_for_the_same_operation_is_a_noop():
+    """A retry of the caller's post-purge finalization must not redo the purge
+    — nor trip the missing-anchor refusal now that the anchors are gone."""
+    graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1"])})
+    rag = _make_rag(
+        graph=graph,
+        full_entities=_KV({}),
+        full_relations=_KV({}),
+        doc_status=_DocStatus(
+            {DOC: _status_row(purge_journal=_journal(KG_PURGE_PHASE_COMPLETED, ["c1"]))}
+        ),
+    )
+
+    await _purge(rag, ["c1"])
+
+    _assert_nothing_deleted(rag)
+    assert graph.reads == []
+
+
+@pytest.mark.asyncio
+async def test_in_flight_journal_for_a_different_operation_is_refused():
+    """A changed chunk set means the journaled phase describes work on a
+    different set, so resuming from it would skip cleanup for the difference."""
+    doc_status = _DocStatus(
+        {
+            DOC: _status_row(
+                purge_journal=_journal(KG_PURGE_PHASE_ANCHORS_PENDING, ["c1"])
+            )
+        }
+    )
+    rag = _make_rag(doc_status=doc_status)
+
+    with pytest.raises(KGPurgeOperationConflictError) as excinfo:
+        await _purge(rag, ["c1", "c2"])
+
+    assert excinfo.value.doc_id == DOC
+    assert excinfo.value.requested_operation_id == make_kg_purge_operation_id(
+        DOC, ["c1", "c2"]
+    )
+    assert excinfo.value.journal_operation_id == make_kg_purge_operation_id(DOC, ["c1"])
+    _assert_nothing_deleted(rag)
+
+
+@pytest.mark.asyncio
+async def test_stale_completed_journal_for_a_different_operation_is_ignored():
+    """A finished purge holds no resume information worth protecting, and its
+    retirement is a separate write a crash can skip — so a stale one must not
+    refuse the next purge forever over dead bookkeeping."""
+    rag = _make_rag(
+        full_entities=_KV({DOC: {"entity_names": [], "count": 0}}),
+        full_relations=_KV({DOC: {"relation_pairs": [], "count": 0}}),
+        doc_status=_DocStatus(
+            {
+                DOC: _status_row(
+                    purge_journal=_journal(KG_PURGE_PHASE_COMPLETED, ["old"])
+                )
+            }
+        ),
+    )
+
+    await _purge(rag, ["c1"])
+
+    assert rag.chunks_vdb.deleted == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_operation_id_ignores_chunk_order_and_duplicates():
+    """The chunk list is assembled from chunks_list unioned with a journal, so
+    its order is an artifact; only the SET determines what gets deleted."""
+    assert make_kg_purge_operation_id(DOC, ["a", "b"]) == make_kg_purge_operation_id(
+        DOC, ["b", "a", "b"]
+    )
+    assert make_kg_purge_operation_id(DOC, ["a"]) != make_kg_purge_operation_id(
+        DOC, ["a", "b"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_journal_write_failure_aborts_before_any_deletion():
+    """If the journal cannot be persisted, the purge must not proceed: a crash
+    later would then be indistinguishable from a never-anchored document."""
+    rag = _make_rag(
+        full_entities=_KV({DOC: {"entity_names": [], "count": 0}}),
+        full_relations=_KV({DOC: {"relation_pairs": [], "count": 0}}),
+    )
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("journal write boom")
+
+    rag._write_kg_purge_phase = boom
+
+    with pytest.raises(RuntimeError, match="journal write boom"):
+        await _purge(rag, ["c1"])
+
+    _assert_nothing_deleted(rag)

--- a/tests/pipeline/test_purge_primitive.py
+++ b/tests/pipeline/test_purge_primitive.py
@@ -21,7 +21,8 @@ import pytest
 import lightrag.operate as operate_module
 
 from lightrag import LightRAG
-from lightrag.constants import GRAPH_FIELD_SEP
+from lightrag.constants import GRAPH_FIELD_SEP, KG_PURGE_METADATA_KEY
+from lightrag.exceptions import StorageRecordNotFoundError
 from lightrag.utils import compute_mdhash_id, make_relation_chunk_key
 
 
@@ -55,6 +56,27 @@ class _KV:
 
     async def index_done_callback(self):
         pass
+
+
+class _DocStatus(_KV):
+    """Minimal ``doc_status`` double: enough for the purge journal writes.
+
+    Whole-document purge is journaled (issue #3400 fail-closed purge), so the
+    primitive now reads and writes ``doc_status.metadata`` around its phases.
+    """
+
+    async def update_doc_status_fields(self, doc_id, fields, *, missing_ok=False):
+        existing = self.data.get(doc_id)
+        if existing is None:
+            if missing_ok:
+                return
+            raise StorageRecordNotFoundError(doc_id)
+        self.data[doc_id] = {**existing, **fields}
+
+    def journal(self, doc_id: str = "d1") -> dict | None:
+        return (self.data.get(doc_id) or {}).get("metadata", {}).get(
+            KG_PURGE_METADATA_KEY
+        )
 
 
 class _Vdb:
@@ -154,9 +176,15 @@ def _make_rag(
     relation_chunks: _KV | None = None,
     text_chunks: _KV | None = None,
     llm_cache: _KV | None = None,
+    doc_status: _DocStatus | None = None,
 ) -> LightRAG:
     rag = LightRAG.__new__(LightRAG)
     rag.chunk_entity_relation_graph = graph
+    # Default: a plain doc_status row with no purge journal and no recorded
+    # kg_write_state — i.e. the recovery proof must come from the anchor rows.
+    rag.doc_status = (
+        doc_status if doc_status is not None else _DocStatus({"d1": {"metadata": {}}})
+    )
     rag.full_entities = full_entities if full_entities is not None else _KV()
     rag.full_relations = full_relations if full_relations is not None else _KV()
     rag.entity_chunks = entity_chunks if entity_chunks is not None else _KV()
@@ -293,12 +321,23 @@ async def test_absent_candidates_are_idempotent_noops():
 @pytest.mark.offline
 @pytest.mark.asyncio
 async def test_empty_chunk_ids_returns_without_touching_storage():
+    """Explicit-candidate (patch rollback) mode keeps the historical early-out.
+
+    Whole-document mode no longer short-circuits on an empty chunk set — it
+    must still resolve a recovery proof, because "no chunks" plus non-empty
+    anchors is itself an unpurgeable state (see the fail-closed suite).
+    """
     graph = _Graph(nodes={"ALICE": _node("ALICE", ["c1"])})
     rag = _make_rag(graph=graph)
     status, lock = _status()
 
     await rag._purge_kg_contributions(
-        "d1", [], pipeline_status=status, pipeline_status_lock=lock
+        "d1",
+        [],
+        candidate_entities=[],
+        candidate_relations=[],
+        pipeline_status=status,
+        pipeline_status_lock=lock,
     )
 
     assert graph.removed_nodes == []
@@ -377,6 +416,9 @@ async def test_graph_delete_failure_keeps_chunks_and_anchors():
     rag = _make_rag(
         graph=graph,
         full_entities=_KV({"d1": {"entity_names": ["ALICE"], "count": 1}}),
+        # Both anchor rows, as real ingestion always writes them (empty rows
+        # included) — a whole-document purge needs both present as its proof.
+        full_relations=_KV({"d1": {"relation_pairs": [], "count": 0}}),
         entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1"]}}),
     )
     status, lock = _status()
@@ -401,6 +443,7 @@ async def test_chunk_delete_failure_keeps_recovery_rows(monkeypatch):
     rag = _make_rag(
         graph=graph,
         full_entities=_KV({"d1": {"entity_names": ["ALICE"], "count": 1}}),
+        full_relations=_KV({"d1": {"relation_pairs": [], "count": 0}}),
         entity_chunks=_KV({"ALICE": {"chunk_ids": ["c1"]}}),
     )
 

--- a/tests/pipeline/test_purge_primitive.py
+++ b/tests/pipeline/test_purge_primitive.py
@@ -74,8 +74,8 @@ class _DocStatus(_KV):
         self.data[doc_id] = {**existing, **fields}
 
     def journal(self, doc_id: str = "d1") -> dict | None:
-        return (self.data.get(doc_id) or {}).get("metadata", {}).get(
-            KG_PURGE_METADATA_KEY
+        return (
+            (self.data.get(doc_id) or {}).get("metadata", {}).get(KG_PURGE_METADATA_KEY)
         )
 
 


### PR DESCRIPTION
## Description

Implements fail-closed recovery proof contract for whole-document KG purge (issue #3400). Previously, when recovery anchor rows (`full_entities`/`full_relations`) were missing, purge would treat them as "no contributions" and silently skip graph cleanup while still deleting chunks. This left unattributable entities stranded in the graph permanently.

This change makes purge fail closed before any writes when recovery proof is absent, guaranteeing data safety. The governing invariant: a purge must never delete something that *carries attribution* — a chunk row, or an anchor row that names objects — while leaving those objects in the graph. Four forms of proof satisfy it:
1. **Anchor rows present** — the primary proof (even if empty, which means "extracted nothing")
2. **`kg_write_state=pre_graph`** — document never reached graph mutations
3. **Purge journal** — previous attempt already deleted anchors legitimately
4. **`empty_scope`** — no chunks and no populated anchor row, so nothing attribution-bearing would be deleted; needs no proof at all (this is what keeps still-queued legacy rows deletable)

## Related Issues

- Issue #3400: Fail-closed whole-document purge with recovery proof

## Changes Made

### Core Implementation
- **`lightrag/lightrag.py`**: 
  - Added `_PurgeRecoveryProof` dataclass to represent proof state
  - Added `_PurgeStageError` exception to track which purge step failed
  - Implemented `_resolve_purge_recovery_proof()` to validate recovery proof before deletion
  - Implemented `_raise_missing_recovery_proof()` to provide actionable error messages
  - Implemented `_write_kg_purge_phase()` to journal purge progress for resumability
  - Implemented `_patch_journal_candidates()` to handle in-flight custom-chunk patches
  - Modified `_update_delete_retry_state()` to use targeted field updates instead of full upsert (preserves concurrent purge journal writes)
  - Added the `empty_scope` proof kind: an operation that removes no attribution carrier needs no proof, re-evaluated against live state on every call (never persisted)
  - Hardened every doc_status read backing KG recovery-state writes (`_resolve_purge_recovery_proof`, `_write_kg_purge_phase`, `_clear_kg_purge_journal`, `_update_delete_retry_state`) to strict point reads via the new `require_doc_status_record` helper — a masked read failure (e.g. OpenSearch reading a not-ready index as `None`) can no longer run a destructive purge unjournaled or clobber the journal with a pre-deletion snapshot
  - Integrated purge primitive into deletion path with recovery proof validation

### Constants & Exceptions
- **`lightrag/constants.py`**: Added KG purge phase constants and metadata keys
- **`lightrag/exceptions.py`**: Added `RecoveryAnchorMissingError` and `KGPurgeOperationConflictError` with detailed reason codes

### Pipeline & Utilities
- **`lightrag/pipeline.py`**: 
  - Initialize `kg_write_state=pre_graph` on document birth (issue #3400)
  - Carry forward KG recovery state through status transitions
  - `_mark_graph_mutation_started` advances the marker in the one window where it flips (anchors durable, first mutation pending) and now aborts the merge when the doc_status row cannot be read — proceeding would write the graph while the stored marker still says `pre_graph`, a false proof
- **`lightrag/utils_pipeline.py`**: 
  - Added helper functions for KG purge journal and write state access
  - Updated metadata carry-over whitelist to preserve recovery state
- **`lightrag/operate.py`**: Added `on_anchors_durable` callback hook for purge journal durability

### Tools & Storage
- **`lightrag/tools/kg_integrity_repair.py`**: the audit certifies documents that legitimately own nothing in the graph (`anchorless_docs`; `apply=True` writes them the present-and-empty anchor pair) — the remedy for legacy `skip_kg` documents that anchor repair alone could never unblock. The doc_status enumeration is strict and batched, and failures propagate instead of being certified over
- **`lightrag/kg/postgres_impl.py`**: AGE `get_all_nodes` / `get_all_edges` are complete-or-raise — corrupt `properties` payloads raise `PGGraphQueryException` instead of silently dropping the node or blanking the edge's `source_id` (a dropped attribution is how a contributing document could be falsely certified empty)
- **`lightrag/storage_migrations.py`**: the chunk-tracking backfill aborts on a failed graph read instead of recording a "completed" backfill built from nothing

### Tests
- **`tests/pipeline/test_purge_fail_closed.py`** (new, ~820 lines): the fail-closed contract at the primitive level
  - Empty anchor rows as valid proof
  - Missing anchor row refusal without deletion
  - `kg_write_state=pre_graph` as standalone proof
  - `empty_scope` boundaries (chunks present ⇒ proof required; a populated surviving anchor row is a carrier)
  - Why a backfilled `pre_graph` marker would reproduce the original defect (pinned so nobody adds one)
  - Journal-based resumability, operation conflict detection, stale journal retirement
  
- **`tests/pipeline/test_delete_fail_closed.py`** (new, ~1,030 lines): end-to-end over real JSON/NetworkX storages
  - Deletion refusal when anchors lost; `audit_kg_integrity` repair closes the loop; retry succeeds after repair
  - Anchorless certification: legacy `skip_kg` documents become deletable, documents that own graph objects are never blanked
  - Zero-entity extraction deletes end to end (row presence, not list truthiness)
  - Masked doc_status read failures abort the merge / refuse the purge / never clobber the journal (all four fail behaviorally on the previous implementation)
  
- **`tests/kg/postgres_impl/test_postgres_get_all_complete_or_raise.py`** (new): AGE enumeration raises on corrupt properties instead of degrading
  
- **`tests/pipeline/test_fault_injection_matrix.py`**: Added 40+ injection points for deletion saga failure scenarios
- **`tests/extraction/test_write_ahead_indexes.py`**: Added tests for `on_anchors_durable` hook
- **`tests/pipeline/test_doc_status_*.py`**: Updated to verify KG recovery state preservation

## Checklist

- [x] Changes tested locally (extensive test suite added)
- [x] Code reviewed (internal)
- [x] Documentation updated (README_KG_INTEGRITY_REPAIR.md, AGENTS.md)
- [x] Unit tests added (2,000+ lines of new tests covering all scenarios)

## Additional Notes

The implementation is fail-closed by design: `_resolve_purge_recovery_proof()` is called before any storage writes, and raises `RecoveryAnchorMissingError` before the first write when no proof applies.

## Behavior changes (release notes)

- **Deleting a document without recovery proof now refuses with HTTP 409 instead of reporting success.** Documents ingested before #3416 introduced the write-ahead anchors — and `ainsert_custom_kg` documents, which are documented as outside the document-level guarantee — have neither anchor rows nor a `kg_write_state` marker. Previously such a delete reported success while silently leaving the document's entities/relations in the graph as permanent, unattributable orphans. Now it refuses before deleting anything. **Remedy**: run `audit_kg_integrity(..., apply=True)` (`python -m lightrag.tools.kg_integrity_repair --apply`) once while the server is idle, then retry. Documents that legitimately own nothing (e.g. legacy `skip_kg` ingests) are certified by the same audit run (`anchorless_docs`); queued documents with no chunks and no populated anchors delete directly via the `empty_scope` rule, no audit needed.
- **`audit_kg_integrity` report gains an `anchorless_docs` field**, and the audit now fails loudly (strict `doc_status` enumeration, propagated errors) instead of certifying from a partial scan.
- **AGE (PostgreSQL) graph enumeration is now complete-or-raise**: corrupt `properties` payloads raise `PGGraphQueryException` in `get_all_nodes` / `get_all_edges` instead of silently dropping the node or blanking the edge's `source_id` attribution. The startup chunk-tracking backfill correspondingly aborts on a failed graph read instead of recording an empty backfill.
- **Backend read failures during merge/purge now abort instead of proceeding.** On backends with strict point reads (all shipped doc_status backends), a doc_status row that cannot be read aborts the merge before its first graph mutation, or the purge before its first destructive write; a deletion retry-state write that cannot re-read the row is skipped rather than rebuilt from a stale snapshot. Previously a masked read failure could leave a stale `pre_graph` marker while the graph was written, run a destructive purge unjournaled, or erase the purge journal — each a path back to the unprovable states this PR exists to prevent.
- **New reserved `doc_status.metadata` keys**: `kg_write_state` (monotonic write-progress marker) and `kg_purge` (resumable purge journal). Both survive status transitions and FAILED→PENDING resets by design.

https://claude.ai/code/session_01MajQBcN6EnYYkMpvmzDxVT

