### PR TITLE
feat(utils): bound thread-pool submission and pin the tokenizer contract

### DIFF
--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -75,7 +75,7 @@ Notes:
 | **doc_status_storage** | `str` | Storage type for documents process status. Supported types: `JsonDocStatusStorage`,`PGDocStatusStorage`,`MongoDocStatusStorage`,`OpenSearchDocStatusStorage` | `JsonDocStatusStorage` |
 | **chunk_token_size** | `int` | Maximum token size per chunk when splitting documents | `1200` |
 | **chunk_overlap_token_size** | `int` | Overlap token size between two chunks when splitting documents | `100` |
-| **tokenizer** | `Tokenizer` | The function used to convert text into tokens (numbers) and back using .encode() and .decode() functions following `TokenizerInterface` protocol. If you don't specify one, it will use the default Tiktoken tokenizer. | `TiktokenTokenizer` |
+| **tokenizer** | `Tokenizer` | The function used to convert text into tokens (numbers) and back using .encode() and .decode() functions following `TokenizerInterface` protocol. If you don't specify one, it will use the default Tiktoken tokenizer. An injected tokenizer must be safe to call concurrently from multiple threads and must survive `copy.deepcopy` — see [Injecting a custom tokenizer](#injecting-a-custom-tokenizer). | `TiktokenTokenizer` |
 | **tiktoken_model_name** | `str` | If you're using the default Tiktoken tokenizer, this is the name of the specific Tiktoken model to use. This setting is ignored if you provide your own tokenizer. | `gpt-4o-mini` |
 | **entity_extract_max_gleaning** | `int` | Number of loops in the entity extraction process, appending history messages | `1` |
 | **node_embedding_algorithm** | `str` | Algorithm for node embedding (currently not used) | `node2vec` |
@@ -567,6 +567,45 @@ To enhance retrieval quality, documents can be re-ranked based on a more effecti
 - **Aliyun**: `ali_rerank`
 
 Inject one of these functions into the `rerank_model_func` attribute of the LightRAG object. For detailed usage, refer to `examples/rerank_example.py`.
+
+### Injecting a Custom Tokenizer
+
+Any object with `encode(str) -> list[int]` and `decode(list[int]) -> str` can be
+wrapped in `Tokenizer` and passed as `tokenizer=`. Two requirements apply:
+
+1. **It must be safe to call concurrently from multiple threads.** Token counting
+   is CPU-bound, so LightRAG runs it in worker threads to keep the asyncio event
+   loop responsive; several of them may enter your `encode`/`decode` at once.
+   LightRAG deliberately does not serialize calls on your behalf — a lock owned
+   by LightRAG would end up being waited on by the event loop behind a worker
+   thread, which is exactly the stall the threading is there to avoid.
+2. **It must survive `copy.deepcopy`.** `LightRAG` is a dataclass and builds its
+   internal config with `dataclasses.asdict`, which deep-copies non-dataclass
+   fields.
+
+The two interact: if you achieve thread safety with an internal `threading.Lock`,
+deep-copying it raises `TypeError: cannot pickle '_thread.lock' object`. Declare
+`__deepcopy__` returning `self`, which is sound precisely because a thread-safe
+tokenizer is safe to share:
+
+```python
+class MyTokenizer:
+    def __init__(self):
+        self._lock = threading.Lock()
+
+    def __deepcopy__(self, memo):
+        return self  # thread-safe, therefore shareable
+
+    def encode(self, content: str) -> list[int]: ...
+    def decode(self, tokens: list[int]) -> str: ...
+
+rag = LightRAG(..., tokenizer=Tokenizer("my-model", MyTokenizer()))
+```
+
+The built-in `TiktokenTokenizer` satisfies both. Note that copying it is not a
+way to get isolation: `tiktoken` caches encodings in a process-wide registry, so
+every `TiktokenTokenizer` for a given model — copies included — resolves to the
+same underlying BPE engine.
 
 ### User Prompt vs. Query
 

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -447,6 +447,20 @@ DEFAULT_MAX_TEXTS_PER_REQUEST = 0
 # body that lies about (or omits) Content-Length is still cut off.
 DEFAULT_MAX_REQUEST_BODY_BYTES = 0
 
+# Submission ceilings for the two single-worker CPU pools (tokenizer, chunking).
+# A ``ThreadPoolExecutor`` wait queue is unbounded, and freeing the event loop
+# means more requests can be in flight at once, so submissions need their own
+# limit. Deliberately fixed process-wide constants rather than anything derived
+# from ``max_parallel_insert``: the submitting helpers are module level and are
+# called from places holding no ``LightRAG`` instance, several instances sharing
+# one event loop would each build their own semaphore and lose the global
+# ceiling, and — the substantive reason — the pools have ONE worker, so queue
+# depth beyond single digits buys no throughput and only pins more pending data
+# in memory. Over the limit the submitting coroutine waits; it is backpressure,
+# not refusal.
+TOKENIZER_SUBMIT_LIMIT = 8
+CHUNKING_SUBMIT_LIMIT = 8
+
 # Per-workspace ceiling on manual retry requests that have been published but
 # not yet ACKed (LR2 §10.1). The channel is sticky — a request survives until an
 # exclusive reset acknowledges it — so an operator hammering /reprocess_failed

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -518,6 +518,16 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     A function that returns a Tokenizer instance.
     If None, and a `tiktoken_model_name` is provided, a TiktokenTokenizer will be created.
     If both are None, the default TiktokenTokenizer is used.
