### PR TITLE
fix(utils): return 0.0 from cosine_similarity on non-finite vectors

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -3313,8 +3313,8 @@ def cosine_similarity(v1, v2):
     norm1 = np.linalg.norm(v1)
     norm2 = np.linalg.norm(v2)
     denom = norm1 * norm2
-    # Zero vectors are orthogonal to everything in ranking use; avoid NaN.
-    if denom == 0:
+    # Zero or non-finite vectors are orthogonal to everything in ranking use; avoid NaN/Inf.
+    if denom == 0 or not np.isfinite(denom) or not np.isfinite(dot_product):
         return 0.0
     return float(dot_product / denom)
 

--- a/tests/test_cosine_similarity_nonfinite.py
+++ b/tests/test_cosine_similarity_nonfinite.py
@@ -1,0 +1,20 @@
+"""Regression tests for non-finite vector handling in :func:`lightrag.utils.cosine_similarity`."""
+
+import numpy as np
+import pytest
+
+from lightrag.utils import cosine_similarity
+
+pytestmark = pytest.mark.offline
+
+
+def test_cosine_similarity_nan_vectors_return_zero():
+    v1 = np.array([np.nan, 1.0])
+    v2 = np.array([1.0, 1.0])
+    assert cosine_similarity(v1, v2) == 0.0
+
+
+def test_cosine_similarity_inf_vectors_return_zero():
+    v1 = np.array([np.inf, 1.0])
+    v2 = np.array([1.0, 1.0])
+    assert cosine_similarity(v1, v2) == 0.0


### PR DESCRIPTION
`cosine_similarity` returned NaN for NaN/Inf embedding components and emitted a divide warning, which can poison ranking.

Repro: `cosine_similarity([nan, 1], [1, 1])` was NaN on main. Treat non-finite dot products or denominators like the zero-denominator case and return `0.0`.
