### PR TITLE
fix(kg): return copies from JsonDocStatusStorage reads

### DIFF
--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -411,17 +411,7 @@ class JsonDocStatusStorage(DocStatusStorage):
                     continue
 
                 try:
-                    # Prepare document data
-                    data = doc_data.copy()
-                    data.pop("content", None)
-                    if not data.get("file_path"):
-                        data["file_path"] = "no-file-path"
-                    if "metadata" not in data:
-                        data["metadata"] = {}
-                    if "error_msg" not in data:
-                        data["error_msg"] = None
-
-                    doc_status = DocProcessingStatus(**data)
+                    doc_status = self._doc_processing_status_from_row(doc_data)
 
                     # Add sort key for sorting
                     if sort_field == "id":
@@ -562,7 +552,7 @@ class JsonDocStatusStorage(DocStatusStorage):
                 if doc_data.get("file_path") == basename and not self._is_duplicate_row(
                     doc_data
                 ):
-                    return doc_id, doc_data
+                    return doc_id, copy.deepcopy(doc_data)
         return None
 
     async def resolve_doc_source_strict(
@@ -729,11 +719,18 @@ class JsonDocStatusStorage(DocStatusStorage):
         """Normalise a raw doc_status row into a FULL DocProcessingStatus.
 
         Single source of the raw → status construction shared by
-        ``get_docs_by_statuses`` and the ``get_full_docs_by_ids`` hydration
-        path. Raises ``KeyError``/``TypeError`` on a malformed row; the caller
-        decides strict (raise) vs relaxed (skip).
+        ``get_docs_by_statuses``, ``get_docs_paginated`` and the
+        ``get_full_docs_by_ids`` hydration path. Raises ``KeyError``/
+        ``TypeError`` on a malformed row; the caller decides strict (raise)
+        vs relaxed (skip).
+
+        Deep-copies ``row`` before use: the returned ``DocProcessingStatus``
+        carries nested mutable fields (``metadata``, ``chunks_list``) that
+        must not alias the live storage row, or a caller mutating them would
+        corrupt persisted state without going through ``upsert`` — the same
+        class of bug fixed for the other read paths.
         """
-        data = dict(row)
+        data = copy.deepcopy(row)
         data.pop("content", None)  # deprecated inline content, never a status field
         if not data.get("file_path"):
             data["file_path"] = "no-file-path"

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -112,6 +112,20 @@ class JsonDocStatusStorage(DocStatusStorage):
     # source-conflict listing/repair APIs — never materialize the whole set.
     _CONFLICT_SAMPLE_CAP: ClassVar[int] = 32
 
+    # DocProcessingStatus fields with no dataclass default — a row missing
+    # any of these fails ``DocProcessingStatus(**data)`` with KeyError.
+    # ``file_path`` is deliberately excluded: ``_doc_processing_status_from_row``
+    # fills it with "no-file-path" when absent/falsy, so its absence never
+    # raises. Used by ``get_docs_paginated`` to reject unhydratable rows
+    # during its lightweight (pre-hydration) scan.
+    _REQUIRED_STATUS_FIELDS: ClassVar[tuple[str, ...]] = (
+        "content_summary",
+        "content_length",
+        "status",
+        "created_at",
+        "updated_at",
+    )
+
     def __post_init__(self):
         # Reject path traversal before using workspace in a file path
         validate_workspace(self.workspace)
@@ -398,56 +412,84 @@ class JsonDocStatusStorage(DocStatusStorage):
         if sort_direction.lower() not in ["asc", "desc"]:
             sort_direction = "desc"
 
-        # For JSON storage, we load all data and sort/filter in memory
-        all_docs = []
-
+        # Phase 1: lightweight projection under the lock — only the sort key
+        # and doc_id, never a copy of the full row. Deep-copying every
+        # matching document (including a potentially large chunks_list) just
+        # to discard all but one page of them made pagination cost scale
+        # with total matching documents instead of page_size, and held
+        # _storage_lock — which upsert/delete also need — for the whole
+        # scan, able to stall concurrent ingestion for a large corpus.
+        # A row missing a field DocProcessingStatus requires with no default
+        # (_REQUIRED_STATUS_FIELDS) would fail hydration in phase 3 anyway;
+        # excluding it here keeps total_count consistent with what phase 3
+        # can actually return, matching the previous single-pass behavior.
+        projections: list[tuple[Any, str]] = []
         async with self._storage_lock:
             for doc_id, doc_data in self._data.items():
-                # Apply status filter
                 if (
                     status_filter_values is not None
                     and doc_data.get("status") not in status_filter_values
                 ):
                     continue
+                if any(f not in doc_data for f in self._REQUIRED_STATUS_FIELDS):
+                    logger.error(
+                        f"[{self.workspace}] Error processing document {doc_id}: "
+                        "missing required status field"
+                    )
+                    continue
 
+                if sort_field == "id":
+                    sort_key = doc_id
+                elif sort_field == "file_path":
+                    # Use pinyin sorting for file_path field to support Chinese
+                    # characters; "no-file-path" mirrors the fallback applied
+                    # during hydration (_doc_processing_status_from_row) so
+                    # sort order matches what phase 3 would have produced.
+                    sort_key = get_pinyin_sort_key(
+                        doc_data.get("file_path") or "no-file-path"
+                    )
+                else:
+                    sort_key = doc_data.get(sort_field, "")
+                projections.append((sort_key, doc_id))
+
+        total_count = len(projections)
+
+        # Phase 2: sort the lightweight projection. No lock held — pure CPU
+        # work with no await point, so nothing can mutate self._data
+        # concurrently while this runs.
+        reverse_sort = sort_direction.lower() == "desc"
+        projections.sort(key=lambda t: t[0], reverse=reverse_sort)
+
+        start_idx = (page - 1) * page_size
+        end_idx = start_idx + page_size
+        page_doc_ids = [doc_id for _, doc_id in projections[start_idx:end_idx]]
+
+        # Phase 3: deep-copy and hydrate ONLY the requested page — bounded by
+        # page_size (<=200) regardless of how many documents matched.
+        paginated_docs: list[tuple[str, DocProcessingStatus]] = []
+        async with self._storage_lock:
+            for doc_id in page_doc_ids:
+                row = self._data.get(doc_id)
+                if row is None:
+                    continue  # deleted concurrently between phase 1 and here
                 try:
-                    doc_status = self._doc_processing_status_from_row(doc_data)
-
-                    # Add sort key for sorting
-                    if sort_field == "id":
-                        doc_status._sort_key = doc_id
-                    elif sort_field == "file_path":
-                        # Use pinyin sorting for file_path field to support Chinese characters
-                        file_path_value = getattr(doc_status, sort_field, "")
-                        doc_status._sort_key = get_pinyin_sort_key(file_path_value)
-                    else:
-                        doc_status._sort_key = getattr(doc_status, sort_field, "")
-
-                    all_docs.append((doc_id, doc_status))
-
-                except KeyError as e:
+                    # Pagination never surfaces chunks_list (DocStatusResponse
+                    # doesn't expose it — see the PG backend's paged CTE,
+                    # which excludes the column for the same reason), so drop
+                    # it before hydration instead of deep-copying a
+                    # potentially large chunk-id list only to discard it.
+                    row_without_chunks = {
+                        k: v for k, v in row.items() if k != "chunks_list"
+                    }
+                    doc_status = self._doc_processing_status_from_row(
+                        row_without_chunks
+                    )
+                except (KeyError, TypeError) as e:
                     logger.error(
                         f"[{self.workspace}] Error processing document {doc_id}: {e}"
                     )
                     continue
-
-        # Sort documents
-        reverse_sort = sort_direction.lower() == "desc"
-        all_docs.sort(
-            key=lambda x: getattr(x[1], "_sort_key", ""), reverse=reverse_sort
-        )
-
-        # Remove sort key from documents
-        for doc_id, doc in all_docs:
-            if hasattr(doc, "_sort_key"):
-                delattr(doc, "_sort_key")
-
-        total_count = len(all_docs)
-
-        # Apply pagination
-        start_idx = (page - 1) * page_size
-        end_idx = start_idx + page_size
-        paginated_docs = all_docs[start_idx:end_idx]
+                paginated_docs.append((doc_id, doc_status))
 
         return paginated_docs, total_count
 

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import copy
 import hashlib
 import heapq
 import json
@@ -176,7 +177,7 @@ class JsonDocStatusStorage(DocStatusStorage):
             for id in ids:
                 data = self._data.get(id, None)
                 if data:
-                    ordered_results.append(data.copy())
+                    ordered_results.append(copy.deepcopy(data) if isinstance(data, dict) else data)
                 else:
                     ordered_results.append(None)
         return ordered_results
@@ -240,8 +241,8 @@ class JsonDocStatusStorage(DocStatusStorage):
             for k, v in self._data.items():
                 if v.get("track_id") == track_id:
                     try:
-                        # Make a copy of the data to avoid modifying the original
-                        data = v.copy()
+                        # Make a deep copy of the data to avoid modifying the original
+                        data = copy.deepcopy(v) if isinstance(v, dict) else v
                         # Remove deprecated content field if it exists
                         data.pop("content", None)
                         # Normalize missing or null file_path
@@ -353,7 +354,7 @@ class JsonDocStatusStorage(DocStatusStorage):
     async def get_by_id(self, id: str) -> Union[dict[str, Any], None]:
         async with self._storage_lock:
             data = self._data.get(id)
-            return data.copy() if isinstance(data, dict) else data
+            return copy.deepcopy(data) if isinstance(data, dict) else data
 
     async def get_docs_paginated(
         self,
@@ -514,7 +515,7 @@ class JsonDocStatusStorage(DocStatusStorage):
             for doc_id, doc_data in self._data.items():
                 if doc_data.get("file_path") == file_path:
                     # Return complete document data, consistent with get_by_ids method
-                    return doc_data.copy() if isinstance(doc_data, dict) else doc_data
+                    return copy.deepcopy(doc_data) if isinstance(doc_data, dict) else doc_data
 
         return None
 
@@ -606,7 +607,7 @@ class JsonDocStatusStorage(DocStatusStorage):
             raise StorageNotInitializedError("JsonDocStatusStorage")
         async with self._storage_lock:
             row = self._data.get(id)
-        return row.copy() if isinstance(row, dict) else row
+        return copy.deepcopy(row) if isinstance(row, dict) else row
 
     async def get_doc_by_content_hash(
         self, content_hash: str, *, exclude_doc_id: str | None = None
@@ -647,7 +648,7 @@ class JsonDocStatusStorage(DocStatusStorage):
                     best = (sort_key, doc_id, doc_data)
         if best is None:
             return None
-        return best[1], best[2]
+        return best[1], copy.deepcopy(best[2]) if isinstance(best[2], dict) else best[2]
 
     # ------------------------------------------------------------------
     # Memory-bounding scheduling API (Phase 1)

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -352,7 +352,8 @@ class JsonDocStatusStorage(DocStatusStorage):
 
     async def get_by_id(self, id: str) -> Union[dict[str, Any], None]:
         async with self._storage_lock:
-            return self._data.get(id)
+            data = self._data.get(id)
+            return data.copy() if isinstance(data, dict) else data
 
     async def get_docs_paginated(
         self,
@@ -513,7 +514,7 @@ class JsonDocStatusStorage(DocStatusStorage):
             for doc_id, doc_data in self._data.items():
                 if doc_data.get("file_path") == file_path:
                     # Return complete document data, consistent with get_by_ids method
-                    return doc_data
+                    return doc_data.copy() if isinstance(doc_data, dict) else doc_data
 
         return None
 

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -177,7 +177,9 @@ class JsonDocStatusStorage(DocStatusStorage):
             for id in ids:
                 data = self._data.get(id, None)
                 if data:
-                    ordered_results.append(copy.deepcopy(data) if isinstance(data, dict) else data)
+                    ordered_results.append(
+                        copy.deepcopy(data) if isinstance(data, dict) else data
+                    )
                 else:
                     ordered_results.append(None)
         return ordered_results
@@ -515,7 +517,11 @@ class JsonDocStatusStorage(DocStatusStorage):
             for doc_id, doc_data in self._data.items():
                 if doc_data.get("file_path") == file_path:
                     # Return complete document data, consistent with get_by_ids method
-                    return copy.deepcopy(doc_data) if isinstance(doc_data, dict) else doc_data
+                    return (
+                        copy.deepcopy(doc_data)
+                        if isinstance(doc_data, dict)
+                        else doc_data
+                    )
 
         return None
 

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -112,20 +112,6 @@ class JsonDocStatusStorage(DocStatusStorage):
     # source-conflict listing/repair APIs — never materialize the whole set.
     _CONFLICT_SAMPLE_CAP: ClassVar[int] = 32
 
-    # DocProcessingStatus fields with no dataclass default — a row missing
-    # any of these fails ``DocProcessingStatus(**data)`` with KeyError.
-    # ``file_path`` is deliberately excluded: ``_doc_processing_status_from_row``
-    # fills it with "no-file-path" when absent/falsy, so its absence never
-    # raises. Used by ``get_docs_paginated`` to reject unhydratable rows
-    # during its lightweight (pre-hydration) scan.
-    _REQUIRED_STATUS_FIELDS: ClassVar[tuple[str, ...]] = (
-        "content_summary",
-        "content_length",
-        "status",
-        "created_at",
-        "updated_at",
-    )
-
     def __post_init__(self):
         # Reject path traversal before using workspace in a file path
         validate_workspace(self.workspace)
@@ -412,30 +398,37 @@ class JsonDocStatusStorage(DocStatusStorage):
         if sort_direction.lower() not in ["asc", "desc"]:
             sort_direction = "desc"
 
-        # Phase 1: lightweight projection under the lock — only the sort key
-        # and doc_id, never a copy of the full row. Deep-copying every
-        # matching document (including a potentially large chunks_list) just
-        # to discard all but one page of them made pagination cost scale
-        # with total matching documents instead of page_size, and held
-        # _storage_lock — which upsert/delete also need — for the whole
-        # scan, able to stall concurrent ingestion for a large corpus.
-        # A row missing a field DocProcessingStatus requires with no default
-        # (_REQUIRED_STATUS_FIELDS) would fail hydration in phase 3 anyway;
-        # excluding it here keeps total_count consistent with what phase 3
-        # can actually return, matching the previous single-pass behavior.
-        projections: list[tuple[Any, str]] = []
+        # Everything below — filtering, hydratability validation, sorting,
+        # page selection, and the final page's deep-copy hydration — runs
+        # inside ONE uninterrupted lock hold. Nothing in this block awaits,
+        # so no concurrent upsert/delete can land between the scan and the
+        # final hydration; splitting these into separate lock acquisitions
+        # let a status update/delete land in that gap, producing a response
+        # that mixed two snapshots (e.g. a status=pending filter returning an
+        # already-updated "processed" row, or overcounting a row that a
+        # concurrent delete then removed before it could be hydrated).
+        #
+        # The scan and validation below are still cheap per document — no
+        # nested-structure copying, just a throwaway shallow
+        # DocProcessingStatus construction (see ``_row_is_hydratable``) — so
+        # holding the lock across them does not reintroduce the "deep-copy
+        # the whole corpus" cost. Only the final page (bounded by page_size,
+        # <=200) is ever deep-copied.
         async with self._storage_lock:
+            projections: list[tuple[Any, str]] = []
             for doc_id, doc_data in self._data.items():
                 if (
                     status_filter_values is not None
                     and doc_data.get("status") not in status_filter_values
                 ):
                     continue
-                if any(f not in doc_data for f in self._REQUIRED_STATUS_FIELDS):
-                    logger.error(
-                        f"[{self.workspace}] Error processing document {doc_id}: "
-                        "missing required status field"
-                    )
+                # Validate via a real (throwaway) construction attempt rather
+                # than checking a fixed set of required-field names: a row
+                # with an extra/unexpected field fails construction too, and
+                # must be excluded from total_count for the same reason a
+                # missing field is — otherwise total_count could count rows
+                # the page-hydration step below can never actually return.
+                if not self._row_is_hydratable(doc_id, doc_data):
                     continue
 
                 if sort_field == "id":
@@ -444,7 +437,7 @@ class JsonDocStatusStorage(DocStatusStorage):
                     # Use pinyin sorting for file_path field to support Chinese
                     # characters; "no-file-path" mirrors the fallback applied
                     # during hydration (_doc_processing_status_from_row) so
-                    # sort order matches what phase 3 would have produced.
+                    # sort order matches what the hydrated page would use.
                     sort_key = get_pinyin_sort_key(
                         doc_data.get("file_path") or "no-file-path"
                     )
@@ -452,43 +445,30 @@ class JsonDocStatusStorage(DocStatusStorage):
                     sort_key = doc_data.get(sort_field, "")
                 projections.append((sort_key, doc_id))
 
-        total_count = len(projections)
+            total_count = len(projections)
 
-        # Phase 2: sort the lightweight projection. No lock held — pure CPU
-        # work with no await point, so nothing can mutate self._data
-        # concurrently while this runs.
-        reverse_sort = sort_direction.lower() == "desc"
-        projections.sort(key=lambda t: t[0], reverse=reverse_sort)
+            reverse_sort = sort_direction.lower() == "desc"
+            projections.sort(key=lambda t: t[0], reverse=reverse_sort)
 
-        start_idx = (page - 1) * page_size
-        end_idx = start_idx + page_size
-        page_doc_ids = [doc_id for _, doc_id in projections[start_idx:end_idx]]
+            start_idx = (page - 1) * page_size
+            end_idx = start_idx + page_size
+            page_doc_ids = [doc_id for _, doc_id in projections[start_idx:end_idx]]
 
-        # Phase 3: deep-copy and hydrate ONLY the requested page — bounded by
-        # page_size (<=200) regardless of how many documents matched.
-        paginated_docs: list[tuple[str, DocProcessingStatus]] = []
-        async with self._storage_lock:
+            # Deep-copy and hydrate ONLY the requested page. Each doc_id here
+            # was validated as hydratable above in this same uninterrupted
+            # critical section, so the row is guaranteed present and usable.
+            paginated_docs: list[tuple[str, DocProcessingStatus]] = []
             for doc_id in page_doc_ids:
-                row = self._data.get(doc_id)
-                if row is None:
-                    continue  # deleted concurrently between phase 1 and here
-                try:
-                    # Pagination never surfaces chunks_list (DocStatusResponse
-                    # doesn't expose it — see the PG backend's paged CTE,
-                    # which excludes the column for the same reason), so drop
-                    # it before hydration instead of deep-copying a
-                    # potentially large chunk-id list only to discard it.
-                    row_without_chunks = {
-                        k: v for k, v in row.items() if k != "chunks_list"
-                    }
-                    doc_status = self._doc_processing_status_from_row(
-                        row_without_chunks
-                    )
-                except (KeyError, TypeError) as e:
-                    logger.error(
-                        f"[{self.workspace}] Error processing document {doc_id}: {e}"
-                    )
-                    continue
+                row = self._data[doc_id]
+                # Pagination never surfaces chunks_list (DocStatusResponse
+                # doesn't expose it — see the PG backend's paged CTE, which
+                # excludes the column for the same reason), so drop it before
+                # hydration instead of deep-copying a potentially large
+                # chunk-id list only to discard it.
+                row_without_chunks = {
+                    k: v for k, v in row.items() if k != "chunks_list"
+                }
+                doc_status = self._doc_processing_status_from_row(row_without_chunks)
                 paginated_docs.append((doc_id, doc_status))
 
         return paginated_docs, total_count
@@ -757,7 +737,24 @@ class JsonDocStatusStorage(DocStatusStorage):
             return None
 
     @staticmethod
-    def _doc_processing_status_from_row(row: dict[str, Any]) -> DocProcessingStatus:
+    def _normalize_status_row(data: dict[str, Any]) -> dict[str, Any]:
+        """Field normalisation shared by hydration and validation: pop the
+        deprecated ``content`` field, default missing/falsy ``file_path``,
+        default missing ``metadata``/``error_msg``. Mutates and returns
+        ``data`` in place — the caller decides whether ``data`` is a deep
+        copy (safe to expose) or a shallow/throwaway one (validation only,
+        see ``_row_is_hydratable``)."""
+        data.pop("content", None)  # deprecated inline content, never a status field
+        if not data.get("file_path"):
+            data["file_path"] = "no-file-path"
+        data.setdefault("metadata", {})
+        data.setdefault("error_msg", None)
+        return data
+
+    @classmethod
+    def _doc_processing_status_from_row(
+        cls, row: dict[str, Any]
+    ) -> DocProcessingStatus:
         """Normalise a raw doc_status row into a FULL DocProcessingStatus.
 
         Single source of the raw → status construction shared by
@@ -772,13 +769,32 @@ class JsonDocStatusStorage(DocStatusStorage):
         corrupt persisted state without going through ``upsert`` — the same
         class of bug fixed for the other read paths.
         """
-        data = copy.deepcopy(row)
-        data.pop("content", None)  # deprecated inline content, never a status field
-        if not data.get("file_path"):
-            data["file_path"] = "no-file-path"
-        data.setdefault("metadata", {})
-        data.setdefault("error_msg", None)
+        data = cls._normalize_status_row(copy.deepcopy(row))
         return DocProcessingStatus(**data)
+
+    def _row_is_hydratable(self, doc_id: str, row: dict[str, Any]) -> bool:
+        """True if ``row`` can be hydrated into a full DocProcessingStatus.
+
+        Used by ``get_docs_paginated``'s validation pass to keep
+        ``total_count`` consistent with what the page-hydration step can
+        actually return: a row missing a required field OR carrying an
+        unexpected one would fail ``DocProcessingStatus(**data)`` — counting
+        it as present without confirming that would let ``total_count``
+        overstate what pages can actually deliver.
+
+        Attempts the SAME normalisation + construction as
+        ``_doc_processing_status_from_row``, but on a shallow copy that is
+        discarded immediately (never returned to a caller), so it validates
+        constructibility without paying the deep-copy cost across every
+        matching document — only the final page (bounded by page_size) is
+        ever deep-copied.
+        """
+        try:
+            DocProcessingStatus(**self._normalize_status_row(dict(row)))
+            return True
+        except (KeyError, TypeError) as e:
+            logger.error(f"[{self.workspace}] Error processing document {doc_id}: {e}")
+            return False
 
     async def get_docs_by_statuses_page(
         self,

--- a/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
+++ b/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
@@ -196,14 +196,62 @@ async def test_get_docs_paginated_returns_copy(tmp_path):
     doc_id, doc_status = docs[0]
     assert doc_id == "doc5"
 
-    # Mutate the returned DocProcessingStatus's nested mutable fields
+    # Pagination never surfaces chunks_list (mirrors the PG backend's paged
+    # CTE, which excludes the column for the same reason: DocStatusResponse
+    # doesn't expose it) — asserted here so the field isn't silently
+    # deep-copied from storage again by a future change.
+    assert doc_status.chunks_list == []
+
+    # Mutate the returned DocProcessingStatus's nested mutable metadata field
     doc_status.metadata["kg_purge"]["phase"] = "corrupted"
-    doc_status.chunks_list.append("c3")
 
     stored = await storage.get_by_id_strict("doc5")
     assert stored is not None
     assert stored["metadata"]["kg_purge"]["phase"] == "prepared"
     assert stored["chunks_list"] == ["c1", "c2"]
+
+
+@pytest.mark.asyncio
+async def test_get_docs_paginated_excludes_malformed_rows(tmp_path):
+    """
+    get_docs_paginated's lightweight pre-hydration scan rejects rows missing
+    a required DocProcessingStatus field before sorting/pagination, matching
+    the previous behavior where such rows raised KeyError during hydration
+    and were silently dropped from both total_count and every page.
+    """
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        workspace="test",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+    )
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "doc7": {
+                "status": "pending",
+                "file_path": "good.pdf",
+                "content_summary": "summary",
+                "content_length": 100,
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+            },
+            # Missing content_summary/content_length: upsert() itself does
+            # not validate required fields, so a malformed row can reach
+            # storage (e.g. from a partial write or external tooling).
+            "doc8": {
+                "status": "pending",
+                "file_path": "malformed.pdf",
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+            },
+        }
+    )
+
+    docs, total = await storage.get_docs_paginated()
+    assert total == 1
+    assert [doc_id for doc_id, _ in docs] == ["doc7"]
 
 
 @pytest.mark.asyncio

--- a/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
+++ b/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
@@ -58,6 +58,7 @@ async def test_get_by_id_returns_copy(tmp_path):
     assert doc_after["metadata"]["key"] == "original"
     assert doc_after["chunks_list"] == []
 
+
 @pytest.mark.asyncio
 async def test_get_doc_by_file_path_returns_copy(tmp_path):
     storage = JsonDocStatusStorage(
@@ -91,6 +92,8 @@ async def test_get_doc_by_file_path_returns_copy(tmp_path):
     assert doc_after is not None
     assert doc_after["status"] == "pending"
     assert doc_after["metadata"]["key"] == "original"
+
+
 @pytest.mark.asyncio
 async def test_get_by_ids_returns_deep_copy(tmp_path):
     """

--- a/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
+++ b/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
@@ -1,4 +1,4 @@
-"""Unit tests verifying that JsonDocStatusStorage read methods return shallow copies to prevent internal state mutation."""
+"""Unit tests verifying that JsonDocStatusStorage read methods return deep copies to prevent internal state mutation of nested status fields."""
 
 import pytest
 from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
@@ -46,14 +46,17 @@ async def test_get_by_id_returns_copy(tmp_path):
     assert doc is not None
     assert doc["status"] == "pending"
 
-    # Mutate returned dictionary
+    # Mutate returned dictionary top-level and nested fields
     doc["status"] = "modified_externally"
+    doc["metadata"]["key"] = "modified_nested"
+    doc["chunks_list"] = ["chunk_1"]
 
     # Verify internal storage was not mutated
     doc_after = await storage.get_by_id_strict("doc1")
     assert doc_after is not None
     assert doc_after["status"] == "pending"
-
+    assert doc_after["metadata"]["key"] == "original"
+    assert doc_after["chunks_list"] == []
 
 @pytest.mark.asyncio
 async def test_get_doc_by_file_path_returns_copy(tmp_path):
@@ -79,10 +82,46 @@ async def test_get_doc_by_file_path_returns_copy(tmp_path):
     assert doc is not None
     assert doc["status"] == "pending"
 
-    # Mutate returned dictionary
+    # Mutate returned dictionary top-level and nested fields
     doc["status"] = "modified_externally"
+    doc["metadata"]["key"] = "modified_nested"
 
     # Verify internal storage was not mutated
     doc_after = await storage.get_by_id_strict("doc2")
     assert doc_after is not None
     assert doc_after["status"] == "pending"
+    assert doc_after["metadata"]["key"] == "original"
+@pytest.mark.asyncio
+async def test_get_by_ids_returns_deep_copy(tmp_path):
+    """
+    Locks out the bug where get_by_ids returned shallow copies, allowing external callers
+    to mutate nested metadata or chunks_list in internal storage.
+    """
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        workspace="test",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+    )
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "doc3": {
+                "status": "pending",
+                "file_path": "data.pdf",
+                "metadata": {"kg_purge": {"phase": "prepared"}},
+                "chunks_list": ["c1", "c2"],
+            }
+        }
+    )
+
+    docs = await storage.get_by_ids(["doc3"])
+    assert len(docs) == 1 and docs[0] is not None
+    docs[0]["metadata"]["kg_purge"]["phase"] = "corrupted"
+    docs[0]["chunks_list"].append("c3")
+
+    stored = await storage.get_by_id_strict("doc3")
+    assert stored is not None
+    assert stored["metadata"]["kg_purge"]["phase"] == "prepared"
+    assert stored["chunks_list"] == ["c1", "c2"]

--- a/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
+++ b/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
@@ -1,0 +1,88 @@
+"""Unit tests verifying that JsonDocStatusStorage read methods return shallow copies to prevent internal state mutation."""
+
+import pytest
+from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
+from lightrag.kg.shared_storage import initialize_share_data, finalize_share_data
+
+pytestmark = pytest.mark.offline
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
+
+
+@pytest.fixture(autouse=True)
+def setup_shared_data():
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_returns_copy(tmp_path):
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        workspace="test",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+    )
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "doc1": {
+                "status": "pending",
+                "file_path": "test.pdf",
+                "metadata": {"key": "original"},
+            }
+        }
+    )
+
+    doc = await storage.get_by_id("doc1")
+    assert doc is not None
+    assert doc["status"] == "pending"
+
+    # Mutate returned dictionary
+    doc["status"] = "modified_externally"
+
+    # Verify internal storage was not mutated
+    doc_after = await storage.get_by_id_strict("doc1")
+    assert doc_after is not None
+    assert doc_after["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_get_doc_by_file_path_returns_copy(tmp_path):
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        workspace="test",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+    )
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "doc2": {
+                "status": "pending",
+                "file_path": "report.pdf",
+                "metadata": {"key": "original"},
+            }
+        }
+    )
+
+    doc = await storage.get_doc_by_file_path("report.pdf")
+    assert doc is not None
+    assert doc["status"] == "pending"
+
+    # Mutate returned dictionary
+    doc["status"] = "modified_externally"
+
+    # Verify internal storage was not mutated
+    doc_after = await storage.get_by_id_strict("doc2")
+    assert doc_after is not None
+    assert doc_after["status"] == "pending"

--- a/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
+++ b/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
@@ -1,9 +1,15 @@
 """Unit tests verifying that JsonDocStatusStorage read methods return deep copies to prevent internal state mutation of nested status fields."""
 
+from unittest.mock import patch
+
 import pytest
 from lightrag.base import DocStatus
 from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
-from lightrag.kg.shared_storage import initialize_share_data, finalize_share_data
+from lightrag.kg.shared_storage import (
+    NamespaceLock,
+    initialize_share_data,
+    finalize_share_data,
+)
 
 pytestmark = pytest.mark.offline
 
@@ -212,12 +218,12 @@ async def test_get_docs_paginated_returns_copy(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_get_docs_paginated_excludes_malformed_rows(tmp_path):
+async def test_get_docs_paginated_excludes_rows_missing_required_fields(tmp_path):
     """
-    get_docs_paginated's lightweight pre-hydration scan rejects rows missing
-    a required DocProcessingStatus field before sorting/pagination, matching
-    the previous behavior where such rows raised KeyError during hydration
-    and were silently dropped from both total_count and every page.
+    get_docs_paginated's validation pass rejects rows missing a required
+    DocProcessingStatus field before sorting/pagination, so such rows are
+    dropped from both total_count and every page — not just logged and
+    silently miscounted.
     """
     storage = JsonDocStatusStorage(
         namespace="doc_status",
@@ -252,6 +258,103 @@ async def test_get_docs_paginated_excludes_malformed_rows(tmp_path):
     docs, total = await storage.get_docs_paginated()
     assert total == 1
     assert [doc_id for doc_id, _ in docs] == ["doc7"]
+
+
+@pytest.mark.asyncio
+async def test_get_docs_paginated_excludes_rows_with_unexpected_fields(tmp_path):
+    """
+    A row can carry every required field and STILL fail to hydrate — e.g. an
+    unexpected top-level key makes ``DocProcessingStatus(**data)`` raise
+    TypeError even though nothing is missing. Regression test for a bug
+    where the validation pass only checked a fixed set of required-field
+    names present, so such a row was counted in total_count but then
+    silently dropped when the page-hydration step actually tried to
+    construct it — total_count and the returned page disagreed.
+    """
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        workspace="test",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+    )
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "doc9": {
+                "status": "pending",
+                "file_path": "good.pdf",
+                "content_summary": "summary",
+                "content_length": 100,
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+            },
+            "doc10": {
+                "status": "pending",
+                "file_path": "unexpected_field.pdf",
+                "content_summary": "summary",
+                "content_length": 100,
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+                "unexpected_field": "x",
+            },
+        }
+    )
+
+    docs, total = await storage.get_docs_paginated()
+    assert total == 1
+    assert [doc_id for doc_id, _ in docs] == ["doc9"]
+
+
+@pytest.mark.asyncio
+async def test_get_docs_paginated_uses_a_single_lock_acquisition(tmp_path):
+    """
+    Regression test for a snapshot-consistency bug: get_docs_paginated used
+    to scan+filter+sort under one lock acquisition, release the lock, then
+    re-acquire a second time to hydrate just the requested page. A
+    concurrent status update or delete landing in the gap between those two
+    acquisitions could mix two snapshots into a single response — e.g. a
+    status=pending filter returning an already-updated "processed" document,
+    or overcounting a row a concurrent delete then removed.
+
+    Filtering, hydratability validation, sorting, page selection and the
+    final page's hydration must all happen inside ONE uninterrupted critical
+    section, so nothing else can run in between. Pinned here by counting
+    NamespaceLock acquisitions during a single call.
+    """
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        workspace="test",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+    )
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "doc11": {
+                "status": "pending",
+                "file_path": "single_lock.pdf",
+                "content_summary": "summary",
+                "content_length": 100,
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        }
+    )
+
+    real_aenter = NamespaceLock.__aenter__
+    acquisitions = []
+
+    async def counting_aenter(self):
+        acquisitions.append(1)
+        return await real_aenter(self)
+
+    with patch.object(NamespaceLock, "__aenter__", counting_aenter):
+        docs, total = await storage.get_docs_paginated()
+
+    assert total == 1
+    assert len(acquisitions) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
+++ b/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
@@ -1,6 +1,7 @@
 """Unit tests verifying that JsonDocStatusStorage read methods return deep copies to prevent internal state mutation of nested status fields."""
 
 import pytest
+from lightrag.base import DocStatus
 from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
 from lightrag.kg.shared_storage import initialize_share_data, finalize_share_data
 
@@ -125,6 +126,118 @@ async def test_get_by_ids_returns_deep_copy(tmp_path):
     docs[0]["chunks_list"].append("c3")
 
     stored = await storage.get_by_id_strict("doc3")
+    assert stored is not None
+    assert stored["metadata"]["kg_purge"]["phase"] == "prepared"
+    assert stored["chunks_list"] == ["c1", "c2"]
+
+
+@pytest.mark.asyncio
+async def test_get_doc_by_file_basename_returns_copy(tmp_path):
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        workspace="test",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+    )
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "doc4": {
+                "status": "pending",
+                "file_path": "basename.pdf",
+                "metadata": {"key": "original"},
+            }
+        }
+    )
+
+    result = await storage.get_doc_by_file_basename("basename.pdf")
+    assert result is not None
+    doc_id, doc = result
+    assert doc_id == "doc4"
+
+    # Mutate returned dictionary top-level and nested fields
+    doc["status"] = "modified_externally"
+    doc["metadata"]["key"] = "modified_nested"
+
+    stored = await storage.get_by_id_strict("doc4")
+    assert stored is not None
+    assert stored["status"] == "pending"
+    assert stored["metadata"]["key"] == "original"
+
+
+@pytest.mark.asyncio
+async def test_get_docs_paginated_returns_copy(tmp_path):
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        workspace="test",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+    )
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "doc5": {
+                "status": "pending",
+                "file_path": "paginated.pdf",
+                "content_summary": "summary",
+                "content_length": 100,
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+                "metadata": {"kg_purge": {"phase": "prepared"}},
+                "chunks_list": ["c1", "c2"],
+            }
+        }
+    )
+
+    docs, total = await storage.get_docs_paginated()
+    assert total == 1
+    doc_id, doc_status = docs[0]
+    assert doc_id == "doc5"
+
+    # Mutate the returned DocProcessingStatus's nested mutable fields
+    doc_status.metadata["kg_purge"]["phase"] = "corrupted"
+    doc_status.chunks_list.append("c3")
+
+    stored = await storage.get_by_id_strict("doc5")
+    assert stored is not None
+    assert stored["metadata"]["kg_purge"]["phase"] == "prepared"
+    assert stored["chunks_list"] == ["c1", "c2"]
+
+
+@pytest.mark.asyncio
+async def test_get_docs_by_statuses_returns_copy(tmp_path):
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        workspace="test",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+    )
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "doc6": {
+                "status": "pending",
+                "file_path": "bystatus.pdf",
+                "content_summary": "summary",
+                "content_length": 100,
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+                "metadata": {"kg_purge": {"phase": "prepared"}},
+                "chunks_list": ["c1", "c2"],
+            }
+        }
+    )
+
+    result = await storage.get_docs_by_statuses([DocStatus.PENDING])
+    doc_status = result["doc6"]
+
+    doc_status.metadata["kg_purge"]["phase"] = "corrupted"
+    doc_status.chunks_list.append("c3")
+
+    stored = await storage.get_by_id_strict("doc6")
     assert stored is not None
     assert stored["metadata"]["kg_purge"]["phase"] == "prepared"
     assert stored["chunks_list"] == ["c1", "c2"]


### PR DESCRIPTION
## Summary

`JsonDocStatusStorage.get_by_id` / `get_doc_by_file_path` return live references into the in-memory store. Callers that mutate the returned dict corrupt persisted document status.

## Problem

```python
doc = await storage.get_by_id("doc1")
doc["status"] = "modified_externally"  # mutates internal _data
```

Any pipeline or API code that annotates a returned status dict then writes those changes into the live store without going through `upsert`.

## Fix

Return a shallow `dict.copy()` from both read paths so external mutation cannot touch storage state.

## Test plan

- [x] `pytest tests/kg/json_impl/test_json_doc_status_copy_on_read.py`