+
+    Injection contract: token counting is CPU-bound and runs in worker threads so
+    it does not block the event loop, so an injected tokenizer MUST be safe to
+    call concurrently from multiple threads, and MUST survive ``copy.deepcopy``
+    (``asdict`` in ``_build_global_config`` copies non-dataclass fields; an
+    implementation guarding itself with a ``threading.Lock`` should declare
+    ``__deepcopy__`` returning ``self``). LightRAG deliberately does not serialize
+    it — a lock owned by LightRAG would be waited on by the event loop and would
+    recreate the freeze the offload removes. The built-in ``TiktokenTokenizer``
+    satisfies both. See :class:`lightrag.utils.Tokenizer`.
     """
 
     tiktoken_model_name: str = field(default="gpt-4o-mini")
@@ -1091,6 +1101,15 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     def _build_global_config(self) -> dict[str, Any]:
         self._ensure_addon_params_cache()
         global_config = asdict(self)
+        # Restore the tokenizer object itself (asdict deep-copies non-dataclass
+        # fields), the same way __post_init__ restores embedding_func. Copying it
+        # was never the isolation it looked like: tiktoken caches encodings in a
+        # process-wide registry and Encoding.__setstate__ rebinds a copy's __dict__
+        # to the registered instance's, so every "independent" copy already shared
+        # one CoreBPE. Now that the injection contract is thread safety, sharing is
+        # what it asks for — and this keeps a tokenizer that holds an internal lock
+        # (deep-copying a lock raises TypeError) off the per-operation copy path.
+        global_config["tokenizer"] = self.tokenizer
         global_config.pop("_addon_params", None)
         global_config.pop("_addon_params_dirty", None)
         global_config.pop("_cached_entity_extraction_use_json", None)

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -18,9 +18,10 @@ import re
 import time
 import uuid
 import warnings
+from concurrent.futures import Future as ConcurrentFuture, ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime
-from functools import wraps
+from functools import partial, wraps
 from hashlib import md5
 from pathlib import Path
 from typing import (
@@ -2581,20 +2582,209 @@ def write_json(json_obj, file_name):
 class TokenizerInterface(Protocol):
     """
     Defines the interface for a tokenizer, requiring encode and decode methods.
+
+    Implementations MUST be safe to call concurrently from multiple OS threads —
+    LightRAG runs token counting in worker threads to keep it off the asyncio
+    event loop, and does not serialize calls on the implementation's behalf. See
+    :class:`Tokenizer` for why serializing here would be the wrong layer.
     """
 
     def encode(self, content: str) -> List[int]:
-        """Encodes a string into a list of tokens."""
+        """Encodes a string into a list of tokens.
+
+        May be called concurrently from multiple threads.
+        """
         ...
 
     def decode(self, tokens: List[int]) -> str:
-        """Decodes a list of tokens into a string."""
+        """Decodes a list of tokens into a string.
+
+        May be called concurrently from multiple threads.
+        """
         ...
+
+
+# ---------------------------------------------------------------------------
+# Bounded submission to a thread pool
+# ---------------------------------------------------------------------------
+#
+# Moving CPU-bound work off the event loop frees the loop to keep accepting
+# requests, which means more work can be in flight at once than before. A
+# ``ThreadPoolExecutor``'s wait queue is unbounded, so submissions need their own
+# ceiling.
+#
+# The subtle part is WHO holds the permit. Writing ``async with sem: await
+# run_in_executor(...)`` is wrong: cancelling the awaiting coroutine returns the
+# permit immediately, but the thread-pool task is not cancelled — an already
+# running ``concurrent.futures.Future.cancel()`` just returns False and the thread
+# runs to completion. A client that repeatedly submits and cancels would hand back
+# permits it is still consuming and rebuild an unbounded queue. The permit
+# therefore belongs to the executor future and is released from its done callback,
+# so permit occupancy tracks actual thread occupancy exactly.
+
+
+def _consume_future_exception(fut: "asyncio.Future") -> None:
+    """Mark a shielded future's exception as retrieved.
+
+    When ``shield`` is cancelled nobody awaits the inner future any more, so an
+    exception raised by the thread would surface as an "exception was never
+    retrieved" traceback at GC time. Retrieving it here only clears that log
+    flag; a caller that is still awaiting still sees the exception.
+    """
+    if not fut.cancelled():
+        fut.exception()
+
+
+async def bounded_submit(
+    executor: ThreadPoolExecutor,
+    semaphore: asyncio.Semaphore,
+    fn: Callable[..., Any],
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Run ``fn`` in ``executor`` under a permit owned by the executor future.
+
+    Args:
+        executor: destination pool.
+        semaphore: submission ceiling for this pool, from :func:`get_loop_semaphore`.
+        fn: synchronous callable to run in the pool.
+        *args, **kwargs: forwarded to ``fn``.
+
+    Returns:
+        Whatever ``fn`` returns.
+
+    Cancelling the caller does not cancel the thread: the work runs to completion
+    and only then is the permit returned. That is deliberate — see the module
+    comment above.
+    """
+    await semaphore.acquire()
+    try:
+        concurrent_future: ConcurrentFuture = executor.submit(
+            contextvars.copy_context().run, partial(fn, *args, **kwargs)
+        )
+    except BaseException:
+        semaphore.release()
+        raise
+
+    loop = asyncio.get_running_loop()
+
+    def _release(_done: ConcurrentFuture) -> None:
+        # Runs on the worker thread, so the release has to be posted back to the
+        # loop that owns the semaphore. A closed loop means the semaphore died
+        # with it and there is nothing left to release.
+        try:
+            loop.call_soon_threadsafe(semaphore.release)
+        except RuntimeError:
+            pass
+
+    concurrent_future.add_done_callback(_release)
+
+    async_future = asyncio.wrap_future(concurrent_future)
+    async_future.add_done_callback(_consume_future_exception)
+    return await asyncio.shield(async_future)
+
+
+# Semaphores are per event loop, executors are per process. ``asyncio.Semaphore``
+# binds to the first loop that has to wait on it and raises from any other loop
+# (``asyncio.mixins._LoopBoundMixin``), and the test suite runs one fresh loop per
+# case, so a module-level singleton would fail. Storing it ON the loop makes its
+# lifetime exactly the loop's; a container keyed by the loop would not, because
+# once contended the semaphore holds a strong reference back to its loop and a
+# ``WeakKeyDictionary`` entry whose value references its key never expires.
+_LOOP_SEMAPHORE_ATTR_PREFIX = "_lightrag_submit_semaphore_"
+_LOOP_SEMAPHORE_FALLBACK: dict[int, tuple[Any, dict[str, asyncio.Semaphore]]] = {}
+
+
+def _fallback_semaphore(loop: Any, name: str, capacity: int) -> asyncio.Semaphore:
+    """Per-loop semaphore for loops that reject attribute assignment.
+
+    The entry keeps a strong reference to the loop on purpose. Deriving the loop
+    from the semaphore does not work: ``Semaphore.acquire()`` only binds ``_loop``
+    when it actually has to wait, so an uncontended semaphore never learns which
+    loop it belongs to, leaving nothing to test ``is_closed()`` on and no way to
+    detect ``id()`` reuse. Closed loops are swept on the next call, so a closed
+    loop outlives itself by at most one lookup.
+    """
+    for stale_key, (stale_loop, _) in list(_LOOP_SEMAPHORE_FALLBACK.items()):
+        if stale_loop.is_closed():
+            _LOOP_SEMAPHORE_FALLBACK.pop(stale_key, None)
+    key = id(loop)
+    entry = _LOOP_SEMAPHORE_FALLBACK.get(key)
+    if entry is None or entry[0] is not loop:
+        entry = (loop, {})
+        _LOOP_SEMAPHORE_FALLBACK[key] = entry
+    semaphores = entry[1]
+    semaphore = semaphores.get(name)
+    if semaphore is None:
+        semaphore = asyncio.Semaphore(capacity)
+        semaphores[name] = semaphore
+    return semaphore
+
+
+def get_loop_semaphore(name: str, capacity: int) -> asyncio.Semaphore:
+    """Return the running loop's semaphore called ``name``, creating it once.
+
+    ``capacity`` is only used on creation. It is intentionally a fixed constant
+    rather than a per-``LightRAG`` setting: this helper is module level and is
+    called from places that hold no instance, and several instances sharing a loop
+    would otherwise each build their own semaphore and lose the global ceiling.
+    """
+    loop = asyncio.get_running_loop()
+    attr = _LOOP_SEMAPHORE_ATTR_PREFIX + name
+    semaphore = getattr(loop, attr, None)
+    if semaphore is not None:
+        return semaphore
+    semaphore = asyncio.Semaphore(capacity)
+    try:
+        setattr(loop, attr, semaphore)
+    except (AttributeError, TypeError):
+        return _fallback_semaphore(loop, name, capacity)
+    return semaphore
 
 
 class Tokenizer:
     """
     A wrapper around a tokenizer to provide a consistent interface for encoding and decoding.
+
+    Thread-safety contract
+    ----------------------
+    ``encode`` and ``decode`` MAY be called concurrently from several OS threads:
+    token counting is CPU-bound and runs in worker threads so it does not block
+    the asyncio event loop. **An injected tokenizer is responsible for its own
+    thread safety** — through immutable state, an internal lock, thread-local
+    state, or whatever its implementation requires. LightRAG does not serialize
+    it, and adding a lock here would be actively harmful: the event loop would
+    then wait on a worker thread holding it, recreating the very freeze that
+    moving this work off the loop exists to remove.
+
+    The built-in :class:`TiktokenTokenizer` satisfies this: ``tiktoken``'s own
+    ``encode_batch`` / ``decode_batch`` fan ``Encoding.encode`` / ``.decode`` of a
+    single instance across a ``ThreadPoolExecutor``, so concurrent use is a
+    supported capability of the library rather than an assumption made here. The
+    dependency floor in ``pyproject.toml`` is pinned to the oldest release for
+    which that holds.
+
+    Note that sharing is the norm, not the exception: ``tiktoken`` caches
+    encodings in a process-wide registry, and ``Encoding.__setstate__`` rebinds a
+    copy's ``__dict__`` to the registered instance's — so every
+    ``TiktokenTokenizer`` in the process, including ones produced by
+    ``copy.deepcopy``, funnels into a single ``CoreBPE``. An injected tokenizer
+    that is not thread-safe cannot be made safe by copying it.
+
+    Deep-copy requirement
+    ---------------------
+    An injected tokenizer must additionally survive ``copy.deepcopy``: ``LightRAG``
+    is a dataclass and ``_build_global_config`` runs ``dataclasses.asdict`` over
+    it, which deep-copies non-dataclass fields. An implementation that achieves
+    thread safety with an internal ``threading.Lock`` would otherwise fail at
+    construction with ``TypeError: cannot pickle '_thread.lock' object``. Such an
+    implementation should define ``__deepcopy__`` returning ``self`` — correct
+    precisely because being thread-safe is what makes it shareable.
+
+    ``_build_global_config`` then restores this object over the copy ``asdict``
+    made, so the per-operation config carries the tokenizer itself and no
+    consumer pays for a copy.
     """
 
     def __init__(self, model_name: str, tokenizer: TokenizerInterface):
