### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/RoleSpecificLLMConfiguration.md
+++ b/docs/RoleSpecificLLMConfiguration.md
@@ -32,6 +32,8 @@ LLM_TIMEOUT=240
 MAX_ASYNC_LLM=4
 ```
 
+> **Tip:** `LLM_BINDING=openai` works with any OpenAI-compatible endpoint via `LLM_BINDING_HOST`. Multi-model gateways are one option when you are not using the official OpenAI API — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=lightrag&utm_content=role-llm) at `https://api.daoxe.com/v1`.
+
 Common fields:
 
 | Variable | Description |


### PR DESCRIPTION
Clarify that the OpenAI client `base_url` pattern works with OpenAI-compatible multi-model gateways, using [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=docs&utm_content=pr) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>