### PR TITLE
feat(parser): add native Jupyter notebook support

### DIFF
--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -71,7 +71,7 @@ MINERU_LOCAL_ENDPOINT=http://localhost:8000
 └─ 规则适用的后缀；`*` 匹配任意后缀
 ```
 
-所以第一条规则的意思是"任何文件都交给 `native` 解析，三种模态全部分析，用 `P` 分块"，第二条是"第一条处理不了的，退回 `legacy` 并用 `R` 分块"。当引擎不支持该后缀、或外部引擎没有配置服务端点时，该规则会被跳过——这正是 `*:native-iteP` 实际只接管 `docx` / `md` / `textpack`、其余文件全部落到 `legacy` 的原因。
+所以第一条规则的意思是"任何文件都交给 `native` 解析，三种模态全部分析，用 `P` 分块"，第二条是"第一条处理不了的，退回 `legacy` 并用 `R` 分块"。当引擎不支持该后缀、或外部引擎没有配置服务端点时，该规则会被跳过——这正是 `*:native-iteP` 实际只接管 `docx` / `ipynb` / `md` / `textpack`、其余文件全部落到 `legacy` 的原因。
 
 完整语法见 §2.3，选项字母见 §2.1，各引擎见 §3。
 
@@ -164,7 +164,7 @@ filename.[-OPTIONS].ext
   | 引擎 | 是什么 | 什么时候用它 |
   | --- | --- | --- |
   | `legacy` | 纯文本抽取，不产出 sidecar | 想保持升级前的行为，或文档本来就是纯文本 |
-  | `native` | 内置结构化抽取器，完全本地，不依赖外部服务 | `docx` / `md` / `textpack`，且希望不部署任何东西就用上 `P` 分块或模态分析 |
+  | `native` | 内置结构化抽取器，完全本地，不依赖外部服务 | `docx` / `ipynb` / `md` / `textpack`，且希望不部署任何东西就用上 `P` 分块或模态分析 |
   | `mineru` | 外部 MinerU 服务 | PDF、扫描件，以及需要版面识别与 OCR 的 office / 图片格式 |
   | `docling` | 外部 docling-serve | MinerU 的替代方案；也是内置路径里唯一能出 LaTeX 公式的 |
 
@@ -267,7 +267,7 @@ LIGHTRAG_PARSER=pdf:legacy-R(chunk_ts=800,chunk_ol=80);*:legacy-R  # 规则
 | 引擎 | 说明 | 支持的文件格式（后缀） |
 | --- | --- | --- |
 | `legacy` | 旧版提取方式，在加入流水线前集中提取内容 | `txt` `md` `mdx` `pdf` `docx` `pptx` `xlsx` `rtf` `odt` `tex` `epub` `html` `htm` `csv` `json` `xml` `yaml` `yml` `log` `conf` `ini` `properties` `sql` `bat` `sh` `c` `h` `cpp` `hpp` `py` `java` `js` `ts` `swift` `go` `rb` `php` `css` `scss` `less` |
-| `native` | 内置智能结构化内容抽取器 | `docx` `md` `textpack` |
+| `native` | 内置智能结构化内容抽取器 | `docx` `ipynb` `md` `textpack` |
 | `mineru` | 外部 MinerU 内容提取引擎 | `pdf` `docx` `pptx` `xlsx` `png` `jpg` `jpeg` `jp2` `webp` `gif` `bmp`（可扩展，见 `MINERU_ADDITIONAL_SUFFIXES`） |
 | `docling` | 外部 Docling 内容提取引擎 | `pdf` `docx` `pptx` `xlsx` `md` `html` `xhtml` `png` `jpg` `jpeg` `tiff` `webp` `bmp`（可扩展，见 `DOCLING_ADDITIONAL_SUFFIXES`） |
 
@@ -279,7 +279,7 @@ LightRAG 在本地会缓存 `mineru` 和 `docling` 引擎的解析结果。重�
 
 ### 3.2 使用 legacy 内容抽取器
 
-`legacy` 是除 `.textpack`（路由层强制交给 `native`）之外所有后缀的兜底引擎，也是不配置 `LIGHTRAG_PARSER` 时的默认行为。它只抽取纯文本，由此带来四个在把文件路由给它之前值得先知道的后果：
+`legacy` 是除 `.ipynb` 和 `.textpack`（路由层强制交给 `native`）之外所有后缀的兜底引擎，也是不配置 `LIGHTRAG_PARSER` 时的默认行为。它只抽取纯文本，由此带来四个在把文件路由给它之前值得先知道的后果：
 
 - **它永不产出 sidecar。** 输出是 `parse_format=raw`，不存在 `drawings.json` / `tables.json` / `equations.json` 供分析阶段读取。因此 `i` / `t` / `e` 选项对 legacy 解析的文档完全无效，`P` 也会因为没有标题结构可切而退化为 `R`（§2.7）。
 - **它没有原始缓存目录**，所以 `LIGHTRAG_FORCE_REPARSE_*` 对它不适用（§3.7）。
@@ -290,10 +290,10 @@ LightRAG 在本地会缓存 `mineru` 和 `docling` 引擎的解析结果。重�
 
 `native` 是 LightRAG 内置的结构化内容抽取引擎，**纯本地运行**：不依赖 MinerU / Docling 等外部服务，抽取阶段也不调用 VLM，开箱即用无需任何部署。运行依赖仅 `python-docx` + `defusedxml`（必备）；其中 markdown 路径的 SVG 栅格化额外依赖**可选**的 `cairosvg`（缺失时跳过该 SVG 并记 warning，不影响其余内容）。为 docx 启用可选的 `smart_heading` 引擎参数时，额外需要钉定版本的 `zh_core_web_sm` / `en_core_web_sm` spaCy 模型（`spacy` 运行时已随 `api` extra 一并安装，模型用 `lightrag-download-cache --spacy --spacy-install` 安装——Docker 主镜像已内置）；从不启用该参数的部署无需模型，另外 smart_heading 路径会在解析阶段调用 EXTRACT 角色 LLM。设置环境变量 `DOCX_SMART_HEADING=true` 后，路由到 native 引擎的 `.docx` 文件默认启用 smart_heading——单个文件/规则可用显式 `native(smart_heading=false)` 关闭——同时服务器会在启动时校验 spaCy 模型并 fail-fast（而不是等到首次解析才报错）；`LIGHTRAG_PARSER` 规则中携带 `native(smart_heading=true)`（或其省值写法 `native(smart_heading)`）时同样触发启动校验。该默认值仅作用于新上传：已入库文档重解析时沿用其持久化的引擎参数。
 
-支持后缀：`docx` / `md` / `textpack`。启用方式：
+支持后缀：`docx` / `ipynb` / `md` / `textpack`。启用方式：
 
 - `docx`、`md` 默认仍走 `legacy`，需显式选择 native，例如默认规则 `LIGHTRAG_PARSER=docx:native`、`LIGHTRAG_PARSER=md:native`，或文件名 hint `report.[native-iet].docx`、`notes.[native].md`（语法见 [§2.4](#24-默认规则lightrag_parser) / [§2.5](#25-单文件覆盖文件名-hint)）。
-- `textpack` 为 native 独占后缀，无需 hint/规则即自动路由到 native。
+- `ipynb` 和 `textpack` 为 native 独占后缀，无需 hint/规则即自动路由到 native。
 
 #### docx 抽取能力
 
@@ -323,7 +323,7 @@ native docx 会采集 Word 2013+ 写入的 `w14:paraId` 作为段落级溯源锚
 
 受影响块的 `positions` 退化为 `[{"type": "paraid", "range": null}]`。这只是提示，**不影响解析成功**；如需精确段落溯源，按提示在 Word 2013+ 中「另存为 .docx」即可重建 id。
 
-#### md / textpack 抽取能力
+#### md / textpack / ipynb 抽取能力
 
 `native` 引擎除 `docx` 外还支持 Markdown：
 
@@ -336,6 +336,7 @@ native docx 会采集 Word 2013+ 写入的 `w14:paraId` 作为段落级溯源锚
     - 查找目录内 `.md` / `.markdown` 文件**必须恰好 1 个**：0 个或多于 1 个均报错。
     - 正文所在目录即资源解析的"包根"（`bundle_root`）。
   - 包内以相对路径（文件引用）内嵌的图片按相对包根目录解析，**允许放在包内任意子目录**（不限于 `assets/`），但禁止目录穿越（`..`、绝对路径、越出包根的引用会被记 warning 跳过）；解析出的字节须通过图片 magic bytes 校验，否则跳过。独立 `.md`（非 textpack）中的相对路径图片不解析（记 warning 跳过）。
+- `ipynb`：Jupyter Notebook 会先在本地转换再走 Markdown 抽取。Markdown 和 raw 单元保留为文本；代码单元按 notebook kernel 元数据的语言写为带语言标记的围栏代码块。执行计数以及所有单元输出（包括 traceback 和二进制展示数据）都不会进入索引。
 - SVG 图片（base64 / textpack 包内文件 / 在线下载）会先经 cairosvg 栅格化为 PNG 再写入 sidecar；cairosvg 不可用或渲染失败时跳过该图（记 warning）。
 - 外部 URL 图片（`![](http://...)`）**默认下载并内嵌**（`NATIVE_MD_IMAGE_DOWNLOAD_ENABLED` 默认 `true`）；无论下载成功与否都会生成 drawing（成功内嵌资源，失败回退为外链）。下载默认仅允许可全球路由的公网 IP（DNS 解析结果与每一跳重定向目标都校验，且 socket 直连已校验 IP 以防 DNS rebinding，忽略环境 `HTTP(S)_PROXY`），私网 / 环回 / 链路本地 / 保留 / CGNAT（`100.64.0.0/10`）等一律拒绝；如需放行特定内网段，用 `NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS` 配置 CIDR 白名单。若设为 `false`，外链图片整个丢弃（不生成对应 drawing，故仅含外链图片的文档不会生成 `drawings.json`）。
 

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -71,7 +71,7 @@ Each comma-separated item of `LIGHTRAG_PARSER` is one routing rule, matched agai
 └─ extension the rule applies to; `*` matches any
 ```
 
-So the first rule says "parse anything with `native`, analyze all three modalities, chunk with `P`", and the second says "anything the first rule cannot handle falls back to `legacy` with `R` chunking". A rule is skipped when the engine does not support that extension, or when an external engine has no endpoint configured — which is exactly how `*:native-iteP` ends up handling only `docx` / `md` / `textpack` while everything else drops through to `legacy`.
+So the first rule says "parse anything with `native`, analyze all three modalities, chunk with `P`", and the second says "anything the first rule cannot handle falls back to `legacy` with `R` chunking". A rule is skipped when the engine does not support that extension, or when an external engine has no endpoint configured — which is exactly how `*:native-iteP` ends up handling only `docx` / `ipynb` / `md` / `textpack` while everything else drops through to `legacy`.
 
 The full grammar is in §2.3, the option letters in §2.1, and the engines in §3.
 
@@ -164,7 +164,7 @@ filename.[-OPTIONS].ext
   | Engine | What it is | Reach for it when |
   | --- | --- | --- |
   | `legacy` | plain-text extraction, no sidecars | you want the pre-upgrade behavior, or the document is plain text anyway |
-  | `native` | built-in structured extractor, fully local, no external service | `docx` / `md` / `textpack`, and you want `P` chunking or modality analysis without deploying anything |
+  | `native` | built-in structured extractor, fully local, no external service | `docx` / `ipynb` / `md` / `textpack`, and you want `P` chunking or modality analysis without deploying anything |
   | `mineru` | external MinerU service | PDFs, scanned documents, and office / image formats that need layout and OCR |
   | `docling` | external docling-serve | an alternative to MinerU; the only built-in path to LaTeX equations |
 
@@ -267,7 +267,7 @@ Currently supported parameters (canonical name / short alias):
 | Engine | Description | Supported file formats (extensions) |
 | --- | --- | --- |
 | `legacy` | Legacy extraction; content is centrally extracted before joining the pipeline | `txt` `md` `mdx` `pdf` `docx` `pptx` `xlsx` `rtf` `odt` `tex` `epub` `html` `htm` `csv` `json` `xml` `yaml` `yml` `log` `conf` `ini` `properties` `sql` `bat` `sh` `c` `h` `cpp` `hpp` `py` `java` `js` `ts` `swift` `go` `rb` `php` `css` `scss` `less` |
-| `native` | Built-in intelligent structured content extractor | `docx` `md` `textpack` |
+| `native` | Built-in intelligent structured content extractor | `docx` `ipynb` `md` `textpack` |
 | `mineru` | External MinerU content extraction engine | `pdf` `docx` `pptx` `xlsx` `png` `jpg` `jpeg` `jp2` `webp` `gif` `bmp` (extensible, see `MINERU_ADDITIONAL_SUFFIXES`) |
 | `docling` | External Docling content extraction engine | `pdf` `docx` `pptx` `xlsx` `md` `html` `xhtml` `png` `jpg` `jpeg` `tiff` `webp` `bmp` (extensible, see `DOCLING_ADDITIONAL_SUFFIXES`) |
 
@@ -279,7 +279,7 @@ LightRAG caches the parsing results of the `mineru` and `docling` engines locall
 
 ### 3.2 Using the legacy Content Extractor
 
-`legacy` is the fallback engine for every extension except `.textpack`, which the routing layer always sends to `native`. It is also what you get with `LIGHTRAG_PARSER` unset. It extracts plain text only, which has four consequences worth knowing before you route anything to it:
+`legacy` is the fallback engine for every extension except `.ipynb` and `.textpack`, which the routing layer always sends to `native`. It is also what you get with `LIGHTRAG_PARSER` unset. It extracts plain text only, which has four consequences worth knowing before you route anything to it:
 
 - **It never writes sidecars.** Its output is `parse_format=raw`, so there is no `drawings.json` / `tables.json` / `equations.json` for the analyze stage to read. The `i` / `t` / `e` options therefore do nothing on a legacy-parsed document, and `P` degrades to `R` because there is no heading structure to split on (§2.7).
 - **It has no raw cache directory**, so `LIGHTRAG_FORCE_REPARSE_*` does not apply to it (§3.7).
@@ -290,10 +290,10 @@ LightRAG caches the parsing results of the `mineru` and `docling` engines locall
 
 `native` is LightRAG's built-in structured content extractor that runs **fully locally**: it does not depend on external services such as MinerU / Docling, the extraction stage never calls a VLM, and it works out of the box with no deployment. Its runtime dependencies are only `python-docx` + `defusedxml` (required); the markdown path additionally relies on the **optional** `cairosvg` for SVG rasterization (when missing, the SVG is skipped with a warning and the rest of the content is unaffected). Enabling the opt-in `smart_heading` engine parameter for docx additionally requires the pinned `zh_core_web_sm` / `en_core_web_sm` spaCy models (the `spacy` runtime ships with the `api` extra; install the models with `lightrag-download-cache --spacy --spacy-install` — the main Docker image already bundles them); deployments that never enable it need no models, and the smart_heading path also calls the EXTRACT-role LLM during parsing. Setting the `DOCX_SMART_HEADING=true` env var enables smart_heading by default for `.docx` files that resolve to the native engine — an explicit `native(smart_heading=false)` rule/hint opts a file back out — and makes the server verify the spaCy models at startup (fail fast instead of failing on the first parse); the same startup check triggers when a `LIGHTRAG_PARSER` rule carries `native(smart_heading=true)` (or its flag shorthand `native(smart_heading)`). The default applies at upload time only: already-ingested documents keep their persisted engine parameters on re-parse.
 
-Supported extensions: `docx` / `md` / `textpack`. How to enable:
+Supported extensions: `docx` / `ipynb` / `md` / `textpack`. How to enable:
 
 - `docx` and `md` still default to `legacy`; select native explicitly, e.g. a default rule `LIGHTRAG_PARSER=docx:native` / `LIGHTRAG_PARSER=md:native`, or a filename hint `report.[native-iet].docx` / `notes.[native].md` (syntax in [§2.4](#24-default-rules-lightrag_parser) / [§2.5](#25-single-file-override-filename-hints)).
-- `textpack` is a native-exclusive extension and is routed to native automatically without a hint/rule.
+- `ipynb` and `textpack` are native-exclusive extensions and are routed to native automatically without a hint/rule.
 
 #### docx Extraction Capabilities
 
@@ -323,7 +323,7 @@ native docx collects the `w14:paraId` written by Word 2013+ as a paragraph-level
 
 The affected blocks' `positions` degrade to `[{"type": "paraid", "range": null}]`. This is only a notice and **does not affect parsing success**; if you need precise paragraph provenance, follow the hint and "Save As .docx" in Word 2013+ to regenerate the ids.
 
-#### md / textpack Extraction Capabilities
+#### md / textpack / ipynb Extraction Capabilities
 
 Beyond `docx`, the `native` engine also supports Markdown:
 
@@ -336,6 +336,7 @@ Beyond `docx`, the `native` engine also supports Markdown:
     - The lookup directory must contain **exactly one** `.md` / `.markdown` file: zero or more than one is an error.
     - The directory holding the body is the "bundle root" (`bundle_root`) used for asset resolution.
   - File-reference images embedded by relative path are resolved relative to the bundle root and **may live in any subdirectory** (not only `assets/`); directory traversal is forbidden (`..`, absolute paths, or references escaping the bundle root are skipped with a warning), and the resolved bytes must pass an image magic-byte check or they are skipped. Relative-path images in a standalone `.md` (not a textpack) are not resolved (skipped with a warning).
+- `ipynb`: Jupyter notebooks are converted locally before Markdown extraction. Markdown and raw cells are kept as text; code cells are kept in language-tagged fenced blocks using the notebook kernel metadata. Execution counts and all cell outputs (including tracebacks and binary display data) are not indexed.
 - SVG images (base64 / textpack file / downloaded) are rasterized to PNG via cairosvg before being written to the sidecar; if cairosvg is unavailable or rendering fails, the image is skipped (with a warning).
 - External URL images (`![](http://...)`) are **downloaded and embedded by default** (`NATIVE_MD_IMAGE_DOWNLOAD_ENABLED` defaults to `true`); a drawing is always emitted (the fetched asset on success, or an external-link fallback on failure). Downloading allows only globally-routable public IPs (both DNS-resolved IPs and every redirect target are checked, and the socket dials the validated IP directly to defeat DNS rebinding; any ambient `HTTP(S)_PROXY` is ignored); private / loopback / link-local / reserved / CGNAT (`100.64.0.0/10`) ranges are all rejected. To allow specific internal ranges, configure a CIDR allowlist via `NATIVE_MD_IMAGE_ALLOWED_NON_PUBLIC_CIDRS`. Set the flag to `false` to instead drop external images entirely (no drawing emitted, so a document whose only images are external links produces no `drawings.json`).
 

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -1254,7 +1254,7 @@ class SupportedFileTypesResponse(BaseModel):
                 "engines": {
                     "legacy": [".md", ".pdf", ".txt"],
                     "mineru": [".jpg", ".pdf", ".png"],
-                    "native": [".docx", ".md", ".textpack"],
+                    "native": [".docx", ".ipynb", ".md", ".textpack"],
                 },
             }
         }