@@ -2603,7 +2793,8 @@ class Tokenizer:
 
         Args:
             model_name: The associated model name for the tokenizer.
-            tokenizer: An instance of a class implementing the TokenizerInterface.
+            tokenizer: An instance of a class implementing the TokenizerInterface,
+                which must be safe to call concurrently from multiple threads.
         """
         self.model_name: str = model_name
         self.tokenizer: TokenizerInterface = tokenizer
@@ -2611,6 +2802,8 @@ class Tokenizer:
     def encode(self, content: str) -> List[int]:
         """
         Encodes a string into a list of tokens using the underlying tokenizer.
+
+        May be called concurrently from multiple threads; see the class docstring.
 
         Args:
             content: The string to encode.
@@ -2640,6 +2833,8 @@ class Tokenizer:
     def decode(self, tokens: List[int]) -> str:
         """
         Decodes a list of tokens into a string using the underlying tokenizer.
+
+        May be called concurrently from multiple threads; see the class docstring.
 
         Args:
             tokens: A list of integer tokens to decode.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,10 @@ dependencies = [
     "python-dotenv",
     "setuptools",
     "tenacity",
-    "tiktoken",
+    # 0.7.0 adds o200k_base, required by the default gpt-4o-mini, and is the
+    # oldest release whose encode_batch/decode_batch fan encode()/decode() of
+    # one Encoding across threads — the thread safety Tokenizer relies on.
+    "tiktoken>=0.7.0",
     "xlsxwriter>=3.1.0",
 ]
 
@@ -69,7 +72,10 @@ api = [
     "python-dotenv",
     "setuptools",
     "tenacity",
-    "tiktoken",
+    # 0.7.0 adds o200k_base, required by the default gpt-4o-mini, and is the
+    # oldest release whose encode_batch/decode_batch fan encode()/decode() of
+    # one Encoding across threads — the thread safety Tokenizer relies on.
+    "tiktoken>=0.7.0",
     "xlsxwriter>=3.1.0",
     "google-api-core>=2.0.0,<3.0.0",
     "google-genai>=1.0.0,<3.0.0",

--- a/tests/llm/test_bounded_submit.py
+++ b/tests/llm/test_bounded_submit.py
@@ -1,0 +1,321 @@
+"""Offline tests for bounded submission to the CPU thread pools.
+
+``bounded_submit`` exists because moving CPU work off the event loop lets more
+requests be in flight at once while a ``ThreadPoolExecutor``'s wait queue stays
+unbounded. Two things are easy to get wrong and are pinned here:
+
+* the permit must belong to the executor future, not to the awaiting coroutine —
+  otherwise cancelling submissions hands back permits that are still consumed;
+* the per-loop semaphore must not outlive its loop, which rules out keying a
+  module-level container by the loop.
+"""
+
+import asyncio
+import gc
+import threading
+import weakref
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from lightrag import utils as lr_utils
+
+pytestmark = pytest.mark.offline
+
+
+class _CountingExecutor(ThreadPoolExecutor):
+    """ThreadPoolExecutor that records how many submissions it accepted."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.submitted = 0
+
+    def submit(self, fn, /, *args, **kwargs):
+        self.submitted += 1
+        return super().submit(fn, *args, **kwargs)
+
+
+def _blocking(release: threading.Event, marker: str) -> str:
+    release.wait(5.0)
+    return marker
+
+
+# ---------------------------------------------------------------------------
+# Basics
+# ---------------------------------------------------------------------------
+
+
+def test_result_is_returned_and_the_loop_keeps_running():
+    async def _main():
+        executor = _CountingExecutor(max_workers=1)
+        try:
+            beats = 0
+
+            async def _heartbeat():
+                nonlocal beats
+                while True:
+                    beats += 1
+                    await asyncio.sleep(0.005)
+
+            pulse = asyncio.create_task(_heartbeat())
+            semaphore = lr_utils.get_loop_semaphore("test-basic", 4)
+            result = await lr_utils.bounded_submit(
+                executor, semaphore, lambda: (threading.Event().wait(0.1), "done")[1]
+            )
+            pulse.cancel()
+
+            assert result == "done"
+            # The loop was free for the whole 100 ms of thread work.
+            assert beats > 1
+
+        finally:
+            executor.shutdown(wait=True)
+
+    asyncio.run(_main())
+
+
+def test_exception_propagates_to_the_caller():
+    async def _main():
+        executor = _CountingExecutor(max_workers=1)
+        try:
+            semaphore = lr_utils.get_loop_semaphore("test-error", 4)
+
+            def _boom():
+                raise ValueError("from the thread")
+
+            with pytest.raises(ValueError, match="from the thread"):
+                await lr_utils.bounded_submit(executor, semaphore, _boom)
+        finally:
+            executor.shutdown(wait=True)
+
+    asyncio.run(_main())
+
+
+def test_kwargs_are_forwarded():
+    async def _main():
+        executor = _CountingExecutor(max_workers=1)
+        try:
+            semaphore = lr_utils.get_loop_semaphore("test-kwargs", 4)
+            result = await lr_utils.bounded_submit(
+                executor, semaphore, lambda a, b=0: a + b, 1, b=41
+            )
+            assert result == 42
+        finally:
+            executor.shutdown(wait=True)
+
+    asyncio.run(_main())
+
+
+# ---------------------------------------------------------------------------
+# Permit ownership — the load-bearing property
+# ---------------------------------------------------------------------------
+
+
+def test_cancelling_a_submission_does_not_return_the_permit_early():
+    """``async with sem: await run_in_executor(...)`` would fail this.
+
+    The thread pool cannot cancel a running task, so returning the permit when
+    the awaiting coroutine is cancelled would let a caller submit-and-cancel in a
+    loop, holding an unbounded number of live tasks with one permit's worth of
+    accounting.
+    """
+
+    async def _main():
+        executor = _CountingExecutor(max_workers=1)
+        release = threading.Event()
+        try:
+            semaphore = lr_utils.get_loop_semaphore("test-cancel", 1)
+
+            first = asyncio.create_task(
+                lr_utils.bounded_submit(executor, semaphore, _blocking, release, "one")
+            )
+            # Let the submission actually happen before cancelling.
+            while executor.submitted < 1:
+                await asyncio.sleep(0.005)
+
+            first.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await first
+
+            follow_ups = [
+                asyncio.create_task(
+                    lr_utils.bounded_submit(executor, semaphore, lambda: "later")
+                )
+                for _ in range(3)
+            ]
+            await asyncio.sleep(0.1)
+
+            # The cancelled task's thread is still running and still owns the
+            # only permit, so nothing new may have been submitted.
+            assert executor.submitted == 1
+            assert not any(task.done() for task in follow_ups)
+
+            release.set()
+            assert (
+                await asyncio.wait_for(asyncio.gather(*follow_ups), timeout=5.0)
+                == ["later"] * 3
+            )
+            assert executor.submitted == 4
+        finally:
+            release.set()
+            executor.shutdown(wait=True)
+
+    asyncio.run(_main())
+
+
+def test_saturation_is_backpressure_not_refusal():
+    async def _main():
+        executor = _CountingExecutor(max_workers=1)
+        release = threading.Event()
+        try:
+            semaphore = lr_utils.get_loop_semaphore("test-backpressure", 2)
+            tasks = [
+                asyncio.create_task(
+                    lr_utils.bounded_submit(
+                        executor, semaphore, _blocking, release, f"m{i}"
+                    )
+                )
+                for i in range(5)
+            ]
+            await asyncio.sleep(0.05)
+            assert executor.submitted == 2  # ceiling honoured
+
+            release.set()
+            results = await asyncio.wait_for(asyncio.gather(*tasks), timeout=5.0)
+            assert results == [f"m{i}" for i in range(5)]  # nobody was dropped
+        finally:
+            release.set()
+            executor.shutdown(wait=True)
+
+    asyncio.run(_main())
+
+
+# ---------------------------------------------------------------------------
+# Per-loop semaphore lifetime
+# ---------------------------------------------------------------------------
+
+
+def test_same_helper_works_across_successive_event_loops():
+    """A module-level singleton semaphore raises 'bound to a different loop'."""
+
+    async def _main():
+        executor = ThreadPoolExecutor(max_workers=1)
+        try:
+            semaphore = lr_utils.get_loop_semaphore("test-crossloop", 2)
+            return await lr_utils.bounded_submit(executor, semaphore, lambda: "ok")
+        finally:
+            executor.shutdown(wait=True)
+
+    assert asyncio.run(_main()) == "ok"
+    assert asyncio.run(_main()) == "ok"
+
+
+def test_a_contended_semaphore_does_not_retain_its_closed_loop():
+    """``WeakKeyDictionary[loop] -> Semaphore`` leaks here.
+
+    Contention is mandatory: ``Semaphore.acquire()`` only records ``_loop`` when
+    it has to wait, and it is that back-reference from the value to the key that
+    makes the weak key immortal. Without contention the leak hides.
+    """
+    captured: dict[str, object] = {}
+
+    async def _main():
+        loop = asyncio.get_running_loop()
+        captured["ref"] = weakref.ref(loop)
+        executor = ThreadPoolExecutor(max_workers=1)
+        release = threading.Event()
+        try:
+            semaphore = lr_utils.get_loop_semaphore("test-gc", 1)
+            tasks = [
+                asyncio.create_task(
+                    lr_utils.bounded_submit(
+                        executor, semaphore, _blocking, release, str(i)
+                    )
+                )
+                for i in range(2)
+            ]
+            await asyncio.sleep(0.05)
+            release.set()
+            await asyncio.wait_for(asyncio.gather(*tasks), timeout=5.0)
+            assert semaphore._loop is loop  # contention really happened
+        finally:
+            release.set()
+            executor.shutdown(wait=True)
+
+    asyncio.run(_main())
+    gc.collect()
+    gc.collect()
+
+    assert captured["ref"]() is None
+
+
+def test_repeated_lookups_in_one_loop_return_the_same_semaphore():
+    async def _main():
+        first = lr_utils.get_loop_semaphore("test-identity", 3)
+        second = lr_utils.get_loop_semaphore("test-identity", 99)
+        assert first is second
+        # Capacity is only honoured on creation, by design.
+        assert second._value == 3
+
+    asyncio.run(_main())
+
+
+# ---------------------------------------------------------------------------
+# Fallback table (loops that reject attribute assignment, e.g. C implementations)
+# ---------------------------------------------------------------------------
+
+
+class _FakeLoop:
+    """Minimal stand-in exposing only what the fallback table needs."""
+
+    def __init__(self):
+        self._closed = False
+
+    def is_closed(self) -> bool:
+        return self._closed
+
+    def close(self) -> None:
+        self._closed = True
+
+
+@pytest.fixture(autouse=True)
+def _clear_fallback_table():
+    lr_utils._LOOP_SEMAPHORE_FALLBACK.clear()
+    yield
+    lr_utils._LOOP_SEMAPHORE_FALLBACK.clear()
+
+
+def test_fallback_table_reuses_one_semaphore_per_loop_and_name():
+    loop = _FakeLoop()
+    first = lr_utils._fallback_semaphore(loop, "a", 2)
+    assert lr_utils._fallback_semaphore(loop, "a", 2) is first
+    assert lr_utils._fallback_semaphore(loop, "b", 2) is not first
+
+
+def test_fallback_table_sweeps_closed_loops_without_needing_contention():
+    """The entry holds the loop itself, so sweeping never depends on ``_loop``.
+
+    The earlier design planned to reach the loop through the semaphore, which
+    only works after contention — an uncontended semaphore never learns its loop,
+    leaving the entry unsweepable and able to collide with a reused ``id()``.
+    """
+    loop = _FakeLoop()
+    lr_utils._fallback_semaphore(loop, "a", 2)  # never contended
+    assert len(lr_utils._LOOP_SEMAPHORE_FALLBACK) == 1
+
+    loop.close()
+    survivor = _FakeLoop()
+    lr_utils._fallback_semaphore(survivor, "a", 2)
+
+    assert list(lr_utils._LOOP_SEMAPHORE_FALLBACK) == [id(survivor)]
+
+
+def test_fallback_table_rejects_an_entry_whose_loop_identity_changed():
+    """Guards against ``id()`` reuse handing a new loop an old semaphore."""
+    loop = _FakeLoop()
+    stale = lr_utils._fallback_semaphore(loop, "a", 2)
+
+    impostor = _FakeLoop()
+    lr_utils._LOOP_SEMAPHORE_FALLBACK[id(impostor)] = (loop, {"a": stale})
+
+    assert lr_utils._fallback_semaphore(impostor, "a", 2) is not stale

