### PR TITLE
[DOC] fix documentation typos, grammar errors, and incorrect warning messages

### DIFF
--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -140,7 +140,7 @@ class QueryParam:
     ll_keywords: list[str] = field(default_factory=list)
     """List of low-level keywords to refine retrieval focus."""
 
-    # History mesages is only send to LLM for context, not used for retrieval
+    # History messages are only sent to LLM for context, not used for retrieval
     conversation_history: list[dict[str, str]] = field(default_factory=list)
     """Stores past conversation history to maintain context.
     Format: [{"role": "user/assistant", "content": "message"}].
@@ -148,8 +148,8 @@ class QueryParam:
 
     user_prompt: str | None = None
     """User-provided prompt for the query.
-    Addition instructions for LLM. If provided, this will be inject into the prompt template.
-    It's purpose is the let user customize the way LLM generate the response.
+    Additional instructions for LLM. If provided, this will be injected into the prompt template.
+    Its purpose is to let the user customize the way LLM generates the response.
     """
 
     enable_rerank: bool = os.getenv("RERANK_BY_DEFAULT", "true").lower() == "true"
@@ -288,7 +288,7 @@ class BaseVectorStorage(StorageNameSpace, ABC):
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         """Insert or update vectors in the storage.
 
-        Importance notes for in-memory storage:
+        Important notes for in-memory storage:
         1. Changes will be persisted to disk during the next index_done_callback
         2. Only one process should updating the storage at a time before index_done_callback,
            KG-storage-log should be used to avoid data corruption
@@ -308,7 +308,7 @@ class BaseVectorStorage(StorageNameSpace, ABC):
     async def delete_entity(self, entity_name: str) -> None:
         """Delete a single entity by its name.
 
-        Importance notes for in-memory storage:
+        Important notes for in-memory storage:
         1. Changes will be persisted to disk during the next index_done_callback
         2. Only one process should updating the storage at a time before index_done_callback,
            KG-storage-log should be used to avoid data corruption
@@ -321,7 +321,7 @@ class BaseVectorStorage(StorageNameSpace, ABC):
     async def delete_entity_relation(self, entity_name: str) -> None:
         """Delete relations for a given entity.
 
-        Importance notes for in-memory storage:
+        Important notes for in-memory storage:
         1. Changes will be persisted to disk during the next index_done_callback
         2. Only one process should updating the storage at a time before index_done_callback,
            KG-storage-log should be used to avoid data corruption
@@ -360,7 +360,7 @@ class BaseVectorStorage(StorageNameSpace, ABC):
     async def delete(self, ids: list[str]):
         """Delete vectors with specified IDs
 
-        Importance notes for in-memory storage:
+        Important notes for in-memory storage:
         1. Changes will be persisted to disk during the next index_done_callback
         2. Only one process should updating the storage at a time before index_done_callback,
            KG-storage-log should be used to avoid data corruption
@@ -438,13 +438,13 @@ class BaseKVStorage(StorageNameSpace, ABC):
 
     @abstractmethod
     async def filter_keys(self, keys: set[str]) -> set[str]:
-        """Return un-exist keys"""
+        """Return keys that do not exist in storage."""
 
     @abstractmethod
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         """Upsert data
 
-        Importance notes for in-memory storage:
+        Important notes for in-memory storage:
         1. Changes will be persisted to disk during the next index_done_callback
         2. update flags to notify other processes that data persistence is needed
 
@@ -464,7 +464,7 @@ class BaseKVStorage(StorageNameSpace, ABC):
     async def delete(self, ids: list[str]) -> None:
         """Delete specific records from storage by their IDs
 
-        Importance notes for in-memory storage:
+        Important notes for in-memory storage:
         1. Changes will be persisted to disk during the next index_done_callback
         2. update flags to notify other processes that data persistence is needed
 
@@ -655,7 +655,7 @@ class BaseGraphStorage(StorageNameSpace, ABC):
     async def upsert_node(self, node_id: str, node_data: dict[str, str]) -> None:
         """Insert a new node or update an existing node in the graph.
 
-        Importance notes for in-memory storage:
+        Important notes for in-memory storage:
         1. Changes will be persisted to disk during the next index_done_callback
         2. Only one process should updating the storage at a time before index_done_callback,
            KG-storage-log should be used to avoid data corruption
@@ -718,7 +718,7 @@ class BaseGraphStorage(StorageNameSpace, ABC):
     ) -> None:
         """Insert a new edge or update an existing edge in the graph.
 
-        Importance notes for in-memory storage:
+        Important notes for in-memory storage:
         1. Changes will be persisted to disk during the next index_done_callback
         2. Only one process should updating the storage at a time before index_done_callback,
            KG-storage-log should be used to avoid data corruption
@@ -733,7 +733,7 @@ class BaseGraphStorage(StorageNameSpace, ABC):
     async def delete_node(self, node_id: str) -> None:
         """Delete a node from the graph.
 
-        Importance notes for in-memory storage:
+        Important notes for in-memory storage:
         1. Changes will be persisted to disk during the next index_done_callback
         2. Only one process should updating the storage at a time before index_done_callback,
            KG-storage-log should be used to avoid data corruption
@@ -746,7 +746,7 @@ class BaseGraphStorage(StorageNameSpace, ABC):
     async def remove_nodes(self, nodes: list[str]):
         """Delete multiple nodes
 
-        Importance notes:
+        Important notes:
         1. Changes will be persisted to disk during the next index_done_callback
         2. Only one process should updating the storage at a time before index_done_callback,
            KG-storage-log should be used to avoid data corruption
@@ -759,7 +759,7 @@ class BaseGraphStorage(StorageNameSpace, ABC):
     async def remove_edges(self, edges: list[tuple[str, str]]):
         """Delete multiple edges
 
