### PR TITLE
fix(kg): report is_truncated correctly in mongo/neo4j/opensearch BFS fallbacks

### DIFF
--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -2664,18 +2664,20 @@ class MongoGraphStorage(BaseGraphStorage):
         max_depth: int,
         max_nodes: int,
     ) -> KnowledgeGraph:
-        if depth > max_depth or len(result.nodes) > max_nodes:
+        if depth > max_depth:
             return result
 
         cursor = self.collection.find({"_id": {"$in": node_labels}})
 
         async for node in cursor:
             node_id = node["_id"]
-            if node_id not in seen_nodes:
-                seen_nodes.add(node_id)
-                result.nodes.append(self._construct_graph_node(node_id, node))
-                if len(result.nodes) > max_nodes:
-                    return result
+            if node_id in seen_nodes:
+                continue
+            if len(result.nodes) >= max_nodes:
+                result.is_truncated = True
+                return result
+            seen_nodes.add(node_id)
+            result.nodes.append(self._construct_graph_node(node_id, node))
 
         # Collect neighbors
         # Get both inbound and outbound one hop nodes
@@ -2817,19 +2819,42 @@ class MongoGraphStorage(BaseGraphStorage):
             key=lambda x: (x["depth"], -x["weight"]),
         )
 
-        # As order matters, we need to use another list to store the node_id
-        # And only take the first max_nodes ones
-        node_ids = []
+        # Dedupe edge endpoints (excluding the start node) preserving the
+        # existing depth/weight priority order.
+        ordered_candidates = []
+        seen_candidates = set()
         for edge in node_edges:
-            if len(node_ids) < max_nodes and edge["source_node_id"] not in seen_nodes:
-                node_ids.append(edge["source_node_id"])
-                seen_nodes.add(edge["source_node_id"])
+            for candidate in (edge["source_node_id"], edge["target_node_id"]):
+                if candidate != node_label and candidate not in seen_candidates:
+                    seen_candidates.add(candidate)
+                    ordered_candidates.append(candidate)
 
-            if len(node_ids) < max_nodes and edge["target_node_id"] not in seen_nodes:
-                node_ids.append(edge["target_node_id"])
-                seen_nodes.add(edge["target_node_id"])
+        # Candidates are raw edge endpoints: upsert_edge only guarantees the
+        # source node exists, not the target, so some candidates may be
+        # dangling (no node document). Resolve real existence in priority
+        # order, in bounded batches, stopping once max_nodes real candidates
+        # are confirmed -- the start node already occupies one of the
+        # max_nodes slots, so only the first max_nodes - 1 real ids end up in
+        # the result, and finding a max_nodes-th real candidate proves
+        # truncation without having to probe the entire reachable set.
+        real_ids = []
+        batch_size = max(max_nodes, 1)
+        for i in range(0, len(ordered_candidates), batch_size):
+            if len(real_ids) >= max_nodes:
+                break
+            batch = ordered_candidates[i : i + batch_size]
+            found_cursor = self.collection.find({"_id": {"$in": batch}}, {"_id": 1})
+            found_ids = {doc["_id"] async for doc in found_cursor}
+            for candidate in batch:
+                if candidate in found_ids:
+                    real_ids.append(candidate)
+                    if len(real_ids) >= max_nodes:
+                        break
 
-        # Filter out all the node whose id is same as node_label so that we do not check existence next step
+        result.is_truncated = len(real_ids) >= max_nodes
+        node_ids = real_ids[: max_nodes - 1]
+        seen_nodes.update(node_ids)
+
         cursor = self.collection.find({"_id": {"$in": node_ids}})
 
         async for doc in cursor:

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -1551,7 +1551,7 @@ class Neo4JStorage(BaseGraphStorage):
         queue = deque([(start_node, None, 0)])
 
         # True BFS implementation using a queue
-        while queue and len(visited_nodes) < max_nodes:
+        while queue:
             # Dequeue the next node to process
             current_node, current_edge, current_depth = queue.popleft()
 
@@ -1565,6 +1565,19 @@ class Neo4JStorage(BaseGraphStorage):
                 )
                 continue
 
+            # This is a real, not-yet-visited, in-depth-limit node that cannot
+            # be added because the cap is already full -- that's the only
+            # condition that proves truncation. Checking the cap here (rather
+            # than after appending, or via the while-loop condition) means a
+            # queue that runs dry exactly at max_nodes never reaches this
+            # check and is never falsely reported as truncated.
+            if len(visited_nodes) >= max_nodes:
+                result.is_truncated = True
+                logger.info(
+                    f"[{self.workspace}] Graph truncated: breadth-first search limited to: {max_nodes} nodes"
+                )
+                break
+
             # Add current node to result
             result.nodes.append(current_node)
             visited_nodes.add(current_node.id)
