### PR TITLE
docs: fix broken links and correct VLM gating semantics

### DIFF
--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -8,7 +8,7 @@
 
 LightRAG Server引入了一个文件处理的中间格式： `LightRAG Document` 。该格式支持表格和图片等多模态数据，同时包含文章的章节段落元数据，方便日后进行内容溯源。
 
-本文以 **LightRAG Server** 的部署与使用视角组织：先给出快速开始可直接套用的配置，再展开内容抽取与分块的配置语法、存储 / 目录布局、去重、并发以及续跑规则。直接通过 Python 代码调用 `LightRAG` 类的开发者请翻到[第八章 Python SDK 调用](#八、Python SDK 调用)。
+本文以 **LightRAG Server** 的部署与使用视角组织：先给出快速开始可直接套用的配置，再展开内容抽取与分块的配置语法、存储 / 目录布局、去重、并发以及续跑规则。直接通过 Python 代码调用 `LightRAG` 类的开发者请翻到[第八章 Python SDK 调用](#八python-sdk-调用)。
 
 ## 一、快速开始
 
@@ -981,7 +981,7 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼�
           └─ parse_queues[<第三方组>] ─► [自定义并发池]  ──┘   ← 按 ParserSpec.queue_group 动态创建
 ```
 
-解析队列**按注册表的 `ParserSpec.queue_group` 动态创建**（每批取一次注册表快照）：内置 native/mineru/docling 各占一组，legacy 共享 native 池（本地、无网络），第三方引擎可声明独立组与自定义并发数（见 `docs/ThirdPartyParser-zh.md`）。入队时 `resolve_stored_document_parser_engine` 根据每个文档的 `parser_engine`（来自 `LIGHTRAG_PARSER` 默认值或文件 hint）把它放入对应解析队列；各解析队列**完全互不阻塞**——mineru 占满不会拖慢 docling 或 native。解析完成后统一进入 `q_analyze`（多模态分析），再进入 `q_process`（实体/关系抽取 + 入库）。
+解析队列**按注册表的 `ParserSpec.queue_group` 动态创建**（每批取一次注册表快照）：内置 native/mineru/docling 各占一组，legacy 共享 native 池（本地、无网络），第三方引擎可声明独立组与自定义并发数（见 [ThirdPartyParser-zh.md](./ThirdPartyParser-zh.md)）。入队时 `resolve_stored_document_parser_engine` 根据每个文档的 `parser_engine`（来自 `LIGHTRAG_PARSER` 默认值或文件 hint）把它放入对应解析队列；各解析队列**完全互不阻塞**——mineru 占满不会拖慢 docling 或 native。解析完成后统一进入 `q_analyze`（多模态分析），再进入 `q_process`（实体/关系抽取 + 入库）。
 
 | 环境变量 | 默认值 | 作用 | 调优建议 |
 | --- | --- | --- | --- |
@@ -1115,5 +1115,23 @@ per-file 个性化的典型场景：管理 UI 单独配置某个文件的 separa
 
 旧 `apipeline_enqueue_documents` 的 `reprocess_existing_non_processed=True` 行为会在 scan 时直接删除非 PROCESSED 的旧记录并重建，与 §五 / §六 的规则相冲突，已整段移除。替代路径：
 
-- 自动续跑：scan 按 §6.4 的分类规则处理同名文件（归档 / 续跑 / 删 stub 后重入队），由 §七 续跑规则在处理循环里统一接管。
+- 自动续跑：scan 按 §5.1 的分类规则处理同名文件（归档 / 续跑 / 删 stub 后重入队），由 §七 续跑规则在处理循环里统一接管。
 - 强制刷新：先调 `/documents/{doc_id}` 删旧文档，再上传同名新文件。
+
+## 附录 A：从旧版升级的注意事项
+
+### A.1 多模态全局开关已被文件级选项取代
+
+`addon_params["enable_multimodal_pipeline"]` 已废弃。多模态分析现在按文档、通过 `i` / `t` / `e` 处理选项选择（§2.5），既可在 `LIGHTRAG_PARSER` 中作为规则默认值设置（§2.2），也可通过文件名 hint 指定（§2.3）。不再存在"全部分析"式的全局开关，因为一篇文档实际含有哪些模态由解析引擎决定、以 sidecar 是否存在来表达，而不是由配置决定。
+
+迁移方式：把原来的全局开关换成路由规则上对应的字母，例如 `LIGHTRAG_PARSER=*:native-iteP,*:legacy-R`。注意 `VLM_PROCESS_ENABLE` 是一个正交的独立开关：它只闸控**图片**分析（表格与公式由 `EXTRACT` 角色分析）；若启用了 `i` 而 VLM 不可用，通过前置过滤的图片会让该文档失败，而不是被跳过。
+
+升级前已入库的文档，其 `process_options` 在入队时就已冻结在 `doc_status` 记录里；改规则或改 hint 都不会追溯修改它们。要让已有文档按新选项重跑，只能删除后重新上传（§7.3）。
+
+### A.2 不主动开启则行为不变
+
+不配置 `LIGHTRAG_PARSER` 时，所有扩展名仍然走 `legacy` 内容抽取器与旧的分块行为，与升级前完全一致。新引擎与新分块策略都是 opt-in 的；§一 给出了三套可直接套用的预设。
+
+### A.3 已移除的 SDK 入参
+
+`apipeline_enqueue_documents(reprocess_existing_non_processed=...)` 已移除，替代路径见 §8.6。

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -981,7 +981,7 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru pool  × N2] ─┼�
           └─ parse_queues[<3rd-party group>] ─► [custom pool] ┘   ← created per ParserSpec.queue_group
 ```
 
-Parse queues are **created dynamically from the registry's `ParserSpec.queue_group`** (one registry snapshot per batch): the built-in native/mineru/docling each own a group, legacy shares the native pool (local, no network), and a third-party engine may declare its own group with a custom worker count (see `docs/ThirdPartyParser-zh.md`). At enqueue time, `resolve_stored_document_parser_engine` puts each document into the corresponding parse queue based on its `parser_engine` (from `LIGHTRAG_PARSER` defaults or the filename hint); the parse queues are **completely non-blocking** with respect to each other — mineru saturation does not slow down docling or native. After parsing, they enter `q_analyze` (multimodal analysis) uniformly, and then enter `q_process` (entity/relation extraction + ingest).
+Parse queues are **created dynamically from the registry's `ParserSpec.queue_group`** (one registry snapshot per batch): the built-in native/mineru/docling each own a group, legacy shares the native pool (local, no network), and a third-party engine may declare its own group with a custom worker count (see [ThirdPartyParser.md](./ThirdPartyParser.md)). At enqueue time, `resolve_stored_document_parser_engine` puts each document into the corresponding parse queue based on its `parser_engine` (from `LIGHTRAG_PARSER` defaults or the filename hint); the parse queues are **completely non-blocking** with respect to each other — mineru saturation does not slow down docling or native. After parsing, they enter `q_analyze` (multimodal analysis) uniformly, and then enter `q_process` (entity/relation extraction + ingest).
 
 | Environment variable | Default | Effect | Tuning advice |
 | --- | --- | --- | --- |
@@ -1115,5 +1115,23 @@ Only effective for the F strategy; other strategies' sub-dictionaries are unaffe
 
 The legacy `apipeline_enqueue_documents` behavior of `reprocess_existing_non_processed=True` would directly delete non-PROCESSED old records and rebuild them during scan, which conflicts with the rules in §5 / §6; it has been entirely removed. Replacement paths:
 
-- Automatic resume: scan handles same-named files per the classification rules in §6.4 (archive / resume / delete stub then re-enqueue), uniformly picked up by the resume rules in §7 inside the processing loop.
+- Automatic resume: scan handles same-named files per the classification rules in §5.1 (archive / resume / delete stub then re-enqueue), uniformly picked up by the resume rules in §7 inside the processing loop.
 - Forced refresh: first call `/documents/{doc_id}` to delete the old document, then upload the same-named new file.
+
+## Appendix A. Notes on Upgrading from Legacy
+
+### A.1 The global multimodal switch has been replaced by per-file options
+
+`addon_params["enable_multimodal_pipeline"]` is deprecated. Multimodal analysis is now selected per document through the `i` / `t` / `e` processing options (§2.5), set either as a rule default in `LIGHTRAG_PARSER` (§2.2) or via a filename hint (§2.3). There is no global "analyze everything" flag any more, because the modality set a document actually contains is decided by the parsing engine and reported through sidecar existence, not by configuration.
+
+Migration: replace the old global switch with the corresponding letters on your routing rules — for example `LIGHTRAG_PARSER=*:native-iteP,*:legacy-R`. Note that `VLM_PROCESS_ENABLE` is a separate, orthogonal switch: it gates **image** analysis only (tables and equations are analyzed by the `EXTRACT` role), and with `i` enabled but no VLM available an image that passes the pre-filters fails the document rather than being skipped.
+
+Documents ingested before the upgrade keep the `process_options` frozen into their `doc_status` record at enqueue time; changing rules or hints does not retroactively alter them. To re-process an existing document under new options, delete it and upload it again (§7.3).
+
+### A.2 Behavior defaults are unchanged unless you opt in
+
+With `LIGHTRAG_PARSER` unset, every extension still routes to the `legacy` content extractor with the legacy chunking behavior, exactly as before the upgrade. The new engines and chunking strategies are opt-in; see §1 for three ready-to-use presets.
+
+### A.3 Removed SDK parameter
+
+`apipeline_enqueue_documents(reprocess_existing_non_processed=...)` has been removed; see §8.6 for the replacement paths.

--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -810,10 +810,9 @@ VLM_LLM_MODEL=gpt-5-mini
 
 ### 多模态分析配置
 
-解析器可以产出图片/绘图、表格和公式 sidecar。VLM 分析只会在两个条件同时满足时运行：
+解析器可以产出图片/绘图、表格和公式 sidecar。某个模态要被分析，需要文档的 `process_options` 包含对应标记（`i` 图片、`t` 表格、`e` 公式），并且对应的 sidecar 存在。
 
-- 文档的 `process_options` 包含对应模态标记：`i` 表示图片，`t` 表示表格，`e` 表示公式。
-- `VLM_PROCESS_ENABLE=true`，且实际生效的 VLM binding 支持图片输入。
+`VLM_PROCESS_ENABLE` **只闸控图片**。表格和公式由 `EXTRACT` 角色分析，不受该开关影响，因此 `*:native-teP` 无需配置任何 VLM 即可工作。若启用了 `i` 而 VLM 不可用，通过了前置过滤（文件存在、栅格格式、长宽均不小于 `VLM_MIN_IMAGE_PIXEL`）的图片会让**该文档失败**而非被跳过：文档进入 `FAILED`，`error_msg` 为 "VLM analysis required but VLM role is not available"。
 
 当前支持视觉输入的 provider 包括 `openai`、`azure_openai`、`gemini`、`bedrock`、`ollama` 和 `anthropic`；`lollms` 不能用于 VLM。典型配置：
 

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -824,10 +824,9 @@ For cross-provider rules, provider-specific options such as `QUERY_OPENAI_LLM_RE
 
 ### Multimodal Analysis Configuration
 
-The parser can produce sidecars for drawings/images, tables, and equations. VLM analysis only runs when both conditions are true:
+The parser can produce sidecars for drawings/images, tables, and equations. Analysis of a modality requires the document's `process_options` to contain the matching flag — `i` for images, `t` for tables, `e` for equations — and the corresponding sidecar to exist.
 
-- The document's `process_options` contains the matching modality flag: `i` for images, `t` for tables, or `e` for equations.
-- `VLM_PROCESS_ENABLE=true` and the effective VLM binding supports image input.
+`VLM_PROCESS_ENABLE` gates **images only**. Tables and equations are analyzed by the `EXTRACT` role and run regardless of this switch, so `*:native-teP` works without any VLM configured. With `i` enabled and the VLM unavailable, an image that survives the pre-filters (file present, raster format, both sides at least `VLM_MIN_IMAGE_PIXEL`) **fails the document** rather than being skipped — it lands in `FAILED` with `error_msg` "VLM analysis required but VLM role is not available".
 
 Current vision-capable providers are `openai`, `azure_openai`, `gemini`, `bedrock`, `ollama`, and `anthropic`; `lollms` is rejected for VLM use. Typical configuration:
 

--- a/docs/LightRAGSidecarFormat-zh.md
+++ b/docs/LightRAGSidecarFormat-zh.md
@@ -81,7 +81,7 @@ inputs/space1/__parsed__/<规范文件名>.parsed/
 | `doc_title` | `str` | 文档标题（通常为首个 H1）；可选。docx smart_heading 模式下为 LLM 识别的标题块主标题，未识别出标题块时为空字符串 |
 | `doc_summary` | `str` | 文档摘要；可选 |
 | `doc_attributes` | `object` | 文章扩展属性对象；可选 |
-| `bbox_attributes` | `object` | bbox possition全局属性；详见[§八](八、positions) |
+| `bbox_attributes` | `object` | bbox possition全局属性；详见[§八](#八positions) |
 
 > LightRAG要求同一个workspace（知识库）内的文件名（document_name）必须唯一。
 
@@ -121,7 +121,7 @@ inputs/space1/__parsed__/<规范文件名>.parsed/
 | `session_type` | Block所处区域：`body` `preface` `TOC` `references` `appendix` |
 | `table_slice` | 可选保留字段；表示Block是否仅包括表格片段。目前分析引擎不会拆分长表格。因此本字段固定为 `"none"`（表示表格不会被分片） |
 | `table_header` | 可选保留字段；在当前块位表格片段的时候，保存识别出来的表格头。目前不存在 |
-| `positions` | `position` 对象数组：标识文本块的版面位置；文本块来与版面的多个位置的时候，则会出现多个`position` 对象。参见[§八](#八、position) |
+| `positions` | `position` 对象数组：标识文本块的版面位置；文本块来与版面的多个位置的时候，则会出现多个`position` 对象。参见[§八](#八positions) |
 
 > - blockid计算方式：`md5(doc_id + ":" + block_index + ":" + heading + ":" + content)`。文档经过分块策略处理得到的 chunk 将保存 blockid 用于溯源 chunk 在s idecar 中的位置。
 > - 不关系文档章节结构的分块策略 `F` `R` `V` 使用的就是 content 字段拼接后的内容进行分块。因此需要保证所有 Block 的 content字段合并在一起能够构成完整的文档内容，不会缺少内容，不会出现重叠的内容。
@@ -196,10 +196,10 @@ inputs/space1/__parsed__/<规范文件名>.parsed/
 | `src` | 原文档中图形的原始引用（远程 URL、外链 target）；多数情况下为空 |
 | `caption` | 可见标题（解析器可能留空） |
 | `footnotes` | 脚注字符串列表 |
-| `surrounding` | 上下文对象：参见[§七](#七、surrounding) |
+| `surrounding` | 上下文对象：参见[§七](#七surrounding) |
 | `self_ref` | 字符串：可选；解析引擎原始输出中的对象引用（如 Docling JSON Pointer `#/pictures/3`，或 MinerU `content_list.json#/23`），用于溯源时回查原始解析产物中的对应对象（页面位置、原始结构等）。native 等不提供此字段时不输出 |
 | `extras` | 对象：可选；引擎专属的旁路字段（如图片中包含的OCR文字等）。不属于 spec 校验范围，下游消费者不应依赖具体键。 |
-| `llm_analyze_result` | 模态分析结果对象：详见 [§九](#九、`llm_analyze_result`) （后续会注入到多模态文本块） |
+| `llm_analyze_result` | 模态分析结果对象：详见 [§九](#九llm_analyze_result) （后续会注入到多模态文本块） |
 | `llm_cache_list` | 模态分析LLM缓存数组（后续会注入到多模态文本块） |
 
 `extras` 中常见的 drawing 专属键：

--- a/docs/ParagraphSemanticChunking-zh.md
+++ b/docs/ParagraphSemanticChunking-zh.md
@@ -381,7 +381,7 @@ parser 保证「一条标题下的正文作为一个基础块」（native 经按
 | `CHUNK_P_OVERLAP_SIZE` | 未设（沿用 `CHUNK_OVERLAP_SIZE`） | P 专用 overlap；只影响同一内容行内长正文 fallback 和表格桥接预算，**不**让表格行级切片互相重叠 |
 | `CHUNK_OVERLAP_SIZE` / `LightRAG(chunk_overlap_token_size=…)` | `100` | 未设 P 专用 overlap 时的全局兜底 |
 
-配置语法、优先级链、`addon_params["chunker"]` 运行时改值等详见 [FileProcessingConfiguration-zh.md](FileProcessingConfiguration-zh.md) §3。
+配置语法、优先级链、`addon_params["chunker"]` 运行时改值等详见 [FileProcessingPipeline-zh.md](./FileProcessingPipeline-zh.md)。
 
 `P` 是与引擎正交的 chunking 选项（`后缀:引擎-选项`），可与任何产出 sidecar 的引擎组合。启用 P 的典型 `LIGHTRAG_PARSER` 写法：
 

--- a/docs/ParagraphSemanticChunking.md
+++ b/docs/ParagraphSemanticChunking.md
@@ -376,7 +376,7 @@ Internally the implementation also uses temporary fields like `paragraphs`, `con
 | `CHUNK_P_OVERLAP_SIZE` | Unset (inherits `CHUNK_OVERLAP_SIZE`) | P-specific overlap; affects only long-body fallback within one content line and the table bridge budget, and does **not** make table row-level slices overlap each other |
 | `CHUNK_OVERLAP_SIZE` / `LightRAG(chunk_overlap_token_size=…)` | `100` | Global fallback when no P-specific overlap is set |
 
-For config syntax, the precedence chain, runtime overrides via `addon_params["chunker"]`, etc., see [FileProcessingConfiguration-zh.md](FileProcessingConfiguration-zh.md) §3.
+For config syntax, the precedence chain, runtime overrides via `addon_params["chunker"]`, etc., see [FileProcessingPipeline.md](./FileProcessingPipeline.md).
 
 `P` is a chunking option orthogonal to the engine (`suffix:engine-options`) and can combine with any sidecar-producing engine. A typical `LIGHTRAG_PARSER` setup enabling P:
 

--- a/docs/ParserDebugCLI-zh.md
+++ b/docs/ParserDebugCLI-zh.md
@@ -101,7 +101,7 @@ python -m lightrag.parser.cli ./inputs/workspace/sample.pdf \
 - **MinerU**：`MINERU_API_MODE`（`local` / `official`）、`MINERU_API_TOKEN`、`MINERU_LOCAL_ENDPOINT` 或 `MINERU_OFFICIAL_ENDPOINT`，可选 `MINERU_ENGINE_VERSION` / `MINERU_MODEL_VERSION` / `MINERU_POLL_INTERVAL_SECONDS` / `MINERU_MAX_POLLS`。
 - **Docling**：`DOCLING_ENDPOINT`，可选 `DOCLING_ENGINE_VERSION` / `DOCLING_DO_OCR` / `DOCLING_FORCE_OCR` / `DOCLING_OCR_ENGINE` / `DOCLING_OCR_PRESET` / `DOCLING_OCR_LANG` / `DOCLING_DO_FORMULA_ENRICHMENT` / `DOCLING_POLL_INTERVAL_SECONDS` / `DOCLING_MAX_POLLS`。
 
-详见 [FileProcessingConfiguration-zh.md](./FileProcessingConfiguration-zh.md)。
+详见 [FileProcessingPipeline-zh.md](./FileProcessingPipeline-zh.md)。
 
 **缓存命中**时（raw 目录已存在且非空，且未传 `--force-reparse`）无需任何外部服务环境变量——可用于离线复现解析输出。
 

--- a/docs/ParserDebugCLI.md
+++ b/docs/ParserDebugCLI.md
@@ -101,7 +101,7 @@ The `mineru` / `docling` engines call external services when the **cache misses*
 - **MinerU**: `MINERU_API_MODE` (`local` / `official`), `MINERU_API_TOKEN`, `MINERU_LOCAL_ENDPOINT` or `MINERU_OFFICIAL_ENDPOINT`, optional `MINERU_ENGINE_VERSION` / `MINERU_MODEL_VERSION` / `MINERU_POLL_INTERVAL_SECONDS` / `MINERU_MAX_POLLS`.
 - **Docling**: `DOCLING_ENDPOINT`, optional `DOCLING_ENGINE_VERSION` / `DOCLING_DO_OCR` / `DOCLING_FORCE_OCR` / `DOCLING_OCR_ENGINE` / `DOCLING_OCR_PRESET` / `DOCLING_OCR_LANG` / `DOCLING_DO_FORMULA_ENRICHMENT` / `DOCLING_POLL_INTERVAL_SECONDS` / `DOCLING_MAX_POLLS`.
 
-See [FileProcessingConfiguration.md](./FileProcessingConfiguration.md) for details.
+See [FileProcessingPipeline.md](./FileProcessingPipeline.md) for details.
 
 When the **cache is hit** (the raw directory already exists and is non-empty, and `--force-reparse` is not passed), no external service environment variables are needed — this can be used to offline-reproduce parsing output.
 

--- a/env.example
+++ b/env.example
@@ -386,6 +386,11 @@ LIGHTRAG_PARSER=*:native-teP;*:legacy-R
 ### outline/numbered heading, or a data table that cannot be cover material).
 ### Past the zone it needs a 版记 tail or 附件 marker as boundary evidence.
 # DOCX_SMART_TITLE_HEAD_ZONE_RECORDS=8
+### Further DOCX_SMART_* thresholds exist (circuit-breaker ratios, confidence
+### ratio, numbering sequence break, TOC detection minimum). They are algorithm
+### internals rather than a supported tuning surface: see lightrag/constants.py
+### for their names and defaults, and prefer reporting a misclassification over
+### tuning them.
 
 ### Native Markdown (.md / .textpack) remote image handling
 ### External http(s) images in markdown are downloaded and embedded into the
@@ -510,6 +515,14 @@ MINERU_LOCAL_IMAGE_ANALYSIS=false
 ### Disables caching of result outcomes
 # LIGHTRAG_FORCE_REPARSE_MINERU=false
 
+### ---- MinerU raw-bundle cache (<base>.mineru_raw/) ----
+### Engine version recorded in the bundle manifest; changing it invalidates the
+### cache. Leave empty to skip the version check.
+# MINERU_ENGINE_VERSION=
+### Default coordinate system for MinerU layout boxes, written into the
+### sidecar meta. NOTE the default differs from DOCLING_BBOX_ATTRIBUTES.
+# MINERU_BBOX_ATTRIBUTES={"origin":"LEFTTOP","max":1000}
+
 ### Docling parser (docling-serve v1 / async API).
 ###
 ### Endpoint: base URL only — the client appends /v1/convert/file/async,
@@ -580,6 +593,7 @@ DOCLING_DO_FORMULA_ENRICHMENT=false
 # DOCLING_POLL_INTERVAL_SECONDS=5
 # DOCLING_MAX_POLLS=240
 # DOCLING_BBOX_ATTRIBUTES={"origin":"LEFTBOTTOM"}
+# DOCLING_ENGINE_VERSION=
 ### Force re-upload of file to Docling on every retry after failure
 ### Disables caching of result outcomes
 # LIGHTRAG_FORCE_REPARSE_DOCLING=false
@@ -689,6 +703,10 @@ DOCLING_DO_FORMULA_ENRICHMENT=false
 ### so deployments can bias context forward or backward as needed.
 # SURROUNDING_LEADING_MAX_TOKENS=2000
 # SURROUNDING_TRAILING_MAX_TOKENS=2000
+### Floor on the multimodal item's own content budget. If the surrounding
+### budgets above leave less than this for the item itself, startup warns and
+### names this variable as the knob to raise (or lower SURROUNDING_* instead).
+# MM_EXTRACT_CONTENT_MIN_TOKENS=100
 
 ### Per-response cap on total entity+relationship rows/records emitted by the LLM
 # MAX_EXTRACTION_RECORDS=100
@@ -837,8 +855,23 @@ QUERY_MAX_ASYNC_LLM=4
 # VLM_LLM_BINDING_HOST=https://api.example.com/v1
 # VLM_LLM_BINDING_API_KEY=your_vlm_api_key
 
-### Master switch for VLM multimodal analysis (i/t/e items).
-### When false, multimodal item is skipped regardless of document process_options
+### Master switch for VLM analysis of IMAGE items (the `i` process option).
+### Table (`t`) and equation (`e`) items are analyzed by the EXTRACT role and
+### are NOT affected by this switch.
+###
+### This switch is only ever consulted for a document whose process_options
+### include `i`. A document without `i` never enters image analysis, so
+### leaving this false is the normal setup for e.g. LIGHTRAG_PARSER=*:native-teP
+### -- such documents keep processing regardless of how many images they carry.
+###
+### For a document WITH `i` and this set to false: the first image that
+### survives the pre-filters (file present, raster format, both sides >=
+### VLM_MIN_IMAGE_PIXEL) FAILS that document rather than being skipped --
+### analysis raises and the document lands in FAILED with "VLM analysis
+### required but VLM role is not available". Images dropped by those
+### pre-filters, and documents whose drawings sidecar is absent, are
+### unaffected and keep processing.
+###
 ### When true, VLM_LLM_BINDING (or the base LLM_BINDING) must be vision-capable
 ### lollms is rejected at startup
 VLM_PROCESS_ENABLE=false

--- a/lightrag/addon_params.py
+++ b/lightrag/addon_params.py
@@ -33,7 +33,7 @@ def _emit_deprecated_addon_warnings(params: Mapping[str, Any]) -> None:
             logger.warning(
                 f"addon_params['{key}'] is deprecated and ignored; per-document "
                 f"behaviour is now controlled by filename-hint process_options "
-                f"(see docs/FileProcessingConfiguration-zh.md)."
+                f"(see docs/FileProcessingPipeline.md)."
             )
             _warned_deprecated_keys.add(key)
 

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -758,9 +758,13 @@ def parse_args() -> argparse.Namespace:
                     f"but required env vars are missing: {', '.join(missing)}"
                 )
 
-    # VLM multimodal master switch — when off, the pipeline emits a warning
-    # and skips every i/t/e item without touching the VLM. When on, the
-    # effective VLM binding must support image inputs.
+    # VLM multimodal master switch. It gates IMAGE (`i`) analysis only —
+    # table and equation items are analyzed by the EXTRACT role and ignore
+    # it. When off, a document carrying `i` does not skip its images: the
+    # first one that survives _analyze_drawing's pre-filters raises and the
+    # document lands in FAILED. When on, the effective VLM binding must
+    # accept image inputs; lollms is the only binding this server offers
+    # whose complete_if_cache rejects image_inputs outright.
     args.vlm_process_enable = get_env_value("VLM_PROCESS_ENABLE", False, bool)
     if args.vlm_process_enable:
         effective_vlm_binding = (

--- a/lightrag/chunker/__init__.py
+++ b/lightrag/chunker/__init__.py
@@ -42,7 +42,7 @@ Two contracts coexist intentionally:
         missing or unreadable.
 
 See ``docs/ParagraphSemanticChunking-zh.md`` for the algorithm behind
-the ``"P"`` strategy and ``docs/FileProcessingConfiguration-zh.md`` for
+the ``"P"`` strategy and ``docs/FileProcessingPipeline.md`` for
 how ``process_options`` and the new ``chunk_options`` snapshot drive
 chunker selection per document.
 """

--- a/lightrag/chunker/paragraph_semantic.py
+++ b/lightrag/chunker/paragraph_semantic.py
@@ -2102,7 +2102,7 @@ def chunking_by_paragraph_semantic(
             (typically ``parsed_data["blocks_path"]``). When ``None``,
             unreadable, or empty, this function falls back to
             :func:`chunking_by_recursive_character` on ``content``
-            (per ``docs/FileProcessingConfiguration-zh.md`` §3).
+            (per ``docs/FileProcessingPipeline.md``).
             That fallback hard-requires ``langchain-text-splitters``;
             an :class:`ImportError` is surfaced rather than silently
             degrading further.
@@ -2198,7 +2198,7 @@ def chunking_by_paragraph_semantic(
         # Defer to recursive-character chunking when the sidecar is
         # absent — ensures non-structured documents and edge-case parses
         # still produce chunks instead of silently dropping content.  The
-        # document contract (FileProcessingConfiguration-zh.md §3) is
+        # document contract (FileProcessingPipeline.md) is
         # explicit that P falls back to R; that contract requires
         # langchain-text-splitters to be installed, so an ImportError
         # here is intentional rather than a silent degrade to F.  Lazy

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -260,7 +260,7 @@ FULL_DOCS_FORMAT_PENDING_PARSE = (
     "pending_parse"  # file saved but not yet parsed; parse_native will read from disk
 )
 # Marker prefix for full_docs.content when format=lightrag.
-# Per docs/FileProcessingConfiguration-zh.md, the content is "{{LRdoc}}" + a
+# Per docs/FileProcessingPipeline.md, the content is "{{LRdoc}}" + a
 # leading summary of the parsed document so paginated APIs can show a real
 # preview without loading the full LightRAG Document file.
 LIGHTRAG_DOC_CONTENT_PREFIX = "{{LRdoc}}"
@@ -344,7 +344,7 @@ PARSED_ARTIFACT_DIR_SUFFIXES: tuple[str, ...] = (
 )
 
 # Per-file processing options carried by filename hints / LIGHTRAG_PARSER rules.
-# See docs/FileProcessingConfiguration-zh.md for the full specification.
+# See docs/FileProcessingPipeline.md for the full specification.
 PROCESS_OPTION_IMAGES = "i"  # Enable VLM analysis for drawings/images
 PROCESS_OPTION_TABLES = "t"  # Enable VLM analysis for tables
 PROCESS_OPTION_EQUATIONS = "e"  # Enable VLM analysis for equations

--- a/lightrag/parser/external/mineru/__init__.py
+++ b/lightrag/parser/external/mineru/__init__.py
@@ -4,7 +4,7 @@ Public surface for the rest of the codebase. ``parse_mineru`` imports
 only from this facade so the inner module layout stays free to evolve.
 
 See ``docs/LightRAGSidecarFormat-zh.md`` for sidecar format and
-``docs/FileProcessingConfiguration-zh.md`` for cache lifecycle.
+``docs/FileProcessingPipeline.md`` for cache lifecycle.
 """
 
 from lightrag.parser.external.mineru.cache import (

--- a/lightrag/parser/routing.py
+++ b/lightrag/parser/routing.py
@@ -647,7 +647,7 @@ def _parse_chunk_param_texts(
 def split_engine_and_options(bracket_inner: str) -> tuple[str | None, str]:
     """Decompose a bracket-hint inner string into ``(engine, options)``.
 
-    Format rules (see docs/FileProcessingPipeline-zh.md):
+    Format rules (see docs/FileProcessingPipeline.md):
         - ``ENGINE-OPTIONS``: first ``-``-separated segment is the engine
           candidate; the remainder is the options string.
         - ``ENGINE``: matches a supported engine name as a whole.

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -661,7 +661,7 @@ class _PipelineMixin:
                 snapshot value is discarded (logged at WARNING) — see
                 :func:`lightrag.utils_pipeline.apply_trusted_sentence_split_regex`
                 and GHSA-32jh-39m7-8x84.  See
-                ``docs/FileProcessingConfiguration-zh.md`` for the schema.
+                ``docs/FileProcessingPipeline.md`` for the schema.
             admission_token: the pending-enqueue reservation the caller already
                 holds (endpoints reserve one before reading the request body).
                 With ``MAX_PENDING_DOCUMENTS > 0`` the admission guard

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -3068,7 +3068,7 @@ async def test_parse_native_archives_docx_after_full_docs_sync(tmp_path, monkeyp
     assert (parsed_artifact_dir / "parsed-after-sync.blocks.jsonl").is_file()
     assert rag.full_docs.data["doc-test"]["parse_engine"] == "native"
     assert rag.full_docs.data["doc-test"]["parse_format"] == "lightrag"
-    # Per docs/FileProcessingConfiguration-zh.md, content uses the {{LRdoc}}
+    # Per docs/FileProcessingPipeline.md, content uses the {{LRdoc}}
     # marker plus a leading-text summary derived from merged blocks.
     assert rag.full_docs.data["doc-test"]["content"].startswith("{{LRdoc}}")
 

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -3258,7 +3258,7 @@ def test_parse_mineru_to_lightrag_document(tmp_path, monkeypatch):
 
         full_doc = await rag.full_docs.get_by_id("doc-1")
         assert full_doc["parse_format"] == "lightrag"
-        # Per docs/FileProcessingConfiguration-zh.md spec, ``content`` is now
+        # Per docs/FileProcessingPipeline.md spec, ``content`` is now
         # ``{{LRdoc}}`` followed by a leading-text summary of the document.
         assert full_doc["content"].startswith("{{LRdoc}}")
         assert full_doc["sidecar_location"].startswith("file://")


### PR DESCRIPTION
## Summary

First of a planned series that reworks `docs/FileProcessingPipeline.md` into something a newcomer can actually follow. This PR is purely corrective — no restructuring — so each item is an independently verifiable existing defect.

## Motivation

While auditing the file-processing docs against `env.example` and the code, two classes of defect surfaced: a factually wrong description of when multimodal analysis runs, and a set of dangling references (including two sibling docs and ten source comments pointing at a file that was renamed long ago).

## What's changed

### VLM gating semantics were wrong in two places

`docs/LightRAG-API-Server.md` said VLM analysis runs "when both conditions are true" (the `i`/`t`/`e` option **and** `VLM_PROCESS_ENABLE`), and `env.example` said a multimodal item is "skipped regardless of document process_options" when the switch is off. Neither holds:

- `_analyze_drawing` is the **only** consumer of the switch (`lightrag/pipeline.py:6515`). Tables and equations go through `_analyze_text_modality`, which needs only the `EXTRACT` role — so `*:native-teP` works with no VLM configured at all, which is exactly what the recommended preset does.
- When the switch is off, an image does **not** get skipped. `_analyze_drawing` raises `MultimodalAnalysisError`, and `_analyze_worker` turns that into a `FAILED` document with the message as `error_msg` (`lightrag/pipeline.py:4595-4610`).

The corrected wording deliberately keeps the pre-filter qualifier: a missing file, a non-raster format (EMF/WMF/SVG), or an image smaller than `VLM_MIN_IMAGE_PIXEL` is skipped **before** the gate and leaves the document processing normally. Only an image that survives those pre-filters fails the document. (Note the `VLM_MAX_IMAGE_BYTES` check sits *after* the gate, so an oversized image does not dodge the failure.)

### Link fixes

- **`Appendix A` never existed.** The processing-options section linked `#appendix-a-notes-on-upgrading-from-legacy`, which was the only pointer to the deprecated `addon_params["enable_multimodal_pipeline"]` migration. Added the appendix in both language files.
- **Scan classification cross-reference** corrected from §6.4 (six lines of rationale) to §5.1 (the actual seven-exit table).
- **The English doc linked the Chinese `ThirdPartyParser-zh.md`**; now points at the English file, and both are real links rather than bare code spans.
- **Chinese SDK-chapter anchor** spelled out the ideographic comma and spaces (`#八、Python SDK 调用`) instead of the GitHub slug — the same file gets it right elsewhere. Four anchors of the same class fixed in `LightRAGSidecarFormat-zh.md`.
- **`FileProcessingConfiguration.md` no longer exists** (renamed to `FileProcessingPipeline.md`). Repointed `ParagraphSemanticChunking`, `ParserDebugCLI` (both languages) and ten source comments. Trailing bare `§3` references dropped, since a cross-file section number goes stale silently.

### env.example completeness

`generate_env_file` (`scripts/setup/lib/file_ops.sh`) only emits keys matching `KEY=` or `# KEY=`, so a prose-only mention never reaches a generated `.env`:

| Variable | Was |
|---|---|
| `DOCLING_ENGINE_VERSION` | described in prose, no assignment line |
| `MINERU_ENGINE_VERSION` | read by code, absent entirely |
| `MINERU_BBOX_ATTRIBUTES` | read by code, absent entirely |
| `MM_EXTRACT_CONTENT_MIN_TOKENS` | named by a runtime warning, absent entirely |

`MINERU_BBOX_ATTRIBUTES` carries a note that its default origin differs from `DOCLING_BBOX_ATTRIBUTES`. A trailing note in the smart_heading block names the remaining `DOCX_SMART_*` thresholds as algorithm internals rather than a supported tuning surface.

## What's not changed

No chapter reordering or renumbering, no content additions beyond Appendix A. Those come in follow-ups.

## Verification

- Repo-wide Markdown link checker resolving both the target file and the `#fragment` (covering cross-file anchors, not just `](#…)`): the entire document-processing cluster is now clean. The 12 remaining findings are pre-existing and outside this cluster (missing example scripts referenced by `ProgramingWithCore.md`, `k8s-deploy` percent-encoded paths, `memory-bank`, `tests/workspace`).
- Confirmed the four new `env.example` keys match the emitter's regex, so `make env-*` will now emit them.
- `ruff check .` and `pre-commit run --files` pass. Python changes are comments only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)