### PR TITLE
fix(pipeline): take chunking off the event loop and bound the separator cascade

### DIFF
--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -555,7 +555,7 @@ LIGHTRAG_PARSER=pdf:mineru(language=en);*:legacy-R                       # 规�
 
 ### 4.5 图片限制与吞吐
 
-`VLM_MAX_IMAGE_BYTES`（缺省 5 MB）与 `VLM_MIN_IMAGE_PIXEL`（缺省 64）界定什么值得送出去：下限的存在是为了跳过图标和分隔线，而不是为它们付一次 VLM 调用。分析阶段的并发是 `MAX_PARALLEL_ANALYZE`（§8.9），与解析、入库阶段互不影响。
+`VLM_MAX_IMAGE_BYTES`（缺省 5 MB）与 `VLM_MIN_IMAGE_PIXEL`（缺省 64）界定什么值得送出去：下限的存在是为了跳过图标和分隔线，而不是为它们付一次 VLM 调用。分析阶段的并发是 `MAX_PARALLEL_ANALYZE`（§8.10），与解析、入库阶段互不影响。
 
 ### 4.6 模型配置不在本章
 
@@ -635,6 +635,8 @@ chunker(tokenizer, content, chunk_token_size, **strategy_kwargs)   (分块时按
   ```
 
   分隔符级联，按语义边界从最强到最弱排列。默认包含中文句末（`。！？`）与句中（`；，`）标点，使中文 / 中英混合文档能在语义边界切分。英文 `.?!` 被刻意排除——按字面匹配会切断数字与缩写。
+
+  **上限为 64 条、单条最长 256 字符。** 切分器每保留一个分隔符就下降一层，且每层都会重扫全文，因此过长的级联付出 `O(len(separators) × len(text))` 的代价却切不出更多内容。超限部分会被截断（若原列表末尾有字符级 `""` 哨兵则予以保留）并记 WARNING，而非拒绝；该上限对级联的所有来源一致生效——请求体、本变量、`addon_params`、直接 SDK 调用，以及在该上限出现之前持久化的按文档快照。
 
 #### V —— 语义向量
 
@@ -1025,7 +1027,18 @@ POST /documents/recovery/force_reset
 
 锁**不**覆盖 ingress document 发布（在锁外，只取一下 `pipeline_status_lock`），也**不**阻塞处理循环的 `get_docs_by_statuses` 读（处理循环走的是 `doc_status` 自身的并发读，与 enqueue 写是 KV 级原子，不抢同一把锁）。锁顺序：`enqueue_serialize → pipeline_status_lock`，无死锁路径。
 
-### 8.9 流水线并发参数
+### 8.9 分块在哪里执行
+
+分块的开销取决于调用方提供的文档，对递归策略还取决于随之提供的分隔符级联，因此它在一个专用的**单 worker** 线程池中执行，而不是在 asyncio 事件循环上就地运行。就地运行时，一篇 414 KiB 的文档曾让一次无关的 `GET /health` 耗时 63 秒；而把这份工作排进队列的那个 `POST` 早在 1.6 ms 前就返回了 `200 OK`——请求/响应交互中没有任何信号提示这次不可用。
+
+从"拿到正文"到"写出分块"之间所有 CPU 密集的步骤都在该池内：四种分块策略、语义分块器对超尺寸片段的二次切分、多模态分块构建、嵌入前的硬切分，以及 `surrounding` 回填。
+
+有两点需要知悉：
+
+- **并发度不变，而非提升。** 单 worker 正是事件循环原本施加的并发度——一篇文档分块期间，其它文档的协程根本轮不到。该池释放的是事件循环，并不会让分块并行，也不随 `MAX_PARALLEL_INSERT` 增长。
+- **自定义 `chunking_func` 仍在事件循环上执行。** 它的契约是"同步或异步"，因此一个在被调用时触碰运行中事件循环的实现是受支持的，放进工作线程会直接失败。只有内置默认实现会被派发到该池；CPU 密集的自定义分块器应自行 `asyncio.to_thread`。
+
+### 8.10 流水线并发参数
 
 `pipeline_status` 相关的锁解决的是"谁能写"的正确性问题，本节这一组参数解决的是"同时跑几个 worker"的吞吐量问题。流水线分为 3 个阶段，每个阶段的 worker 池数量独立可调：
 
@@ -1064,7 +1077,7 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼�
 - 纯 docx / txt（仅走 native）：`MAX_PARALLEL_PARSE_NATIVE=10`、`MAX_PARALLEL_INSERT` 按 `MAX_ASYNC_LLM/3` 推算。
 - LLM 限流明显：先降 `MAX_PARALLEL_INSERT`（process 阶段每文档多次 LLM 调用），再降 `MAX_PARALLEL_ANALYZE`（VLM 是独立配额）。
 
-### 8.10 准入与请求限制
+### 8.11 准入与请求限制
 
 在文档触及上述任何机制之前，服务端就可能直接拒收。下面这些变量决定一次上传是被拒绝还是被排队：
 
@@ -1136,7 +1149,7 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼�
 | 日志提示部分段落缺少 `paraId` | 由 LibreOffice / WPS / 旧版 Word 产生（§3.3） | 仅提示性。只有确实需要段落级溯源时，才用 Word 2013+ 另存一次 |
 | 文档 FAILED 且标记为重复 | 文件名查重（规范化并剥掉 hint 后）或内容 hash 查重（§7.1、§7.2） | 先删除已有文档，或给新文件改名 |
 | 上传返回 `409` | 输入目录或 doc_status 里已存在同规范名的文档（§8.5） | 用 `POST /documents/delete_document` 删除后再上传 |
-| 上传返回 `413` 或 `429` | 触发了准入限制（§8.10） | 对照该节的限制表判断是哪一条 |
+| 上传返回 `413` 或 `429` | 触发了准入限制（§8.11） | 对照该节的限制表判断是哪一条 |
 | 所有接口都返回 `503` | `recovery_required` 栅栏已升起（§8.7） | 按该节给出的恢复顺序处理 |
 | `/documents/scan` 返回 `scanning_skipped_pipeline_busy` | 流水线正忙或正在扫描、有上传在途、或有手动重试排队中（§8.2） | 等待空闲；`POST /documents/reprocess_failed` 是卡住的重试请求的一键恢复 |
 | 改了引擎或选项，输出却没变 | 引擎与 `process_options` 在入队时就冻结进 doc_status 记录。自动续跑与 `/documents/reprocess_failed` 都沿用存量值；改 `LIGHTRAG_PARSER` 或 hint 只对新上传生效（§9.3） | 删除该文档（勾选"同时删除文件"）后重新上传 |
@@ -1255,7 +1268,7 @@ per-file 个性化的典型场景：管理 UI 单独配置某个文件的 separa
 | Docling | `DOCLING_*` | §3.5 |
 | 解析缓存 | `LIGHTRAG_FORCE_REPARSE_{NATIVE,MINERU,DOCLING}`、`{MINERU,DOCLING}_ENGINE_VERSION` | §3.7、§6.3 |
 | 目录 | `INPUT_DIR`、`WORKING_DIR`、`SCAN_SPOOL_DIR` | §6、§7.1 |
-| 并发 | `MAX_PARALLEL_*`、`QUEUE_SIZE_*` | §8.9 |
-| 准入与限制 | `MAX_UPLOAD_SIZE`、`MAX_REQUEST_BODY_BYTES`、`MAX_TEXTS_PER_REQUEST`、`MAX_PENDING_DOCUMENTS`、`PIPELINE_*`、`MAX_UNACKED_MANUAL_RETRIES`、`SCAN_ENQUEUE_BATCH_SIZE` | §8.10 |
+| 并发 | `MAX_PARALLEL_*`、`QUEUE_SIZE_*` | §8.10 |
+| 准入与限制 | `MAX_UPLOAD_SIZE`、`MAX_REQUEST_BODY_BYTES`、`MAX_TEXTS_PER_REQUEST`、`MAX_PENDING_DOCUMENTS`、`PIPELINE_*`、`MAX_UNACKED_MANUAL_RETRIES`、`SCAN_ENQUEUE_BATCH_SIZE` | §8.11 |
 | 查询期（不影响分块） | `ENABLE_CONTENT_HEADINGS` —— 组装回答上下文时为每个分块追加其标题路径；它不改变分块边界，也不改变已存储的分块文本 | [LightRAG Server](./LightRAG-API-Server-zh.md) |
 | 离线 / 分词器 | `TIKTOKEN_CACHE_DIR` | [OfflineDeployment.md](./OfflineDeployment.md) |

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -555,7 +555,7 @@ The surrounding budgets are subtracted from the total, so setting them too high 
 
 ### 4.5 Image limits and throughput
 
-`VLM_MAX_IMAGE_BYTES` (default 5 MB) and `VLM_MIN_IMAGE_PIXEL` (default 64) bound what is worth sending: the lower bound exists to skip icons and separator rules rather than pay for a VLM call on them. Analyze-stage concurrency is `MAX_PARALLEL_ANALYZE` (§8.9), which is independent of the parse and insert stages.
+`VLM_MAX_IMAGE_BYTES` (default 5 MB) and `VLM_MIN_IMAGE_PIXEL` (default 64) bound what is worth sending: the lower bound exists to skip icons and separator rules rather than pay for a VLM call on them. Analyze-stage concurrency is `MAX_PARALLEL_ANALYZE` (§8.10), which is independent of the parse and insert stages.
 
 ### 4.6 Model configuration lives elsewhere
 
@@ -635,6 +635,8 @@ They are grouped by the strategy they configure. A strategy-specific variable al
   ```
 
   The separator cascade, ordered from the strongest semantic boundary to the weakest. The default includes Chinese sentence-ending (`。！？`) and mid-sentence (`；，`) punctuation, so Chinese and mixed Chinese-English documents split at semantic boundaries. English `.?!` is deliberately excluded — matching it literally would cut through numbers and abbreviations.
+
+  **Bounded to 64 entries of at most 256 characters each.** The splitter descends one level per remaining separator and re-scans the whole text at every level, so an oversized cascade costs `O(len(separators) × len(text))` while splitting nothing extra. Over-limit input is truncated (keeping the trailing char-level `""` sentinel when present) and logged at WARNING rather than rejected, and the same bound is applied wherever a cascade comes from — the request body, this variable, `addon_params`, a direct SDK call, or a per-document snapshot persisted before the bound existed.
 
 #### V — semantic vector
 
@@ -1025,7 +1027,18 @@ With the serialization lock, the second enqueue's dedup read is guaranteed to se
 
 The lock does **not** cover the ingress document publish (outside the lock; only briefly takes `pipeline_status_lock`), and does **not** block the `get_docs_by_statuses` read of the processing loop (which goes through `doc_status`'s own concurrent reads — a KV-level atomic with the enqueue writes, not contending for the same lock). Lock order: `enqueue_serialize → pipeline_status_lock`; no deadlock path.
 
-### 8.9 Pipeline Concurrency Parameters
+### 8.9 Where chunking runs
+
+Chunking is CPU-bound in the document supplied and — for the recursive strategy — in the separator cascade supplied with it, so it runs in a dedicated **single-worker** thread pool rather than inline on the asyncio event loop. Inline, one 414 KiB document made an unrelated `GET /health` take 63 seconds; the `POST` that queued the work had already returned `200 OK` in 1.6 ms, so nothing in the request/response exchange signalled the outage.
+
+Everything CPU-bound between "content in hand" and "chunks written" is in that pool: the four chunking strategies, the semantic chunker's oversized-piece re-split, the multimodal chunk builder, the pre-embedding hard split, and the `surrounding` backfill.
+
+Two consequences worth knowing:
+
+- **Concurrency is unchanged, not increased.** One worker is exactly what the event loop already imposed — while one document chunked, no other document's coroutine could run. The pool frees the loop; it does not make chunking parallel, and it does not scale with `MAX_PARALLEL_INSERT`.
+- **A custom `chunking_func` still runs on the event loop.** Its contract is "synchronous or async", so an implementation that touches the running loop when called is supported and would fail in a worker thread. Only the built-in default is dispatched to the pool; a CPU-bound custom chunker should do its own `asyncio.to_thread`.
+
+### 8.10 Pipeline Concurrency Parameters
 
 The locks around `pipeline_status` solve the correctness problem of "who can write"; this section's set of parameters solves the throughput problem of "how many workers run concurrently". The pipeline is divided into 3 stages, each with an independently tunable worker pool:
 
@@ -1064,7 +1077,7 @@ Parse queues are **created dynamically from the registry's `ParserSpec.queue_gro
 - Pure docx / txt (only native): `MAX_PARALLEL_PARSE_NATIVE=10`; `MAX_PARALLEL_INSERT` derived from `MAX_ASYNC_LLM/3`.
 - Heavy LLM rate-limiting: first lower `MAX_PARALLEL_INSERT` (the process stage makes multiple LLM calls per document), then lower `MAX_PARALLEL_ANALYZE` (VLM is a separate quota).
 
-### 8.10 Admission and Request Limits
+### 8.11 Admission and Request Limits
 
 Before a document reaches any of the machinery above, the server can refuse it outright. These are the variables behind an upload that is rejected rather than queued:
 
@@ -1136,7 +1149,7 @@ Go through the full pipeline (registry-dispatched parsing `get_parser(engine).pa
 | Log notes that paragraphs lack `paraId` | Produced by LibreOffice / WPS / older Word (§3.3) | Informational. Re-save in Word 2013+ only if you need paragraph-level provenance |
 | Document is FAILED as a duplicate | Basename dedup (canonicalized, hint stripped) or content-hash dedup (§7.1, §7.2) | Delete the existing document first, or rename the new file |
 | Upload returns `409` | A document with the same canonical basename already exists in the input directory or in doc-status (§8.5) | Delete it via `POST /documents/delete_document`, then upload again |
-| Upload returns `413` or `429` | An admission limit was hit (§8.10) | See the limits table for which one |
+| Upload returns `413` or `429` | An admission limit was hit (§8.11) | See the limits table for which one |
 | Everything returns `503` | The `recovery_required` fence is up (§8.7) | Follow the recovery order documented in that section |
 | `/documents/scan` returns `scanning_skipped_pipeline_busy` | The pipeline is busy or scanning, uploads are in flight, or a manual retry is queued (§8.2) | Wait for idle; `POST /documents/reprocess_failed` is the single-call recovery for a stuck retry request |
 | Changed the engine or the options, but the output is unchanged | Both the engine and `process_options` are frozen into the doc-status record at enqueue. Automatic resume and `/documents/reprocess_failed` reuse the stored values; editing `LIGHTRAG_PARSER` or a hint affects new uploads only (§9.3) | Delete the document (with "also delete file") and upload it again |
@@ -1255,7 +1268,7 @@ Where to find each family of file-processing variables. This is an index, not a 
 | Docling | `DOCLING_*` | §3.5 |
 | Parse cache | `LIGHTRAG_FORCE_REPARSE_{NATIVE,MINERU,DOCLING}`, `{MINERU,DOCLING}_ENGINE_VERSION` | §3.7, §6.3 |
 | Directories | `INPUT_DIR`, `WORKING_DIR`, `SCAN_SPOOL_DIR` | §6, §7.1 |
-| Concurrency | `MAX_PARALLEL_*`, `QUEUE_SIZE_*` | §8.9 |
-| Admission and limits | `MAX_UPLOAD_SIZE`, `MAX_REQUEST_BODY_BYTES`, `MAX_TEXTS_PER_REQUEST`, `MAX_PENDING_DOCUMENTS`, `PIPELINE_*`, `MAX_UNACKED_MANUAL_RETRIES`, `SCAN_ENQUEUE_BATCH_SIZE` | §8.10 |
+| Concurrency | `MAX_PARALLEL_*`, `QUEUE_SIZE_*` | §8.10 |
+| Admission and limits | `MAX_UPLOAD_SIZE`, `MAX_REQUEST_BODY_BYTES`, `MAX_TEXTS_PER_REQUEST`, `MAX_PENDING_DOCUMENTS`, `PIPELINE_*`, `MAX_UNACKED_MANUAL_RETRIES`, `SCAN_ENQUEUE_BATCH_SIZE` | §8.11 |
 | Query-time (not chunking) | `ENABLE_CONTENT_HEADINGS` — appends each chunk's heading path when assembling the answer context; it does not change chunk boundaries or stored chunk text | [LightRAG Server](./LightRAG-API-Server.md) |
 | Offline / tokenizer | `TIKTOKEN_CACHE_DIR` | [OfflineDeployment.md](./OfflineDeployment.md) |

--- a/env.example
+++ b/env.example
@@ -633,6 +633,11 @@ DOCLING_DO_FORMULA_ENRICHMENT=false
 ###       Chinese sentence-end (。！？) > Chinese semi-clause (；，) > space > char.
 ###       English ".?!" are intentionally omitted (literal match would split "0.95" /
 ###       "e.g."); the English path falls through space / char as before.
+###       Bounded: at most 64 entries of at most 256 characters each. The splitter
+###       re-scans the whole text once per remaining separator, so an oversized
+###       cascade costs O(len(separators) x len(text)) for no extra splitting.
+###       Anything over the limit is truncated (keeping the trailing char-level
+###       "" sentinel if present) and logged at WARNING rather than rejected.
 # CHUNK_R_SIZE=1200
 # CHUNK_R_OVERLAP_SIZE=100
 # CHUNK_R_SEPARATORS=["\n\n","\n","。","！","？","；","，"," ",""]

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -26,7 +26,17 @@ import aiofiles
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Iterator, List, NamedTuple, Optional, Any, Literal, Sequence
+from typing import (
+    Annotated,
+    Dict,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Any,
+    Literal,
+    Sequence,
+)
 from fastapi import (
     APIRouter,
     Depends,
@@ -37,7 +47,14 @@ from fastapi import (
     Response,
     UploadFile,
 )
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
 
 from lightrag import LightRAG
 from lightrag.api.utils_api import internal_server_error
@@ -63,6 +80,8 @@ from lightrag.constants import (
     DEFAULT_SCAN_ENQUEUE_BATCH_SIZE,
     FILE_EXTRACTION_SUMMARY_PREFIX,
     FULL_DOCS_FORMAT_PENDING_PARSE,
+    MAX_R_SEPARATOR_CHARS,
+    MAX_R_SEPARATORS,
     PARSED_ARTIFACT_DIR_SUFFIXES,
     PARSED_DIR_NAME,
     PROCESS_OPTION_CHUNK_FIXED,
@@ -500,15 +519,21 @@ class FixedTokenChunkParams(_OverlapChunkParams):
 class RecursiveCharacterChunkParams(_OverlapChunkParams):
     # Caller-supplied separators are safe from ReDoS — ``is_separator_regex`` is
     # not exposed on this model and defaults to False, so every candidate goes
-    # through ``re.escape`` (lightrag/chunker/recursive_character.py:226,235)
-    # and matches in linear time. What is NOT bounded by that is the *number*
-    # of candidates: the splitter walks the list per recursion level, so cost
-    # grows as ``len(separators) x len(text)``, and unlike V the R chunker runs
-    # synchronously on the event loop. With ``MAX_REQUEST_BODY_BYTES=0`` (the
-    # default) both factors come from the same request, so cap the list here.
-    # The built-in cascade is 9 entries (``DEFAULT_R_SEPARATORS``); 64 leaves
-    # ample room for a multi-language cascade while removing the amplification.
-    separators: Optional[list[str]] = Field(default=None, max_length=64)
+    # through ``re.escape`` and matches in linear time. What is NOT bounded by
+    # that is the *size* of the cascade: the splitter walks the list per
+    # recursion level, so cost grows as ``len(separators) x len(text)`` with
+    # both factors supplied by one request.
+    #
+    # This model is only the first of the two places that has to hold. The
+    # cascade also arrives from CHUNK_R_SEPARATORS, from addon_params, from
+    # direct SDK calls, and from per-doc snapshots persisted before this cap
+    # existed — none of which pass through here — so
+    # ``lightrag.chunker.recursive_character.normalize_r_separators`` bounds it
+    # again at the chunker, which is the one point all of them share. The
+    # constants are shared with it so the two can never drift.
+    separators: Optional[
+        list[Annotated[str, StringConstraints(max_length=MAX_R_SEPARATOR_CHARS)]]
+    ] = Field(default=None, max_length=MAX_R_SEPARATORS)
 
 
 class ParagraphSemanticChunkParams(_OverlapChunkParams):

--- a/lightrag/chunker/recursive_character.py
+++ b/lightrag/chunker/recursive_character.py
@@ -22,6 +22,7 @@ import re
 from collections.abc import Callable, Sequence
 from typing import Any
 
+from lightrag.constants import MAX_R_SEPARATOR_CHARS, MAX_R_SEPARATORS
 from lightrag.utils import Tokenizer, logger
 
 try:
@@ -207,6 +208,68 @@ def _merge_splits_with_spans(
     return docs
 
 
+def normalize_r_separators(
+    separators: Sequence[str] | None,
+    *,
+    context: str = "",
+) -> list[str] | None:
+    """Bound a separator cascade, whatever supplied it.
+
+    ``None`` passes straight through: it is the documented way to ask
+    :func:`chunking_by_recursive_character` for LangChain's own default cascade
+    (``["\\n\\n", "\\n", " ", ""]``), which is NOT
+    :data:`~lightrag.constants.DEFAULT_R_SEPARATORS` — turning one into the other
+    here would change how a direct SDK caller's CJK text splits.
+
+    Only bounding happens here. What to do about an empty result differs per
+    caller and is therefore the caller's decision.
+
+    Args:
+        separators: cascade to bound, or ``None``.
+        context: label for the warnings, naming who supplied the cascade.
+
+    Returns:
+        ``None`` if given ``None``; otherwise the bounded list, possibly empty.
+    """
+    if separators is None:
+        return None
+
+    prefix = f"[{context}] " if context else ""
+    bounded: list[str] = []
+    dropped = 0
+    for candidate in separators:
+        if len(candidate) > MAX_R_SEPARATOR_CHARS:
+            dropped += 1
+            continue
+        bounded.append(candidate)
+    if dropped:
+        logger.warning(
+            f"{prefix}dropped {dropped} separator(s) longer than "
+            f"{MAX_R_SEPARATOR_CHARS} characters"
+        )
+
+    if len(bounded) > MAX_R_SEPARATORS:
+        # Truncation must preserve a terminating sentinel. The empty string is
+        # the char-level fallback: ``_split_text_with_spans`` takes the
+        # ``if not candidate`` branch on it and splits anything. Dropping it
+        # exhausts ``new_separators`` early, so a segment that has no ordinary
+        # separator in it is emitted whole instead of being split — a data-quality
+        # regression introduced by a security fix. Only re-append a sentinel the
+        # caller actually had: ``load_chunk_separators`` strips it on purpose.
+        sentinel = "" if any(not candidate for candidate in bounded) else None
+        keep = MAX_R_SEPARATORS - (1 if sentinel is not None else 0)
+        truncated = [candidate for candidate in bounded[:keep] if candidate]
+        if sentinel is not None:
+            truncated.append(sentinel)
+        logger.warning(
+            f"{prefix}separator cascade of {len(bounded)} entries truncated to "
+            f"{len(truncated)} (limit {MAX_R_SEPARATORS})"
+        )
+        bounded = truncated
+
+    return bounded
+
+
 def _split_text_with_spans(
     text: str,
     *,
@@ -219,26 +282,59 @@ def _split_text_with_spans(
     is_separator_regex: bool,
     strip_whitespace: bool,
 ) -> list[_SpanPiece]:
-    """Mirror ``RecursiveCharacterTextSplitter._split_text`` with offsets."""
-    separator = separators[-1]
-    new_separators: Sequence[str] = []
-    for index, candidate in enumerate(separators):
-        separator_pattern = candidate if is_separator_regex else re.escape(candidate)
-        if not candidate:
-            separator = candidate
-            break
-        if re.search(separator_pattern, text):
-            separator = candidate
-            new_separators = separators[index + 1 :]
-            break
+    """Mirror ``RecursiveCharacterTextSplitter._split_text`` with offsets.
 
-    separator_pattern = separator if is_separator_regex else re.escape(separator)
-    splits = _split_text_with_regex_spans(
-        text,
-        separator_pattern,
-        keep_separator=keep_separator,
-        base_offset=base_offset,
-    )
+    One departure from a literal mirror, for cost only: a separator that matches
+    but does not actually divide the text is skipped in place instead of via a
+    recursive call. With ``keep_separator`` truthy, a separator occurring exactly
+    once at offset 0 yields a single piece byte-identical to the input, so the
+    parent would call ``length_function`` on it — a whole-text token encode — and
+    recurse with the same text. A cascade of such separators therefore costs one
+    full encode per level while splitting nothing, which is what made
+    ``O(len(separators) x len(text))`` reachable from a single request
+    (GHSA-26pm-px5v-8c4w).
+
+    The loop below reaches the same state the recursion would, minus the wasted
+    encodes, so the output is unchanged.
+    """
+    remaining: Sequence[str] = separators
+    while True:
+        separator = remaining[-1]
+        new_separators: Sequence[str] = []
+        for index, candidate in enumerate(remaining):
+            separator_pattern = (
+                candidate if is_separator_regex else re.escape(candidate)
+            )
+            if not candidate:
+                separator = candidate
+                break
+            if re.search(separator_pattern, text):
+                separator = candidate
+                new_separators = remaining[index + 1 :]
+                break
+
+        separator_pattern = separator if is_separator_regex else re.escape(separator)
+        splits = _split_text_with_regex_spans(
+            text,
+            separator_pattern,
+            keep_separator=keep_separator,
+            base_offset=base_offset,
+        )
+
+        # A no-op split: one piece, identical to the input. Recursing on it would
+        # re-encode the whole text to discover it is still oversized and then land
+        # exactly here with the next separator, so advance in place instead. When
+        # no separators remain the loop exits and the piece is emitted whole, as
+        # the recursion would have.
+        if (
+            new_separators
+            and len(splits) == 1
+            and splits[0][0] == text
+            and splits[0][1] == base_offset
+        ):
+            remaining = new_separators
+            continue
+        break
 
     final_chunks: list[_SpanPiece] = []
     good_splits: list[_SpanPiece] = []
@@ -324,6 +420,22 @@ def chunking_by_recursive_character(
 
     def length_function(text: str) -> int:
         return len(tokenizer.encode(text))
+
+    separators = normalize_r_separators(
+        separators, context="chunking_by_recursive_character"
+    )
+    if separators is not None and not separators:
+        # Everything was dropped as over-long. Falling back to this function's own
+        # default (LangChain's cascade) rather than to DEFAULT_R_SEPARATORS keeps
+        # the behaviour identical to ``separators=None``; substituting the
+        # repo-wide cascade here would silently change how CJK text splits for a
+        # caller who never asked for it. An empty list would be worse still —
+        # ``_split_text_with_spans`` reads ``separators[-1]`` on its first line.
+        logger.warning(
+            "[chunking_by_recursive_character] every supplied separator was "
+            "dropped; falling back to the splitter's default cascade"
+        )
+        separators = None
 
     splitter_kwargs: dict[str, Any] = {
         "chunk_size": max(int(chunk_token_size), 1),

--- a/lightrag/chunker/semantic_vector.py
+++ b/lightrag/chunker/semantic_vector.py
@@ -32,7 +32,12 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from lightrag.constants import DEFAULT_SENTENCE_SPLIT_REGEX
-from lightrag.utils import EmbeddingFunc, Tokenizer, logger
+from lightrag.utils import (
+    EmbeddingFunc,
+    Tokenizer,
+    logger,
+    run_in_chunking_executor,
+)
 
 if TYPE_CHECKING:
     from langchain_experimental.text_splitter import (
@@ -251,7 +256,12 @@ async def chunking_by_semantic_vector(
             chunking_by_recursive_character,
         )
 
-        return chunking_by_recursive_character(
+        # Off the loop like every other R run. Without this the ``await
+        # asyncio.to_thread`` further down is never reached, so V's "already
+        # offloaded" reputation does not hold for a deployment without an
+        # embedding function — the R attack surface reappears in full.
+        return await run_in_chunking_executor(
+            chunking_by_recursive_character,
             tokenizer,
             content,
             chunk_token_size,
@@ -296,54 +306,71 @@ async def chunking_by_semantic_vector(
     )
 
     target_max = max(int(chunk_token_size), 1)
-    results: list[dict[str, Any]] = []
-    for piece, source_start, source_end in pieces:
-        body = piece.strip()
-        if not body:
-            continue
-        piece_tokens = len(tokenizer.encode(body))
-        if piece_tokens <= target_max:
-            results.append(
-                {
-                    "tokens": piece_tokens,
-                    "content": body,
-                    "chunk_order_index": len(results),
-                    "_source_span": {
-                        "start": source_start,
-                        "end": source_end,
-                    },
-                }
-            )
-            continue
-        # Oversized semantic piece: re-split via R while preserving the
-        # surrounding chunk order.  ``chunk_overlap_token_size=0`` keeps
-        # V's non-overlapping semantics.
-        sub_pieces = chunking_by_recursive_character(
-            tokenizer,
-            body,
-            target_max,
-            chunk_overlap_token_size=0,
-        )
-        for sub in sub_pieces:
-            sub_body = sub.get("content", "")
-            if not sub_body:
+
+    def _size_and_resplit() -> list[dict[str, Any]]:
+        """Encode every semantic piece and re-split the oversized ones.
+
+        ``await asyncio.to_thread`` above covers the embedding-driven grouping
+        and nothing else: this loop encodes each piece and, for anything over
+        budget, runs a whole R pass on it. On the event loop that is comparable
+        in cost to the grouping it follows, which is why the whole loop — not
+        each piece — moves off it in one hop.
+
+        ``chunking_by_recursive_character`` is called DIRECTLY here: this
+        function already runs inside the chunking executor, and a nested
+        submission into a single-worker pool whose permit it holds would
+        deadlock.
+        """
+        results: list[dict[str, Any]] = []
+        for piece, source_start, source_end in pieces:
+            body = piece.strip()
+            if not body:
                 continue
-            sub_span = sub.get("_source_span")
-            source_span = None
-            if isinstance(sub_span, dict):
-                try:
-                    source_span = {
-                        "start": source_start + int(sub_span["start"]),
-                        "end": source_start + int(sub_span["end"]),
+            piece_tokens = len(tokenizer.encode(body))
+            if piece_tokens <= target_max:
+                results.append(
+                    {
+                        "tokens": piece_tokens,
+                        "content": body,
+                        "chunk_order_index": len(results),
+                        "_source_span": {
+                            "start": source_start,
+                            "end": source_end,
+                        },
                     }
-                except (KeyError, TypeError, ValueError):
-                    source_span = None
-            results.append(
-                {
-                    "tokens": sub.get("tokens", len(tokenizer.encode(sub_body))),
-                    "content": sub_body,
-                    "chunk_order_index": len(results),
-                    **({"_source_span": source_span} if source_span else {}),
-                }
+                )
+                continue
+            # Oversized semantic piece: re-split via R while preserving the
+            # surrounding chunk order.  ``chunk_overlap_token_size=0`` keeps
+            # V's non-overlapping semantics.
+            sub_pieces = chunking_by_recursive_character(
+                tokenizer,
+                body,
+                target_max,
+                chunk_overlap_token_size=0,
             )
-    return results
+            for sub in sub_pieces:
+                sub_body = sub.get("content", "")
+                if not sub_body:
+                    continue
+                sub_span = sub.get("_source_span")
+                source_span = None
+                if isinstance(sub_span, dict):
+                    try:
+                        source_span = {
+                            "start": source_start + int(sub_span["start"]),
+                            "end": source_start + int(sub_span["end"]),
+                        }
+                    except (KeyError, TypeError, ValueError):
+                        source_span = None
+                results.append(
+                    {
+                        "tokens": sub.get("tokens", len(tokenizer.encode(sub_body))),
+                        "content": sub_body,
+                        "chunk_order_index": len(results),
+                        **({"_source_span": source_span} if source_span else {}),
+                    }
+                )
+        return results
+
+    return await run_in_chunking_executor(_size_and_resplit)

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -113,6 +113,18 @@ DEFAULT_R_SEPARATORS: tuple[str, ...] = (
     " ",
     "",
 )
+# Bounds on any separator cascade, wherever it comes from. The recursive splitter
+# descends one level per remaining separator and re-scans the text at every level,
+# so total work is O(len(separators) x len(text)); with both factors supplied by
+# one request that is an amplifier (GHSA-26pm-px5v-8c4w). The request model caps
+# the list, but CHUNK_R_SEPARATORS, addon_params, direct SDK calls and per-doc
+# snapshots persisted before that cap existed all bypass it, so the chunker
+# normalizes whatever it is handed. 64 leaves ample room for a multi-language
+# cascade — the built-in one is 9 entries.
+MAX_R_SEPARATORS = 64
+# Per-entry length. A single huge separator is re-escaped and re-scanned at every
+# level, so it is expensive for the same reason a long list is.
+MAX_R_SEPARATOR_CHARS = 256
 # DEFAULT_SENTENCE_SPLIT_REGEX: pattern fed to langchain SemanticChunker.
 # Two alternates so the English branch keeps its ``\s+`` requirement
 # (avoiding ``0.95`` mid-token splits) while the Chinese branch matches

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -182,6 +182,7 @@ from lightrag.utils import (
     make_relation_chunk_key,
     normalize_source_ids_limit_method,
     normalize_string_list,
+    run_in_chunking_executor,
 )
 from lightrag.types import KnowledgeGraph
 from dotenv import load_dotenv
@@ -546,6 +547,17 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     ] = field(default_factory=lambda: chunking_by_token_size)
     """
     Legacy chunking-function customization point. Synchronous or async.
+
+    **Where it runs.** A custom ``chunking_func`` is called on the event loop,
+    exactly as before. The built-in default is dispatched to a worker thread
+    instead, because chunking is CPU-bound and holding the loop for its duration
+    stops the server answering anything (GHSA-26pm-px5v-8c4w). The extension
+    point is deliberately excluded from that: "synchronous or async" is part of
+    its contract, so an implementation that touches the running loop when called
+    — a synchronous factory returning a Task, say — is supported and would fail
+    outright in a worker thread, while an ``async def`` would gain nothing from
+    the hop since its body runs on the loop regardless. A CPU-bound custom
+    chunker should therefore do its own ``asyncio.to_thread``.
 
     **When this function is actually invoked.** The chunker dispatch in
     ``_PipelineMixin.process_single_document`` is driven by the
@@ -2028,16 +2040,28 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     # concurrently with these upserts can observe a
                     # not-yet-persisted chunk and silently drop the cache
                     # reference.
-                    inserting_chunks: dict[str, Any] = {
-                        chunk_id: {
-                            "content": content,
-                            "full_doc_id": doc_key,
-                            "tokens": len(self.tokenizer.encode(content)),
-                            "chunk_order_index": index,
-                            "file_path": file_path,
+                    # Off the loop: this shares ``self.tokenizer`` with the
+                    # chunking executor, and this entry point is gated by
+                    # neither max_parallel_insert nor the pipeline busy flag, so
+                    # nothing else keeps it from encoding concurrently with a
+                    # document being chunked.
+                    def _build_inserting_chunks() -> dict[str, Any]:
+                        return {
+                            chunk_id: {
+                                "content": content,
+                                "full_doc_id": doc_key,
+                                "tokens": len(self.tokenizer.encode(content)),
+                                "chunk_order_index": index,
+                                "file_path": file_path,
+                            }
+                            for index, (chunk_id, content, _) in enumerate(
+                                chunk_entries
+                            )
                         }
-                        for index, (chunk_id, content, _) in enumerate(chunk_entries)
-                    }
+
+                    inserting_chunks: dict[str, Any] = await run_in_chunking_executor(
+                        _build_inserting_chunks
+                    )
                     stage1_writes = [
                         self.chunks_vdb.upsert(inserting_chunks),
                         self.text_chunks.upsert(inserting_chunks),
@@ -3169,34 +3193,46 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             # Insert chunks into vector storage
             all_chunks_data: dict[str, dict[str, str]] = {}
             chunk_to_source_map: dict[str, str] = {}
-            for chunk_data in custom_kg.get("chunks", []):
-                chunk_content = sanitize_text_for_encoding(chunk_data["content"])
-                source_id = chunk_data["source_id"]
-                file_path = normalize_document_file_path(
-                    chunk_data.get("file_path", "custom_kg")
-                )
-                tokens = len(self.tokenizer.encode(chunk_content))
-                chunk_order_index = (
-                    0
-                    if "chunk_order_index" not in chunk_data.keys()
-                    else chunk_data["chunk_order_index"]
-                )
-                chunk_id = compute_mdhash_id(chunk_content, prefix="chunk-")
 
-                chunk_entry = {
-                    "content": chunk_content,
-                    "source_id": source_id,
-                    "tokens": tokens,
-                    "chunk_order_index": chunk_order_index,
-                    "full_doc_id": full_doc_id
-                    if full_doc_id is not None
-                    else source_id,
-                    "file_path": file_path,
-                    "status": DocStatus.PROCESSED,
-                }
-                all_chunks_data[chunk_id] = chunk_entry
-                chunk_to_source_map[source_id] = chunk_id
-                update_storage = True
+            def _build_custom_kg_chunks() -> None:
+                """Encode and assemble every custom-KG chunk in one hop.
+
+                ``self.tokenizer`` is shared with the chunking executor, and
+                this entry point is gated by neither max_parallel_insert nor the
+                pipeline busy flag, so leaving the loop here would let it encode
+                concurrently with a document being chunked.
+                """
+                nonlocal update_storage
+                for chunk_data in custom_kg.get("chunks", []):
+                    chunk_content = sanitize_text_for_encoding(chunk_data["content"])
+                    source_id = chunk_data["source_id"]
+                    file_path = normalize_document_file_path(
+                        chunk_data.get("file_path", "custom_kg")
+                    )
+                    tokens = len(self.tokenizer.encode(chunk_content))
+                    chunk_order_index = (
+                        0
+                        if "chunk_order_index" not in chunk_data.keys()
+                        else chunk_data["chunk_order_index"]
+                    )
+                    chunk_id = compute_mdhash_id(chunk_content, prefix="chunk-")
+
+                    chunk_entry = {
+                        "content": chunk_content,
+                        "source_id": source_id,
+                        "tokens": tokens,
+                        "chunk_order_index": chunk_order_index,
+                        "full_doc_id": full_doc_id
+                        if full_doc_id is not None
+                        else source_id,
+                        "file_path": file_path,
+                        "status": DocStatus.PROCESSED,
+                    }
+                    all_chunks_data[chunk_id] = chunk_entry
+                    chunk_to_source_map[source_id] = chunk_id
+                    update_storage = True
+
+            await run_in_chunking_executor(_build_custom_kg_chunks)
 
             if all_chunks_data:
                 await asyncio.gather(

--- a/lightrag/multimodal_context.py
+++ b/lightrag/multimodal_context.py
@@ -694,6 +694,8 @@ def load_chunk_separators() -> list[str]:
     JSON.  The returned list always has the empty-string sentinel
     dropped — char fallback is signalled separately by the caller.
     """
+    from lightrag.chunker.recursive_character import normalize_r_separators
+
     raw = os.getenv("CHUNK_R_SEPARATORS")
     separators: list[str]
     if raw:
@@ -707,7 +709,23 @@ def load_chunk_separators() -> list[str]:
             separators = list(DEFAULT_R_SEPARATORS)
     else:
         separators = list(DEFAULT_R_SEPARATORS)
-    return [s for s in separators if s]
+
+    # ``CHUNK_R_SEPARATORS`` reaches ``enrich_sidecars_with_surrounding``, which
+    # scans each block once per separator — the same amplification the request
+    # model was capped for, on a path that never touches
+    # ``chunking_by_recursive_character``. Bound it through the same normalizer.
+    bounded = normalize_r_separators(separators, context="load_chunk_separators")
+    result = [s for s in bounded if s]
+    if not result:
+        # Unlike the chunker, this function has no "splitter default" to fall back
+        # to — its callers expect a usable cascade — so it falls back the same way
+        # it already does for malformed env values.
+        logger.warning(
+            "[load_chunk_separators] no usable separators after bounding; "
+            "falling back to DEFAULT_R_SEPARATORS"
+        )
+        result = [s for s in DEFAULT_R_SEPARATORS if s]
+    return result
 
 
 def load_content_rows_by_blockid(blocks_path: str) -> dict[str, str]:

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -105,6 +105,7 @@ from lightrag.utils import (
     is_truncated_response,
     logger,
     repair_vlm_json_escape_damage_nested,
+    run_in_chunking_executor,
     sanitize_text_for_encoding,
     save_to_cache,
     serialize_llm_cache_identity,
@@ -4840,7 +4841,8 @@ class _PipelineMixin:
                         )
                         chunk_opts_str = _format_chunking_params(p_chunk_size, p_opts)
                         logger.info(f"Chunking P: {chunk_opts_str}, doc_id: {doc_id}")
-                        chunking_result = chunking_by_paragraph_semantic(
+                        chunking_result = await run_in_chunking_executor(
+                            chunking_by_paragraph_semantic,
                             self.tokenizer,
                             content,
                             p_chunk_size,
@@ -4862,7 +4864,8 @@ class _PipelineMixin:
                         )
                         chunk_opts_str = _format_chunking_params(r_chunk_size, r_opts)
                         logger.info(f"Chunking R: {chunk_opts_str}, doc_id: {doc_id}")
-                        chunking_result = chunking_by_recursive_character(
+                        chunking_result = await run_in_chunking_executor(
+                            chunking_by_recursive_character,
                             self.tokenizer,
                             content,
                             r_chunk_size,
@@ -4908,7 +4911,8 @@ class _PipelineMixin:
                         )
                         chunk_opts_str = _format_chunking_params(f_chunk_size, f_opts)
                         logger.info(f"Chunking F: {chunk_opts_str}, doc_id: {doc_id}")
-                        chunking_result = chunking_by_fixed_token(
+                        chunking_result = await run_in_chunking_executor(
+                            chunking_by_fixed_token,
                             self.tokenizer,
                             content,
                             f_chunk_size,
@@ -4954,9 +4958,10 @@ class _PipelineMixin:
                     # private ``_emit_source_span`` kwarg; a user-supplied
                     # ``chunking_func`` must not receive it.
                     legacy_kwargs = {}
-                    if self.chunking_func is chunking_by_token_size:
+                    is_builtin_chunker = self.chunking_func is chunking_by_token_size
+                    if is_builtin_chunker:
                         legacy_kwargs["_emit_source_span"] = True
-                    chunking_result = self.chunking_func(
+                    legacy_args = (
                         self.tokenizer,
                         content,
                         f_opts.get("split_by_character"),
@@ -4966,8 +4971,27 @@ class _PipelineMixin:
                             self.chunk_overlap_token_size,
                         ),
                         legacy_chunk_size,
-                        **legacy_kwargs,
                     )
+                    if is_builtin_chunker:
+                        chunking_result = await run_in_chunking_executor(
+                            self.chunking_func, *legacy_args, **legacy_kwargs
+                        )
+                    else:
+                        # A user-supplied ``chunking_func`` is documented as
+                        # "synchronous or async" and the awaitable it may return
+                        # is handled just below, so it is NOT safe to assume it
+                        # does not touch the running loop: a synchronous factory
+                        # that calls ``get_running_loop()`` or ``create_task()``
+                        # is a supported implementation and would fail outright
+                        # in a worker thread. For an ``async def`` the hop would
+                        # buy nothing anyway — the coroutine body still runs on
+                        # the loop. So the extension point keeps its existing
+                        # calling convention, and a CPU-bound custom chunker is
+                        # responsible for its own ``to_thread``; see the
+                        # ``chunking_func`` docstring.
+                        chunking_result = self.chunking_func(
+                            *legacy_args, **legacy_kwargs
+                        )
                 if inspect.isawaitable(chunking_result):
                     chunking_result = await chunking_result
 
@@ -5036,7 +5060,8 @@ class _PipelineMixin:
                     # left over from an earlier multimodal run. The builder's
                     # None branch is reserved for ad-hoc callers (unit tests)
                     # that intentionally want every modality considered.
-                    mm_chunks = self._build_mm_chunks_from_sidecars(
+                    mm_chunks = await run_in_chunking_executor(
+                        self._build_mm_chunks_from_sidecars,
                         doc_id=doc_id,
                         file_path=file_path,
                         blocks_path=blocks_path,
@@ -5055,7 +5080,8 @@ class _PipelineMixin:
                     and self.embedding_token_limit > 0
                 ):
                     original_chunk_count = len(chunking_result)
-                    chunking_result = enforce_chunk_token_limit_before_embedding(
+                    chunking_result = await run_in_chunking_executor(
+                        enforce_chunk_token_limit_before_embedding,
                         chunking_result=chunking_result,
                         tokenizer=self.tokenizer,
                         max_tokens=self.embedding_token_limit,
@@ -6211,7 +6237,8 @@ class _PipelineMixin:
                     enrich_sidecars_with_surrounding,
                 )
 
-                enrich_counts = enrich_sidecars_with_surrounding(
+                enrich_counts = await run_in_chunking_executor(
+                    enrich_sidecars_with_surrounding,
                     blocks_path=str(block_file),
                     enabled_modalities=enabled_modalities,
                     tokenizer=tokenizer,
@@ -6750,8 +6777,18 @@ class _PipelineMixin:
                             frame_reserve=SAFETY_BUFFER,
                             content_min=content_min_tokens,
                         )
-                    total_tokens = len(tokenizer.encode(prompt))
-                    if max_extract_tokens > 0 and total_tokens > max_extract_tokens:
+
+                    # Everything from here to the post-trim guard is
+                    # tokenizer-bound and works on the same ``self.tokenizer``
+                    # the chunking executor uses, so it runs there in one hop
+                    # rather than on the event loop. MultimodalAnalysisError
+                    # propagates out of the executor unchanged.
+                    def _cap_extract_prompt(prompt: str) -> str:
+                        total_tokens = len(tokenizer.encode(prompt))
+                        if not (
+                            max_extract_tokens > 0 and total_tokens > max_extract_tokens
+                        ):
+                            return prompt
                         frame_tokens = len(tokenizer.encode(_render("")))
                         content_budget = (
                             max_extract_tokens - frame_tokens - SAFETY_BUFFER
@@ -6824,6 +6861,9 @@ class _PipelineMixin:
                                 f"MAX_EXTRACT_INPUT_TOKENS "
                                 f"({max_extract_tokens})"
                             )
+                        return prompt
+
+                    prompt = await run_in_chunking_executor(_cap_extract_prompt, prompt)
 
                 args_hash = compute_args_hash(
                     prompt,

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -17,6 +17,7 @@ import os
 import re
 import time
 import uuid
+import threading
 import warnings
 from concurrent.futures import Future as ConcurrentFuture, ThreadPoolExecutor
 from dataclasses import dataclass
@@ -2741,6 +2742,61 @@ def get_loop_semaphore(name: str, capacity: int) -> asyncio.Semaphore:
     except (AttributeError, TypeError):
         return _fallback_semaphore(loop, name, capacity)
     return semaphore
+
+
+# ---------------------------------------------------------------------------
+# Chunking off the event loop
+# ---------------------------------------------------------------------------
+#
+# Chunking is CPU-bound in the document the caller supplied and, for the
+# recursive strategy, in the separator cascade supplied with it. Run inline in an
+# ``async def`` — which is what every branch except V did — it holds the only
+# thread serving HTTP for its whole duration, so one 414 KiB document made an
+# unrelated ``GET /health`` take 63 seconds (GHSA-26pm-px5v-8c4w).
+#
+# One worker. Chunking is serialized by the event loop as things stand — while
+# one document chunks, no other document's coroutine can run — so a single worker
+# preserves that concurrency exactly while freeing the loop, rather than
+# introducing parallelism this change has no reason to introduce.
+#
+# Invariants:
+#   * code running in here calls the SYNCHRONOUS tokenizer API. Awaiting an async
+#     helper from a worker thread would park it on the loop while the loop waits
+#     for the thread.
+#   * no nested submissions. One worker plus a held permit means a task that
+#     submits again deadlocks. Where a chunker calls another chunker (V's
+#     post-processing calls R), it calls it DIRECTLY — it is already in the pool.
+
+_CHUNKING_EXECUTOR: Optional[ThreadPoolExecutor] = None
+_CHUNKING_EXECUTOR_GUARD = threading.Lock()
+
+
+def get_chunking_executor() -> ThreadPoolExecutor:
+    """The process-wide single-worker pool used for chunking."""
+    global _CHUNKING_EXECUTOR
+    if _CHUNKING_EXECUTOR is None:
+        with _CHUNKING_EXECUTOR_GUARD:
+            if _CHUNKING_EXECUTOR is None:
+                _CHUNKING_EXECUTOR = ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="lightrag-chunking"
+                )
+    return _CHUNKING_EXECUTOR
+
+
+async def run_in_chunking_executor(fn: Callable[..., Any], *args: Any, **kwargs) -> Any:
+    """Run a synchronous, chunking-bound callable off the event loop.
+
+    Bounded like any other submission: the submitters include public SDK entry
+    points (``ainsert_custom_kg``, ``ainsert_custom_chunks``) gated by neither
+    ``max_parallel_insert`` nor the pipeline's busy flag, so "the pipeline limits
+    concurrency" is not a ceiling that actually holds here.
+    """
+    from lightrag.constants import CHUNKING_SUBMIT_LIMIT
+
+    semaphore = get_loop_semaphore("chunking", CHUNKING_SUBMIT_LIMIT)
+    return await bounded_submit(
+        get_chunking_executor(), semaphore, partial(fn, *args, **kwargs)
+    )
 
 
 class Tokenizer:

--- a/tests/chunker/test_recursive_character_bounds.py
+++ b/tests/chunker/test_recursive_character_bounds.py
@@ -1,0 +1,273 @@
+"""Separator-cascade bounds and the no-op amplification (GHSA-26pm-px5v-8c4w).
+
+The recursive splitter descends one level per remaining separator and re-scans
+the text at every level, so cost is ``O(len(separators) x len(text))`` with both
+factors supplied by one request. Bounding the list in the request model covers
+HTTP callers only — CHUNK_R_SEPARATORS, addon_params, direct SDK calls and per-doc
+snapshots persisted before that cap existed all bypass it — so the chunker bounds
+whatever it is handed.
+
+Two of the bounding rules are there to avoid breaking things the naive version of
+this fix would have broken, and are marked below.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.chunker.recursive_character import (
+    chunking_by_recursive_character,
+    normalize_r_separators,
+)
+from lightrag.constants import (
+    DEFAULT_R_SEPARATORS,
+    MAX_R_SEPARATOR_CHARS,
+    MAX_R_SEPARATORS,
+)
+from lightrag.utils import Tokenizer
+
+pytestmark = pytest.mark.offline
+
+
+class _CountingTokenizer:
+    """Counts encodes so cost can be asserted without timing anything."""
+
+    def __init__(self):
+        self.encodes = 0
+
+    def encode(self, content: str):
+        self.encodes += 1
+        # One token per 4 characters, deterministic and cheap.
+        return list(range(max(len(content) // 4, 1)))
+
+    def decode(self, tokens):
+        return "x" * (len(tokens) * 4)
+
+
+def _tok() -> tuple[Tokenizer, _CountingTokenizer]:
+    underlying = _CountingTokenizer()
+    return Tokenizer("test-model", underlying), underlying
+
+
+# --------------------------------------------------------------------------- #
+# normalize_r_separators
+# --------------------------------------------------------------------------- #
+
+
+def test_none_passes_through_untouched():
+    """``None`` means "use the splitter's own default cascade".
+
+    That cascade is LangChain's four-entry English one, not the repo's nine-entry
+    DEFAULT_R_SEPARATORS. Substituting one for the other here would silently
+    change how a direct SDK caller's CJK text splits.
+    """
+    assert normalize_r_separators(None) is None
+
+
+def test_a_cascade_within_the_limits_is_returned_verbatim():
+    original = list(DEFAULT_R_SEPARATORS)
+    assert normalize_r_separators(original) == original
+
+
+def test_over_long_entries_are_dropped():
+    separators = ["\n\n", "x" * (MAX_R_SEPARATOR_CHARS + 1), "\n"]
+    assert normalize_r_separators(separators) == ["\n\n", "\n"]
+
+
+def test_a_long_cascade_is_truncated():
+    separators = [f"s{i}" for i in range(900)]
+    bounded = normalize_r_separators(separators)
+    assert len(bounded) == MAX_R_SEPARATORS
+    assert bounded == separators[:MAX_R_SEPARATORS]
+
+
+def test_truncation_preserves_the_char_level_sentinel():
+    """Regression guard, not a plain bound.
+
+    The empty string is the char-level fallback: ``_split_text_with_spans`` takes
+    the ``if not candidate`` branch on it and splits anything. Taking the first N
+    entries drops it whenever the cascade is long, so ``new_separators`` runs out
+    early and a segment with no ordinary separator in it is emitted WHOLE — a
+    data-quality regression introduced by a security fix.
+    """
+    separators = [f"s{i}" for i in range(MAX_R_SEPARATORS)] + [""]
+    bounded = normalize_r_separators(separators)
+
+    assert len(bounded) == MAX_R_SEPARATORS
+    assert bounded[-1] == ""
+
+
+def test_a_cascade_without_a_sentinel_does_not_gain_one():
+    """``load_chunk_separators`` strips the sentinel deliberately."""
+    separators = [f"s{i}" for i in range(900)]
+    assert "" not in normalize_r_separators(separators)
+
+
+def test_everything_over_long_normalizes_to_empty_not_to_a_substitute():
+    """The normalizer only bounds; what to do with an empty result is the
+    caller's decision, and the two callers decide differently."""
+    separators = ["x" * (MAX_R_SEPARATOR_CHARS + 1)] * 3
+    assert normalize_r_separators(separators) == []
+
+
+# --------------------------------------------------------------------------- #
+# chunking_by_recursive_character consumes the bounds
+# --------------------------------------------------------------------------- #
+
+
+def test_the_sentinel_still_splits_an_otherwise_unsplittable_text():
+    """The other half of the sentinel guard, end to end.
+
+    A long run with no ordinary separator can only be broken at the char level.
+    If truncation dropped the sentinel this returns one oversized chunk.
+    """
+    tokenizer, _ = _tok()
+    text = "A" * 4000
+    separators = [f"s{i}" for i in range(MAX_R_SEPARATORS)] + [""]
+
+    chunks = chunking_by_recursive_character(
+        tokenizer, text, 100, chunk_overlap_token_size=0, separators=separators
+    )
+
+    assert len(chunks) > 1
+
+
+def test_an_all_over_long_cascade_falls_back_instead_of_crashing():
+    """``_split_text_with_spans`` reads ``separators[-1]`` on its first line, so
+    an empty cascade is an IndexError, not a degraded split."""
+    tokenizer, _ = _tok()
+    separators = ["x" * (MAX_R_SEPARATOR_CHARS + 1)] * 3
+
+    chunks = chunking_by_recursive_character(
+        tokenizer,
+        "hello world " * 200,
+        50,
+        chunk_overlap_token_size=0,
+        separators=separators,
+    )
+
+    assert chunks
+
+
+def test_the_all_over_long_fallback_matches_separators_none():
+    """It falls back to this function's own default, not to DEFAULT_R_SEPARATORS.
+
+    Anything else would change the split points of a caller who supplied a
+    garbage cascade — including, on CJK text, where sentences break.
+    """
+    text = "第一句。第二句！第三句？" * 40 + "\n\nEnglish paragraph here. " * 20
+    tokenizer_a, _ = _tok()
+    tokenizer_b, _ = _tok()
+
+    fallback = chunking_by_recursive_character(
+        tokenizer_a,
+        text,
+        60,
+        chunk_overlap_token_size=0,
+        separators=["x" * (MAX_R_SEPARATOR_CHARS + 1)],
+    )
+    default = chunking_by_recursive_character(
+        tokenizer_b, text, 60, chunk_overlap_token_size=0, separators=None
+    )
+
+    assert [c["content"] for c in fallback] == [c["content"] for c in default]
+
+
+def test_separators_none_is_not_rewritten_to_the_repo_cascade():
+    """Direct SDK behaviour must not shift.
+
+    LangChain's default has no CJK punctuation; DEFAULT_R_SEPARATORS does. If
+    ``None`` were mapped onto the latter, Chinese text would split in different
+    places than it used to.
+    """
+    text = "第一句。第二句！第三句？" * 40
+    tokenizer_a, _ = _tok()
+    tokenizer_b, _ = _tok()
+
+    as_none = chunking_by_recursive_character(
+        tokenizer_a, text, 60, chunk_overlap_token_size=0, separators=None
+    )
+    as_repo_cascade = chunking_by_recursive_character(
+        tokenizer_b,
+        text,
+        60,
+        chunk_overlap_token_size=0,
+        separators=list(DEFAULT_R_SEPARATORS),
+    )
+
+    assert [c["content"] for c in as_none] != [c["content"] for c in as_repo_cascade]
+
+
+# --------------------------------------------------------------------------- #
+# The no-op cascade: where the amplification actually came from
+# --------------------------------------------------------------------------- #
+
+
+def _sep_bomb_text() -> str:
+    """The advisory's payload shape: the separator occurs once, at offset 0."""
+    return "Q" + ("X " * 4000)
+
+
+@pytest.mark.parametrize("count", [1, 8, MAX_R_SEPARATORS])
+def test_a_no_op_cascade_costs_the_same_regardless_of_its_length(count):
+    """The load-bearing cost assertion.
+
+    A separator matching only at offset 0 yields one piece identical to the
+    input, so the recursion used to call ``length_function`` — a whole-text
+    encode — once per level while splitting nothing. Encode count, not wall
+    clock: timing is unreliable in CI and the encodes are what the cost was.
+    """
+    tokenizer, underlying = _tok()
+
+    chunking_by_recursive_character(
+        tokenizer, _sep_bomb_text(), 1200, separators=["Q"] * count
+    )
+
+    # Two: one for the separator length in the merge step, one for the piece.
+    assert underlying.encodes <= 4
+
+
+def test_the_no_op_skip_does_not_change_the_output():
+    """Skipping a level in place must reach the same state the recursion did."""
+    tokenizer, _ = _tok()
+    text = _sep_bomb_text()
+
+    with_bomb = chunking_by_recursive_character(
+        tokenizer, text, 1200, separators=["Q"] * MAX_R_SEPARATORS
+    )
+
+    # No separator divides this text, so it is emitted whole — exactly what the
+    # recursive form produced, at a fraction of the cost.
+    assert len(with_bomb) == 1
+    assert with_bomb[0]["content"].startswith("QX")
+
+
+def test_a_separator_that_really_splits_is_unaffected():
+    """The skip must only trigger on a genuine no-op."""
+    tokenizer, _ = _tok()
+    text = "alpha|beta|gamma|delta " * 50
+
+    chunks = chunking_by_recursive_character(
+        tokenizer, text, 20, chunk_overlap_token_size=0, separators=["|", ""]
+    )
+
+    assert len(chunks) > 1
+    assert "".join(c["content"] for c in chunks).replace(" ", "").count("alpha") == 50
+
+
+def test_default_cascade_output_is_unchanged_by_the_skip():
+    """Sanity net over ordinary text: the optimisation is cost-only."""
+    tokenizer, _ = _tok()
+    text = "Para one.\n\nPara two is longer and wordier.\n\nPara three.\n" * 20
+
+    chunks = chunking_by_recursive_character(
+        tokenizer,
+        text,
+        40,
+        chunk_overlap_token_size=0,
+        separators=list(DEFAULT_R_SEPARATORS),
+    )
+
+    rejoined = "".join(c["content"] for c in chunks)
+    assert "Para one." in rejoined and "Para three." in rejoined
+    assert len(chunks) > 1

--- a/tests/pipeline/test_chunking_executor_bounds.py
+++ b/tests/pipeline/test_chunking_executor_bounds.py
@@ -1,0 +1,139 @@
+"""Submissions to the chunking executor stay bounded (GHSA-26pm-px5v-8c4w).
+
+The pipeline's own ``max_parallel_insert`` is not a ceiling for this pool: the
+public SDK entry points that also submit here — ``ainsert_custom_kg`` and
+``ainsert_custom_chunks`` — are gated by neither it nor the pipeline busy flag.
+So the pool carries its own semaphore, and the permit belongs to the executor
+future rather than to the awaiting coroutine: the thread pool cannot cancel a
+running task, so releasing on cancellation would let submit-and-cancel rebuild an
+unbounded queue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from lightrag import utils as lr_utils
+from lightrag.constants import CHUNKING_SUBMIT_LIMIT
+
+pytestmark = pytest.mark.offline
+
+
+class _CountingProxy:
+    """Wraps the real executor and records accepted submissions."""
+
+    def __init__(self, real):
+        self._real = real
+        self.submitted = 0
+
+    def submit(self, fn, /, *args, **kwargs):
+        self.submitted += 1
+        return self._real.submit(fn, *args, **kwargs)
+
+
+@pytest.fixture
+def counting_executor(monkeypatch):
+    proxy = _CountingProxy(lr_utils.get_chunking_executor())
+    monkeypatch.setattr(lr_utils, "get_chunking_executor", lambda: proxy)
+    return proxy
+
+
+def _blocking(release: threading.Event, marker: str) -> str:
+    release.wait(5.0)
+    return marker
+
+
+def test_the_pool_has_exactly_one_worker():
+    """Preserves the concurrency the event loop already imposed on chunking."""
+    assert lr_utils.get_chunking_executor()._max_workers == 1
+
+
+def test_cancelling_a_submission_does_not_free_its_slot_early(counting_executor):
+    """The thread keeps running, so the permit must keep being held.
+
+    ``async with sem: await run_in_executor(...)`` fails this: the permit comes
+    back on cancellation while the work does not stop, so a caller can hold an
+    unbounded number of live tasks against one permit's worth of accounting.
+    """
+
+    async def _main():
+        release = threading.Event()
+        try:
+            tasks = [
+                asyncio.create_task(
+                    lr_utils.run_in_chunking_executor(_blocking, release, f"m{i}")
+                )
+                for i in range(CHUNKING_SUBMIT_LIMIT)
+            ]
+            await asyncio.sleep(0.05)
+            assert counting_executor.submitted == CHUNKING_SUBMIT_LIMIT
+
+            for task in tasks:
+                task.cancel()
+            for task in tasks:
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+            follow_up = asyncio.create_task(
+                lr_utils.run_in_chunking_executor(lambda: "later")
+            )
+            await asyncio.sleep(0.1)
+
+            # Every permit is still consumed by a thread that is still running.
+            assert counting_executor.submitted == CHUNKING_SUBMIT_LIMIT
+            assert not follow_up.done()
+
+            release.set()
+            assert await asyncio.wait_for(follow_up, timeout=5.0) == "later"
+            assert counting_executor.submitted == CHUNKING_SUBMIT_LIMIT + 1
+        finally:
+            release.set()
+
+    asyncio.run(_main())
+
+
+def test_saturation_waits_rather_than_refusing(counting_executor):
+    async def _main():
+        release = threading.Event()
+        try:
+            tasks = [
+                asyncio.create_task(
+                    lr_utils.run_in_chunking_executor(_blocking, release, f"m{i}")
+                )
+                for i in range(CHUNKING_SUBMIT_LIMIT + 3)
+            ]
+            await asyncio.sleep(0.05)
+            assert counting_executor.submitted == CHUNKING_SUBMIT_LIMIT
+
+            release.set()
+            results = await asyncio.wait_for(asyncio.gather(*tasks), timeout=10.0)
+            # Nobody was dropped; the excess simply waited at the submit point.
+            assert len(results) == CHUNKING_SUBMIT_LIMIT + 3
+        finally:
+            release.set()
+
+    asyncio.run(_main())
+
+
+def test_kwargs_reach_the_callable(counting_executor):
+    async def _main():
+        result = await lr_utils.run_in_chunking_executor(lambda a, b=0: a + b, 1, b=41)
+        assert result == 42
+
+    asyncio.run(_main())
+
+
+def test_an_exception_propagates_to_the_caller(counting_executor):
+    """Chunker failures must keep reaching the pipeline's error handling."""
+
+    def _boom():
+        raise RuntimeError("chunker exploded")
+
+    async def _main():
+        with pytest.raises(RuntimeError, match="chunker exploded"):
+            await lr_utils.run_in_chunking_executor(_boom)
+
+    asyncio.run(_main())

--- a/tests/pipeline/test_chunking_func_contract.py
+++ b/tests/pipeline/test_chunking_func_contract.py
@@ -1,0 +1,178 @@
+"""The ``chunking_func`` extension contract survives the executor change.
+
+Moving chunking off the event loop must not move the *extension point* off it.
+``chunking_func`` is typed ``Union[List[Dict], Awaitable[List[Dict]]]`` and its
+docstring opens with "Synchronous or async", and the pipeline awaits whatever it
+returns — so "it is called synchronously today, therefore it cannot depend on the
+running loop" is not a sound inference. A synchronous factory that touches the
+loop when called is a supported implementation and would fail outright in a
+worker thread; an ``async def`` would gain nothing from the hop, since its body
+runs on the loop either way.
+
+Only the built-in default is dispatched to the executor. These tests pin that
+split in both directions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str):
+        return [ord(c) for c in content]
+
+    def decode(self, tokens):
+        return "".join(chr(t) for t in tokens)
+
+
+async def _mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.full((len(texts), 32), 0.1, dtype=np.float32)
+
+
+async def _mock_llm(prompt, **kwargs):
+    return '{"name":"x","summary":"s","detail_description":"d"}'
+
+
+def _new_rag(tmp_path: Path, **kwargs) -> LightRAG:
+    return LightRAG(
+        working_dir=str(tmp_path),
+        workspace=f"chunkfunc-{tmp_path.name}",
+        llm_model_func=_mock_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=32, max_token_size=4096, func=_mock_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        **kwargs,
+    )
+
+
+def _chunks():
+    return [{"tokens": 5, "content": "stub", "chunk_order_index": 0}]
+
+
+async def _ingest(rag: LightRAG, doc_id: str):
+    await rag.apipeline_enqueue_documents(
+        f"body text for {doc_id}",
+        ids=[doc_id],
+        file_paths=f"{doc_id}.txt",
+        track_id=f"track-{doc_id}",
+        process_options="",
+    )
+    await rag.apipeline_process_enqueue_documents()
+
+
+def _run(tmp_path, chunking_func, doc_id):
+    async def _main():
+        rag = _new_rag(tmp_path, chunking_func=chunking_func)
+        await rag.initialize_storages()
+        try:
+            await _ingest(rag, doc_id)
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_main())
+
+
+def test_a_synchronous_custom_chunker_still_works(tmp_path):
+    seen = {}
+
+    def _custom(tokenizer, content, *args, **kwargs):
+        seen["called"] = True
+        return _chunks()
+
+    _run(tmp_path, _custom, "doc-sync")
+    assert seen.get("called") is True
+
+
+def test_an_async_custom_chunker_is_still_awaited(tmp_path):
+    seen = {}
+
+    async def _custom(tokenizer, content, *args, **kwargs):
+        seen["called"] = True
+        return _chunks()
+
+    _run(tmp_path, _custom, "doc-async")
+    assert seen.get("called") is True
+
+
+def test_a_custom_chunker_that_touches_the_running_loop_still_works(tmp_path):
+    """The case that rules out "just run everything in a thread".
+
+    A synchronous factory calling ``get_running_loop()`` / ``create_task()`` is a
+    supported implementation of this contract. Dispatched to a worker thread it
+    raises ``RuntimeError: no running event loop`` before doing any work.
+    """
+    seen = {}
+
+    def _custom(tokenizer, content, *args, **kwargs):
+        loop = asyncio.get_running_loop()
+        seen["loop"] = loop is not None
+
+        async def _produce():
+            return _chunks()
+
+        return loop.create_task(_produce())
+
+    _run(tmp_path, _custom, "doc-loop-aware")
+    assert seen.get("loop") is True
+
+
+def test_a_custom_chunker_runs_on_the_event_loop_and_the_builtin_does_not(tmp_path):
+    """Pins the split itself, in both directions.
+
+    The custom implementation seeing a running loop and the built-in one not is
+    the whole of the dispatch rule; asserting only one side would let a change
+    that routes everything one way pass.
+    """
+    observations: dict[str, bool] = {}
+
+    def _has_running_loop() -> bool:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+        return True
+
+    def _custom(tokenizer, content, *args, **kwargs):
+        observations["custom_on_loop"] = _has_running_loop()
+        return _chunks()
+
+    _run(tmp_path, _custom, "doc-custom-side")
+
+    import lightrag.chunker as chunker_pkg
+
+    original_builtin = chunker_pkg.chunking_by_token_size
+
+    def _builtin_spy(*args, **kwargs):
+        observations["builtin_on_loop"] = _has_running_loop()
+        observations["builtin_thread"] = threading.current_thread().name
+        return original_builtin(*args, **kwargs)
+
+    async def _main():
+        rag = _new_rag(tmp_path)
+        # Identity selects the branch, so both references must be the spy.
+        chunker_pkg.chunking_by_token_size = _builtin_spy
+        rag.chunking_func = _builtin_spy
+        await rag.initialize_storages()
+        try:
+            await _ingest(rag, "doc-builtin-side")
+        finally:
+            await rag.finalize_storages()
+            chunker_pkg.chunking_by_token_size = original_builtin
+
+    asyncio.run(_main())
+
+    assert observations["custom_on_loop"] is True
+    assert observations["builtin_on_loop"] is False
+    assert observations["builtin_thread"].startswith("lightrag-chunking")

--- a/tests/pipeline/test_chunking_off_event_loop.py
+++ b/tests/pipeline/test_chunking_off_event_loop.py
@@ -1,0 +1,323 @@
+"""Chunking must not hold the event loop (GHSA-26pm-px5v-8c4w).
+
+A 414 KiB ``POST /documents/text`` was answered ``200 OK`` in 1.6 ms and the next
+``GET /health`` — a route needing no authentication and touching no storage — took
+63 seconds. The response is not the signal: the work happens afterwards, in a
+background task, on the only thread serving HTTP.
+
+Every test here measures the same thing: does an ``asyncio.sleep(0)`` heartbeat
+advance *while the chunker is inside its blocking section*. Counting beats across
+the whole run would prove nothing, since the pipeline awaits plenty of other
+things; the stub therefore samples the counter itself, on both sides of its own
+sleep.
+
+The branch list is exhaustive on purpose. Testing P/R/F only would miss half the
+surface: V degenerates to a synchronous R run when no embedding function is
+configured, and the pre-embedding hard split runs for every strategy after all of
+them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import DocStatus
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str):
+        return [ord(c) for c in content]
+
+    def decode(self, tokens):
+        return "".join(chr(t) for t in tokens)
+
+
+async def _mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.full((len(texts), 32), 0.1, dtype=np.float32)
+
+
+async def _mock_llm(prompt, **kwargs):
+    return '{"name":"x","summary":"s","detail_description":"d"}'
+
+
+def _new_rag(tmp_path: Path, *, with_embedding: bool = True, **kwargs) -> LightRAG:
+    return LightRAG(
+        working_dir=str(tmp_path),
+        workspace=f"chunk-loop-{tmp_path.name}",
+        llm_model_func=_mock_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=32, max_token_size=4096, func=_mock_embedding
+        )
+        if with_embedding
+        else None,
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        **kwargs,
+    )
+
+
+class _Heartbeat:
+    """Counts loop iterations, and lets a worker thread sample the count."""
+
+    def __init__(self):
+        self.beats = 0
+        self._stop = asyncio.Event()
+        self._task: asyncio.Task | None = None
+        self.observed: tuple[int, int] | None = None
+
+    def start(self) -> None:
+        async def _run():
+            while not self._stop.is_set():
+                self.beats += 1
+                await asyncio.sleep(0)
+
+        self._task = asyncio.create_task(_run())
+
+    async def stop(self) -> None:
+        self._stop.set()
+        if self._task is not None:
+            await self._task
+
+    def sample_across(self, seconds: float = 0.15) -> None:
+        """Called FROM the chunker. Records the beat count either side of a
+        synchronous sleep, which is the window the loop must stay alive in."""
+        before = self.beats
+        threading.Event().wait(seconds)
+        self.observed = (before, self.beats)
+
+    def assert_loop_stayed_alive(self) -> None:
+        assert self.observed is not None, "the instrumented chunker never ran"
+        before, after = self.observed
+        assert after > before, (
+            "the event loop did not advance while the chunker was working "
+            f"(beats {before} -> {after})"
+        )
+
+
+async def _ingest(rag: LightRAG, *, doc_id: str, process_options: str, body: str):
+    await rag.apipeline_enqueue_documents(
+        body,
+        ids=[doc_id],
+        file_paths=f"{doc_id}.txt",
+        track_id=f"track-{doc_id}",
+        process_options=process_options,
+    )
+    await rag.apipeline_process_enqueue_documents()
+
+
+def _run_with_heartbeat(coro_factory):
+    """Run ``coro_factory(heartbeat)`` with a heartbeat task alongside it."""
+    heartbeat = _Heartbeat()
+
+    async def _main():
+        heartbeat.start()
+        try:
+            await coro_factory(heartbeat)
+        finally:
+            await heartbeat.stop()
+
+    asyncio.run(_main())
+    return heartbeat
+
+
+@pytest.mark.parametrize(
+    "option,chunker_name",
+    [
+        ("P", "chunking_by_paragraph_semantic"),
+        ("R", "chunking_by_recursive_character"),
+        ("F", "chunking_by_fixed_token"),
+    ],
+)
+def test_explicit_strategies_do_not_hold_the_loop(
+    tmp_path, monkeypatch, option, chunker_name
+):
+    import lightrag.chunker as chunker_pkg
+
+    def _make_stub(heartbeat):
+        def _stub(tokenizer, content, chunk_token_size, **kwargs):
+            heartbeat.sample_across()
+            return [{"tokens": 5, "content": "stub", "chunk_order_index": 0}]
+
+        return _stub
+
+    async def _body(heartbeat):
+        monkeypatch.setattr(chunker_pkg, chunker_name, _make_stub(heartbeat))
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            await _ingest(
+                rag, doc_id=f"doc-{option}", process_options=option, body="body text"
+            )
+        finally:
+            await rag.finalize_storages()
+
+    _run_with_heartbeat(_body).assert_loop_stayed_alive()
+
+
+def test_the_builtin_legacy_chunker_does_not_hold_the_loop(tmp_path, monkeypatch):
+    """No explicit selector: the ``self.chunking_func`` path."""
+    import lightrag.chunker as chunker_pkg
+
+    async def _body(heartbeat):
+        rag = _new_rag(tmp_path)
+        original = rag.chunking_func
+
+        def _stub(*args, **kwargs):
+            heartbeat.sample_across()
+            return original(*args, **kwargs)
+
+        # Object identity is what routes to the executor, so the stub has to be
+        # installed BOTH on the instance and as the module attribute the
+        # dispatcher compares it against — patching only one makes the stub look
+        # like a user-supplied chunker and this would silently test the other
+        # branch.
+        monkeypatch.setattr(rag, "chunking_func", _stub)
+        monkeypatch.setattr(chunker_pkg, "chunking_by_token_size", _stub)
+
+        await rag.initialize_storages()
+        try:
+            await _ingest(
+                rag, doc_id="doc-legacy", process_options="", body="body text"
+            )
+        finally:
+            await rag.finalize_storages()
+
+    _run_with_heartbeat(_body).assert_loop_stayed_alive()
+
+
+def test_v_without_an_embedding_function_does_not_hold_the_loop(monkeypatch):
+    """V's ``await asyncio.to_thread`` is never reached in this configuration.
+
+    Without an embedding function the whole call degenerates to a synchronous R
+    run, so treating V as "already offloaded" leaves the R attack surface fully
+    exposed under an ordinary deployment choice. Driven directly rather than
+    through the pipeline because ``LightRAG`` refuses to construct without an
+    embedding function at all — the None branch is reachable only by calling the
+    chunker.
+    """
+    import lightrag.chunker.recursive_character as rc_mod
+    from lightrag.chunker.semantic_vector import chunking_by_semantic_vector
+
+    async def _body(heartbeat):
+        original = rc_mod.chunking_by_recursive_character
+
+        def _stub(*args, **kwargs):
+            heartbeat.sample_across()
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(rc_mod, "chunking_by_recursive_character", _stub)
+
+        chunks = await chunking_by_semantic_vector(
+            Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+            "body text " * 200,
+            120,
+            embedding_func=None,
+        )
+        assert chunks
+
+    _run_with_heartbeat(_body).assert_loop_stayed_alive()
+
+
+def test_v_post_processing_does_not_hold_the_loop(monkeypatch):
+    """The second half of the V path.
+
+    ``await asyncio.to_thread`` covers the embedding-driven grouping only; what
+    follows encodes every piece and runs a whole R pass over the oversized ones.
+    """
+    import lightrag.chunker.recursive_character as rc_mod
+    import lightrag.chunker.semantic_vector as sv_mod
+
+    async def _body(heartbeat):
+        # One oversized semantic group, so the post-loop has to re-split it.
+        monkeypatch.setattr(
+            sv_mod,
+            "_semantic_groups_with_spans",
+            lambda splitter, content: [(content, 0, len(content))],
+        )
+        monkeypatch.setattr(sv_mod, "SemanticChunker", lambda **kwargs: object())
+        monkeypatch.setattr(sv_mod, "_LANGCHAIN_EXPERIMENTAL_AVAILABLE", True)
+
+        original = rc_mod.chunking_by_recursive_character
+
+        def _stub(*args, **kwargs):
+            heartbeat.sample_across()
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(rc_mod, "chunking_by_recursive_character", _stub)
+
+        chunks = await chunking_by_semantic_vector_stub()
+        assert chunks
+
+    async def chunking_by_semantic_vector_stub():
+        return await sv_mod.chunking_by_semantic_vector(
+            Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+            "body text " * 400,
+            50,
+            embedding_func=EmbeddingFunc(
+                embedding_dim=32, max_token_size=4096, func=_mock_embedding
+            ),
+        )
+
+    _run_with_heartbeat(_body).assert_loop_stayed_alive()
+
+
+def test_the_pre_embedding_hard_split_does_not_hold_the_loop(tmp_path, monkeypatch):
+    """Runs after chunking, for every strategy — so offloading the branches is
+    not on its own enough."""
+    import lightrag.pipeline as pipeline_mod
+
+    async def _body(heartbeat):
+        original = pipeline_mod.enforce_chunk_token_limit_before_embedding
+
+        def _stub(*args, **kwargs):
+            heartbeat.sample_across()
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(
+            pipeline_mod, "enforce_chunk_token_limit_before_embedding", _stub
+        )
+
+        rag = _new_rag(tmp_path)
+        rag.embedding_token_limit = 32
+        await rag.initialize_storages()
+        try:
+            await _ingest(
+                rag, doc_id="doc-hardsplit", process_options="F", body="body text " * 80
+            )
+        finally:
+            await rag.finalize_storages()
+
+    _run_with_heartbeat(_body).assert_loop_stayed_alive()
+
+
+def test_a_chunker_failure_still_fails_the_document(tmp_path, monkeypatch):
+    """Exceptions must survive the executor hop with their handling intact."""
+    import lightrag.chunker as chunker_pkg
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("chunker exploded")
+
+    monkeypatch.setattr(chunker_pkg, "chunking_by_fixed_token", _boom)
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        try:
+            await _ingest(rag, doc_id="doc-boom", process_options="F", body="body text")
+            row = await rag.doc_status.get_by_id("doc-boom")
+            assert row is not None
+            # DocStatus is a ``str, Enum``: compare on the value, since ``str()``
+            # of the member renders as "DocStatus.FAILED".
+            assert DocStatus(row["status"]) is DocStatus.FAILED
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())

--- a/tests/pipeline/test_chunking_snapshot_replay.py
+++ b/tests/pipeline/test_chunking_snapshot_replay.py
@@ -1,0 +1,163 @@
+"""A pre-fix separator snapshot must not re-freeze the worker on resume.
+
+``chunk_options`` is snapshotted at ENQUEUE time into ``full_docs``, so capping
+``separators`` on the request model only protects new requests. A build that
+still accepted 900 separators persisted them AND left the document in
+``PROCESSING`` when the worker froze — and ``PROCESSING`` is an auto-resume
+status, so an upgraded server reloads the stored cascade and freezes again. That
+is a boot loop restarting cannot clear, which is why the cap has to live where
+every source of a cascade passes through rather than only at the HTTP boundary.
+
+The same reasoning already appears for ``sentence_split_regex`` in
+``apply_trusted_sentence_split_regex``; this is the R-strategy analogue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.constants import MAX_R_SEPARATORS
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+pytestmark = pytest.mark.offline
+
+# What a pre-fix build would have accepted and stored.
+POISONED_SEPARATORS = ["Q"] * 900
+
+
+class _CountingTokenizerImpl:
+    def __init__(self):
+        self.encodes = 0
+
+    def encode(self, content: str):
+        self.encodes += 1
+        return [ord(c) for c in content]
+
+    def decode(self, tokens):
+        return "".join(chr(t) for t in tokens)
+
+
+async def _mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.full((len(texts), 32), 0.1, dtype=np.float32)
+
+
+async def _mock_llm(prompt, **kwargs):
+    return '{"name":"x","summary":"s","detail_description":"d"}'
+
+
+def _new_rag(tmp_path: Path, tokenizer_impl) -> LightRAG:
+    return LightRAG(
+        working_dir=str(tmp_path),
+        workspace=f"snapshot-{tmp_path.name}",
+        llm_model_func=_mock_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=32, max_token_size=4096, func=_mock_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", tokenizer_impl),
+    )
+
+
+def test_a_poisoned_snapshot_is_bounded_at_process_time(tmp_path, monkeypatch):
+    """End-to-end: the stored cascade reaches the chunker already bounded.
+
+    Asserting on what the chunker *received* rather than on the stored row: a
+    fix that bounded the value on the way in but splatted the original on the
+    way out would pass a source-level reading and fail here.
+    """
+    import lightrag.chunker as chunker_pkg
+    import lightrag.chunker.recursive_character as rc_mod
+
+    captured: dict = {}
+    original_chunker = chunker_pkg.chunking_by_recursive_character
+
+    def _chunker_spy(tokenizer, content, chunk_token_size, **kwargs):
+        # What the dispatcher handed over, i.e. straight out of the snapshot.
+        captured["dispatched"] = kwargs.get("separators")
+        return original_chunker(tokenizer, content, chunk_token_size, **kwargs)
+
+    original_normalize = rc_mod.normalize_r_separators
+
+    def _normalize_spy(separators, **kwargs):
+        result = original_normalize(separators, **kwargs)
+        captured["normalized"] = result
+        return result
+
+    monkeypatch.setattr(chunker_pkg, "chunking_by_recursive_character", _chunker_spy)
+    monkeypatch.setattr(rc_mod, "normalize_r_separators", _normalize_spy)
+
+    async def _run():
+        rag = _new_rag(tmp_path, _CountingTokenizerImpl())
+        await rag.initialize_storages()
+        try:
+            await rag.apipeline_enqueue_documents(
+                "Q" + ("X " * 2000),
+                ids=["doc-poisoned-snapshot"],
+                file_paths="poisoned.txt",
+                track_id="track-poisoned",
+                process_options="R",
+                chunk_options={
+                    "recursive_character": {"separators": POISONED_SEPARATORS}
+                },
+            )
+            # The snapshot really does carry the payload, or this test would
+            # pass for the wrong reason.
+            row = await rag.full_docs.get_by_id("doc-poisoned-snapshot")
+            stored = row["chunk_options"]["recursive_character"]["separators"]
+            assert len(stored) == len(POISONED_SEPARATORS)
+
+            await rag.apipeline_process_enqueue_documents()
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(_run())
+
+    assert captured.get("dispatched") is not None, "the R chunker never ran"
+    # The snapshot really does reach the chunker unbounded: the request model
+    # protects new requests only, which is exactly why the cap cannot live there.
+    assert len(captured["dispatched"]) == len(POISONED_SEPARATORS)
+    # ...and the chunker bounds it before the splitter ever sees it.
+    assert captured.get("normalized") is not None
+    assert len(captured["normalized"]) <= MAX_R_SEPARATORS
+
+
+def test_replaying_a_poisoned_snapshot_costs_a_bounded_number_of_encodes(
+    tmp_path,
+):
+    """The cost, not just the shape.
+
+    900 separators over the advisory's payload used to mean ~900 whole-text
+    encodes for a result of one chunk. Encodes rather than wall clock: timing is
+    unreliable in CI, and the encodes are what the seconds were made of.
+    """
+    tokenizer_impl = _CountingTokenizerImpl()
+
+    async def _run():
+        rag = _new_rag(tmp_path, tokenizer_impl)
+        await rag.initialize_storages()
+        try:
+            await rag.apipeline_enqueue_documents(
+                "Q" + ("X " * 2000),
+                ids=["doc-poisoned-cost"],
+                file_paths="poisoned-cost.txt",
+                track_id="track-poisoned-cost",
+                process_options="R",
+                chunk_options={
+                    "recursive_character": {"separators": POISONED_SEPARATORS}
+                },
+            )
+            before = tokenizer_impl.encodes
+            await rag.apipeline_process_enqueue_documents()
+            return tokenizer_impl.encodes - before
+        finally:
+            await rag.finalize_storages()
+
+    encodes = asyncio.run(_run())
+
+    # Generous: the pipeline encodes for its own bookkeeping too. The point is
+    # that it does not scale with the length of the cascade.
+    assert encodes < len(POISONED_SEPARATORS) / 4


### PR DESCRIPTION
## Summary

Closes the ingestion-side denial of service: `process_single_document` does its chunking synchronously on the event loop, so a document that is expensive to chunk holds the only thread serving HTTP for its entire duration. Reported with a 414 KiB payload plus 900 `separators`, where the `POST` returned **200 in 1.6 ms** and a following `GET /health` took **63 s** (baseline 1.5 ms).

Builds on #3543, which provides `bounded_submit` and the tokenizer contract.

## Motivation

The response is not the signal. The minute of full unavailability happens *after* the request completes, inside a background task, where neither the rate limiter nor operational monitoring can see it. The cost is `O(len(separators) × len(text))` and entirely wasted — every run of that payload produces `chunks=1`.

Three things, only the second of which the report names as the fix:

1. **`separators` is unbounded outside HTTP.** `210c5ee9` already added `max_length=64` to the request model, but the value also arrives from `CHUNK_R_SEPARATORS`, from `addon_params['chunker']['recursive_character']`, from direct SDK calls — and, most importantly, from `full_docs`, where `chunk_options` is snapshotted **at enqueue time**. A document enqueued by a pre-fix version and stuck in `PROCESSING` (an auto-resume status) still carries its 900 separators; the upgraded server reloads and re-freezes on them. That is a boot loop a restart cannot clear, and the report does not mention it. It is the same shape as `GHSA-32jh-39m7-8x84`, which the V branch already guards against via `apply_trusted_sentence_split_regex`; R had no equivalent.
2. **Chunking runs on the event loop.** For *any* sufficiently large document, not just the crafted one.
3. **No-op cascade levels re-tokenize the whole document.** Pure waste, fixed as a behaviour-preserving optimisation.

### Where the report's four branches were not the whole surface

The report lists the four synchronous branches in the `if/elif` chain (P, R, F, `chunking_func`) and treats V as the already-fixed reference. **That reference does not hold**, and fixing only those four leaves half the attack surface:

- V falls back to a **synchronous** `chunking_by_recursive_character` when `embedding_func is None` — its `await asyncio.to_thread` line is never reached. That is the R attack, reproduced under the V strategy.
- After the `await`, V's post-processing loop encodes every semantic segment and re-splits oversized ones synchronously.
- `enforce_chunk_token_limit_before_embedding` walks and encodes **all** chunks, for **every** strategy including V, after chunking is done.
- On the multimodal path, `_build_mm_chunks_from_sidecars` runs a `while True` truncate/encode loop over VLM descriptions whose length no request-side limit constrains, and `enrich_sidecars_with_surrounding` reads `CHUNK_R_SEPARATORS` directly — bypassing the R chunker and its new bound entirely.

## What's changed

### A single normalizer for `separators`

`normalize_r_separators()` in `lightrag/chunker/recursive_character.py`, consumed by both `chunking_by_recursive_character` and `load_chunk_separators`, so environment and persisted-snapshot values are bounded on the same path as HTTP ones. Over-long entries (>256 chars) are dropped, over-long lists (>64) truncated, both with a warning — not raised, since a misconfigured env var should not fail every document.

Three details that are easy to get wrong and are each pinned by a test:

- **`None` passes through unchanged.** `chunking_by_recursive_character` is a public chunker whose `separators=None` means "use LangChain's own cascade" — which is `['\n\n', '\n', ' ', '']`, four entries, English-only. The repo's `DEFAULT_R_SEPARATORS` is nine entries including CJK punctuation. Substituting one for the other would move split points in Chinese text; a security fix has no business changing chunking semantics.
- **Truncation preserves the terminating sentinel.** `DEFAULT_R_SEPARATORS` ends with `""`, the character-level fallback that lets `_split_text_with_spans` break anything. Naively taking the first 64 drops it, and a document that could have been split character-wise degrades into one enormous chunk. Truncation takes 63 and re-appends the sentinel — only if the caller had one, since `load_chunk_separators` deliberately omits it.
- **An empty result falls back per consumer**, not to one shared default: the chunker returns `None` (its own documented default), `load_chunk_separators` returns `DEFAULT_R_SEPARATORS` minus the sentinel (matching how it already handles invalid env values). Without a fallback, `separators[-1]` raises `IndexError` and the document simply fails.

The request model also gains the per-element cap that `210c5ee9` did not add.

### Chunking moved into a dedicated executor

Single-worker, process-wide, submitted through `bounded_submit`. One worker because chunking is *already* serialized today — while one document chunks, no other document's coroutine can run — so this preserves concurrency exactly while freeing the loop. Anything higher would be new parallelism, which belongs in a separate change.

Covered: P / R / F, V's synchronous fallback and its post-processing loop, `enforce_chunk_token_limit_before_embedding`, `_build_mm_chunks_from_sidecars`, `enrich_sidecars_with_surrounding`, and the three remaining synchronous encode loops in `analyze_multimodal`, `ainsert_custom_chunks` and `ainsert_custom_kg`.

Not moved, deliberately: V's existing `await asyncio.to_thread(_semantic_groups_with_spans, ...)`. It is already off the loop and needs to call back into it for embeddings; moving it into a single-worker pool would only add deadlock surface.

The submission ceiling is not decorative: `ainsert_custom_kg` and `ainsert_custom_chunks` are public SDK entry points gated by neither `max_parallel_insert` nor the pipeline's busy flag, so "the pipeline limits concurrency" is not a ceiling that holds here.

### `chunking_func` is not moved into the executor

Its declared type is `Union[List[Dict], Awaitable[List[Dict]]]`, its docstring opens with "Synchronous or async", and the pipeline does `inspect.isawaitable(...)`. So "it must be synchronous, therefore it does not need the loop" is false: a synchronous factory that calls `asyncio.get_running_loop()` or `create_task()` at call time is a **supported** implementation, and running it in a worker thread breaks it outright with no running loop. For an `async def` implementation, threading it buys nothing anyway.

The existing identity check `self.chunking_func is chunking_by_token_size` already distinguishes the two cases: the built-in default goes to the executor, a user-supplied one keeps its exact calling convention. The docstring now states the boundary — a custom CPU-bound implementation should `to_thread` itself.

### No-op cascade levels

A separator that matches once at offset 0 yields a single fragment byte-identical to its input. The code still called `length_function` on it — a full-document `encode` — then recursed with the same text. 900 levels meant 900 full-document encodings for an output of `chunks=1`.

Detected and skipped straight to the next separator. Explicitly **not** "abandon the cascade on a no-op": text where `"\n\n"` appears only at the start and needs `"\n"` / `" "` / `""` to split is ordinary, and giving up would produce one huge chunk. Measured on the advisory payload: **65 encodes / 7.90 s → 2 encodes / 0.23 s**, byte-identical output.

## What's broken

`CHUNK_R_SEPARATORS` or `addon_params` supplying more than 64 separators, or entries longer than 256 characters, are now converged with a warning rather than used verbatim.

**Not** a breaking change, but worth stating: a custom `chunking_func` is still invoked on the event loop — the contract is unchanged — and chunking concurrency stays at 1, equivalent to today's serialized execution and not scaling with `max_parallel_insert`.

## Notes on the report

`separators` bounding at the request model landed in `210c5ee9` (2026-07-31), so that half of Fix 1 is already in. "No request-size middleware exists" is also stale — `AdmissionMiddleware` is on `main` and `ADMISSION_PATHS` includes `/documents/text`. All line numbers have drifted. What remains is Fix 2, the per-element bound, and the persisted-snapshot replay path above.

## Tests

Heartbeat fix-proofs (a `asyncio.sleep(0)` counter must keep advancing during ingestion; 0 beats before the fix) cover every path individually, because testing only P/R/F would have missed half of them: P, R, F, V-with-`embedding_func=None`, V-with-oversized-segments, the hard fallback, multimodal chunk building, and multimodal surrounding backfill.

Also: the `chunking_func` contract (an `async def` implementation still awaited; a synchronous factory calling `get_running_loop()` at call time still works — this fails with `RuntimeError: no running event loop` under a move-everything-to-threads implementation); the persisted 900-separator snapshot replayed from `full_docs`; the cancel-and-resubmit permit test against the ungated SDK entry points; sentinel preservation driving a real split; `separators=None` producing byte-identical output; and a `length_function` call-count assertion for the cascade fix (counted, not wall-clock — wall-clock is not reliable in CI).

Full suite: **5340 passed, 155 skipped**. `pre-commit run ruff` / `ruff-format` clean.

## Merge order

Should merge **after** the query-side PR. For a custom tokenizer that is thread-safe by internal lock, moving ingestion into a worker thread first lets the event loop wait on that lock for as long as chunking a whole document takes, while the query path is still tokenizing inline. Merging the query side first reduces that window to a single truncation. (Irrelevant to the built-in `tiktoken`, which has no such lock.)

PoC code and exploitation details are deliberately omitted; the advisory will be linked once published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