--- a/lightrag/parser/__init__.py
+++ b/lightrag/parser/__init__.py
@@ -8,6 +8,8 @@ Sub-packages and modules:
   parser debugging across all engines.
 - ``docx``: native ``.docx`` parser. Additional native format parsers
   should live as sibling sub-packages here (e.g. ``parser/pdf/``).
+- ``notebook``: native ``.ipynb`` parser that delegates rendered cells to the
+  Markdown extraction pipeline.
 - ``external``: adapters for external parsing services (``mineru``,
   ``docling``) that post to a remote API and cache the raw bundle.
 """

--- a/lightrag/parser/native_dispatch.py
+++ b/lightrag/parser/native_dispatch.py
@@ -2,9 +2,9 @@
 
 The registry exposes a single ``native`` engine with one ``impl``; routing
 yields the engine key and ``get_parser("native")`` returns this one instance.
-Suffix capabilities (``docx`` / ``md`` / ``textpack``) are declared on the
-registry spec but do NOT pick an implementation — that is this dispatcher's
-job.
+Suffix capabilities (``docx`` / ``ipynb`` / ``md`` / ``textpack``) are
+declared on the registry spec but do NOT pick an implementation — that is this
+dispatcher's job.
 
 It delegates the **entire** ``parse(ctx)`` to the matching concrete parser
 (rather than subclassing :class:`NativeParserBase` and only forwarding the
@@ -21,16 +21,18 @@ from lightrag.constants import PARSER_ENGINE_NATIVE
 from lightrag.parser.base import BaseParser, ParseContext, ParseResult
 
 _MARKDOWN_SUFFIXES = {".md", ".textpack"}
+_NOTEBOOK_SUFFIXES = {".ipynb"}
 
 
 class NativeParser(BaseParser):
-    """Routes a document to the docx or markdown native parser by suffix."""
+    """Routes a document to the matching native parser by suffix."""
 
     engine_name = PARSER_ENGINE_NATIVE
 
     def __init__(self) -> None:
         self._docx: BaseParser | None = None
         self._markdown: BaseParser | None = None
+        self._notebook: BaseParser | None = None
 
     def _docx_parser(self) -> BaseParser:
         parser = self._docx
@@ -50,10 +52,21 @@ class NativeParser(BaseParser):
             self._markdown = parser
         return parser
 
+    def _notebook_parser(self) -> BaseParser:
+        parser = self._notebook
+        if parser is None:
+            from lightrag.parser.notebook.parser import NativeNotebookParser
+
+            parser = NativeNotebookParser()
+            self._notebook = parser
+        return parser
+
     async def parse(self, ctx: ParseContext) -> ParseResult:
         suffix = Path(ctx.file_path).suffix.lower()
         if suffix in _MARKDOWN_SUFFIXES:
             return await self._markdown_parser().parse(ctx)
+        if suffix in _NOTEBOOK_SUFFIXES:
+            return await self._notebook_parser().parse(ctx)
         # Default to docx; its validate_source raises a clear error for any
         # other suffix the native engine was (mis)routed for.
         return await self._docx_parser().parse(ctx)

--- a/lightrag/parser/notebook/__init__.py
+++ b/lightrag/parser/notebook/__init__.py
@@ -1,0 +1,1 @@
+"""Native Jupyter notebook parser package."""

--- a/lightrag/parser/notebook/parser.py
+++ b/lightrag/parser/notebook/parser.py
@@ -1,0 +1,144 @@
+"""Native Jupyter notebook parser built on the Markdown parsing pipeline."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from lightrag.constants import PARSER_ENGINE_NATIVE
+from lightrag.parser.markdown.parser import NativeMarkdownParser
+from lightrag.parser.native_base import NativeExtractRuntime
+from lightrag.utils import logger
+
+
+class NativeNotebookParser(NativeMarkdownParser):
+    """Convert notebook text and code cells into Markdown before extraction."""
+
+    engine_name = PARSER_ENGINE_NATIVE
+    empty_content_label = "Notebook"
+
+    def validate_source(self, source: Path, file_path: str) -> None:
+        if not (
+            source.exists() and source.is_file() and source.suffix.lower() == ".ipynb"
+        ):
+            raise ValueError(
+                f"Native notebook parser does not support pending file: {file_path}"
+            )
+
+    def extract(
+        self,
+        source: Path,
+        *,
+        parsed_dir: Path,
+        asset_dir: Path,
+        base_name: str,
+        runtime: NativeExtractRuntime | None = None,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any], dict[str, Any]]:
+        markdown, cell_counts = self._notebook_to_markdown(source)
+        blocks, warnings, metadata = self._extract_text(markdown, bundle_root=None)
+        metadata.update(cell_counts)
+
+        ignored_params = (
+            sorted(k for k, value in runtime.engine_params.items() if value)
+            if runtime
+            else []
+        )
+        if ignored_params:
+            logger.warning(
+                "[native_notebook] engine params %s are ignored for %s",
+                ignored_params,
+                source.name,
+            )
+            warnings["engine_params_ignored"] = 1
+
+        return blocks, warnings, metadata
+
+    @classmethod
+    def _notebook_to_markdown(cls, source: Path) -> tuple[str, dict[str, int]]:
+        try:
+            notebook = json.loads(source.read_text(encoding="utf-8-sig"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError(f"Invalid Jupyter notebook: {source.name}") from exc
+
+        if not isinstance(notebook, dict):
+            raise ValueError(
+                f"Invalid Jupyter notebook: {source.name} must be an object"
+            )
+        cells = notebook.get("cells")
+        if not isinstance(cells, list):
+            raise ValueError(
+                f"Invalid Jupyter notebook: {source.name} has no cells list"
+            )
+
+        language = cls._notebook_language(notebook)
+        parts: list[str] = []
+        counts = {
+            "notebook_code_cells": 0,
+            "notebook_markdown_cells": 0,
+            "notebook_raw_cells": 0,
+        }
+        for index, cell in enumerate(cells):
+            if not isinstance(cell, dict):
+                raise ValueError(
+                    f"Invalid Jupyter notebook: cell {index} in {source.name} is not an object"
+                )
+            cell_type = cell.get("cell_type")
+            text = cls._cell_source(cell, index=index, source_name=source.name)
+            if cell_type == "markdown":
+                counts["notebook_markdown_cells"] += 1
+                if text.strip():
+                    parts.append(text.rstrip())
+            elif cell_type == "code":
+                counts["notebook_code_cells"] += 1
+                if text.strip():
+                    parts.append(cls._fenced_code(text, language))
+            elif cell_type == "raw":
+                counts["notebook_raw_cells"] += 1
+                if text.strip():
+                    parts.append(text.rstrip())
+            else:
+                raise ValueError(
+                    f"Invalid Jupyter notebook: unsupported cell type {cell_type!r} "
+                    f"at cell {index} in {source.name}"
+                )
+
+        return "\n\n".join(parts), counts
+
+    @staticmethod
+    def _cell_source(cell: dict[str, Any], *, index: int, source_name: str) -> str:
+        value = cell.get("source", "")
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list) and all(isinstance(part, str) for part in value):
+            return "".join(value)
+        raise ValueError(
+            f"Invalid Jupyter notebook: source for cell {index} in {source_name} "
+            "must be a string or list of strings"
+        )
+
+    @staticmethod
+    def _notebook_language(notebook: dict[str, Any]) -> str:
+        metadata = notebook.get("metadata")
+        if not isinstance(metadata, dict):
+            return ""
+        kernelspec = metadata.get("kernelspec")
+        language_info = metadata.get("language_info")
+        candidates = (
+            kernelspec.get("language") if isinstance(kernelspec, dict) else None,
+            language_info.get("name") if isinstance(language_info, dict) else None,
+        )
+        for candidate in candidates:
+            if isinstance(candidate, str) and re.fullmatch(
+                r"[A-Za-z0-9_+.-]+", candidate
+            ):
+                return candidate
+        return ""
+
+    @staticmethod
+    def _fenced_code(code: str, language: str) -> str:
+        runs = re.findall(r"`+", code)
+        fence = "`" * max([3, *(len(run) + 1 for run in runs)])
+        language_suffix = language if language else ""
+        return f"{fence}{language_suffix}\n{code.rstrip()}\n{fence}"

--- a/lightrag/parser/registry.py
+++ b/lightrag/parser/registry.py
@@ -266,10 +266,10 @@ _DOCLING_SUFFIXES = frozenset(
 _REGISTRY: dict[str, ParserSpec] = {
     PARSER_ENGINE_NATIVE: ParserSpec(
         engine_name=PARSER_ENGINE_NATIVE,
-        # Single ``native`` engine; the dispatcher picks docx vs markdown by
-        # source suffix (see lightrag.parser.native_dispatch).
+        # Single ``native`` engine; the dispatcher picks the concrete parser
+        # by source suffix (see lightrag.parser.native_dispatch).
         impl="lightrag.parser.native_dispatch:NativeParser",
-        suffixes=frozenset({"docx", "md", "textpack"}),
+        suffixes=frozenset({"docx", "ipynb", "md", "textpack"}),
         queue_group=PARSER_ENGINE_NATIVE,
         # Built-in groups are sized by the LightRAG ``max_parallel_parse_*``
         # instance field (supports constructor override), so no spec-level

--- a/lightrag/parser/routing.py
+++ b/lightrag/parser/routing.py
@@ -60,11 +60,14 @@ from copy import deepcopy
 _PARSER_HINT_RE = re.compile(r"\.\[([^\]]*)\](\.[^.]+)$")
 
 # Per-suffix default engine override, consulted before the global ``legacy``
-# fallback. ``.textpack`` is handled only by the native engine, so it routes
-# there automatically (no filename hint / LIGHTRAG_PARSER rule needed). ``.md``
-# is deliberately absent — it keeps the legacy default and opts into native the
-# same way ``.docx`` does (hint or rule).
-_DEFAULT_ENGINE_BY_SUFFIX: dict[str, str] = {"textpack": PARSER_ENGINE_NATIVE}
+# fallback. ``.textpack`` and ``.ipynb`` are handled only by the native engine,
+# so they route there automatically (no filename hint / LIGHTRAG_PARSER rule
+# needed). ``.md`` is deliberately absent — it keeps the legacy default and
+# opts into native the same way ``.docx`` does (hint or rule).
+_DEFAULT_ENGINE_BY_SUFFIX: dict[str, str] = {
+    "ipynb": PARSER_ENGINE_NATIVE,
+    "textpack": PARSER_ENGINE_NATIVE,
+}
 
 
 class ParserRoutingConfigError(ValueError):

--- a/tests/api/routes/test_supported_file_types_endpoint.py
+++ b/tests/api/routes/test_supported_file_types_endpoint.py
@@ -71,7 +71,7 @@ def test_default_deployment_contract(client):
     assert "mineru" not in engines and "docling" not in engines
     # Internal (non-user-selectable) engines are never advertised.
     assert "reuse" not in engines and "passthrough" not in engines
-    assert engines["native"] == [".docx", ".md", ".textpack"]
+    assert engines["native"] == [".docx", ".ipynb", ".md", ".textpack"]
     for suffixes in engines.values():
         assert all(s.startswith(".") and s == s.lower() for s in suffixes)
 

--- a/tests/parser/markdown/test_routing.py
+++ b/tests/parser/markdown/test_routing.py
@@ -19,12 +19,13 @@ def _engine(path: str, rules: str = "") -> str:
 
 def test_native_declares_markdown_suffixes():
     assert registry.suffix_capabilities("native") == frozenset(
-        {"docx", "md", "textpack"}
+        {"docx", "ipynb", "md", "textpack"}
     )
 
 
 def test_textpack_and_md_in_upload_allowlist():
     suffixes = registry.available_engine_suffixes()
+    assert "ipynb" in suffixes
     assert "textpack" in suffixes
     assert "md" in suffixes
 
@@ -36,6 +37,10 @@ def test_get_parser_native_is_dispatcher():
 
 def test_textpack_defaults_to_native_without_hint():
     assert _engine("note.textpack") == "native"
+
+
+def test_notebook_defaults_to_native_without_hint():
+    assert _engine("guide.ipynb") == "native"
 
 
 def test_md_defaults_to_legacy_opt_in_for_native():
@@ -70,12 +75,14 @@ def _dispatch(file_path: str) -> str:
     dispatcher = NativeParser()
     dispatcher._docx = _SentinelParser("docx")
     dispatcher._markdown = _SentinelParser("markdown")
+    dispatcher._notebook = _SentinelParser("notebook")
     return asyncio.run(dispatcher.parse(_Ctx(file_path)))
 
 
 def test_dispatcher_routes_by_suffix():
     assert _dispatch("a.md") == "markdown"
     assert _dispatch("a.textpack") == "markdown"
+    assert _dispatch("a.ipynb") == "notebook"
     assert _dispatch("a.[native-iet].md") == "markdown"
     assert _dispatch("a.docx") == "docx"
     assert _dispatch("report.[native].docx") == "docx"

--- a/tests/parser/notebook/__init__.py
+++ b/tests/parser/notebook/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the native Jupyter notebook parser."""

--- a/tests/parser/notebook/test_parser.py
+++ b/tests/parser/notebook/test_parser.py
@@ -1,0 +1,150 @@
+"""Regression tests for native ``.ipynb`` parsing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lightrag.parser.notebook.parser import NativeNotebookParser
+from lightrag.sidecar import write_sidecar
+
+
+def _write_notebook(path: Path, cells: list[dict]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "cells": cells,
+                "metadata": {"kernelspec": {"language": "python"}},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_notebook_cells_render_as_markdown_and_fenced_code(tmp_path: Path):
+    source = tmp_path / "guide.ipynb"
+    _write_notebook(
+        source,
+        [
+            {"cell_type": "markdown", "source": ["# Guide\n", "Intro text."]},
+            {
+                "cell_type": "code",
+                "source": ["value = 2\n", "print(value)"],
+                "execution_count": 1,
+                "outputs": [{"output_type": "stream", "text": "2\n"}],
+            },
+            {"cell_type": "raw", "source": "Raw context."},
+        ],
+    )
+
+    markdown, counts = NativeNotebookParser._notebook_to_markdown(source)
+
+    assert markdown == (
+        "# Guide\nIntro text.\n\n"
+        "```python\nvalue = 2\nprint(value)\n```\n\n"
+        "Raw context."
+    )
+    assert counts == {
+        "notebook_code_cells": 1,
+        "notebook_markdown_cells": 1,
+        "notebook_raw_cells": 1,
+    }
+    assert "execution_count" not in markdown
+    assert "output_type" not in markdown
+
+
+def test_notebook_extracts_content_without_execution_output(tmp_path: Path):
+    source = tmp_path / "guide.ipynb"
+    _write_notebook(
+        source,
+        [
+            {"cell_type": "markdown", "source": "# Guide\n\nHello notebook."},
+            {
+                "cell_type": "code",
+                "source": "answer = 42",
+                "outputs": [{"output_type": "stream", "text": "secret output"}],
+            },
+        ],
+    )
+
+    blocks, warnings, metadata = NativeNotebookParser().extract(
+        source, parsed_dir=tmp_path, asset_dir=tmp_path, base_name="guide"
+    )
+
+    rendered = "\n".join(block["content"] for block in blocks)
+    assert "Hello notebook." in rendered
+    assert "answer = 42" in rendered
+    assert "secret output" not in rendered
+    assert metadata["notebook_code_cells"] == 1
+    assert metadata["notebook_markdown_cells"] == 1
+    assert not warnings
+
+
+def test_notebook_writes_ipynb_sidecar(tmp_path: Path):
+    source = tmp_path / "guide.ipynb"
+    _write_notebook(
+        source,
+        [
+            {"cell_type": "markdown", "source": "# Guide\n\nHello notebook."},
+            {"cell_type": "code", "source": "answer = 42"},
+        ],
+    )
+    parser = NativeNotebookParser()
+    parsed_dir = tmp_path / "guide.ipynb.parsed"
+    asset_dir = parsed_dir / "guide.blocks.assets"
+    parsed_dir.mkdir()
+    asset_dir.mkdir()
+    blocks, _, metadata = parser.extract(
+        source, parsed_dir=parsed_dir, asset_dir=asset_dir, base_name="guide"
+    )
+    ir = parser.build_ir(
+        blocks,
+        document_name=source.name,
+        asset_dir_name=asset_dir.name,
+        metadata=metadata,
+    )
+
+    write_sidecar(
+        ir,
+        parsed_dir=parsed_dir,
+        doc_id="doc-test",
+        engine="native",
+        clean_parsed_dir=False,
+        block_drawing_path_style=parser.sidecar_path_style,
+    )
+
+    lines = [
+        json.loads(line)
+        for line in (parsed_dir / "guide.blocks.jsonl").read_text().splitlines()
+    ]
+    assert lines[0]["document_format"] == "ipynb"
+    assert lines[0]["doc_title"] == "Guide"
+    assert any("answer = 42" in line.get("content", "") for line in lines)
+
+
+def test_notebook_code_fence_outgrows_backticks_in_source():
+    rendered = NativeNotebookParser._fenced_code("value = ```example```", "python")
+
+    assert rendered.startswith("````python\n")
+    assert rendered.endswith("\n````")
+
+
+@pytest.mark.parametrize(
+    "cells, message",
+    [
+        ([{"cell_type": "code", "source": 42}], "must be a string or list of strings"),
+        ([{"cell_type": "unknown", "source": "x"}], "unsupported cell type"),
+    ],
+)
+def test_notebook_rejects_invalid_cell_shape(
+    tmp_path: Path, cells: list[dict], message: str
+):
+    source = tmp_path / "invalid.ipynb"
+    _write_notebook(source, cells)
+
+    with pytest.raises(ValueError, match=message):
+        NativeNotebookParser._notebook_to_markdown(source)

--- a/tests/parser/test_registry.py
+++ b/tests/parser/test_registry.py
@@ -22,7 +22,7 @@ def test_supported_engines_are_user_selectable_only():
 def test_suffix_capabilities_lookup():
     assert "pdf" in registry.suffix_capabilities("mineru")
     assert registry.suffix_capabilities("native") == frozenset(
-        {"docx", "md", "textpack"}
+        {"docx", "ipynb", "md", "textpack"}
     )
     assert registry.suffix_capabilities("unknown-engine") == frozenset()
 


### PR DESCRIPTION
## Description

Adds local native parsing for Jupyter `.ipynb` files so notebook knowledge can enter the structured LightRAG pipeline without an external parser.

## Related Issues

Fixes #3414

## Changes Made

- Route `.ipynb` to a native notebook parser by default and expose it in native suffix capabilities.
- Convert Markdown and raw cells to text, and code cells to language-tagged fenced blocks using notebook kernel metadata.
- Exclude execution counts and all cell outputs, including tracebacks and binary display payloads.
- Reuse the Markdown IR and sidecar pipeline, with tests for conversion, invalid cell shapes, routing, registry wiring, and sidecar generation.
- Document the native notebook behavior and automatic routing in the English and Chinese pipeline guides.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Validation completed:

- `uv run pre-commit run --all-files`
- `uv run pytest tests/parser/notebook/test_parser.py tests/parser/markdown/test_routing.py tests/parser/test_registry.py` (39 passed)
- `uv run pytest tests/parser --ignore=tests/parser/markdown/test_parser.py --ignore=tests/parser/markdown/test_raw_cache.py` (1292 passed, 44 skipped)
- `uv run ruff check lightrag/parser tests/parser`

The five omitted SVG tests require the host Cairo shared library, which is unavailable on this macOS environment; they exercise existing SVG rasterization only and are unrelated to notebook parsing.