### PR TITLE
docs: extract parser service deployment runbooks

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -474,6 +474,7 @@ LightRAG は、農業、コンピュータサイエンス、法律、混合ド�
 | ドキュメント | 内容 |
 |---|---|
 | [FileProcessingPipeline.md](./docs/FileProcessingPipeline.md) 🇨🇳 | パイプライン仕様：`LIGHTRAG_PARSER` のルーティング規則、エンジン別パラメータ、マルチモーダル解析、ドキュメント状態のライフサイクル |
+| [ParserServiceDeployment.md](./docs/ParserServiceDeployment.md) 🇨🇳 | 外部解析サービス MinerU / docling-serve の自前ホスティング（Docker、GPU、モデル重み） |
 | [ParagraphSemanticChunking.md](./docs/ParagraphSemanticChunking.md) 🇨🇳 | `Paragraph semantic (P)` チャンク戦略：見出し／段落／表の境界に合わせた分割、参考文献の除外 |
 | [LightRAGSidecarFormat.md](./docs/LightRAGSidecarFormat.md) 🇨🇳 | マルチモーダル対応パーサーエンジンが必ず出力すべき sidecar（`*.parsed/`）交換フォーマットの仕様 |
 | [ThirdPartyParser.md](./docs/ThirdPartyParser.md) 🇨🇳 | 独自パーサーエンジンの開発と登録 |

--- a/README-zh.md
+++ b/README-zh.md
@@ -474,6 +474,7 @@ LightRAG 在农业、计算机科学、法律和混合等领域均显著优于 N
 | 文档 | 内容 |
 |---|---|
 | [FileProcessingPipeline-zh.md](./docs/FileProcessingPipeline-zh.md) | 流水线规格说明：`LIGHTRAG_PARSER` 路由规则、各引擎参数、多模态分析、文档状态生命周期 |
+| [ParserServiceDeployment-zh.md](./docs/ParserServiceDeployment-zh.md) | 自行搭建 MinerU 与 docling-serve 外部解析服务（Docker、GPU、模型权重） |
 | [ParagraphSemanticChunking-zh.md](./docs/ParagraphSemanticChunking-zh.md) | `Paragraph semantic (P)` 分块策略：对齐标题/段落/表格边界、参考文献丢弃 |
 | [LightRAGSidecarFormat-zh.md](./docs/LightRAGSidecarFormat-zh.md) | sidecar（`*.parsed/`）交换格式规范，所有支持多模态的解析引擎都必须遵循 |
 | [ThirdPartyParser-zh.md](./docs/ThirdPartyParser-zh.md) | 开发并注册自定义 parser 引擎 |

--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ Entries marked 🇨🇳 also ship a Chinese translation as `*-zh.md` in the same
 | Document | What it covers |
 |---|---|
 | [FileProcessingPipeline.md](./docs/FileProcessingPipeline.md) 🇨🇳 | Pipeline specification: `LIGHTRAG_PARSER` routing rules, per-engine parameters, multimodal analysis, document status lifecycle |
+| [ParserServiceDeployment.md](./docs/ParserServiceDeployment.md) 🇨🇳 | Self-hosting the external MinerU and docling-serve parsing services (Docker, GPU, model weights) |
 | [ParagraphSemanticChunking.md](./docs/ParagraphSemanticChunking.md) 🇨🇳 | The `Paragraph semantic (P)` chunking strategy: heading/paragraph/table-aware boundaries, reference dropping |
 | [LightRAGSidecarFormat.md](./docs/LightRAGSidecarFormat.md) 🇨🇳 | The sidecar (`*.parsed/`) interchange format every multimodal-capable parser engine must emit |
 | [ThirdPartyParser.md](./docs/ThirdPartyParser.md) 🇨🇳 | Developing and registering your own parser engine |

--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -260,7 +260,7 @@ MINERU_API_TOKEN=<your_token>
 # MINERU_OFFICIAL_ENDPOINT=https://mineru.net   # 默认值，通常无需修改
 ```
 
-* `local`模式：使用本地部署的MInerU服务。部署方式见后面的说明。本地MinerU服务启动后在LightRAG的 `.env` 文件中添加以下配置：
+* `local`模式：使用本地部署的 MinerU 服务，部署方式见 [ParserServiceDeployment-zh.md §1](./ParserServiceDeployment-zh.md#1-本地部署-mineru-服务)。本地MinerU服务启动后在LightRAG的 `.env` 文件中添加以下配置：
 
 ```bash
 MINERU_API_MODE=local