@@ -1573,14 +1586,6 @@ class Neo4JStorage(BaseGraphStorage):
             if current_edge and current_edge.id not in visited_edges:
                 result.edges.append(current_edge)
                 visited_edges.add(current_edge.id)
-
-            # Stop if we've reached the node limit
-            if len(visited_nodes) >= max_nodes:
-                result.is_truncated = True
-                logger.info(
-                    f"[{self.workspace}] Graph truncated: breadth-first search limited to: {max_nodes} nodes"
-                )
-                break
 
             # Get all edges and target nodes for the current node (even at max_depth)
             async with self._driver.session(

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -4798,9 +4798,10 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         seen_nodes.add(start_label)
         result.nodes.append(self._construct_graph_node(start_label, start_node))
 
+        truncated_by_cap = False
         current_level = [start_label]
         for _ in range(max_depth):
-            if not current_level or len(seen_nodes) >= max_nodes:
+            if not current_level:
                 break
 
             # Batch fetch all edges for current level
@@ -4821,35 +4822,52 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             # the subgraph while is_truncated stays False (looks complete).
             resp = await self.client.search(index=self._edges_index, body=body)
 
-            next_level = set()
+            # Ordered + deduped (mget needs a JSON-serializable list, and a
+            # candidate must be excluded from seen_nodes here at construction
+            # time -- not "later" -- or an already-collected node reachable
+            # via a reverse edge would resurface next round and re-trip the
+            # cap check below on a node that isn't actually new).
+            next_level_candidates = []
+            next_level_seen = set()
             for hit in resp["hits"]["hits"]:
                 src = hit["_source"]["source_node_id"]
                 tgt = hit["_source"]["target_node_id"]
-                if src not in seen_nodes:
-                    next_level.add(src)
-                if tgt not in seen_nodes:
-                    next_level.add(tgt)
+                for candidate in (src, tgt):
+                    if candidate not in seen_nodes and candidate not in next_level_seen:
+                        next_level_seen.add(candidate)
+                        next_level_candidates.append(candidate)
 
-            # Limit to max_nodes
-            new_ids = []
-            for nid in next_level:
-                if len(seen_nodes) + len(new_ids) >= max_nodes:
-                    break
-                new_ids.append(nid)
-
-            if new_ids:
-                # Batch fetch node data
+            # Resolve which candidates are real nodes before making any
+            # capacity decision: an edge only guarantees its source node
+            # exists (see upsert_edge), so a candidate may be a dangling
+            # target with no node document. Deciding truncation/capacity from
+            # raw edge endpoints would let a dangling id steal a real node's
+            # slot, or falsely report truncation when nothing real was cut.
+            real_docs = []
+            if next_level_candidates:
                 node_resp = await self.client.mget(
-                    index=self._nodes_index, body={"ids": new_ids}
+                    index=self._nodes_index, body={"ids": next_level_candidates}
                 )
-                for doc in node_resp["docs"]:
-                    if doc.get("found"):
-                        seen_nodes.add(doc["_id"])
-                        result.nodes.append(
-                            self._construct_graph_node(doc["_id"], doc["_source"])
-                        )
+                real_docs = [
+                    doc
+                    for doc in node_resp["docs"]
+                    if doc.get("found") and doc["_id"] not in seen_nodes
+                ]
 
-            current_level = new_ids
+            new_docs = []
+            for doc in real_docs:
+                if len(seen_nodes) + len(new_docs) >= max_nodes:
+                    truncated_by_cap = True
+                    break
+                new_docs.append(doc)
+
+            for doc in new_docs:
+                seen_nodes.add(doc["_id"])
+                result.nodes.append(
+                    self._construct_graph_node(doc["_id"], doc["_source"])
+                )
+
+            current_level = [doc["_id"] for doc in new_docs]
 
         # Fetch all edges between seen nodes using PIT scrolling
         all_ids = list(seen_nodes)
@@ -4859,7 +4877,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             # (but small) subgraph.
             await self._append_edges_between_nodes(all_ids, result)
 
-        result.is_truncated = len(seen_nodes) >= max_nodes
+        result.is_truncated = truncated_by_cap
         return result
 
     async def get_all_nodes(self) -> list[dict]:

--- a/tests/kg/mongo_impl/test_mongo_storage.py
+++ b/tests/kg/mongo_impl/test_mongo_storage.py
@@ -14,6 +14,7 @@ from lightrag.kg.mongo_impl import (
     MongoGraphStorage,
     _canonical_edge_endpoints,
 )
+from lightrag.types import KnowledgeGraph
 
 pytestmark = pytest.mark.offline
 
@@ -37,11 +38,52 @@ class _AsyncCursor:
             raise StopAsyncIteration
 
 
+def _make_node_find_side_effect(real_ids: set):
+    """Mock ``collection.find({"_id": {"$in": ids}})``, dropping ids that have
+    no node document -- mirrors a dangling edge endpoint (upsert_edge only
+    guarantees the source node exists, never the target)."""
+
+    def _find(query, projection=None):
+        ids = query["_id"]["$in"]
+        return _AsyncCursor(
+            [{"_id": i, "entity_type": "person"} for i in ids if i in real_ids]
+        )
+
+    return _find
+
+
+def _make_edge_find_side_effect(edges: list):
+    """Mock ``edge_collection.find`` for both the ``$or`` (neighbor lookup)
+    and ``$and`` (final edge-set) query shapes used by the bidirectional BFS."""
+
+    def _find(query):
+        if "$or" in query:
+            ids = set(query["$or"][0]["source_node_id"]["$in"])
+            return _AsyncCursor(
+                [
+                    e
+                    for e in edges
+                    if e["source_node_id"] in ids or e["target_node_id"] in ids
+                ]
+            )
+        ids = set(query["$and"][0]["source_node_id"]["$in"])
+        return _AsyncCursor(
+            [
+                e
+                for e in edges
+                if e["source_node_id"] in ids and e["target_node_id"] in ids
+            ]
+        )
+
+    return _find
+
+
 class TestMongoGraphStorage:
     def _make_storage(self):
         storage = MongoGraphStorage.__new__(MongoGraphStorage)
         storage.workspace = "test"
         storage.global_config = {"max_graph_nodes": 1000}
+        storage._collection_name = "test_nodes"
         storage._edge_collection_name = "test_edges"
         storage.collection = SimpleNamespace()
         storage.edge_collection = SimpleNamespace()
@@ -101,6 +143,226 @@ class TestMongoGraphStorage:
         assert len(result.edges) == 1
         assert result.edges[0].source == "A"
         assert result.edges[0].target == "B"
+
+    @pytest.mark.asyncio
+    async def test_bidirectional_bfs_reports_truncated_and_respects_cap(self):
+        """Star graph exceeding max_nodes must be flagged truncated and must
+        never return more than max_nodes nodes."""
+        storage = self._make_storage()
+        real_ids = {"A", "B", "C", "D", "E", "F"}
+        edges = [
+            {"source_node_id": "A", "target_node_id": leaf}
+            for leaf in ["B", "C", "D", "E", "F"]
+        ]
+        storage.collection.find = Mock(
+            side_effect=_make_node_find_side_effect(real_ids)
+        )
+        storage.edge_collection.find = Mock(
+            side_effect=_make_edge_find_side_effect(edges)
+        )
+
+        result = await storage.get_knowledge_subgraph_bidirectional_bfs(
+            "A", 0, max_depth=2, max_nodes=3
+        )
+
+        assert result.is_truncated is True
+        assert len(result.nodes) <= 3
+
+    @pytest.mark.asyncio
+    async def test_bidirectional_bfs_not_truncated_when_exactly_at_cap(self):
+        """Diamond graph (A-B-D, A-C-D) whose 4 nodes exactly fill max_nodes
+        must not be falsely reported as truncated."""
+        storage = self._make_storage()
+        real_ids = {"A", "B", "C", "D"}
+        edges = [
+            {"source_node_id": "A", "target_node_id": "B"},
+            {"source_node_id": "A", "target_node_id": "C"},
+            {"source_node_id": "B", "target_node_id": "D"},
+            {"source_node_id": "C", "target_node_id": "D"},
+        ]
+        storage.collection.find = Mock(
+            side_effect=_make_node_find_side_effect(real_ids)
+        )
+        storage.edge_collection.find = Mock(
+            side_effect=_make_edge_find_side_effect(edges)
+        )
+
+        result = await storage.get_knowledge_subgraph_bidirectional_bfs(
+            "A", 0, max_depth=2, max_nodes=4
+        )
+
+        assert result.is_truncated is False
+        assert {node.id for node in result.nodes} == real_ids
+
+    @pytest.mark.asyncio
+    async def test_bidirectional_bfs_depth_limit_not_reported_as_node_truncation(self):
+        """A-B-C chain with max_depth=1, max_nodes=2: A and B exactly fill the
+        cap, and C is excluded purely by depth -- must not be misreported as
+        node-cap truncation."""
+        storage = self._make_storage()
+        real_ids = {"A", "B", "C"}
+        edges = [
+            {"source_node_id": "A", "target_node_id": "B"},
+            {"source_node_id": "B", "target_node_id": "C"},
+        ]
+        storage.collection.find = Mock(
+            side_effect=_make_node_find_side_effect(real_ids)
+        )
+        storage.edge_collection.find = Mock(
+            side_effect=_make_edge_find_side_effect(edges)
+        )
+
+        result = await storage._bidirectional_bfs_nodes(
+            ["A"], set(), KnowledgeGraph(), depth=0, max_depth=1, max_nodes=2
+        )
+
+        assert [node.id for node in result.nodes] == ["A", "B"]
+        assert result.is_truncated is False
+
+    @pytest.mark.asyncio
+    async def test_bidirectional_bfs_ignores_dangling_edge_endpoint(self):
+        """An edge pointing at "X" with no node document must not be treated
+        as a real node, and must not pollute is_truncated."""
+        storage = self._make_storage()
+        real_ids = {"A", "B"}
+        edges = [
+            {"source_node_id": "A", "target_node_id": "X"},
+            {"source_node_id": "A", "target_node_id": "B"},
+        ]
+        storage.collection.find = Mock(
+            side_effect=_make_node_find_side_effect(real_ids)
+        )
+        storage.edge_collection.find = Mock(
+            side_effect=_make_edge_find_side_effect(edges)
+        )
+
+        result = await storage.get_knowledge_subgraph_bidirectional_bfs(
+            "A", 0, max_depth=2, max_nodes=5
+        )
+
+        assert {node.id for node in result.nodes} == {"A", "B"}
+        assert result.is_truncated is False
+
+    @pytest.mark.asyncio
+    async def test_in_out_bound_bfs_reports_truncated_and_respects_cap(self):
+        storage = self._make_storage()
+        real_ids = {"A", "B", "C", "D", "E", "F"}
+        storage.collection.find_one = AsyncMock(
+            return_value={"_id": "A", "entity_type": "person"}
+        )
+        storage.collection.aggregate = AsyncMock(
+            return_value=_AsyncCursor(
+                [
+                    {
+                        "connected_edges": [
+                            {
+                                "source_node_id": "A",
+                                "target_node_id": leaf,
+                                "depth": 0,
+                                "weight": 1.0,
+                            }
+                            for leaf in ["B", "C", "D", "E", "F"]
+                        ]
+                    }
+                ]
+            )
+        )
+        storage.collection.find = Mock(
+            side_effect=_make_node_find_side_effect(real_ids)
+        )
+
+        result = await storage.get_knowledge_subgraph_in_out_bound_bfs(
+            "A", max_depth=2, max_nodes=3
+        )
+
+        assert result.is_truncated is True
+        assert len(result.nodes) <= 3
+
+    @pytest.mark.asyncio
+    async def test_in_out_bound_bfs_not_truncated_when_exactly_at_cap(self):
+        storage = self._make_storage()
+        real_ids = {"A", "B", "C"}
+        storage.collection.find_one = AsyncMock(
+            return_value={"_id": "A", "entity_type": "person"}
+        )
+        storage.collection.aggregate = AsyncMock(
+            return_value=_AsyncCursor(
+                [
+                    {
+                        "connected_edges": [
+                            {
+                                "source_node_id": "A",
+                                "target_node_id": leaf,
+                                "depth": 0,
+                                "weight": 1.0,
+                            }
+                            for leaf in ["B", "C"]
+                        ]
+                    }
+                ]
+            )
+        )
+        storage.collection.find = Mock(
+            side_effect=_make_node_find_side_effect(real_ids)
+        )
+
+        result = await storage.get_knowledge_subgraph_in_out_bound_bfs(
+            "A", max_depth=2, max_nodes=3
+        )
+
+        assert result.is_truncated is False
+        assert {node.id for node in result.nodes} == real_ids
+
+    @pytest.mark.asyncio
+    async def test_in_out_bound_bfs_dangling_edge_endpoint_does_not_steal_real_node_slot(
+        self,
+    ):
+        """A dangling candidate "X" ordered ahead of the real "C" (higher
+        edge weight -> sorted first) must not consume a node slot that would
+        otherwise go to a real node."""
+        storage = self._make_storage()
+        real_ids = {"A", "B", "C"}
+        storage.collection.find_one = AsyncMock(
+            return_value={"_id": "A", "entity_type": "person"}
+        )
+        storage.collection.aggregate = AsyncMock(
+            return_value=_AsyncCursor(
+                [
+                    {
+                        "connected_edges": [
+                            {
+                                "source_node_id": "A",
+                                "target_node_id": "X",
+                                "depth": 0,
+                                "weight": 2.0,
+                            },
+                            {
+                                "source_node_id": "A",
+                                "target_node_id": "B",
+                                "depth": 0,
+                                "weight": 1.0,
+                            },
+                            {
+                                "source_node_id": "A",
+                                "target_node_id": "C",
+                                "depth": 0,
+                                "weight": 1.0,
+                            },
+                        ]
+                    }
+                ]
+            )
+        )
+        storage.collection.find = Mock(
+            side_effect=_make_node_find_side_effect(real_ids)
+        )
+
+        result = await storage.get_knowledge_subgraph_in_out_bound_bfs(
+            "A", max_depth=2, max_nodes=3
+        )
+
+        assert {node.id for node in result.nodes} == {"A", "B", "C"}
+        assert result.is_truncated is False
 
 
 class TestMongoEdgeKey:

--- a/tests/kg/neo4j_impl/test_neo4j_robust_fallback_truncation.py
+++ b/tests/kg/neo4j_impl/test_neo4j_robust_fallback_truncation.py
@@ -1,0 +1,143 @@
+"""Regression tests for ``Neo4JStorage._robust_fallback`` truncation reporting.
+
+This is the pure-Cypher BFS fallback used when the APOC plugin is unavailable.
+It used to set ``is_truncated = True`` unconditionally the instant the node
+cap was reached, without checking whether the queue actually still held an
+unvisited, in-depth-limit candidate -- so a graph whose full node count
+exactly equals ``max_nodes`` was falsely reported as truncated.
+
+These tests run without a live Neo4j instance, mirroring the fake
+driver/session style in ``test_workspace_label_injection.py``.
+"""
+
+import pytest
+
+from lightrag.kg.neo4j_impl import Neo4JStorage
+
+
+class _FakeNode(dict):
+    """Minimal stand-in for a neo4j Node: dict-like plus a `._properties`."""
+
+    def __init__(self, entity_id: str):
+        props = {"entity_id": entity_id}
+        super().__init__(props)
+        self._properties = props
+
+
+class _FakeRel(dict):
+    """Minimal stand-in for a neo4j Relationship: dict-like plus `.type`."""
+
+    def __init__(self, rel_type: str = "RELATED"):
+        super().__init__({"weight": 1.0})
+        self.type = rel_type
+
+
+class _FakeResult:
+    def __init__(self, records: list):
+        self._records = records
+
+    async def single(self):
+        return self._records[0] if self._records else None
+
+    async def fetch(self, n: int):
+        return self._records[:n]
+
+    async def consume(self):
+        return None
+
+
+class _FakeSession:
+    """Routes ``run`` calls by query shape: start-node lookup vs neighbor scan."""
+
+    def __init__(self, node_docs: dict, edges_by_node: dict):
+        self._node_docs = node_docs
+        self._edges_by_node = edges_by_node
+
+    async def run(self, query, entity_id=None, **kwargs):
+        if "RETURN id(n) as node_id, n" in query:
+            node = self._node_docs.get(entity_id)
+            return _FakeResult([{"n": node, "node_id": 1}] if node else [])
+        return _FakeResult(self._edges_by_node.get(entity_id, []))
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeDriver:
+    def __init__(self, session: _FakeSession):
+        self._session = session
+
+    def session(self, **kwargs):
+        return self._session
+
+
+def _make_storage(node_docs: dict, edges_by_node: dict) -> Neo4JStorage:
+    storage = Neo4JStorage(
+        namespace="test", global_config={}, embedding_func=None, workspace="ws"
+    )
+    storage._driver = _FakeDriver(_FakeSession(node_docs, edges_by_node))
+    storage._DATABASE = None
+    return storage
+
+
+def _edge(edge_id: str, target_entity_id: str) -> dict:
+    return {"r": _FakeRel(), "b": _FakeNode(target_entity_id), "edge_id": edge_id}
+
+
+@pytest.mark.asyncio
+async def test_robust_fallback_not_truncated_when_exactly_at_cap():
+    """A-B-C chain: all 3 real nodes exactly fill max_nodes=3 -- must not be
+    falsely reported as truncated."""
+    node_docs = {n: _FakeNode(n) for n in ["A", "B", "C"]}
+    edges_by_node = {
+        "A": [_edge("e1", "B")],
+        "B": [_edge("e1", "A"), _edge("e2", "C")],
+        "C": [_edge("e2", "B")],
+    }
+    storage = _make_storage(node_docs, edges_by_node)
+
+    result = await storage._robust_fallback("A", max_depth=5, max_nodes=3)
+
+    assert {n.id for n in result.nodes} == {"A", "B", "C"}
+    assert result.is_truncated is False
+
+
+@pytest.mark.asyncio
+async def test_robust_fallback_reports_truncated_over_cap():
+    """Star graph (A + 5 leaves) with max_nodes=3 must be flagged truncated
+    and must never return more than max_nodes nodes."""
+    leaves = ["B", "C", "D", "E", "F"]
+    node_docs = {n: _FakeNode(n) for n in ["A"] + leaves}
+    edges_by_node = {"A": [_edge(f"e{i}", leaf) for i, leaf in enumerate(leaves)]}
+    for i, leaf in enumerate(leaves):
+        edges_by_node[leaf] = [_edge(f"e{i}", "A")]
+    storage = _make_storage(node_docs, edges_by_node)
+
+    result = await storage._robust_fallback("A", max_depth=5, max_nodes=3)
+
+    assert result.is_truncated is True
+    assert len(result.nodes) <= 3
+
+
+@pytest.mark.asyncio
+async def test_robust_fallback_duplicate_queue_entries_not_falsely_truncated():
+    """Diamond graph (A->B, A->C, B->D, C->D): D is reachable via two
+    parents and gets queued twice before ever being visited. The duplicate
+    entry must be dropped by the visited check, not misread as a real
+    candidate that didn't fit under the cap."""
+    node_docs = {n: _FakeNode(n) for n in ["A", "B", "C", "D"]}
+    edges_by_node = {
+        "A": [_edge("e1", "B"), _edge("e2", "C")],
+        "B": [_edge("e1", "A"), _edge("e3", "D")],
+        "C": [_edge("e2", "A"), _edge("e4", "D")],
+        "D": [_edge("e3", "B"), _edge("e4", "C")],
+    }
+    storage = _make_storage(node_docs, edges_by_node)
+
+    result = await storage._robust_fallback("A", max_depth=5, max_nodes=4)
+
+    assert {n.id for n in result.nodes} == {"A", "B", "C", "D"}
+    assert result.is_truncated is False

--- a/tests/kg/opensearch_impl/test_opensearch_strict_reads.py
+++ b/tests/kg/opensearch_impl/test_opensearch_strict_reads.py
@@ -624,6 +624,140 @@ async def test_bfs_subgraph_transient_error_raises_not_reports_false_complete(
         await storage.get_knowledge_graph("start", max_depth=2, max_nodes=100)
 
 
+def _bfs_mget_side_effect(real_nodes: dict):
+    """Mock ``client.mget`` for both the single-id start-node lookup and the
+    batched per-level neighbor resolution. Ids absent from `real_nodes` come
+    back ``found: False``, mirroring a dangling edge endpoint (upsert_edge
+    only guarantees the source node exists, never the target)."""
+
+    async def _mget(index=None, body=None, **kwargs):
+        docs = []
+        for node_id in body["ids"]:
+            if node_id in real_nodes:
+                docs.append(
+                    {"_id": node_id, "found": True, "_source": real_nodes[node_id]}
+                )
+            else:
+                docs.append({"_id": node_id, "found": False})
+        return {"docs": docs}
+
+    return _mget
+
+
+def _bfs_search_side_effect(edges: list):
+    """Mock ``client.search`` for both the per-level edge scan (``should``,
+    at least one endpoint in the frontier) and the final PIT-scrolled
+    edge fetch (``must``, both endpoints in the seen-node set)."""
+
+    async def _search(index=None, body=None, **kwargs):
+        bool_query = body["query"]["bool"]
+        if "should" in bool_query:
+            ids = set(bool_query["should"][0]["terms"]["source_node_id"])
+            hits = [
+                {"_source": e}
+                for e in edges
+                if e["source_node_id"] in ids or e["target_node_id"] in ids
+            ]
+        else:
+            ids = set(bool_query["must"][0]["terms"]["source_node_id"])
+            hits = [
+                {"_source": e}
+                for e in edges
+                if e["source_node_id"] in ids and e["target_node_id"] in ids
+            ]
+        return {"hits": {"hits": hits}}
+
+    return _search
+
+
+async def _make_bfs_storage(global_config, real_nodes: dict, edges: list):
+    client = _make_graph_client()
+    storage = await _make_graph(global_config, client)
+    storage._ppl_graphlookup_available = False
+    client.mget = AsyncMock(side_effect=_bfs_mget_side_effect(real_nodes))
+    client.search = AsyncMock(side_effect=_bfs_search_side_effect(edges))
+    return storage
+
+
+async def test_bfs_subgraph_counter_example_not_falsely_truncated(global_config):
+    """A only connects to B and C, and B/C's only neighbor is the already-
+    visited A. Filling max_nodes=3 exactly on round 1 must not make round 2's
+    top-of-loop capacity check falsely declare truncation before confirming
+    there is nothing left to explore."""
+    real_nodes = {n: {"entity_type": "person"} for n in ["A", "B", "C"]}
+    edges = [
+        {"source_node_id": "A", "target_node_id": "B"},
+        {"source_node_id": "A", "target_node_id": "C"},
+    ]
+    storage = await _make_bfs_storage(global_config, real_nodes, edges)
+
+    result = await storage.get_knowledge_graph("A", max_depth=2, max_nodes=3)
+
+    assert {n.id for n in result.nodes} == {"A", "B", "C"}
+    assert result.is_truncated is False
+
+
+async def test_bfs_subgraph_diamond_not_truncated(global_config):
+    real_nodes = {n: {"entity_type": "person"} for n in ["A", "B", "C", "D"]}
+    edges = [
+        {"source_node_id": "A", "target_node_id": "B"},
+        {"source_node_id": "A", "target_node_id": "C"},
+        {"source_node_id": "B", "target_node_id": "D"},
+        {"source_node_id": "C", "target_node_id": "D"},
+    ]
+    storage = await _make_bfs_storage(global_config, real_nodes, edges)
+
+    result = await storage.get_knowledge_graph("A", max_depth=2, max_nodes=4)
+
+    assert {n.id for n in result.nodes} == {"A", "B", "C", "D"}
+    assert result.is_truncated is False
+
+
+async def test_bfs_subgraph_star_reports_truncated_and_respects_cap(global_config):
+    leaves = ["B", "C", "D", "E", "F"]
+    real_nodes = {n: {"entity_type": "person"} for n in ["A"] + leaves}
+    edges = [{"source_node_id": "A", "target_node_id": leaf} for leaf in leaves]
+    storage = await _make_bfs_storage(global_config, real_nodes, edges)
+
+    result = await storage.get_knowledge_graph("A", max_depth=2, max_nodes=3)
+
+    assert result.is_truncated is True
+    assert len(result.nodes) <= 3
+
+
+async def test_bfs_subgraph_dangling_only_neighbor_not_falsely_truncated(
+    global_config,
+):
+    """The only neighbor is a dangling id (edge-referenced, no node
+    document) -- nothing real was cut, so this must not be truncated."""
+    real_nodes = {"A": {"entity_type": "person"}}
+    edges = [{"source_node_id": "A", "target_node_id": "X"}]
+    storage = await _make_bfs_storage(global_config, real_nodes, edges)
+
+    result = await storage.get_knowledge_graph("A", max_depth=2, max_nodes=1)
+
+    assert {n.id for n in result.nodes} == {"A"}
+    assert result.is_truncated is False
+
+
+async def test_bfs_subgraph_dangling_candidate_does_not_steal_real_node_slot(
+    global_config,
+):
+    """A occupies one of max_nodes=2 slots; the real neighbor B must fill the
+    second slot even though a dangling candidate X is also in the frontier."""
+    real_nodes = {"A": {"entity_type": "person"}, "B": {"entity_type": "person"}}
+    edges = [
+        {"source_node_id": "A", "target_node_id": "X"},
+        {"source_node_id": "A", "target_node_id": "B"},
+    ]
+    storage = await _make_bfs_storage(global_config, real_nodes, edges)
+
+    result = await storage.get_knowledge_graph("A", max_depth=2, max_nodes=2)
+
+    assert {n.id for n in result.nodes} == {"A", "B"}
+    assert result.is_truncated is False
+
+
 async def test_vector_query_raises_on_whole_call_transient(global_config):
     """Matches the raise-on-unexpected-error convention every other vector
     backend's query() follows (Postgres/Milvus/Qdrant/Mongo)."""


### PR DESCRIPTION
## Summary

Follow-up to #3558, which fixed `NetworkXStorage.get_knowledge_graph` reporting `is_truncated=False` even when BFS actually cut off reachable nodes at `max_nodes`. Auditing the other graph storage backends for the same class of bug turned up three more instances, of varying severity, all in the node_label (non-wildcard) BFS path:

1. **`lightrag/kg/mongo_impl.py`** — the default path (`get_knowledge_subgraph_bidirectional_bfs` / `_bidirectional_bfs_nodes`) and the opt-in path (`get_knowledge_subgraph_in_out_bound_bfs`, via `MONGO_GRAPH_BFS_MODE=in_out_bound`) never assigned `result.is_truncated` at all for a specific `node_label` query — it stayed at its default `False` regardless of whether the graph was actually truncated. This is the most severe of the three: not an edge-case miss, a missing feature.
2. **`lightrag/kg/neo4j_impl.py::_robust_fallback`** (used when the APOC plugin is unavailable) — set `is_truncated=True` unconditionally the instant `len(visited_nodes) >= max_nodes`, without checking whether the queue actually still held an unvisited candidate. A graph whose total node count exactly equals `max_nodes` (e.g. a 3-node chain with `max_nodes=3`) was falsely reported as truncated even though the whole graph was returned.
3. **`lightrag/kg/opensearch_impl.py::_bfs_subgraph`** (client-side fallback when PPL `graphlookup` is unavailable) — same exact-cap false positive as neo4j (`is_truncated = len(seen_nodes) >= max_nodes`), plus a related issue: capacity/truncation decisions were made against raw edge-endpoint ids rather than confirmed-real node documents, so a dangling edge endpoint (an edge only guarantees its *source* node exists — see `upsert_edge` in both mongo and opensearch — not its *target*) could steal a real node's slot or trigger a false positive on its own.

The rest of each backend's code (the `"*"` wildcard branches, neo4j's main APOC path, memgraph, postgres, mongo's `get_knowledge_graph_all_by_degree`, opensearch's `_get_knowledge_graph_all`/`_bfs_subgraph_ppl`) already compute a real total/reachable count server-side before comparing against `max_nodes`, so they were not affected and are untouched here.

## What changed

- **mongo_impl.py**
  - `_bidirectional_bfs_nodes`: removed the node-cap check from the function's entry guard (it was conflating "depth exhausted" with "node cap reached" whenever both happened to coincide) and moved the cap decision to the point where the node cursor actually yields a real, unvisited, in-depth-limit document that can't fit. Depth-only exclusions no longer get misreported as cap truncation, and dangling ids (which never appear in the cursor's results) can no longer trigger a false positive.
  - `get_knowledge_subgraph_in_out_bound_bfs`: candidate node ids are now resolved against real node documents (in bounded batches, stopping once `max_nodes` real candidates are confirmed — no unbounded `$in` query over the whole reachable set) *before* being counted against the node cap, instead of capping on raw edge-endpoint ids. This fixes both a false-negative (a dangling id could previously make the node count look "complete" while silently dropping a real node) and keeps the query bounded.

- **neo4j_impl.py::_robust_fallback**: moved the cap check to right after the existing visited/depth skip checks and before appending the node, and changed the outer loop to `while queue`. `is_truncated` is now only set when a real, unvisited, in-depth node is dequeued and genuinely can't fit — a queue that runs dry exactly at `max_nodes` no longer reaches that check.

- **opensearch_impl.py::_bfs_subgraph**: removed the "top of loop, cap already reached" short-circuit (it could fire before ever checking whether the current frontier's neighbors have anything new to offer). Per-level neighbor candidates are now resolved via `mget` into real node documents first, and the cap/truncation decision is made against that real-node list, not raw edge-endpoint ids.

## Test plan

- [x] New regression tests per backend covering: the true-positive case (must report truncated + must never return more than `max_nodes` nodes), the false-positive case (exact-cap / diamond-graph graphs must not be misreported as truncated), a depth-vs-cap coincidence case (mongo), a duplicate-queue-entry case (neo4j, mirroring the diamond-graph regression from #3558), and dangling-edge-endpoint cases (mongo + opensearch) proving a phantom id can't steal a real node's slot or skew the flag.
  - `tests/kg/mongo_impl/test_mongo_storage.py`
  - `tests/kg/neo4j_impl/test_neo4j_robust_fallback_truncation.py` (new file)
  - `tests/kg/opensearch_impl/test_opensearch_strict_reads.py`
- [x] `./scripts/test.sh tests/kg/` — 1458 passed, 141 skipped (no regressions)
- [x] `ruff check` / pre-commit `ruff-format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)