-        Importance notes:
+        Important notes:
         1. Changes will be persisted to disk during the next index_done_callback
         2. Only one process should updating the storage at a time before index_done_callback,
            KG-storage-log should be used to avoid data corruption
@@ -787,7 +787,7 @@ class BaseGraphStorage(StorageNameSpace, ABC):
         Args:
             node_label: Label(entity name) of the starting node，* means all nodes
             max_depth: Maximum depth of the subgraph, Defaults to 3
-            max_nodes: Maxiumu nodes to return, Defaults to 1000（BFS if possible)
+            max_nodes: Maximum nodes to return, Defaults to 1000 (BFS if possible)
 
         Returns:
             KnowledgeGraph object containing nodes and edges, with an is_truncated flag

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1225,11 +1225,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             )
         if self.summary_context_size > self.max_total_tokens:
             logger.warning(
-                f"summary_context_size({self.summary_context_size}) should no greater than max_total_tokens({self.max_total_tokens})"
+                f"summary_context_size({self.summary_context_size}) should not be greater than max_total_tokens({self.max_total_tokens})"
             )
         if self.summary_length_recommended > self.summary_max_tokens:
             logger.warning(
-                f"max_total_tokens({self.summary_max_tokens}) should greater than summary_length_recommended({self.summary_length_recommended})"
+                f"summary_max_tokens({self.summary_max_tokens}) should be greater than summary_length_recommended({self.summary_length_recommended})"
             )
 
         if self.rerank_model_func is not None:

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -456,7 +456,7 @@ async def _handle_entity_relation_summary(
                     )
                     current_chunk = []  # next group is empty
                     current_tokens = 0
-                else:  # curren_chunk is ready for summary in reduce phase
+                else:  # current_chunk is ready for summary in reduce phase
                     chunks.append(current_chunk)
                     current_chunk = [desc]  # leave it for next group
                     current_tokens = desc_tokens
@@ -1409,7 +1409,6 @@ async def _process_extraction_result(
         chunk_key (str): The chunk key for source tracking
         file_path (str): The file path for citation
         tuple_delimiter (str): Delimiter for tuple fields
-        record_delimiter (str): Delimiter for records
         completion_delimiter (str): Delimiter for completion
     Returns:
         tuple: (nodes_dict, edges_dict) containing the extracted entities and relationships

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -310,10 +310,8 @@ Your task is to synthesize a list of descriptions of a given entity or relation 
   - In cases of conflicting or inconsistent descriptions, first determine if these conflicts arise from multiple, distinct entities or relationships that share the same name.
   - If distinct entities/relations are identified, summarize each one *separately* within the overall output.
   - If conflicts within a single entity/relation (e.g., historical discrepancies) exist, attempt to reconcile them or present both viewpoints with noted uncertainty.
-7. Length Constraint:The summary's total length must not exceed {summary_length} tokens, while still maintaining depth and completeness.
-8. Language: The entire output must be written in {language}. Proper nouns (e.g., personal names, place names, organization names) may in their original language if proper translation is not available.
-  - The entire output must be written in {language}.
-  - Proper nouns (e.g., personal names, place names, organization names) should be retained in their original language if a proper, widely accepted translation is not available or would cause ambiguity.
+7. Length Constraint: The summary's total length must not exceed {summary_length} tokens, while still maintaining depth and completeness.
+8. Language: The entire output must be written in {language}. Proper nouns (e.g., personal names, place names, organization names) should be retained in their original language if a proper, widely accepted translation is not available or would cause ambiguity.
 
 ---Input---
 {description_type} Name: {description_name}

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -980,7 +980,7 @@ def priority_limit_async_func_call(
         Decorator function
     """
 
-    def final_decro(func):
+    def final_dec(func):
         # Ensure func is callable
         if not callable(func):
             raise TypeError(f"Expected a callable object, got {type(func)}")
@@ -2334,7 +2334,7 @@ def priority_limit_async_func_call(
 
         return wait_func
 
-    return final_decro
+    return final_dec
 
 
 def wrap_embedding_func_with_attrs(**kwargs):
@@ -2407,7 +2407,7 @@ def wrap_embedding_func_with_attrs(**kwargs):
         A decorator that wraps the function as an EmbeddingFunc instance
     """
 
-    def final_decro(func) -> EmbeddingFunc:
+    def final_dec(func) -> EmbeddingFunc:
         embedding_kwargs = dict(kwargs)
         # Auto-detect supports_asymmetric from the wrapped function's signature
         # if the caller did not declare it explicitly. Without this, any user or
@@ -2425,7 +2425,7 @@ def wrap_embedding_func_with_attrs(**kwargs):
         new_func = EmbeddingFunc(**embedding_kwargs, func=func)
         return new_func
 
-    return final_decro
+    return final_dec
 
 
 def load_json(file_name):


### PR DESCRIPTION
Fixes documentation issues across multiple files:

- Fix final_decro typo in utils.py
- Fix warning messages in lightrag.py (wrong variable names, grammar)
- Fix docstring typos in base.py (mesages, un-exist, Maxiumu, Importance)
- Fix prompt.py duplicate language instruction and missing space
- Fix operate.py docstring for removed parameter and comment typo