@@ -269,105 +269,7 @@ MINERU_LOCAL_ENDPOINT=http://<your_mineru_local_server_ip>:8000
 
 其余MinerU的详细配置请参考仓库根目录环境变量示例文件 [env.example](https://github.com/HKUDS/LightRAG/blob/main/env.example) 中的 MinerU 小节。针对 `official` 和 `local` 两种模式，分别有不同的环境变量配置。需要仔细阅读示例文件中的说明。
 
-#### **本地部署 MinerU 服务**
-
-从 Github官方仓库   [opendatalab/MinerU](https://github.com/opendatalab/MinerU) 把 Dockerfile 和 compose.yaml 拷贝到本地。这两个文件应该在仓库的 docker 目录可以找到。针对中国供应商的特殊显卡需要选择相应的 Dockerfile 。
-
-准备好上诉两个文件后通过以下命令构建 docker 镜像:
-
-```bash
-docker build --tag mineru:latest .
-```
-
-镜像构建好之后通过以下命令启动 API 服务（参数 `--profile api` 标识仅启动MinerU的 API 服务，服务默认监听 8000 端口）：
-
-```bash
-docker compose -f compose.yaml --profile api up -d
-```
-
-镜像构建细节、GPU 驱动准备、模型权重位置等请参考官方 README：<https://github.com/opendatalab/MinerU>。
-
-**进阶配置：开启 vLLM 预加载与标题层级修正（可选）**
-
-在基础部署之上，建议为本地 MinerU 额外开启两项 MinerU **服务端**功能。这两项都改的是 MinerU 容器侧配置（容器内 `mineru.json` 与官方 `compose.yaml`），不涉及 LightRAG 的 env 变量；其中标题层级修正还需要一个可用的 LLM API。
-
-- **vLLM 启动预加载**：让容器启动时就把 VLM 模型加载进显存，避免首个解析请求承担模型加载延迟。
-- **标题层级修正（`title_aided`）**：MinerU 借助一个外部 LLM 修正解析输出的标题层级，提升结构化产物质量。这对依赖标题结构的 [P（段落语义）分块策略](#25-文件处理选项)尤其有帮助；`P分块策略` 优先按标题分割，标题层级越准确，分块语义越好。
-
-**步骤1：导出并修改 `mineru-lightrag.json`**
-
-从官方镜像中把 `/root/mineru.json` 拷到宿主机当前目录的 `mineru-lightrag.json`（用固定容器名 `temp_mineru`，无需运行容器）：
-
-```bash
-docker create --name temp_mineru mineru:latest
-docker cp temp_mineru:/root/mineru.json ./mineru-lightrag.json
-docker rm temp_mineru
-```
-
-然后修改 `mineru-lightrag.json` 中的 `llm-aided-config.title_aided`：填入 `api_key`，并把 `enable` 改为 `true`：
-
-```json
-"llm-aided-config": {
-    "title_aided": {
-        "api_key": "your_api_key",
-        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-        "model": "qwen3.5-plus",
-        "enable_thinking": false,
-        "enable": true
-    }
-}
-```
-
-> `api_key` / `base_url` / `model` 需替换为用户自己可用的 LLM 服务（示例使用阿里云 DashScope 的 OpenAI 兼容接口）。
-
-**步骤2：修改官方 `compose.yaml` 的 `api` profile 服务（`mineru-api`）**
-
-在 `mineru-api` 服务上做三处改动：`environment` 增加 `MINERU_TOOLS_CONFIG_JSON`（让 MinerU 读改过的配置而非镜像内置 `mineru.json`），`volumes` 把宿主机 `mineru-lightrag.json` 挂进容器，`command` 追加 `--enable-vlm-preload true` 开启 vLLM 预加载。改好后的完整 `mineru-api` profile 如下（以 `# <-- 新增` 标注三处增量）：
-
-```yaml
-  mineru-api:
-    image: mineru:latest
-    container_name: mineru-api
-    restart: always
-    profiles: ["api"]
-    ports:
-      - 8000:8000
-    environment:
-      MINERU_MODEL_SOURCE: local
-      MINERU_TOOLS_CONFIG_JSON: /root/mineru-lightrag.json   # <-- Added
-    volumes:
-      - ./mineru-lightrag.json:/root/mineru-lightrag.json    # <-- Added
-    entrypoint: mineru-api
-    command:
-      --host 0.0.0.0
-      --port 8000
-      --allow-public-http-client
-      --gpu-memory-utilization 0.45                          # Reserved 10GB is fine, preventing OOM errors
-      --enable-vlm-preload true                              # <-- Added
-    ulimits:
-      memlock: -1
-      stack: 67108864
-    ipc: host
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              device_ids: ["0"]
-              capabilities: [gpu]
-```
-
-> 示范中请按实际显卡情况调整 `gpu-memory-utilization` ；`environment` / `volumes` / `command` 三处为本次新增项，其余保持官方原样。
-
-**步骤3：重启生效**
-
-改完后重新启动 API 服务让改动生效：
-
-```bash
-docker compose -f compose.yaml --profile api up -d
-```
+> **本地部署 MinerU 服务**（Docker 镜像构建、vLLM 预加载、标题层级修正）见 [ParserServiceDeployment-zh.md §1](./ParserServiceDeployment-zh.md#1-本地部署-mineru-服务)。
 
 #### 使用 Docling 文件解析引擎
 
@@ -386,7 +288,7 @@ DOCLING_ENDPOINT=http://localhost:5001
 | `DOCLING_OCR_ENGINE` | `auto` | OCR 引擎选择（不建议修改） |
 | `DOCLING_OCR_PRESET` | `auto` | OCR 引擎 preset（不建议修改） |
 | `DOCLING_OCR_LANG` | （空） | 按照OCR引擎要求设置（不建议修改） |
-| `DOCLING_DO_FORMULA_ENRICHMENT` | `false` | 是识别文档中的公式并按LaTex格式输出；启用前需要确保Docling后台下载了公式识别模型（见后面说明） |
+| `DOCLING_DO_FORMULA_ENRICHMENT` | `false` | 是识别文档中的公式并按LaTex格式输出；启用前需要确保Docling后台下载了公式识别模型（见 [ParserServiceDeployment-zh.md §2](./ParserServiceDeployment-zh.md#2-本地部署-docling-serve启用-latex-公式识别)） |
 
 未配置 `DOCLING_OCR_ENGINE` / `DOCLING_OCR_PRESET` 时等同于 `auto`；未配置 `DOCLING_OCR_LANG` 时不向 docling-serve 传递语言列表，由 OCR 引擎使用自身默认值。解析缓存按这些有效参数计算签名，因此“未配置”和“显式填写默认值”不会导致缓存失效。
 
@@ -419,78 +321,7 @@ Bundle 缓存 3 个 env：
 
 **`DOCLING_DO_FORMULA_ENRICHMENT` 启用前提**：docling-serve 侧需就绪 code-formula 模型权重。adapter 双轨兼容 —— 启用时 `text` 字段为 LaTeX，关闭或权重缺失导致 `text == orig` 时自动按普通文本处理，不写 `equations.json`。因此默认 `false` 是保守值，部署侧确认模型就绪后再开启。
 
-#### Docling本地部署(启用 LaTeX 公式识别)
-
-下面以 Docker 部署 docling-serve 为例，给出从镜像下载到模型挂载的完整步骤，部署完成后将 `DOCLING_DO_FORMULA_ENRICHMENT=true` 写入 LightRAG 的 `.env` 即可启用 LaTeX 公式识别。
-
-> **重要提示**：以下步骤基于显卡支持 CUDA 13 的环境。如果显卡较老旧、不支持 CUDA 13，需要把命令与 compose 文件中的镜像名 `docling-serve-cu130:main` 替换为对应 CUDA 版本的标签。可选镜像列表参见 [docling-serve Packages](https://github.com/orgs/docling-project/packages?repo_name=docling-serve)。
-
-**1. 下载镜像**
-
-```bash
-docker pull ghcr.io/docling-project/docling-serve-cu130:main
-```
-
-**2. 下载模型**
-
-```bash
-# 创建 docling 工作目录
-mkdir docling
-cd docling
-
-# 创建模型挂载目录
-mkdir models
-
-# 把容器内的原有模型拷贝到 models 目录
-docker run --rm -it \
-  -v "$(pwd)/models:/opt/app-root/src/models" \
-  ghcr.io/docling-project/docling-serve-cu130:main \
-  cp -r /opt/app-root/src/.cache/docling/models /opt/app-root/src/
-
-# 下载公式识别模型
-docker run --rm \
-  -v "$(pwd)/models:/opt/app-root/src/models" \
-  -e DOCLING_SERVE_ARTIFACTS_PATH="/opt/app-root/src/models" \
-  ghcr.io/docling-project/docling-serve-cu130:main \
-  docling-tools models download-hf-repo docling-project/CodeFormulaV2 -o models
-```
-
-**3. 创建 `docker-compose.yaml` 文件**
-
-在上一步的 `docling` 目录下创建 `docker-compose.yaml`，内容如下：
-
-```yaml
-services:
-  docling-serve:
-    image: ghcr.io/docling-project/docling-serve-cu130:main
-    container_name: docling-serve
-    ports:
-      - "5001:5001"
-    environment:
-      DOCLING_SERVE_ENABLE_UI: "true"
-      NVIDIA_VISIBLE_DEVICES: "all"
-      DOCLING_SERVE_ARTIFACTS_PATH: "/opt/app-root/src/models"
-    # deploy:  # This section is for compatibility with Swarm
-    #   resources:
-    #     reservations:
-    #       devices:
-    #         - driver: nvidia
-    #           count: all
-    #           capabilities: [gpu]
-    runtime: nvidia
-    restart: always
-    volumes:
-      - ./models:/opt/app-root/src/models
-```
-
-随后在该目录执行 `docker compose up -d` 启动服务。容器就绪后，在 LightRAG 的 `.env` 中设置：
-
-```bash
-DOCLING_ENDPOINT=http://localhost:5001
-DOCLING_DO_FORMULA_ENRICHMENT=true
-```
-
-即可让 LightRAG 通过本地 docling-serve 识别文档中的公式并以 LaTeX 形式输出。
+> **本地部署 docling-serve**（含 `DOCLING_DO_FORMULA_ENRICHMENT` 所需的公式识别模型下载）见 [ParserServiceDeployment-zh.md §2](./ParserServiceDeployment-zh.md#2-本地部署-docling-serve启用-latex-公式识别)。
 
 ### 2.5 文件处理选项
 

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -260,7 +260,7 @@ MINERU_API_TOKEN=<your_token>
 # MINERU_OFFICIAL_ENDPOINT=https://mineru.net   # Default value, usually no need to change
 ```
 
-* `local` mode: uses a locally deployed MinerU service. See the deployment instructions below. After the local MinerU service is started, add the following configuration to LightRAG's `.env` file:
+* `local` mode: uses a locally deployed MinerU service, see [ParserServiceDeployment.md §1](./ParserServiceDeployment.md#1-local-deployment-of-the-mineru-service). After the local MinerU service is started, add the following configuration to LightRAG's `.env` file:
 
 ```bash
 MINERU_API_MODE=local
@@ -269,105 +269,7 @@ MINERU_LOCAL_ENDPOINT=http://<your_mineru_local_server_ip>:8000
 
 For the remaining detailed MinerU configuration, refer to the MinerU section of the environment variable example file [env.example](https://github.com/HKUDS/LightRAG/blob/main/env.example) at the repository root. The `official` and `local` modes each have different environment variable configurations; read the instructions in the example file carefully.
 
-#### **Local Deployment of the MinerU Service**
-
-Copy `Dockerfile` and `compose.yaml` from the official GitHub repository [opendatalab/MinerU](https://github.com/opendatalab/MinerU) to your local machine. Both files can be found in the repository's `docker` directory. For special GPUs from Chinese vendors, you need to choose the corresponding `Dockerfile`.
-
-After preparing the two files above, build the Docker image with the following command:
-
-```bash
-docker build --tag mineru:latest .
-```
-
-Once the image is built, start the API service with the following command (the `--profile api` parameter indicates starting only MinerU's API service; the service listens on port 8000 by default):
-
-```bash
-docker compose -f compose.yaml --profile api up -d
-```
-
-For image build details, GPU driver setup, model weight locations, etc., refer to the official README: <https://github.com/opendatalab/MinerU>.
-
-**Advanced configuration: enabling vLLM preload and title-level correction (optional)**
-
-On top of the basic deployment, it is recommended to additionally enable two MinerU **server-side** features for your local MinerU. Both modify MinerU container-side configuration (the in-container `mineru.json` and the official `compose.yaml`), and do not involve any LightRAG env variable; title-level correction additionally requires an available LLM API.
-
-- **vLLM startup preload**: loads the VLM model into GPU memory at container startup, avoiding the model-loading latency on the first parse request.
-- **Title-level correction (`title_aided`)**: MinerU uses an external LLM to correct the title hierarchy of the parsed output, improving the quality of the structured artifacts. This is especially helpful for the [P (paragraph semantic) chunking strategy](#25-file-processing-options), which depends on the title structure; the `P` chunking strategy splits by titles first, so the more accurate the title hierarchy, the better the chunking semantics.
-
-**Step 1: Export and modify `mineru-lightrag.json`**
-
-Copy `/root/mineru.json` from the official image to `mineru-lightrag.json` in the host's current directory (using the fixed container name `temp_mineru`, without running the container):
-
-```bash
-docker create --name temp_mineru mineru:latest
-docker cp temp_mineru:/root/mineru.json ./mineru-lightrag.json
-docker rm temp_mineru
-```
-
-Then modify `llm-aided-config.title_aided` in `mineru-lightrag.json`: fill in `api_key` and change `enable` to `true`:
-
-```json
-"llm-aided-config": {
-    "title_aided": {
-        "api_key": "your_api_key",
-        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
-        "model": "qwen3.5-plus",
-        "enable_thinking": false,
-        "enable": true
-    }
-}
-```
-
-> `api_key` / `base_url` / `model` should be replaced with an LLM service available to you (the example uses Alibaba Cloud DashScope's OpenAI-compatible endpoint).
-
-**Step 2: Modify the `api` profile service (`mineru-api`) in the official `compose.yaml`**
-
-Make three changes to the `mineru-api` service: add `MINERU_TOOLS_CONFIG_JSON` to `environment` (so MinerU reads the modified config instead of the image's built-in `mineru.json`), mount the host's `mineru-lightrag.json` into the container via `volumes`, and append `--enable-vlm-preload true` to `command` to enable vLLM preload. The complete `mineru-api` profile after modification is as follows (the three increments are marked with `# <-- added`):
-
-```yaml
-  mineru-api:
-    image: mineru:latest
-    container_name: mineru-api
-    restart: always
-    profiles: ["api"]
-    ports:
-      - 8000:8000
-    environment:
-      MINERU_MODEL_SOURCE: local
-      MINERU_TOOLS_CONFIG_JSON: /root/mineru-lightrag.json   # <-- added
-    volumes:
-      - ./mineru-lightrag.json:/root/mineru-lightrag.json    # <-- added
-    entrypoint: mineru-api
-    command:
-      --host 0.0.0.0
-      --port 8000
-      --allow-public-http-client
-      --gpu-memory-utilization 0.45         #
-      --enable-vlm-preload true             # <-- added
-    ulimits:
-      memlock: -1
-      stack: 67108864
-    ipc: host
-    healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              device_ids: ["0"]  # For multiple GPUs: ["0", "1"]
-              capabilities: [gpu]
-```
-
-> In the example, adjust `gpu-memory-utilization` according to your actual GPU setup. The three items `environment` / `volumes` / `command` are the additions for this change; keep everything else as in the official file.
-
-**Step 3: Restart to take effect**
-
-After making the changes, restart the API service for them to take effect:
-
-```bash
-docker compose -f compose.yaml --profile api up -d
-```
+> **Local deployment of the MinerU service** (Docker image build, vLLM preload, title-level correction) is described in [ParserServiceDeployment.md §1](./ParserServiceDeployment.md#1-local-deployment-of-the-mineru-service).
 
 #### Using the Docling File Parsing Engine
 
@@ -386,7 +288,7 @@ DOCLING_ENDPOINT=http://localhost:5001
 | `DOCLING_OCR_ENGINE` | `auto` | OCR engine selection (not recommended to change) |
 | `DOCLING_OCR_PRESET` | `auto` | OCR engine preset (not recommended to change) |
 | `DOCLING_OCR_LANG` | (empty) | Set per OCR engine requirements (not recommended to change) |
-| `DOCLING_DO_FORMULA_ENRICHMENT` | `false` | Whether to recognize equations in the document and output them in LaTeX format; before enabling, ensure that Docling has downloaded the equation recognition model on the backend (see explanation below) |
+| `DOCLING_DO_FORMULA_ENRICHMENT` | `false` | Whether to recognize equations in the document and output them in LaTeX format; before enabling, ensure that Docling has downloaded the equation recognition model on the backend (see [ParserServiceDeployment.md §2](./ParserServiceDeployment.md#2-local-deployment-of-docling-serve-latex-equation-recognition)) |
 
 When `DOCLING_OCR_ENGINE` / `DOCLING_OCR_PRESET` are not configured, they are equivalent to `auto`; when `DOCLING_OCR_LANG` is not configured, no language list is passed to docling-serve, and the OCR engine uses its own default. The parse cache signature is computed from these effective parameters, so "not configured" and "explicitly set to the default value" do not invalidate the cache.
 
@@ -419,78 +321,7 @@ Three bundle-cache envs:
 
 **Prerequisites for `DOCLING_DO_FORMULA_ENRICHMENT`**: the docling-serve side must have the code-formula model weights ready. The adapter is dual-track compatible — when enabled, the `text` field is LaTeX; when disabled, or when missing weights cause `text == orig`, it falls back to plain text and does not write `equations.json`. Therefore the default of `false` is conservative; turn it on only after confirming the model is ready on the deployment side.
 
-#### Docling Local Deployment (enabling LaTeX equation recognition)
-
-The following uses a Docker-based docling-serve deployment as an example, giving the complete steps from image download to model mounting. After deployment completes, write `DOCLING_DO_FORMULA_ENRICHMENT=true` into LightRAG's `.env` to enable LaTeX equation recognition.
-
-> **Important**: the steps below are based on an environment where the GPU supports CUDA 13. If your GPU is older and does not support CUDA 13, replace the image name `docling-serve-cu130:main` in the command and compose file with the tag corresponding to your CUDA version. For the list of available images, see [docling-serve Packages](https://github.com/orgs/docling-project/packages?repo_name=docling-serve).
-
-**1. Pull the image**
-
-```bash
-docker pull ghcr.io/docling-project/docling-serve-cu130:main
-```
-
-**2. Download models**
-
-```bash
-# Create the docling working directory
-mkdir docling
-cd docling
-
-# Create the model mount directory
-mkdir models
-
-# Copy the existing models inside the container into the models directory
-docker run --rm -it \
-  -v "$(pwd)/models:/opt/app-root/src/models" \
-  ghcr.io/docling-project/docling-serve-cu130:main \
-  cp -r /opt/app-root/src/.cache/docling/models /opt/app-root/src/
-
-# Download the equation recognition model
-docker run --rm \
-  -v "$(pwd)/models:/opt/app-root/src/models" \
-  -e DOCLING_SERVE_ARTIFACTS_PATH="/opt/app-root/src/models" \
-  ghcr.io/docling-project/docling-serve-cu130:main \
-  docling-tools models download-hf-repo docling-project/CodeFormulaV2 -o models
-```
-
-**3. Create `docker-compose.yaml`**
-
-Create `docker-compose.yaml` in the `docling` directory from the previous step, with the following contents:
-
-```yaml
-services:
-  docling-serve:
-    image: ghcr.io/docling-project/docling-serve-cu130:main
-    container_name: docling-serve
-    ports:
-      - "5001:5001"
-    environment:
-      DOCLING_SERVE_ENABLE_UI: "true"
-      NVIDIA_VISIBLE_DEVICES: "all"
-      DOCLING_SERVE_ARTIFACTS_PATH: "/opt/app-root/src/models"
-    # deploy:  # This section is for compatibility with Swarm
-    #   resources:
-    #     reservations:
-    #       devices:
-    #         - driver: nvidia
-    #           count: all
-    #           capabilities: [gpu]
-    runtime: nvidia
-    restart: always
-    volumes:
-      - ./models:/opt/app-root/src/models
-```
-
-Then execute `docker compose up -d` in that directory to start the service. After the container is ready, set the following in LightRAG's `.env`:
-
-```bash
-DOCLING_ENDPOINT=http://localhost:5001
-DOCLING_DO_FORMULA_ENRICHMENT=true
-```
-
-This enables LightRAG to recognize equations in documents via the local docling-serve and output them in LaTeX form.
+> **Local deployment of docling-serve**, including downloading the equation-recognition model required by `DOCLING_DO_FORMULA_ENRICHMENT`, is described in [ParserServiceDeployment.md §2](./ParserServiceDeployment.md#2-local-deployment-of-docling-serve-latex-equation-recognition).
 
 ### 2.5 File Processing Options
 

--- a/docs/ParserServiceDeployment-zh.md
+++ b/docs/ParserServiceDeployment-zh.md
@@ -1,0 +1,180 @@
+# 解析服务本地部署
+
+MinerU 与 Docling 都是**外部服务**：LightRAG 通过 HTTP 与它们通信，不会在进程内运行它们的模型。只有当你把文件路由到 `mineru` 或 `docling` 引擎、并且希望自行搭建该服务（而不是使用现成的服务端点）时，才需要本文档。
+
+本文档内容全部是这两个上游项目的容器侧配置，其中没有任何 LightRAG 环境变量。LightRAG 侧的配置（哪个扩展名交给哪个引擎、服务端点、凭据、引擎参数）请见 [FileProcessingPipeline-zh.md](./FileProcessingPipeline-zh.md)。
+
+## 1. 本地部署 MinerU 服务
+
+
+从 Github官方仓库   [opendatalab/MinerU](https://github.com/opendatalab/MinerU) 把 Dockerfile 和 compose.yaml 拷贝到本地。这两个文件应该在仓库的 docker 目录可以找到。针对中国供应商的特殊显卡需要选择相应的 Dockerfile 。
+
+准备好上诉两个文件后通过以下命令构建 docker 镜像:
+
+```bash
+docker build --tag mineru:latest .
+```
+
+镜像构建好之后通过以下命令启动 API 服务（参数 `--profile api` 标识仅启动MinerU的 API 服务，服务默认监听 8000 端口）：
+
+```bash
+docker compose -f compose.yaml --profile api up -d
+```
+
+镜像构建细节、GPU 驱动准备、模型权重位置等请参考官方 README：<https://github.com/opendatalab/MinerU>。
+
+**进阶配置：开启 vLLM 预加载与标题层级修正（可选）**
+
+在基础部署之上，建议为本地 MinerU 额外开启两项 MinerU **服务端**功能。这两项都改的是 MinerU 容器侧配置（容器内 `mineru.json` 与官方 `compose.yaml`），不涉及 LightRAG 的 env 变量；其中标题层级修正还需要一个可用的 LLM API。
+
+- **vLLM 启动预加载**：让容器启动时就把 VLM 模型加载进显存，避免首个解析请求承担模型加载延迟。
+- **标题层级修正（`title_aided`）**：MinerU 借助一个外部 LLM 修正解析输出的标题层级，提升结构化产物质量。这对依赖标题结构的 [P（段落语义）分块策略](./FileProcessingPipeline-zh.md#25-文件处理选项)尤其有帮助；`P分块策略` 优先按标题分割，标题层级越准确，分块语义越好。
+
+**步骤1：导出并修改 `mineru-lightrag.json`**
+
+从官方镜像中把 `/root/mineru.json` 拷到宿主机当前目录的 `mineru-lightrag.json`（用固定容器名 `temp_mineru`，无需运行容器）：
+
+```bash
+docker create --name temp_mineru mineru:latest
+docker cp temp_mineru:/root/mineru.json ./mineru-lightrag.json
+docker rm temp_mineru
+```
+
+然后修改 `mineru-lightrag.json` 中的 `llm-aided-config.title_aided`：填入 `api_key`，并把 `enable` 改为 `true`：
+
+```json
+"llm-aided-config": {
+    "title_aided": {
+        "api_key": "your_api_key",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "model": "qwen3.5-plus",
+        "enable_thinking": false,
+        "enable": true
+    }
+}
+```
+
+> `api_key` / `base_url` / `model` 需替换为用户自己可用的 LLM 服务（示例使用阿里云 DashScope 的 OpenAI 兼容接口）。
+
+**步骤2：修改官方 `compose.yaml` 的 `api` profile 服务（`mineru-api`）**
+
+在 `mineru-api` 服务上做三处改动：`environment` 增加 `MINERU_TOOLS_CONFIG_JSON`（让 MinerU 读改过的配置而非镜像内置 `mineru.json`），`volumes` 把宿主机 `mineru-lightrag.json` 挂进容器，`command` 追加 `--enable-vlm-preload true` 开启 vLLM 预加载。改好后的完整 `mineru-api` profile 如下（以 `# <-- 新增` 标注三处增量）：
+
+```yaml
+  mineru-api:
+    image: mineru:latest
+    container_name: mineru-api
+    restart: always
+    profiles: ["api"]
+    ports:
+      - 8000:8000
+    environment:
+      MINERU_MODEL_SOURCE: local
+      MINERU_TOOLS_CONFIG_JSON: /root/mineru-lightrag.json   # <-- Added
+    volumes:
+      - ./mineru-lightrag.json:/root/mineru-lightrag.json    # <-- Added
+    entrypoint: mineru-api
+    command:
+      --host 0.0.0.0
+      --port 8000
+      --allow-public-http-client
+      --gpu-memory-utilization 0.45                          # Reserved 10GB is fine, preventing OOM errors
+      --enable-vlm-preload true                              # <-- Added
+    ulimits:
+      memlock: -1
+      stack: 67108864
+    ipc: host
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+```
+
+> 示范中请按实际显卡情况调整 `gpu-memory-utilization` ；`environment` / `volumes` / `command` 三处为本次新增项，其余保持官方原样。
+
+**步骤3：重启生效**
+
+改完后重新启动 API 服务让改动生效：
+
+```bash
+docker compose -f compose.yaml --profile api up -d
+```
+
+## 2. 本地部署 docling-serve（启用 LaTeX 公式识别）
+
+
+下面以 Docker 部署 docling-serve 为例，给出从镜像下载到模型挂载的完整步骤，部署完成后将 `DOCLING_DO_FORMULA_ENRICHMENT=true` 写入 LightRAG 的 `.env` 即可启用 LaTeX 公式识别。
+
+> **重要提示**：以下步骤基于显卡支持 CUDA 13 的环境。如果显卡较老旧、不支持 CUDA 13，需要把命令与 compose 文件中的镜像名 `docling-serve-cu130:main` 替换为对应 CUDA 版本的标签。可选镜像列表参见 [docling-serve Packages](https://github.com/orgs/docling-project/packages?repo_name=docling-serve)。
+
+**1. 下载镜像**
+
+```bash
+docker pull ghcr.io/docling-project/docling-serve-cu130:main
+```
+
+**2. 下载模型**
+
+```bash
+# 创建 docling 工作目录
+mkdir docling
+cd docling
+
+# 创建模型挂载目录
+mkdir models
+
+# 把容器内的原有模型拷贝到 models 目录
+docker run --rm -it \
+  -v "$(pwd)/models:/opt/app-root/src/models" \
+  ghcr.io/docling-project/docling-serve-cu130:main \
+  cp -r /opt/app-root/src/.cache/docling/models /opt/app-root/src/
+
+# 下载公式识别模型
+docker run --rm \
+  -v "$(pwd)/models:/opt/app-root/src/models" \
+  -e DOCLING_SERVE_ARTIFACTS_PATH="/opt/app-root/src/models" \
+  ghcr.io/docling-project/docling-serve-cu130:main \
+  docling-tools models download-hf-repo docling-project/CodeFormulaV2 -o models
+```
+
+**3. 创建 `docker-compose.yaml` 文件**
+
+在上一步的 `docling` 目录下创建 `docker-compose.yaml`，内容如下：
+
+```yaml
+services:
+  docling-serve:
+    image: ghcr.io/docling-project/docling-serve-cu130:main
+    container_name: docling-serve
+    ports:
+      - "5001:5001"
+    environment:
+      DOCLING_SERVE_ENABLE_UI: "true"
+      NVIDIA_VISIBLE_DEVICES: "all"
+      DOCLING_SERVE_ARTIFACTS_PATH: "/opt/app-root/src/models"
+    # deploy:  # This section is for compatibility with Swarm
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+    runtime: nvidia
+    restart: always
+    volumes:
+      - ./models:/opt/app-root/src/models
+```
+
+随后在该目录执行 `docker compose up -d` 启动服务。容器就绪后，在 LightRAG 的 `.env` 中设置：
+
+```bash
+DOCLING_ENDPOINT=http://localhost:5001
+DOCLING_DO_FORMULA_ENRICHMENT=true
+```
+
+即可让 LightRAG 通过本地 docling-serve 识别文档中的公式并以 LaTeX 形式输出。

--- a/docs/ParserServiceDeployment.md
+++ b/docs/ParserServiceDeployment.md
@@ -1,0 +1,180 @@
+# Parser Service Deployment
+
+MinerU and Docling are **external services**: LightRAG talks to them over HTTP and never runs their models in-process. You need this document only if you route files to the `mineru` or `docling` engine and want to host that service yourself instead of using a hosted endpoint.
+
+Everything here is container-side configuration for those upstream projects. Nothing on this page is a LightRAG environment variable — for the LightRAG side (which engine handles which extension, endpoints, credentials, per-engine options) see [FileProcessingPipeline.md](./FileProcessingPipeline.md).
+
+## 1. Local Deployment of the MinerU Service
+
+
+Copy `Dockerfile` and `compose.yaml` from the official GitHub repository [opendatalab/MinerU](https://github.com/opendatalab/MinerU) to your local machine. Both files can be found in the repository's `docker` directory. For special GPUs from Chinese vendors, you need to choose the corresponding `Dockerfile`.
+
+After preparing the two files above, build the Docker image with the following command:
+
+```bash
+docker build --tag mineru:latest .
+```
+
+Once the image is built, start the API service with the following command (the `--profile api` parameter indicates starting only MinerU's API service; the service listens on port 8000 by default):
+
+```bash
+docker compose -f compose.yaml --profile api up -d
+```
+
+For image build details, GPU driver setup, model weight locations, etc., refer to the official README: <https://github.com/opendatalab/MinerU>.
+
+**Advanced configuration: enabling vLLM preload and title-level correction (optional)**
+
+On top of the basic deployment, it is recommended to additionally enable two MinerU **server-side** features for your local MinerU. Both modify MinerU container-side configuration (the in-container `mineru.json` and the official `compose.yaml`), and do not involve any LightRAG env variable; title-level correction additionally requires an available LLM API.
+
+- **vLLM startup preload**: loads the VLM model into GPU memory at container startup, avoiding the model-loading latency on the first parse request.
+- **Title-level correction (`title_aided`)**: MinerU uses an external LLM to correct the title hierarchy of the parsed output, improving the quality of the structured artifacts. This is especially helpful for the [P (paragraph semantic) chunking strategy](./FileProcessingPipeline.md#25-file-processing-options), which depends on the title structure; the `P` chunking strategy splits by titles first, so the more accurate the title hierarchy, the better the chunking semantics.
+
+**Step 1: Export and modify `mineru-lightrag.json`**
+
+Copy `/root/mineru.json` from the official image to `mineru-lightrag.json` in the host's current directory (using the fixed container name `temp_mineru`, without running the container):
+
+```bash
+docker create --name temp_mineru mineru:latest
+docker cp temp_mineru:/root/mineru.json ./mineru-lightrag.json
+docker rm temp_mineru
+```
+
+Then modify `llm-aided-config.title_aided` in `mineru-lightrag.json`: fill in `api_key` and change `enable` to `true`:
+
+```json
+"llm-aided-config": {
+    "title_aided": {
+        "api_key": "your_api_key",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "model": "qwen3.5-plus",
+        "enable_thinking": false,
+        "enable": true
+    }
+}
+```
+
+> `api_key` / `base_url` / `model` should be replaced with an LLM service available to you (the example uses Alibaba Cloud DashScope's OpenAI-compatible endpoint).
+
+**Step 2: Modify the `api` profile service (`mineru-api`) in the official `compose.yaml`**
+
+Make three changes to the `mineru-api` service: add `MINERU_TOOLS_CONFIG_JSON` to `environment` (so MinerU reads the modified config instead of the image's built-in `mineru.json`), mount the host's `mineru-lightrag.json` into the container via `volumes`, and append `--enable-vlm-preload true` to `command` to enable vLLM preload. The complete `mineru-api` profile after modification is as follows (the three increments are marked with `# <-- added`):
+
+```yaml
+  mineru-api:
+    image: mineru:latest
+    container_name: mineru-api
+    restart: always
+    profiles: ["api"]
+    ports:
+      - 8000:8000
+    environment:
+      MINERU_MODEL_SOURCE: local
+      MINERU_TOOLS_CONFIG_JSON: /root/mineru-lightrag.json   # <-- added
+    volumes:
+      - ./mineru-lightrag.json:/root/mineru-lightrag.json    # <-- added
+    entrypoint: mineru-api
+    command:
+      --host 0.0.0.0
+      --port 8000
+      --allow-public-http-client
+      --gpu-memory-utilization 0.45         #
+      --enable-vlm-preload true             # <-- added
+    ulimits:
+      memlock: -1
+      stack: 67108864
+    ipc: host
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]  # For multiple GPUs: ["0", "1"]
+              capabilities: [gpu]
+```
+
+> In the example, adjust `gpu-memory-utilization` according to your actual GPU setup. The three items `environment` / `volumes` / `command` are the additions for this change; keep everything else as in the official file.
+
+**Step 3: Restart to take effect**
+
+After making the changes, restart the API service for them to take effect:
+
+```bash
+docker compose -f compose.yaml --profile api up -d
+```
+
+## 2. Local Deployment of docling-serve (LaTeX equation recognition)
+
+
+The following uses a Docker-based docling-serve deployment as an example, giving the complete steps from image download to model mounting. After deployment completes, write `DOCLING_DO_FORMULA_ENRICHMENT=true` into LightRAG's `.env` to enable LaTeX equation recognition.
+
+> **Important**: the steps below are based on an environment where the GPU supports CUDA 13. If your GPU is older and does not support CUDA 13, replace the image name `docling-serve-cu130:main` in the command and compose file with the tag corresponding to your CUDA version. For the list of available images, see [docling-serve Packages](https://github.com/orgs/docling-project/packages?repo_name=docling-serve).
+
+**1. Pull the image**
+
+```bash
+docker pull ghcr.io/docling-project/docling-serve-cu130:main
+```
+
+**2. Download models**
+
+```bash
+# Create the docling working directory
+mkdir docling
+cd docling
+
+# Create the model mount directory
+mkdir models
+
+# Copy the existing models inside the container into the models directory
+docker run --rm -it \
+  -v "$(pwd)/models:/opt/app-root/src/models" \
+  ghcr.io/docling-project/docling-serve-cu130:main \
+  cp -r /opt/app-root/src/.cache/docling/models /opt/app-root/src/
+
+# Download the equation recognition model
+docker run --rm \
+  -v "$(pwd)/models:/opt/app-root/src/models" \
+  -e DOCLING_SERVE_ARTIFACTS_PATH="/opt/app-root/src/models" \
+  ghcr.io/docling-project/docling-serve-cu130:main \
+  docling-tools models download-hf-repo docling-project/CodeFormulaV2 -o models
+```
+
+**3. Create `docker-compose.yaml`**
+
+Create `docker-compose.yaml` in the `docling` directory from the previous step, with the following contents:
+
+```yaml
+services:
+  docling-serve:
+    image: ghcr.io/docling-project/docling-serve-cu130:main
+    container_name: docling-serve
+    ports:
+      - "5001:5001"
+    environment:
+      DOCLING_SERVE_ENABLE_UI: "true"
+      NVIDIA_VISIBLE_DEVICES: "all"
+      DOCLING_SERVE_ARTIFACTS_PATH: "/opt/app-root/src/models"
+    # deploy:  # This section is for compatibility with Swarm
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+    runtime: nvidia
+    restart: always
+    volumes:
+      - ./models:/opt/app-root/src/models
+```
+
+Then execute `docker compose up -d` in that directory to start the service. After the container is ready, set the following in LightRAG's `.env`:
+
+```bash
+DOCLING_ENDPOINT=http://localhost:5001
+DOCLING_DO_FORMULA_ENRICHMENT=true
+```
+
+This enables LightRAG to recognize equations in documents via the local docling-serve and output them in LaTeX form.


### PR DESCRIPTION
## Summary

Second of the file-processing docs series. **Stacked on #3539** — review that one first; this PR's diff is against it.

Moves the MinerU and docling-serve local-deployment runbooks out of `FileProcessingPipeline.md` into a new `docs/ParserServiceDeployment.md` (+ `-zh`).

## Motivation

`FileProcessingPipeline.md` is described in the README as a pipeline specification, but 169 of its lines were operator runbooks for two *upstream* projects: building the MinerU Docker image, editing the in-container `mineru.json`, a 33-line compose file, pulling `docling-serve`, downloading HuggingFace model weights, and a second compose file.

None of that is LightRAG configuration, and it sat between the MinerU engine section and the Docling one. The practical cost: a reader looking up what the `P` chunking option means had to scroll past both Docker runbooks first, because the processing-options table lives *after* them.

## What's changed

- New `docs/ParserServiceDeployment.md` and `docs/ParserServiceDeployment-zh.md`, each opening with a short "you only need this if you self-host MinerU or docling-serve" intro that draws the line explicitly: everything in the file is container-side configuration for the upstream project, and no LightRAG environment variable appears in it.
- A pointer left at each removal site in `FileProcessingPipeline.md`.
- Two back-references that read "See the deployment instructions below" and "(see explanation below)" now name the new document, instead of pointing at text that is no longer below them.
- The one link *inside* the MinerU runbook (to the processing-options section, explaining why `title_aided` helps `P` chunking) becomes a cross-file link.
- A row in the **Document Processing** table of all three READMEs.

`FileProcessingPipeline.md` drops from 1137 to 968 lines. Both language files remain structurally parallel (same line count, same heading tree).

## Why only these two blocks

The two runbooks were the only sections with **zero inbound anchors**, so the move costs nothing in link churn. Chapters 5–7 (dedup, concurrency, resume) are densely cross-referenced with the rest of the file in both directions and are deliberately left in place.

## Verification

- Repo-wide Markdown link checker (resolves target file *and* `#fragment`, so cross-file anchors are covered): no findings involving either the new or the source document. The 12 remaining findings are pre-existing and unrelated (missing example scripts referenced by `ProgramingWithCore.md`, `k8s-deploy` percent-encoded paths, `memory-bank`, `tests/workspace`).
- Heading tree and line count verified identical between the two new language files.
- Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)