### PR TITLE
fix(kg): set is_truncated when get_knowledge_graph hits max_nodes

### DIFF
--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -593,13 +593,19 @@ class NetworkXStorage(BaseGraphStorage):
 
                     # Check if we've reached max_nodes
                     if len(bfs_nodes) >= max_nodes:
-                        if idx < len(current_level_nodes) - 1:
+                        if any(
+                            n not in visited
+                            for n, _, _ in current_level_nodes[idx + 1 :]
+                        ):
                             has_unprocessed_level_nodes = True
                         break
 
             # Check if graph is truncated - either due to max_nodes limit or depth limit
+            has_unvisited_in_queue = any(n not in visited for n, _, _ in queue)
             has_max_nodes_truncation = len(bfs_nodes) >= max_nodes and (
-                bool(queue) or has_unprocessed_level_nodes or has_unexplored_neighbors
+                has_unvisited_in_queue
+                or has_unprocessed_level_nodes
+                or has_unexplored_neighbors
             )
             if has_max_nodes_truncation or has_unexplored_neighbors:
                 if has_max_nodes_truncation:

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -547,6 +547,7 @@ class NetworkXStorage(BaseGraphStorage):
 
             # Flag to track if there are unexplored neighbors due to depth limit
             has_unexplored_neighbors = False
+            has_unprocessed_level_nodes = False
 
             # Modified breadth-first search with degree-based prioritization
             while queue and len(bfs_nodes) < max_nodes:
@@ -562,7 +563,7 @@ class NetworkXStorage(BaseGraphStorage):
                 current_level_nodes.sort(key=lambda x: x[2], reverse=True)
 
                 # Process all nodes at current depth in order of degree
-                for current_node, depth, degree in current_level_nodes:
+                for idx, (current_node, depth, degree) in enumerate(current_level_nodes):
                     if current_node not in visited:
                         visited.add(current_node)
                         bfs_nodes.append(current_node)
@@ -590,11 +591,16 @@ class NetworkXStorage(BaseGraphStorage):
 
                     # Check if we've reached max_nodes
                     if len(bfs_nodes) >= max_nodes:
+                        if idx < len(current_level_nodes) - 1:
+                            has_unprocessed_level_nodes = True
                         break
 
             # Check if graph is truncated - either due to max_nodes limit or depth limit