--- a/tests/llm/test_tokenizer_contract.py
+++ b/tests/llm/test_tokenizer_contract.py
@@ -1,0 +1,281 @@
+"""Offline tests for the tokenizer thread-safety contract (GHSA-r8jh / GHSA-26pm).
+
+Token counting is CPU-bound, so it is moved off the asyncio event loop into
+worker threads. That makes concurrent calls into one tokenizer routine, and the
+contract places responsibility for handling them on the injected implementation
+rather than on LightRAG.
+
+Two things have to keep holding for that to be the right call, and each is easy
+to break without noticing:
+
+* the built-in ``TiktokenTokenizer`` really is safe to call concurrently — an
+  upgrade that changed this would turn every token count into a data race;
+* LightRAG really does not serialize callers itself — a lock owned here would be
+  waited on by the event loop behind a worker thread, recreating the freeze the
+  offload exists to remove.
+
+The tests also pin *why* thread safety, rather than "deep-copy into independent
+state", is the property the contract asks for: copies are not independent, and
+never were.
+"""
+
+import copy
+import dataclasses
+import threading
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+
+# Accessed via the module (not ``from``-imports) on purpose: another test in the
+# suite reloads lightrag.utils in place, which would leave from-imported class
+# references pointing at the pre-reload class.
+from lightrag import utils as lr_utils
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+pytestmark = pytest.mark.offline
+
+
+class _PlainTokenizer:
+    """Minimal conforming implementation: immutable, therefore thread-safe."""
+
+    def encode(self, content: str) -> list[int]:
+        return [len(content)]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "x" * sum(tokens)
+
+
+class _OverlapDetectingTokenizer:
+    """Records whether ``encode`` is ever entered by two threads at once."""
+
+    def __init__(self, hold: float = 0.0):
+        self._hold = hold
+        self._inside = 0
+        self._guard = threading.Lock()
+        self.max_concurrency = 0
+
+    def encode(self, content: str) -> list[int]:
+        with self._guard:
+            self._inside += 1
+            self.max_concurrency = max(self.max_concurrency, self._inside)
+        try:
+            if self._hold:
+                # Plain sleep: this stands in for CPU work, so it must not yield
+                # to the event loop.
+                threading.Event().wait(self._hold)
+            return [len(content)]
+        finally:
+            with self._guard:
+                self._inside -= 1
+
+    def decode(self, tokens: list[int]) -> str:
+        return "x" * sum(tokens)
+
+
+class _LockHoldingTokenizer:
+    """Achieves thread safety with an internal lock, the documented way.
+
+    ``copy.deepcopy`` of a ``threading.Lock`` raises ``TypeError: cannot pickle
+    '_thread.lock' object``, and ``LightRAG`` is a dataclass whose
+    ``_build_global_config`` runs ``dataclasses.asdict``. So the contract asks a
+    lock-based implementation to define ``__deepcopy__`` returning ``self`` —
+    correct precisely because being thread-safe is what makes it shareable.
+    """
+
+    def __init__(self, deepcopyable: bool = True):
+        self._lock = threading.Lock()
+        if deepcopyable:
+            self.__deepcopy__ = lambda _memo: self
+
+    def encode(self, content: str) -> list[int]:
+        with self._lock:
+            return [len(content)]
+
+    def decode(self, tokens: list[int]) -> str:
+        with self._lock:
+            return "x" * sum(tokens)
+
+
+async def _mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.zeros((len(texts), 16))
+
+
+async def _mock_llm(*_args, **_kwargs) -> str:
+    return "mock"
+
+
+def _make_rag(tmp_path, tokenizer):
+    return LightRAG(
+        working_dir=str(tmp_path / "tokenizer-contract"),
+        workspace="tokenizer-contract",
+        llm_model_func=_mock_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=16, max_token_size=4096, func=_mock_embedding
+        ),
+        tokenizer=tokenizer,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The property the contract now rests on: tiktoken tolerates concurrent calls
+# ---------------------------------------------------------------------------
+
+
+def test_builtin_tokenizer_survives_concurrent_encode_and_decode():
+    """Guards the assumption a tiktoken upgrade could silently invalidate.
+
+    ``tiktoken`` itself fans ``Encoding.encode``/``decode`` out across a
+    ``ThreadPoolExecutor`` in ``encode_batch``/``decode_batch``, so this is a
+    documented capability rather than an accident. If it ever stops holding, the
+    whole "the implementation owns its thread safety" contract has to be
+    revisited — so it fails here rather than as corrupted token counts.
+    """
+    tokenizer = lr_utils.TiktokenTokenizer()
+    texts = [f"hello {i} 中文测试 " * 200 for i in range(8)]
+    expected = [tokenizer.encode(text) for text in texts]
+
+    failures: list[str] = []
+
+    def work(index: int) -> None:
+        try:
+            for _ in range(10):
+                tokens = tokenizer.encode(texts[index])
+                if tokens != expected[index]:
+                    failures.append(f"encode mismatch at {index}")
+                if tokenizer.decode(tokens) != texts[index]:
+                    failures.append(f"decode mismatch at {index}")
+        except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
+            failures.append(f"{type(exc).__name__}: {exc}")
+
+    threads = [threading.Thread(target=work, args=(i,)) for i in range(len(texts))]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert failures == []
+
+
+# ---------------------------------------------------------------------------
+# Why the contract is thread safety and not "deep-copy into independent state"
+# ---------------------------------------------------------------------------
+
+
+def test_builtin_tokenizers_all_share_one_underlying_encoding():
+    """``tiktoken`` caches encodings process-wide, so copies are not isolation.
+
+    Every ``TiktokenTokenizer`` for a given model — in LightRAG, in the Ollama
+    routes, in the reranker — resolves to the same ``Encoding``. Any design that
+    tried to buy thread safety by handing each consumer "its own" tokenizer would
+    be reasoning about an object that does not exist.
+    """
+    first = lr_utils.TiktokenTokenizer()
+    second = lr_utils.TiktokenTokenizer()
+    assert first.tokenizer is second.tokenizer
+
+
+def test_deepcopy_of_the_builtin_still_shares_the_same_core_bpe():
+    """A deep copy produces a new wrapper over the *same* BPE engine.
+
+    ``Encoding.__getstate__`` returns just the encoding name for a registered
+    encoding and ``__setstate__`` rebinds the new object's ``__dict__`` to the
+    registered instance's. So the copy is superficial exactly where it would have
+    had to be deep. A ``KeyError`` here means tiktoken restructured its
+    internals and this reasoning must be re-verified.
+    """
+    tokenizer = lr_utils.TiktokenTokenizer()
+    clone = copy.deepcopy(tokenizer)
+
+    assert clone.tokenizer is not tokenizer.tokenizer  # wrapper differs...
+    assert vars(clone.tokenizer)["_core_bpe"] is vars(tokenizer.tokenizer)["_core_bpe"]
+    assert clone.encode("hello world") == tokenizer.encode("hello world")
+
+
+# ---------------------------------------------------------------------------
+# LightRAG must not serialize callers, and must not copy the tokenizer
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_callers_are_not_serialized_by_the_wrapper():
+    """Fix-proof against reintroducing a LightRAG-owned tokenizer lock.
+
+    Such a lock would be acquired by whichever thread got there first and waited
+    on by the others — including the event loop, which is precisely the freeze
+    being removed. Two threads must genuinely overlap inside one wrapper.
+    """
+    underlying = _OverlapDetectingTokenizer(hold=0.15)
+    tokenizer = Tokenizer("test-model", underlying)
+    barrier = threading.Barrier(2)
+
+    def work() -> None:
+        barrier.wait(timeout=5)
+        tokenizer.encode("abcdef")
+
+    threads = [threading.Thread(target=work) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert underlying.max_concurrency == 2
+
+
+def test_build_global_config_hands_out_the_tokenizer_itself(tmp_path):
+    """``asdict`` would deep-copy it; ``_build_global_config`` restores it.
+
+    Consumers read ``global_config["tokenizer"]`` on every operation, so a copy
+    per operation is pure overhead once the contract is thread safety.
+    """
+    tokenizer = Tokenizer("test-model", _PlainTokenizer())
+    rag = _make_rag(tmp_path, tokenizer)
+
+    assert rag._build_global_config()["tokenizer"] is tokenizer
+
+
+def test_a_lock_based_tokenizer_is_injectable_when_it_declares_deepcopy(tmp_path):
+    """Pins the escape hatch the deep-copy clause of the contract prescribes.
+
+    An internal lock is a legitimate way to satisfy "be thread-safe", but
+    ``LightRAG`` is a dataclass and ``__post_init__`` runs ``asdict`` over it, so
+    a bare lock would fail at construction. Declaring ``__deepcopy__`` makes such
+    an implementation usable.
+    """
+    tokenizer = Tokenizer("test-model", _LockHoldingTokenizer())
+    rag = _make_rag(tmp_path, tokenizer)
+
+    global_config = rag._build_global_config()
+    assert global_config["tokenizer"] is tokenizer
+    assert global_config["tokenizer"].encode("abcd") == [4]
+
+
+def test_a_lock_based_tokenizer_without_deepcopy_fails_at_construction(tmp_path):
+    """Documents the boundary the escape hatch exists for.
+
+    This is the failure mode the contract's deep-copy clause warns about, pinned
+    so the warning cannot quietly stop being true (or quietly start applying to
+    implementations that do declare ``__deepcopy__``).
+    """
+    tokenizer = Tokenizer("test-model", _LockHoldingTokenizer(deepcopyable=False))
+
+    with pytest.raises(TypeError, match="cannot pickle"):
+        _make_rag(tmp_path, tokenizer)
+
+
+def test_tokenizer_wrapper_is_deepcopyable(tmp_path):
+    """The wrapper keeps no un-copyable state of its own.
+
+    Deep copies of a ``LightRAG`` remain possible outside the hot path, so a lock
+    stored on the wrapper instance would surface as ``cannot pickle RLock`` here.
+    """
+
+    @dataclasses.dataclass
+    class Holder:
+        tokenizer: object
+
+    tokenizer = Tokenizer("test-model", _PlainTokenizer())
+    assert copy.deepcopy(tokenizer).encode("abc") == [3]
+    assert dataclasses.asdict(Holder(tokenizer=tokenizer))["tokenizer"].encode(
+        "abcd"
+    ) == [4]


### PR DESCRIPTION
## Summary

Preparatory infrastructure for moving CPU-bound token counting (query side) and chunking (ingestion side) off the asyncio event loop. Both follow-ups need the same submission primitive, and neither depends on the other, so it lands here first.

Two parts:

1. **The tokenizer thread-safety contract**, stated where implementers will read it. Responsibility for concurrent calls sits with the injected tokenizer; LightRAG does not serialize it.
2. **`bounded_submit`** plus the per-event-loop semaphore machinery both follow-ups submit through.

No behavioural change on its own: the submission helper has no callers yet, and the contract makes explicit what the built-in tokenizer already satisfies.

> **Revised after review.** The first version of this PR put a LightRAG-owned lock on `Tokenizer.encode`/`decode`, with a tier system, a strict-mode gate and an event-loop guard. That was the wrong layer — see [What changed after review](#what-changed-after-review) at the bottom.

## Motivation

Token counting is CPU-bound and roughly linear in caller-chosen input (~0.5 s/MiB), so doing it inline in an `async def` stops the process answering anything at all for the duration, `/health` included. The fix is to run it in worker threads — which makes concurrent calls into one tokenizer routine, and raises the question of who is responsible for them.

Separately, freeing the event loop lets more requests be in flight at once while a `ThreadPoolExecutor`'s wait queue stays unbounded, so submissions need their own ceiling. Getting that wrong is easy and the failure mode is silent, so it is introduced here with its own tests rather than buried inside a larger change.

## What's changed

### The tokenizer thread-safety contract

`TokenizerInterface.encode()` / `decode()` may be called concurrently from several OS threads. **An injected tokenizer is responsible for its own thread safety** — immutable state, an internal lock, thread-local state, whatever its implementation needs.

LightRAG deliberately does not serialize it. A lock owned here would be acquired by a worker thread and then *waited on by the event loop*, which is precisely the freeze the offload exists to remove; it would also penalise an implementation that is already thread-safe. The right layer is the extension point.

The built-in `TiktokenTokenizer` is the only tokenizer LightRAG ships, and concurrent use is a supported capability of tiktoken rather than an assumption made here: `encode_batch` / `decode_batch` fan `Encoding.encode` / `.decode` of a **single instance** across a `ThreadPoolExecutor` ([`core.py`](https://github.com/openai/tiktoken/blob/0.12.0/tiktoken/core.py#L174-L205)).

**Copying was never an alternative to thread safety**, and the contract says so because the opposite is easy to assume. `tiktoken` caches encodings in a process-wide registry, and `Encoding.__setstate__` rebinds a copy's `__dict__` to the registered instance's — so every `TiktokenTokenizer` in the process, deep copies included, already funnels into one `CoreBPE`:

```python
>>> a, b = TiktokenTokenizer(), TiktokenTokenizer()
>>> a.tokenizer is b.tokenizer
True
>>> c = copy.deepcopy(a)
>>> c.tokenizer is a.tokenizer, vars(c.tokenizer)["_core_bpe"] is vars(a.tokenizer)["_core_bpe"]
(False, True)          # new wrapper, same engine
```

### Dependency floor

`tiktoken` was declared without a lower bound. Since the contract now rests on a property of that library, the floor is pinned to **`>=0.7.0`** — the oldest release whose `encode_batch`/`decode_batch` fan a single `Encoding` across threads, and also the oldest carrying `o200k_base`, which the default `gpt-4o-mini` needs. Verified by reading the source of 0.5.2 / 0.6.0 / 0.7.0 / 0.8.0 / 0.12.0 / 0.13.0, not from memory.

### Deep-copy requirement, and one line that makes it cheap

`LightRAG` is a dataclass and `_build_global_config` runs `dataclasses.asdict` over it, which deep-copies non-dataclass fields. An implementation that guards itself with a `threading.Lock` would fail at construction with `TypeError: cannot pickle '_thread.lock' object`. The contract therefore also asks that an injected tokenizer survive `copy.deepcopy`, and points lock-based implementations at `__deepcopy__` returning `self` — sound precisely because being thread-safe is what makes it shareable.

`_build_global_config` now restores the tokenizer object over the copy `asdict` made, the same one-liner already used for `embedding_func`. Consumers reading `global_config["tokenizer"]` get the instance itself, no operation pays for a copy, and there is one tokenizer object to reason about instead of a per-operation copy that was never independent anyway.

### Bounded submission

- `bounded_submit(executor, semaphore, fn, ...)` — **the permit belongs to the executor future**, not the awaiting coroutine. `async with sem: await run_in_executor(...)` returns the permit on cancellation while the thread keeps running (an already-running `concurrent.futures.Future.cancel()` returns `False`), so submit-and-cancel would rebuild an unbounded queue.
- Semaphores are per event loop, because `asyncio.Semaphore` binds to the first loop that waits on it. They are stored **on the loop** rather than in a container keyed by it: once contended the semaphore strongly references its loop, so a `WeakKeyDictionary` entry whose value references its key never expires. Loops that reject attribute assignment fall back to an id-keyed table that holds the loop itself — deriving it from the semaphore fails for an uncontended one, which never learns which loop it belongs to.
- `TOKENIZER_SUBMIT_LIMIT` / `CHUNKING_SUBMIT_LIMIT` are fixed process-wide constants, not derived from `max_parallel_insert`: the helpers are module level and are called from places holding no `LightRAG` instance, several instances sharing a loop would each build their own semaphore and lose the global ceiling, and the pools have one worker, so queue depth beyond single digits buys no throughput. Over the limit the submitting coroutine waits — backpressure, not refusal.

## What's broken and how it works

Nothing is broken for the built-in path.

The one user-visible addition is the **injection contract** for custom tokenizers, documented in [`docs/ProgramingWithCore.md`](docs/ProgramingWithCore.md#injecting-a-custom-tokenizer) with a worked example: be thread-safe, and survive `copy.deepcopy`. A lock-based implementation needs `__deepcopy__` returning `self` — which is already true today, since `asdict` already deep-copies the field.

The `tiktoken>=0.7.0` floor is not a new practical constraint: the default `gpt-4o-mini` has always needed `o200k_base`, which no earlier release ships.

## Follow-up ordering

The two follow-ups are no longer freely orderable. **Query-side migration should merge before ingestion-side chunking.** For a custom tokenizer that is thread-safe *by internal lock*, either single-sided state leaves a window where the event loop can wait on that lock — but the windows are very different in size: an ingestion worker holds it for as long as chunking a whole document takes, while a query worker holds it for one truncation. Doing the query side first keeps the exposure to milliseconds. (Irrelevant to `tiktoken`, which has no such lock.)

## Tests

19 offline tests. Three are load-bearing and were each verified to fail against the wrong implementation:

- `test_concurrent_callers_are_not_serialized_by_the_wrapper` — two threads must genuinely overlap inside one tokenizer. Re-adding a LightRAG-owned lock drops observed concurrency from 2 to 1.
- `test_cancelling_a_submission_does_not_return_the_permit_early` — fails when the permit is released by the coroutine (observed: 2 submissions instead of 1).
- `test_a_contended_semaphore_does_not_retain_its_closed_loop` — fails under `WeakKeyDictionary[loop] -> Semaphore` (observed: closed loop still reachable after `gc.collect()`). Forcing contention is mandatory; `Semaphore.acquire()` only records `_loop` when it has to wait, so without it the leak hides.

Also pinned: concurrent `encode`/`decode` correctness on one `TiktokenTokenizer` (the property the contract now rests on, so a tiktoken upgrade that broke it fails here rather than as corrupted counts); the registry/`__setstate__` sharing that makes copying no defence; `_build_global_config` handing out the tokenizer itself; and both sides of the deep-copy boundary.

Full suite: **5304 passed, 155 skipped**. `pre-commit run ruff` / `ruff-format` clean.

## What changed after review

Review pointed out that `TiktokenTokenizer` is the only built-in implementation and that tiktoken is thread-safe, so the responsibility belongs on the extension point. Agreed — and investigating it turned up something stronger than a simplification argument.

The old design keyed its lock on the *underlying* tokenizer object. Because `tiktoken` caches encodings process-wide, every `TiktokenTokenizer` — LightRAG's, the Ollama route's, the reranker's, and every `asdict` copy — resolves to the same `Encoding`. So the old tier-1 policy would have put **one process-wide lock on the default path**, creating a global serialization point that does not exist today, and arming the event-loop gate against the built-in tokenizer.

The second branch of the old contract, *"deep-copy into fully independent state"*, was also not true of the only implementation that was said to satisfy it: the copy shares `_core_bpe`. A test asserting the wrapper differed passed while the property it was named for did not hold.

Removed: the identity-keyed lock registry and its weakref/id reclamation, the `lightrag_thread_safe` marker and three-tier policy, `TokenizerLoopBlockError`, `LIGHTRAG_STRICT_TOKENIZER_OFFLOAD`, and the serialization test file (~350 lines). Kept: `bounded_submit`, per-loop semaphores, permit ownership, and the submission ceilings.

Two of the boundaries raised alongside the proposal are handled directly rather than passed to users: the deep-copy interaction is resolved for the hot path by restoring the tokenizer in `_build_global_config` (and documented, with the `__deepcopy__` escape hatch, for the construction path that remains), and the version floor is pinned from source rather than left to a regression test alone. The third — merge ordering — is recorded above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
