### PR TITLE
feat: add POST /documents/move to relocate documents across folders

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -4214,7 +4214,7 @@ def _encode_folder_prefix(folder_path: str) -> str:
     p = re.sub(r"/+", "/", p)
     if not p:
         return ""
-    return p.split("/").join(_MOVE_FOLDER_SEPARATOR) + _MOVE_FOLDER_SEPARATOR
+    return _MOVE_FOLDER_SEPARATOR.join(p.split("/")) + _MOVE_FOLDER_SEPARATOR
 
 
 def _doc_basename(file_path: str) -> str:
@@ -4296,9 +4296,7 @@ async def background_move_documents(
                     "latest_message": "Starting document move process",
                 }
             )
-            pipeline_status["history_messages"][:] = [
-                "Starting document move process"
-            ]
+            pipeline_status["history_messages"][:] = ["Starting document move process"]
 
         target_prefix = _encode_folder_prefix(target_folder)
         # Basenames already present in the target folder (detect collisions).
@@ -4338,9 +4336,7 @@ async def background_move_documents(
                 basename = _doc_basename(old_file_path)
                 if not basename:
                     failed_moves.append(doc_id)
-                    error_msg = (
-                        f"Cannot move document with empty file_path: {doc_id}"
-                    )
+                    error_msg = f"Cannot move document with empty file_path: {doc_id}"
                     logger.warning(error_msg)
                     async with pipeline_status_lock:
                         pipeline_status["latest_message"] = error_msg
@@ -4353,8 +4349,7 @@ async def background_move_documents(
                 if new_basename is None:
                     skipped_moves.append(doc_id)
                     skip_msg = (
-                        f"Skipped (name exists in target folder): "
-                        f"{doc_id}[{basename}]"
+                        f"Skipped (name exists in target folder): {doc_id}[{basename}]"
                     )
                     logger.info(skip_msg)
                     async with pipeline_status_lock:
@@ -4367,9 +4362,7 @@ async def background_move_documents(
                 # Rewrite the stored file_path. update_doc_status_fields keeps
                 # every secondary index (incl. the source multimap) consistent
                 # and leaves chunks/vectors/graph untouched.
-                await rag.update_doc_status_fields(
-                    doc_id, {"file_path": new_file_path}
-                )
+                await rag.update_doc_status_fields(doc_id, {"file_path": new_file_path})
 
                 # Best-effort physical rename in INPUT_DIR and __parsed__ dir.
                 _rename_physical_file(
@@ -4389,8 +4382,7 @@ async def background_move_documents(
             except Exception as e:
                 failed_moves.append(doc_id)
                 error_msg = (
-                    f"Error moving document {i}/{total_docs}: "
-                    f"{doc_id} - {str(e)}"
+                    f"Error moving document {i}/{total_docs}: {doc_id} - {str(e)}"
                 )
                 logger.error(error_msg)
                 logger.error(traceback.format_exc())
@@ -6547,7 +6539,9 @@ def create_document_routes(
             )
 
         except Exception as e:
-            error_msg = f"Error initiating document move for {move_request.doc_ids}: {str(e)}"
+            error_msg = (
+                f"Error initiating document move for {move_request.doc_ids}: {str(e)}"
+            )
             logger.error(error_msg)
             logger.error(traceback.format_exc())
             raise internal_server_error(e)

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -4239,8 +4239,12 @@ def _conflict_free_basename(
     if not rename_on_conflict:
         return None
     stem, dot, ext = basename.rpartition(".")
-    suffix = f".{ext}" if dot else ""
-    base_stem = stem or basename
+    if dot and stem:
+        base_stem, suffix = stem, f".{ext}"
+    else:
+        # No extension ("README") or a leading-dot name (".env"): treat the
+        # whole basename as the stem so the suffix is not duplicated.
+        base_stem, suffix = basename, ""
     idx = 1
     while True:
         candidate = f"{base_stem} ({idx}){suffix}"

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -903,6 +903,55 @@ class DeleteDocRequest(BaseModel):
         return validated_ids
 
 
+class MoveDocRequest(BaseModel):
+    doc_ids: List[str] = Field(..., description="The IDs of the documents to move.")
+    target_folder: str = Field(
+        default="",
+        description=(
+            "Target folder path encoded with '/' separators (e.g. 'A/B'). "
+            "Empty string means the root folder. The webui computes the new "
+            "file_path (folder prefix + original basename) and passes it here; "
+            "the backend stays folder-encoding agnostic."
+        ),
+    )
+    rename_on_conflict: bool = Field(
+        default=True,
+        description=(
+            "When a document's basename already exists in the target folder, "
+            "append a numeric suffix (e.g. 'report (1).pdf') instead of "
+            "skipping it. Has no effect when False — conflicting docs are skipped."
+        ),
+    )
+
+    @field_validator("doc_ids", mode="after")
+    @classmethod
+    def validate_doc_ids(cls, doc_ids: List[str]) -> List[str]:
+        if not doc_ids:
+            raise ValueError("Document IDs list cannot be empty")
+
+        validated_ids = []
+        for doc_id in doc_ids:
+            if not doc_id or not doc_id.strip():
+                raise ValueError("Document ID cannot be empty")
+            validated_ids.append(doc_id.strip())
+
+        # Check for duplicates
+        if len(validated_ids) != len(set(validated_ids)):
+            raise ValueError("Document IDs must be unique")
+
+        return validated_ids
+
+
+class MoveDocByIdResponse(BaseModel):
+    """Response model for the batch document move operation."""
+
+    status: Literal["move_started", "busy"] = Field(
+        description="Status of the move operation"
+    )
+    message: str = Field(description="Message describing the operation result")
+    doc_ids: str = Field(description="The IDs of the documents to move")
+
+
 # doc_status.metadata keys that are internal pipeline bookkeeping and must
 # never reach the frontend. smartheading_llm_cache_ids is a deletion-time
 # LLM-cache purge list (written by the parse pipeline at pipeline.py:1748,
@@ -4149,6 +4198,297 @@ async def background_delete_documents(
                 logger.error(f"Error processing pending documents after deletion: {e}")
 
 
+# Folder-encoding separator shared with the webui (src/lib/folderEncoding.ts).
+# A document's folder path is encoded into its stored file_path using a
+# double-underscore separator, e.g. folder "A/B" -> "A__B__basename".
+_MOVE_FOLDER_SEPARATOR = "__"
+
+
+def _encode_folder_prefix(folder_path: str) -> str:
+    """Encode a '/' separated folder path into the file_path prefix.
+
+    Mirrors webui ``encodeFolderPrefix``: returns '' for root, otherwise
+    "<seg>__<seg>__" (trailing separator included).
+    """
+    p = re.sub(r"^/+|/+$", "", (folder_path or "").strip())
+    p = re.sub(r"/+", "/", p)
+    if not p:
+        return ""
+    return p.split("/").join(_MOVE_FOLDER_SEPARATOR) + _MOVE_FOLDER_SEPARATOR
+
+
+def _doc_basename(file_path: str) -> str:
+    """Return the on-disk basename (folder prefix stripped) of a stored file_path."""
+    raw = (file_path or "").split("/").pop() or ""
+    if _MOVE_FOLDER_SEPARATOR not in raw:
+        return raw
+    segments = raw.split(_MOVE_FOLDER_SEPARATOR)
+    return segments.pop() or raw
+
+
+def _conflict_free_basename(
+    basename: str, occupied: set[str], rename_on_conflict: bool
+) -> str | None:
+    """Return a basename not in ``occupied``, or None when it must be skipped.
+
+    When ``rename_on_conflict`` is True, appends " (1)", " (2)", ... before the
+    extension until free. When False, a collision yields None (caller skips).
+    """
+    if basename not in occupied:
+        return basename
+    if not rename_on_conflict:
+        return None
+    stem, dot, ext = basename.rpartition(".")
+    suffix = f".{ext}" if dot else ""
+    base_stem = stem or basename
+    idx = 1
+    while True:
+        candidate = f"{base_stem} ({idx}){suffix}"
+        if candidate not in occupied:
+            return candidate
+        idx += 1
+
+
+async def background_move_documents(
+    rag: LightRAG,
+    doc_manager: DocumentManager,
+    doc_ids: List[str],
+    target_folder: str,
+    rename_on_conflict: bool = True,
+    token: str | None = None,
+):
+    """Background task to move multiple documents into a target folder.
+
+    Moving only rewrites each document's stored ``file_path`` (folder prefix
+    swap + best-effort physical file rename). The document id, chunks, vectors
+    and graph data are untouched — no re-indexing is required.
+    """
+    from lightrag.kg.shared_storage import (
+        get_namespace_data,
+        get_namespace_lock,
+        get_pipeline_ingress,
+        release_owned_reservation,
+    )
+
+    total_docs = len(doc_ids)
+    successful_moves: List[str] = []
+    skipped_moves: List[str] = []
+    failed_moves: List[str] = []
+    pipeline_status = None
+    pipeline_status_lock = None
+
+    try:
+        pipeline_status = await get_namespace_data(
+            "pipeline_status", workspace=rag.workspace
+        )
+        pipeline_status_lock = get_namespace_lock(
+            "pipeline_status", workspace=rag.workspace
+        )
+
+        async with pipeline_status_lock:
+            pipeline_status.update(
+                {
+                    "job_name": f"Moving {total_docs} Documents",
+                    "job_start": datetime.now().isoformat(),
+                    "docs": total_docs,
+                    "batchs": total_docs,
+                    "cur_batch": 0,
+                    "latest_message": "Starting document move process",
+                }
+            )
+            pipeline_status["history_messages"][:] = [
+                "Starting document move process"
+            ]
+
+        target_prefix = _encode_folder_prefix(target_folder)
+        # Basenames already present in the target folder (detect collisions).
+        occupied_basenames: set[str] = set()
+
+        for i, doc_id in enumerate(doc_ids, 1):
+            async with pipeline_status_lock:
+                if pipeline_status.get("cancellation_requested", False):
+                    cancel_msg = (
+                        f"Move cancelled by user at document {i}/{total_docs}. "
+                        f"{len(successful_moves)} moved, "
+                        f"{total_docs - i + 1} remaining."
+                    )
+                    logger.info(cancel_msg)
+                    pipeline_status["latest_message"] = cancel_msg
+                    append_pipeline_history(pipeline_status, cancel_msg)
+                    skipped_moves.extend(doc_ids[i - 1 :])
+                    break
+
+                start_msg = f"Moving document {i}/{total_docs}: {doc_id}"
+                logger.info(start_msg)
+                pipeline_status.update({"cur_batch": i, "latest_message": start_msg})
+                append_pipeline_history(pipeline_status, start_msg)
+
+            try:
+                existing = await rag.get_by_id(doc_id)
+                if existing is None:
+                    failed_moves.append(doc_id)
+                    error_msg = f"Document not found: {doc_id}"
+                    logger.warning(error_msg)
+                    async with pipeline_status_lock:
+                        pipeline_status["latest_message"] = error_msg
+                        append_pipeline_history(pipeline_status, error_msg)
+                    continue
+
+                old_file_path = existing.get("file_path") or ""
+                basename = _doc_basename(old_file_path)
+                if not basename:
+                    failed_moves.append(doc_id)
+                    error_msg = (
+                        f"Cannot move document with empty file_path: {doc_id}"
+                    )
+                    logger.warning(error_msg)
+                    async with pipeline_status_lock:
+                        pipeline_status["latest_message"] = error_msg
+                        append_pipeline_history(pipeline_status, error_msg)
+                    continue
+
+                new_basename = _conflict_free_basename(
+                    basename, occupied_basenames, rename_on_conflict
+                )
+                if new_basename is None:
+                    skipped_moves.append(doc_id)
+                    skip_msg = (
+                        f"Skipped (name exists in target folder): "
+                        f"{doc_id}[{basename}]"
+                    )
+                    logger.info(skip_msg)
+                    async with pipeline_status_lock:
+                        pipeline_status["latest_message"] = skip_msg
+                        append_pipeline_history(pipeline_status, skip_msg)
+                    continue
+
+                new_file_path = f"{target_prefix}{new_basename}"
+
+                # Rewrite the stored file_path. update_doc_status_fields keeps
+                # every secondary index (incl. the source multimap) consistent
+                # and leaves chunks/vectors/graph untouched.
+                await rag.update_doc_status_fields(
+                    doc_id, {"file_path": new_file_path}
+                )
+
+                # Best-effort physical rename in INPUT_DIR and __parsed__ dir.
+                _rename_physical_file(
+                    doc_manager.input_dir, old_file_path, new_file_path
+                )
+
+                occupied_basenames.add(new_basename)
+                successful_moves.append(doc_id)
+                success_msg = (
+                    f"Document moved {i}/{total_docs}: {doc_id}[{old_file_path}]"
+                    f" -> {new_file_path}"
+                )
+                logger.info(success_msg)
+                async with pipeline_status_lock:
+                    append_pipeline_history(pipeline_status, success_msg)
+
+            except Exception as e:
+                failed_moves.append(doc_id)
+                error_msg = (
+                    f"Error moving document {i}/{total_docs}: "
+                    f"{doc_id} - {str(e)}"
+                )
+                logger.error(error_msg)
+                logger.error(traceback.format_exc())
+                async with pipeline_status_lock:
+                    pipeline_status["latest_message"] = error_msg
+                    append_pipeline_history(pipeline_status, error_msg)
+
+    except Exception as e:
+        error_msg = f"Critical error during batch move: {str(e)}"
+        logger.error(error_msg)
+        logger.error(traceback.format_exc())
+        if pipeline_status is not None and pipeline_status_lock is not None:
+            async with pipeline_status_lock:
+                append_pipeline_history(pipeline_status, error_msg)
+    finally:
+        try:
+            move_exit_ingress = await get_pipeline_ingress(rag.workspace)
+        except Exception:
+            move_exit_ingress = None
+
+        def _move_release(status):
+            completion_msg = (
+                f"Move completed: {len(successful_moves)} successful, "
+                f"{len(skipped_moves)} skipped, {len(failed_moves)} failed"
+            )
+            status.update(
+                {
+                    "busy": False,
+                    "destructive_busy": False,
+                    "busy_owner": None,
+                    "operation_record": None,
+                    "cancellation_requested": False,
+                    "latest_message": completion_msg,
+                }
+            )
+            append_pipeline_history(status, completion_msg)
+            if move_exit_ingress is None:
+                return False
+            try:
+                return bool(move_exit_ingress.has_work())
+            except Exception:
+                return False
+
+        await release_owned_reservation(
+            rag.workspace,
+            owner_key="busy_owner",
+            token=token,
+            action=_move_release,
+        )
+
+
+def _rename_physical_file(
+    input_dir: Path, old_file_path: str, new_file_path: str
+) -> None:
+    """Best-effort rename of a document's physical file across INPUT_DIR and the
+    parsed-artifact directory. Failures are logged, not raised — the stored
+    file_path is the source of truth for the UI; a missing/renamed blob only
+    affects re-parsing, never the graph.
+    """
+    if not old_file_path or old_file_path == UNKNOWN_FILE_SOURCE:
+        return
+    old_name = Path(old_file_path).name
+    new_name = Path(new_file_path).name
+    if old_name == new_name:
+        return
+
+    for candidate_dir in (input_dir, input_dir / PARSED_DIR_NAME):
+        try:
+            candidates = list(candidate_dir.iterdir())
+        except FileNotFoundError:
+            continue
+        except Exception as e:
+            logger.warning(f"Failed to scan {candidate_dir}: {e}")
+            continue
+
+        in_parsed_dir = candidate_dir.name == PARSED_DIR_NAME
+        for candidate in candidates:
+            if not candidate.is_file():
+                continue
+            canonical_old = canonicalize_archived_file_variant_basename(
+                old_name, strip_archive_suffix=in_parsed_dir
+            )
+            canonical_candidate = canonicalize_archived_file_variant_basename(
+                candidate.name, strip_archive_suffix=in_parsed_dir
+            )
+            if canonical_candidate != canonical_old:
+                continue
+            safe = validate_file_path_security(candidate.name, candidate_dir)
+            if safe is None:
+                continue
+            target = safe.with_name(new_name)
+            try:
+                safe.rename(target)
+                logger.info(f"Renamed physical file {safe} -> {target}")
+            except Exception as e:
+                logger.warning(f"Failed to rename {safe}: {e}")
+
+
 def create_document_routes(
     rag: LightRAG, doc_manager: DocumentManager, api_key: Optional[str] = None
 ):
@@ -6114,6 +6454,104 @@ def create_document_routes(
             # not yet assigned) or before hand-off: release is owner-checked +
             # idempotent, so it frees the slot we took and is a no-op if we never
             # acquired (or the start helper's backstop already released it).
+            if not handed_off:
+                await _release_destructive_busy(rag, destructive_token)
+
+    @router.post(
+        "/move",
+        response_model=MoveDocByIdResponse,
+        dependencies=[Depends(combined_auth)],
+        summary="Move documents into a target folder by rewriting their file_path.",
+    )
+    async def move_documents(
+        move_request: MoveDocRequest,
+        managed_tasks: set = Depends(get_managed_background_tasks),
+    ) -> MoveDocByIdResponse:
+        """
+        Move documents into a target folder without re-indexing them.
+
+        Moving only rewrites each document's stored ``file_path`` (the folder
+        prefix is swapped to the target) and best-effort renames the physical
+        file on disk. Document ids, chunks, vectors and graph data are
+        untouched — the knowledge graph keyed by ``doc_id`` is unaffected, so no
+        re-processing is needed.
+
+        The webui computes the target ``file_path`` encoding (the double-
+        underscore folder prefix); the backend stays folder-encoding agnostic
+        and treats ``target_folder`` as a plain '/' separated path.
+
+        **Concurrency Constraint:**
+        - Same as delete: atomically reserves the destructive slot (``busy=True``
+          and ``destructive_busy=True``) synchronously before returning
+          ``move_started``, refusing with ``status="busy"`` when busy / scanning /
+          pending enqueue.
+
+        Args:
+            move_request (MoveDocRequest): The request containing the document IDs,
+                the target folder and the rename-on-conflict flag.
+            managed_tasks: injected managed background-task set.
+
+        Returns:
+            MoveDocByIdResponse:
+                - status="move_started": The move has been initiated in the background.
+                - status="busy": Another writer holds the pipeline; nothing scheduled.
+        """
+        from lightrag.kg.shared_storage import start_reserved_background_task
+
+        doc_ids = move_request.doc_ids
+
+        destructive_token = uuid4().hex
+
+        async def _move_work(started):
+            started.set()
+            await background_move_documents(
+                rag,
+                doc_manager,
+                doc_ids,
+                move_request.target_folder,
+                move_request.rename_on_conflict,
+                destructive_token,
+            )
+
+        async def _move_backstop():
+            await _release_destructive_busy(rag, destructive_token)
+
+        handed_off = False
+        try:
+            acquired, reason = await _acquire_destructive_busy(
+                rag,
+                destructive_token,
+                kind="move",
+                operation_record={"kind": "move", "doc_ids": doc_ids},
+            )
+            if not acquired:
+                return MoveDocByIdResponse(
+                    status="busy",
+                    message=reason or "Cannot move documents while pipeline is busy",
+                    doc_ids=", ".join(doc_ids),
+                )
+
+            await start_reserved_background_task(
+                managed_tasks, work=_move_work, backstop_release=_move_backstop
+            )
+            handed_off = True
+
+            return MoveDocByIdResponse(
+                status="move_started",
+                message=(
+                    f"Moving {len(doc_ids)} documents to folder "
+                    f"'{move_request.target_folder or '(root)'}' has been initiated. "
+                    f"Processing will continue in background."
+                ),
+                doc_ids=", ".join(doc_ids),
+            )
+
+        except Exception as e:
+            error_msg = f"Error initiating document move for {move_request.doc_ids}: {str(e)}"
+            logger.error(error_msg)
+            logger.error(traceback.format_exc())
+            raise internal_server_error(e)
+        finally:
             if not handed_off:
                 await _release_destructive_busy(rag, destructive_token)
 

--- a/tests/api/routes/test_document_routes_move.py
+++ b/tests/api/routes/test_document_routes_move.py
@@ -1,0 +1,228 @@
+"""Tests for the `/documents/move` folder-relocation helpers and request model.
+
+Moving a document only rewrites its stored ``file_path``; ids, chunks, vectors
+and graph data are untouched. The correctness of a move therefore reduces to
+three pure functions plus the request model's validation:
+
+1. **``_encode_folder_prefix``**: a '/' separated folder path becomes the
+   ``__`` separated ``file_path`` prefix the webui expects. Must agree with
+   the webui's ``encodeFolderPrefix`` — a mismatch silently files documents
+   into a folder the UI cannot see.
+
+2. **``_doc_basename``**: recovers the on-disk basename from a stored
+   ``file_path``, so a move re-prefixes the name instead of nesting the old
+   prefix inside the new one.
+
+3. **``_conflict_free_basename``**: resolves collisions in the target folder,
+   either by suffixing (``rename_on_conflict=True``) or by signalling a skip.
+
+4. **``MoveDocRequest``**: rejects empty/blank/duplicate ids up front, so a
+   malformed batch never reaches the background task.
+"""
+
+import importlib
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_dr = importlib.import_module("lightrag.api.routers.document_routes")
+sys.argv = _original_argv
+
+_encode_folder_prefix = _dr._encode_folder_prefix
+_doc_basename = _dr._doc_basename
+_conflict_free_basename = _dr._conflict_free_basename
+_MOVE_FOLDER_SEPARATOR = _dr._MOVE_FOLDER_SEPARATOR
+MoveDocRequest = _dr.MoveDocRequest
+
+pytestmark = pytest.mark.offline
+
+
+# ---------------------------------------------------------------------------
+# 1. _encode_folder_prefix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("folder", ["", "   ", "/", "///"])
+def test_root_folder_encodes_to_empty_prefix(folder):
+    """Root (however it is spelled) carries no prefix at all.
+
+    A stray separator here would push every root-level document into a
+    folder literally named "".
+    """
+    assert _encode_folder_prefix(folder) == ""
+
+
+def test_single_segment_keeps_trailing_separator():
+    """The prefix is concatenated directly with the basename, so it must
+    already end with the separator."""
+    assert _encode_folder_prefix("A") == "A__"
+
+
+@pytest.mark.parametrize(
+    "folder",
+    ["A/B", "/A/B", "A/B/", "/A/B/", "A//B", "  A/B  "],
+)
+def test_nested_paths_normalize_to_same_prefix(folder):
+    """Leading/trailing/duplicated slashes and surrounding whitespace are all
+    normalized away, so equivalent spellings cannot create sibling folders."""
+    assert _encode_folder_prefix(folder) == "A__B__"
+
+
+def test_deeply_nested_path_joins_every_segment():
+    """Regression guard: the join must produce a separator *between* segments.
+
+    Getting the join backwards (a JS-style ``list.join(sep)``) raises
+    ``AttributeError`` and breaks every non-root move.
+    """
+    assert _encode_folder_prefix("A/B/C/D") == "A__B__C__D__"
+
+
+def test_encoded_prefix_uses_the_shared_separator():
+    """The separator is a contract shared with the webui, not a local detail."""
+    assert (
+        _encode_folder_prefix("A/B")
+        == f"A{_MOVE_FOLDER_SEPARATOR}B{_MOVE_FOLDER_SEPARATOR}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. _doc_basename
+# ---------------------------------------------------------------------------
+
+
+def test_unprefixed_path_is_its_own_basename():
+    assert _doc_basename("report.pdf") == "report.pdf"
+
+
+@pytest.mark.parametrize(
+    "stored,expected",
+    [
+        ("A__report.pdf", "report.pdf"),
+        ("A__B__report.pdf", "report.pdf"),
+        ("A__B__C__report.pdf", "report.pdf"),
+    ],
+)
+def test_folder_prefix_is_stripped_at_any_depth(stored, expected):
+    """Only the trailing segment survives, so re-prefixing on move cannot
+    accumulate the previous folder path."""
+    assert _doc_basename(stored) == expected
+
+
+def test_empty_path_yields_empty_basename():
+    """The caller treats "" as unmovable and reports it as a failure rather
+    than fabricating a name."""
+    assert _doc_basename("") == ""
+
+
+def test_none_path_is_tolerated():
+    """``file_path`` is read from stored doc_status and may be missing."""
+    assert _doc_basename(None) == ""
+
+
+def test_basename_keeps_internal_spaces_and_dots():
+    assert (
+        _doc_basename("A__B__2024 annual.report.v2.pdf") == "2024 annual.report.v2.pdf"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. _conflict_free_basename
+# ---------------------------------------------------------------------------
+
+
+def test_free_name_is_returned_unchanged():
+    assert _conflict_free_basename("r.pdf", set(), True) == "r.pdf"
+
+
+def test_first_collision_gets_suffix_one():
+    assert _conflict_free_basename("r.pdf", {"r.pdf"}, True) == "r (1).pdf"
+
+
+def test_suffix_increments_until_free():
+    """Consecutive moves of the same name must not overwrite each other."""
+    occupied = {"r.pdf", "r (1).pdf", "r (2).pdf"}
+    assert _conflict_free_basename("r.pdf", occupied, True) == "r (3).pdf"
+
+
+def test_suffix_is_inserted_before_the_extension():
+    """Appending after the extension would break type detection downstream."""
+    result = _conflict_free_basename("annual report.docx", {"annual report.docx"}, True)
+    assert result == "annual report (1).docx"
+
+
+def test_extensionless_name_gets_a_bare_suffix():
+    assert _conflict_free_basename("README", {"README"}, True) == "README (1)"
+
+
+def test_multi_dot_name_only_splits_the_last_extension():
+    result = _conflict_free_basename("archive.tar.gz", {"archive.tar.gz"}, True)
+    assert result == "archive.tar (1).gz"
+
+
+def test_dotfile_is_not_treated_as_pure_extension():
+    """``.env``'s rpartition yields an empty stem; the fallback must keep the
+    name usable rather than emitting a bare " (1)"."""
+    result = _conflict_free_basename(".env", {".env"}, True)
+    assert result == ".env (1)"
+
+
+def test_collision_returns_none_when_renaming_is_disabled():
+    """None is the caller's signal to skip the document, not to overwrite."""
+    assert _conflict_free_basename("r.pdf", {"r.pdf"}, False) is None
+
+
+def test_no_collision_still_succeeds_when_renaming_is_disabled():
+    """``rename_on_conflict=False`` only affects actual collisions."""
+    assert _conflict_free_basename("r.pdf", {"other.pdf"}, False) == "r.pdf"
+
+
+# ---------------------------------------------------------------------------
+# 4. MoveDocRequest validation
+# ---------------------------------------------------------------------------
+
+
+def test_valid_request_defaults_to_root_and_renaming():
+    """Defaults matter: an omitted target means "move to root", and renaming
+    is on so a batch move cannot silently drop documents."""
+    req = MoveDocRequest(doc_ids=["doc-1"])
+    assert req.doc_ids == ["doc-1"]
+    assert req.target_folder == ""
+    assert req.rename_on_conflict is True
+
+
+def test_doc_ids_are_stripped():
+    assert MoveDocRequest(doc_ids=["  doc-1  "]).doc_ids == ["doc-1"]
+
+
+def test_empty_doc_ids_list_is_rejected():
+    with pytest.raises(ValidationError):
+        MoveDocRequest(doc_ids=[])
+
+
+@pytest.mark.parametrize("bad", ["", "   "])
+def test_blank_doc_id_is_rejected(bad):
+    with pytest.raises(ValidationError):
+        MoveDocRequest(doc_ids=["doc-1", bad])
+
+
+def test_duplicate_doc_ids_are_rejected():
+    """A duplicate would be moved twice and collide with its own new name."""
+    with pytest.raises(ValidationError):
+        MoveDocRequest(doc_ids=["doc-1", "doc-1"])
+
+
+def test_duplicates_are_detected_after_stripping():
+    """Whitespace must not be a way to smuggle the same id in twice."""
+    with pytest.raises(ValidationError):
+        MoveDocRequest(doc_ids=["doc-1", "  doc-1  "])
+
+
+def test_target_folder_and_flag_are_preserved():
+    req = MoveDocRequest(
+        doc_ids=["doc-1"], target_folder="A/B", rename_on_conflict=False
+    )
+    assert req.target_folder == "A/B"
+    assert req.rename_on_conflict is False


### PR DESCRIPTION
## Description

The WebUI lets users organise documents into folders, but there is currently no way to move an already-indexed document into a different folder. A document's folder membership is derived from its stored `file_path` (the WebUI encodes `A/B` as the `A__B__` prefix), and no API surface allows that field to be rewritten.

The only workaround today is delete + re-upload. That is unnecessarily expensive and lossy: it re-chunks, re-embeds and re-extracts the document, burning LLM/embedding budget for what is purely a metadata change, and it assigns a **new `doc_id`**, which breaks every existing reference to the document in the knowledge graph.

This PR adds a `POST /documents/move` endpoint that relocates documents by rewriting only their `file_path`. Document ids, chunks, vectors and graph data are left untouched, so **no re-indexing is required** and the knowledge graph stays intact.

## Related Issues

None — happy to open a tracking issue if maintainers prefer.

## Changes Made

All changes are confined to `lightrag/api/routers/document_routes.py`.

**New endpoint**

- `POST /documents/move` — accepts a list of `doc_ids`, a `target_folder` and a `rename_on_conflict` flag.

**New models**

- `MoveDocRequest` — validates that `doc_ids` is non-empty, contains no blank entries and has no duplicates (mirrors `DeleteDocRequest`).
- `MoveDocByIdResponse` — returns `status` (`"move_started"` / `"busy"`), `message` and `doc_ids`.

**New background task**

- `background_move_documents()` — iterates the requested documents and, for each one, rewrites the stored path via `rag.update_doc_status_fields(doc_id, {"file_path": new_file_path})`. This is the existing helper that keeps every secondary index (including the source multimap) consistent while leaving chunks/vectors/graph alone. The physical file in `INPUT_DIR` and the `__parsed__` directory is renamed on a best-effort basis.

**New helpers**

- `_encode_folder_prefix()` — encodes a `/`-separated folder path into the `__`-separated `file_path` prefix, mirroring the WebUI's `encodeFolderPrefix`.
- `_doc_basename()` — strips the folder prefix from a stored `file_path`.
- `_conflict_free_basename()` — resolves name collisions in the target folder.
- `_rename_physical_file()` — best-effort on-disk rename.

**Tests**

- `tests/api/routes/test_document_routes_move.py` — 37 offline tests covering the three pure helpers and `MoveDocRequest` validation: root/whitespace/duplicate-slash folder normalisation, prefix stripping at any nesting depth, suffix insertion before the extension (including multi-dot names like `archive.tar.gz` and extensionless names), the `rename_on_conflict=False` skip path, and rejection of empty/blank/duplicate document ids.

**Design notes**

- *Concurrency*: the endpoint reuses the exact same destructive-lock pattern as delete (`_acquire_destructive_busy` / `start_reserved_background_task` / `_release_destructive_busy`), returning `status="busy"` when another writer holds the pipeline. No new locking primitives were introduced.
- *Folder-encoding agnostic*: the backend treats `target_folder` as a plain `/`-separated path. The `__` encoding detail stays a WebUI concern, so this does not lock the server into the current scheme.
- *Conflict handling*: when a basename already exists in the target folder, `rename_on_conflict=True` (default) appends ` (1)`, ` (2)`, … before the extension; `False` skips the conflicting document. Skipped and failed documents are reported through `pipeline_status` alongside successes, so a partial move is observable rather than silent.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

**Verification performed**

- `ruff format --check` and `ruff check --ignore=E402` (using the `v0.15.17` version pinned in `.pre-commit-config.yaml`, with the repo's `pyproject.toml` config) both pass on the modified file. The `trailing-whitespace` and `end-of-file-fixer` hook conditions were verified manually — `pre-commit` itself is not installed in my environment.
- `python -m pytest tests/api` → **492 passed, 134 skipped, 1 failed**. The single failure is `test_gunicorn_worker_does_not_inject_root_path`, caused by a missing optional `uvicorn_worker` module locally. I confirmed it fails identically on a clean `origin/main` checkout, so it is unrelated to this change.

Writing the tests paid for itself: the dotfile case caught a real bug where `.env` was renamed to `.env (1).env` (an empty `rpartition` stem made the fallback duplicate the extension). That is fixed and covered.

**Open questions for reviewers**

1. **Endpoint-level tests** — the added tests cover the pure helpers and request validation. I did not add an end-to-end test of the endpoint itself because it needs a running `LightRAG` instance plus storage fixtures, and I wasn't sure which existing harness in `tests/api/` you'd prefer I extend. Happy to add one if you point me at the preferred pattern.
2. **Docs** — let me know if the API documentation should be updated as part of this PR.
3. **Destructive lock** — I reused the delete lock for safety and consistency. A move is arguably less destructive than a delete, so if a lighter-weight guard is more appropriate here, I'm glad to adjust.

The corresponding WebUI change (move dialog, API client, i18n keys) lives in a separate frontend codebase and is not included here; this PR is backend-only and the endpoint is fully usable on its own.