-            if (queue and len(bfs_nodes) >= max_nodes) or has_unexplored_neighbors:
-                if len(bfs_nodes) >= max_nodes:
+            has_max_nodes_truncation = len(bfs_nodes) >= max_nodes and (
+                bool(queue) or has_unprocessed_level_nodes or has_unexplored_neighbors
+            )
+            if has_max_nodes_truncation or has_unexplored_neighbors:
+                if has_max_nodes_truncation:
                     result.is_truncated = True
                     logger.info(
                         f"[{self.workspace}] Graph truncated: max_nodes limit {max_nodes} reached"
@@ -603,7 +609,6 @@ class NetworkXStorage(BaseGraphStorage):
                     logger.info(
                         f"[{self.workspace}] Graph truncated: found {len(bfs_nodes)} nodes within max_depth {max_depth}"
                     )
-
             # Create subgraph with BFS discovered nodes
             subgraph = graph.subgraph(bfs_nodes)
 

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -563,7 +563,9 @@ class NetworkXStorage(BaseGraphStorage):
                 current_level_nodes.sort(key=lambda x: x[2], reverse=True)
 
                 # Process all nodes at current depth in order of degree
-                for idx, (current_node, depth, degree) in enumerate(current_level_nodes):
+                for idx, (current_node, depth, degree) in enumerate(
+                    current_level_nodes
+                ):
                     if current_node not in visited:
                         visited.add(current_node)
                         bfs_nodes.append(current_node)

--- a/tests/kg/networkx_impl/test_networkx_get_kg_truncation.py
+++ b/tests/kg/networkx_impl/test_networkx_get_kg_truncation.py
@@ -23,8 +23,12 @@ async def test_get_knowledge_graph_is_truncated_when_max_nodes_reached(tmp_path)
     result = await storage.get_knowledge_graph("A", max_depth=2, max_nodes=3)
     assert len(result.nodes) == 3
     assert result.is_truncated is True
+
+
 @pytest.mark.asyncio
-async def test_get_knowledge_graph_is_not_truncated_when_all_nodes_returned_with_duplicates(tmp_path):
+async def test_get_knowledge_graph_is_not_truncated_when_all_nodes_returned_with_duplicates(
+    tmp_path,
+):
     """
     Locks out the bug where duplicate queue entries from multi-parent traversal
     (e.g., diamond graph) caused is_truncated to falsely report True even though

--- a/tests/kg/networkx_impl/test_networkx_get_kg_truncation.py
+++ b/tests/kg/networkx_impl/test_networkx_get_kg_truncation.py
@@ -23,3 +23,31 @@ async def test_get_knowledge_graph_is_truncated_when_max_nodes_reached(tmp_path)
     result = await storage.get_knowledge_graph("A", max_depth=2, max_nodes=3)
     assert len(result.nodes) == 3
     assert result.is_truncated is True
+@pytest.mark.asyncio
+async def test_get_knowledge_graph_is_not_truncated_when_all_nodes_returned_with_duplicates(tmp_path):
+    """
+    Locks out the bug where duplicate queue entries from multi-parent traversal
+    (e.g., diamond graph) caused is_truncated to falsely report True even though
+    all reachable nodes were included in the returned graph.
+    """
+    initialize_share_data()
+    storage = NetworkXStorage(
+        namespace="test_graph_diamond",
+        workspace="ws",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=None,
+    )
+    await storage.initialize()
+
+    g = nx.Graph()
+    # Diamond graph: A -> B, A -> C, B -> D, C -> D
+    g.add_edge("A", "B")
+    g.add_edge("A", "C")
+    g.add_edge("B", "D")
+    g.add_edge("C", "D")
+    storage._graph = g
+
+    # All 4 nodes (A, B, C, D) are returned, so graph must not be reported as truncated.
+    result = await storage.get_knowledge_graph("A", max_depth=2, max_nodes=4)
+    assert len(result.nodes) == 4
+    assert result.is_truncated is False

--- a/tests/kg/networkx_impl/test_networkx_get_kg_truncation.py
+++ b/tests/kg/networkx_impl/test_networkx_get_kg_truncation.py
@@ -1,0 +1,25 @@
+import pytest
+import networkx as nx
+from lightrag.kg.shared_storage import initialize_share_data
+from lightrag.kg.networkx_impl import NetworkXStorage
+
+
+@pytest.mark.asyncio
+async def test_get_knowledge_graph_is_truncated_when_max_nodes_reached(tmp_path):
+    initialize_share_data()
+    storage = NetworkXStorage(
+        namespace="test_graph",
+        workspace="ws",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=None,
+    )
+    await storage.initialize()
+
+    g = nx.Graph()
+    for target in ["B", "C", "D", "E", "F"]:
+        g.add_edge("A", target)
+    storage._graph = g
+
+    result = await storage.get_knowledge_graph("A", max_depth=2, max_nodes=3)
+    assert len(result.nodes) == 3
+    assert result.is_truncated is True


### PR DESCRIPTION
## Summary

`NetworkXStorage.get_knowledge_graph` can hit `max_nodes` while draining a BFS level into a local list, leave the queue empty, and still report `is_truncated=False`.

## Problem

The truncation check is `(queue and len(bfs_nodes) >= max_nodes) or has_unexplored_neighbors`. Nodes at the current depth are fully popped into `current_level_nodes` before processing. When `max_nodes` stops processing mid-level, remaining same-level nodes are not back in `queue`, so the flag stays false even though the returned subgraph is capped.

Example: star graph centered at `A` with 5 leaves, `max_nodes=3` → 3 nodes returned, `is_truncated is False`.

## Fix

Track unprocessed nodes left in the current level when the `max_nodes` break fires, and treat that as max-nodes truncation alongside a non-empty queue.

## Test plan

- [x] `pytest tests/kg/networkx_impl/test_networkx_get_kg_truncation.py`
