### PR TITLE
fix(utils): strip whitespace before bool env conversion

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -285,7 +285,7 @@ def get_env_value(
         return None
 
     if value_type is bool:
-        return value.lower() in ("true", "1", "yes", "t", "on")
+        return value.strip().lower() in ("true", "1", "yes", "t", "on")
 
     # Handle list type with JSON parsing
     if value_type is list:

--- a/tests/test_get_env_value_padded_bool.py
+++ b/tests/test_get_env_value_padded_bool.py
@@ -1,0 +1,14 @@
+"""Regression tests for whitespace-padded boolean env values in :func:`lightrag.utils.get_env_value`."""
+
+import pytest
+
+from lightrag.utils import get_env_value
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.mark.parametrize("raw", [" true ", "  false\n", "\tyes\t", " 1 ", " ON "])
+def test_get_env_value_padded_bool(raw, monkeypatch):
+    monkeypatch.setenv("LIGHTRAG_TEST_BOOL_ENV", raw)
+    expected = raw.strip().lower() in ("true", "1", "yes", "t", "on")
+    assert get_env_value("LIGHTRAG_TEST_BOOL_ENV", not expected, bool) is expected


### PR DESCRIPTION
`get_env_value(..., bool)` compared the raw string to truthy tokens. Values like `' true '` from padded env files became `False`.

Strip whitespace before the boolean membership check.
