### PR TITLE
fix(graph): normalize manually managed entity names

### DIFF
--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1057,6 +1057,8 @@ Entity names supplied to `create_entity` and new names supplied during
 `edit_entity` renames use the same normalization rules as extracted entity
 names. When editing an existing entity, LightRAG first preserves an exact
 legacy name match and otherwise falls back to the normalized name.
+`insert_custom_kg` applies the same rules to declared entity names and both
+endpoints of every relationship before writing any custom KG data.
 
 All operations are available in both synchronous and asynchronous versions. Async versions have the prefix "a" (e.g., `acreate_entity`, `aedit_relation`).
 

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1053,6 +1053,11 @@ updated_relation = rag.edit_relation("Google", "Google Mail", {
 })
 ```
 
+Entity names supplied to `create_entity` and new names supplied during
+`edit_entity` renames use the same normalization rules as extracted entity
+names. When editing an existing entity, LightRAG first preserves an exact
+legacy name match and otherwise falls back to the normalized name.
+
 All operations are available in both synchronous and asynchronous versions. Async versions have the prefix "a" (e.g., `acreate_entity`, `aedit_relation`).
 
 * Insert Custom KG

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1059,6 +1059,9 @@ names. When editing an existing entity, LightRAG first preserves an exact
 legacy name match and otherwise falls back to the normalized name.
 `insert_custom_kg` applies the same rules to declared entity names and both
 endpoints of every relationship before writing any custom KG data.
+`merge_entities` resolves existing exact legacy source/target names first and
+otherwise uses normalized names. The target may be an existing entity or a
+new normalized name created by the merge.
 
 All operations are available in both synchronous and asynchronous versions. Async versions have the prefix "a" (e.g., `acreate_entity`, `aedit_relation`).
 

--- a/lightrag/api/routers/graph_routes.py
+++ b/lightrag/api/routers/graph_routes.py
@@ -63,7 +63,7 @@ class EntityMergeRequest(BaseModel):
     )
     entity_to_change_into: str = Field(
         ...,
-        description="Target entity name that will receive all relationships from the source entities. This entity will be preserved.",
+        description="Target entity name that will receive all relationships from the source entities. An existing entity is preserved and merged; a missing target is created.",
         min_length=1,
         examples=["Elon Musk"],
     )
@@ -714,7 +714,8 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
 
         HTTP Status Codes:
             200: Entities merged successfully
-            400: Invalid request (e.g., empty entity list, target entity doesn't exist)
+            400: Invalid request (e.g., empty entity list, source entity doesn't exist,
+                 or a name is empty after normalization)
             500: Internal server error
 
         Example Request:
@@ -725,7 +726,7 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             }
 
         Note:
-            - The target entity (entity_to_change_into) must exist in the knowledge graph
+            - The target entity may already exist or may be a new canonical name
             - Source entities will be permanently deleted after the merge
             - This operation cannot be undone, so verify entity names before merging
         """
@@ -735,9 +736,12 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
                 source_entities=request.entities_to_change,
                 target_entity=request.entity_to_change_into,
             )
+            merged_entity_name = result.get(
+                "entity_name", request.entity_to_change_into
+            )
             return {
                 "status": "success",
-                "message": f"Successfully merged {len(request.entities_to_change)} entities into '{request.entity_to_change_into}'",
+                "message": f"Successfully merged {len(request.entities_to_change)} entities into '{merged_entity_name}'",
                 "data": result,
             }
         except HTTPException:

--- a/lightrag/api/routers/graph_routes.py
+++ b/lightrag/api/routers/graph_routes.py
@@ -563,10 +563,11 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
                 entity_name=request.entity_name,
                 entity_data=request.entity_data,
             )
+            created_entity_name = result.get("entity_name", request.entity_name)
 
             return {
                 "status": "success",
-                "message": f"Entity '{request.entity_name}' created successfully",
+                "message": f"Entity '{created_entity_name}' created successfully",
                 "data": result,
             }
         except HTTPException:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -182,6 +182,7 @@ from lightrag.utils import (
     make_relation_vdb_ids,
     subtract_source_ids,
     make_relation_chunk_key,
+    normalize_entity_name,
     normalize_source_ids_limit_method,
     normalize_string_list,
     run_in_chunking_executor,
@@ -3240,6 +3241,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     ) -> None:
         """Insert caller-constructed KG objects directly into the stores.
 
+        Entity names and relationship endpoints are normalized with the same
+        contract used by document extraction before any storage write begins.
+
         .. warning:: (issue #3400 Phase 5 — direct-writer audit)
            This path is OUTSIDE the document-level recovery guarantee. It has
            no durable operation journal and does not prewrite
@@ -3257,6 +3261,50 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         update_storage = False
         try:
+
+            def _normalize_custom_kg_entity_name(value: Any, *, field: str) -> str:
+                if not isinstance(value, str):
+                    raise ValueError(f"Custom KG {field} must be a string")
+                normalized_value = normalize_entity_name(value)
+                if not normalized_value:
+                    raise ValueError(
+                        f"Custom KG {field} cannot be empty after normalization"
+                    )
+                return normalized_value
+
+            # Validate and canonicalize the complete identifier set before
+            # chunks or graph objects are written. Copies keep the caller's
+            # custom_kg payload unchanged.
+            normalized_entities: list[dict[str, Any]] = []
+            for index, entity_data in enumerate(custom_kg.get("entities", [])):
+                normalized_entity_data = dict(entity_data)
+                normalized_entity_data["entity_name"] = (
+                    _normalize_custom_kg_entity_name(
+                        entity_data["entity_name"],
+                        field=f"entities[{index}].entity_name",
+                    )
+                )
+                normalized_entities.append(normalized_entity_data)
+
+            normalized_relationships: list[dict[str, Any]] = []
+            for index, relationship_data in enumerate(
+                custom_kg.get("relationships", [])
+            ):
+                normalized_relationship_data = dict(relationship_data)
+                normalized_relationship_data["src_id"] = (
+                    _normalize_custom_kg_entity_name(
+                        relationship_data["src_id"],
+                        field=f"relationships[{index}].src_id",
+                    )
+                )
+                normalized_relationship_data["tgt_id"] = (
+                    _normalize_custom_kg_entity_name(
+                        relationship_data["tgt_id"],
+                        field=f"relationships[{index}].tgt_id",
+                    )
+                )
+                normalized_relationships.append(normalized_relationship_data)
+
             # Insert chunks into vector storage
             all_chunks_data: dict[str, dict[str, str]] = {}
             chunk_to_source_map: dict[str, str] = {}
@@ -3310,7 +3358,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             # Keep the last declaration for each entity_name so batch backends
             # preserve the old serial upsert semantics deterministically.
             deduped_entities: dict[str, dict[str, Any]] = {}
-            for entity_data in custom_kg.get("entities", []):
+            for entity_data in normalized_entities:
                 entity_name = entity_data["entity_name"]
                 deduped_entities.pop(entity_name, None)
                 deduped_entities[entity_name] = entity_data
@@ -3350,7 +3398,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             # Relationship storage is undirected, so keep only the last update
             # for each endpoint pair regardless of order.
             deduped_relationships: dict[tuple[str, str], dict[str, Any]] = {}
-            for relationship_data in custom_kg.get("relationships", []):
+            for relationship_data in normalized_relationships:
                 src_id = relationship_data["src_id"]
                 tgt_id = relationship_data["tgt_id"]
                 relation_key = tuple(sorted((src_id, tgt_id)))

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -20,6 +20,7 @@ from lightrag.utils import (
     compute_mdhash_id,
     Tokenizer,
     TokenBudgetError,
+    normalize_entity_name,
     sanitize_and_normalize_extracted_text,
     sanitize_text_for_encoding,
     repair_vlm_json_escape_damage_nested,
@@ -625,9 +626,7 @@ def _handle_single_entity_extraction(
         return None
 
     try:
-        entity_name = sanitize_and_normalize_extracted_text(
-            record_attributes[1], remove_inner_quotes=True
-        )
+        entity_name = normalize_entity_name(record_attributes[1])
 
         # Validate entity name after all cleaning steps
         if not entity_name or not entity_name.strip():
@@ -714,12 +713,8 @@ def _handle_single_relationship_extraction(
         return None
 
     try:
-        source = sanitize_and_normalize_extracted_text(
-            record_attributes[1], remove_inner_quotes=True
-        )
-        target = sanitize_and_normalize_extracted_text(
-            record_attributes[2], remove_inner_quotes=True
-        )
+        source = normalize_entity_name(record_attributes[1])
+        target = normalize_entity_name(record_attributes[2])
 
         # Validate entity names after all cleaning steps
         if not source:
@@ -875,9 +870,7 @@ async def _process_json_extraction_result(
             continue
 
         try:
-            entity_name = sanitize_and_normalize_extracted_text(
-                str(entity_data.get("name", "")), remove_inner_quotes=True
-            )
+            entity_name = normalize_entity_name(str(entity_data.get("name", "")))
             if not entity_name or not entity_name.strip():
                 logger.info(
                     f"{chunk_key}: Empty entity name found after sanitization in JSON result"
@@ -943,12 +936,8 @@ async def _process_json_extraction_result(
             continue
 
         try:
-            source = sanitize_and_normalize_extracted_text(
-                str(rel_data.get("source", "")), remove_inner_quotes=True
-            )
-            target = sanitize_and_normalize_extracted_text(
-                str(rel_data.get("target", "")), remove_inner_quotes=True
-            )
+            source = normalize_entity_name(str(rel_data.get("source", "")))
+            target = normalize_entity_name(str(rel_data.get("target", "")))
 
             if not source:
                 logger.info(

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4694,6 +4694,11 @@ def sanitize_and_normalize_extracted_text(
     return ""
 
 
+def normalize_entity_name(input_text: str) -> str:
+    """Normalize an entity identifier using the extraction naming contract."""
+    return sanitize_and_normalize_extracted_text(input_text, remove_inner_quotes=True)
+
+
 def normalize_extracted_info(name: str, remove_inner_quotes=False) -> str:
     """Normalize entity/relation names and description with the following rules:
     - Clean HTML tags (paragraph and line break tags)

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1449,14 +1449,12 @@ async def _merge_entities_impl(
                     edge_data = await chunk_entity_relation_graph.get_edge(src, tgt)
                     all_relations.append((src, tgt, edge_data))
 
-    # 5. Create or update the target entity
+    # 5. Create or update the target entity. A missing target is intentional:
+    # spelling-repair merges may consolidate sources into a new canonical name.
     merged_entity_data["entity_id"] = target_entity
-    if not target_exists:
-        await chunk_entity_relation_graph.upsert_node(target_entity, merged_entity_data)
-        logger.info(f"Entity Merge: created target '{target_entity}'")
-    else:
-        await chunk_entity_relation_graph.upsert_node(target_entity, merged_entity_data)
-        logger.info(f"Entity Merge: Updated target '{target_entity}'")
+    await chunk_entity_relation_graph.upsert_node(target_entity, merged_entity_data)
+    target_action = "updated" if target_exists else "created"
+    logger.info(f"Entity Merge: {target_action} target '{target_entity}'")
 
     # 6. Recreate all relations pointing to the target entity in KG
     # Also collect chunk tracking information in the same loop
@@ -1880,10 +1878,26 @@ async def amerge_entities(
     Returns:
         Dictionary containing the merged entity information
     """
-    # Collect all entities involved (source + target) and lock them all in sorted order
-    all_entities = set(source_entities)
-    all_entities.add(target_entity)
-    lock_keys = sorted(all_entities)
+    if not source_entities:
+        raise ValueError("At least one source entity is required for merge")
+
+    requested_source_entities = list(source_entities)
+    normalized_source_entities = [
+        _normalize_manual_entity_name(entity_name)
+        for entity_name in requested_source_entities
+    ]
+    requested_target_entity = target_entity
+    normalized_target_entity = _normalize_manual_entity_name(requested_target_entity)
+
+    # Lock every exact/canonical candidate before resolving legacy keys. This
+    # shares the extraction pipeline's canonical locks while preserving access
+    # to historical manually-created names.
+    lock_key_set = set(requested_source_entities)
+    lock_key_set.update(name for name in normalized_source_entities if name)
+    lock_key_set.add(requested_target_entity)
+    if normalized_target_entity:
+        lock_key_set.add(normalized_target_entity)
+    lock_keys = sorted(lock_key_set)
 
     workspace = entities_vdb.global_config.get("workspace", "")
     namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
@@ -1891,11 +1905,49 @@ async def amerge_entities(
         lock_keys, namespace=namespace, enable_logging=False
     ):
         try:
+            resolved_source_entities: list[str] = []
+            seen_source_entities: set[str] = set()
+            for requested_name, normalized_name in zip(
+                requested_source_entities,
+                normalized_source_entities,
+                strict=True,
+            ):
+                if (
+                    requested_name != normalized_name
+                    and await chunk_entity_relation_graph.has_node(requested_name)
+                ):
+                    resolved_name = requested_name
+                elif normalized_name:
+                    resolved_name = normalized_name
+                else:
+                    raise ValueError(
+                        "Source entity name cannot be empty after normalization"
+                    )
+
+                # Multiple caller spellings may resolve to one canonical node.
+                # Merge it once so relations, vectors, and deletion are not
+                # processed repeatedly.
+                if resolved_name not in seen_source_entities:
+                    seen_source_entities.add(resolved_name)
+                    resolved_source_entities.append(resolved_name)
+
+            if (
+                requested_target_entity != normalized_target_entity
+                and await chunk_entity_relation_graph.has_node(requested_target_entity)
+            ):
+                target_entity = requested_target_entity
+            elif normalized_target_entity:
+                target_entity = normalized_target_entity
+            else:
+                raise ValueError(
+                    "Target entity name cannot be empty after normalization"
+                )
+
             return await _merge_entities_impl(
                 chunk_entity_relation_graph,
                 entities_vdb,
                 relationships_vdb,
-                source_entities,
+                resolved_source_entities,
                 target_entity,
                 merge_strategy=merge_strategy,
                 target_entity_data=target_entity_data,

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -13,6 +13,7 @@ from .utils import (
     compute_mdhash_id,
     logger,
     make_relation_vdb_ids,
+    normalize_entity_name,
     safe_vdb_operation_with_exception,
 )
 from .base import StorageNameSpace
@@ -25,6 +26,13 @@ def _require_non_empty_description(
         raise ValueError(
             f"{object_type.capitalize()} description cannot be empty for {operation} operation"
         )
+
+
+def _normalize_manual_entity_name(entity_name: Any) -> str:
+    """Apply the extraction naming contract to a manual entity identifier."""
+    if not isinstance(entity_name, str):
+        raise ValueError("Entity name must be a string")
+    return normalize_entity_name(entity_name)
 
 
 async def _persist_graph_updates(
@@ -622,32 +630,78 @@ async def aedit_entity(
             updated_data.get("description"), operation="edit", object_type="entity"
         )
 
-    new_entity_name = updated_data.get("entity_name", entity_name)
-    is_renaming = new_entity_name != entity_name
+    requested_entity_name = entity_name
+    normalized_entity_name = _normalize_manual_entity_name(requested_entity_name)
+    updated_data = dict(updated_data)
 
-    # Lock the (old, new) entity names. The doc-ingest pipeline acquires
+    has_new_entity_name = "entity_name" in updated_data
+    requested_new_entity_name = updated_data.get("entity_name")
+    normalized_new_entity_name = (
+        _normalize_manual_entity_name(requested_new_entity_name)
+        if has_new_entity_name
+        else None
+    )
+
+    # Lock every exact/canonical source and target candidate before resolving
+    # legacy manual names. The doc-ingest pipeline acquires
     # edge locks as sorted([src, tgt]) in the same namespace, and
     # get_storage_keyed_lock takes one mutex per key — so locking the
     # entity name already mutually excludes any concurrent edge write that
     # touches it, no need to enumerate incident edges here.
-    lock_keys = sorted({entity_name, new_entity_name}) if is_renaming else [entity_name]
+    lock_keys = {requested_entity_name}
+    if normalized_entity_name:
+        lock_keys.add(normalized_entity_name)
+    if has_new_entity_name:
+        lock_keys.add(requested_new_entity_name)
+        if normalized_new_entity_name:
+            lock_keys.add(normalized_new_entity_name)
 
     workspace = entities_vdb.global_config.get("workspace", "")
     namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
 
-    operation_summary: dict[str, Any] = {
-        "merged": False,
-        "merge_status": "not_attempted",
-        "merge_error": None,
-        "operation_status": "success",
-        "target_entity": None,
-        "final_entity": new_entity_name if is_renaming else entity_name,
-        "renamed": is_renaming,
-    }
     async with get_storage_keyed_lock(
-        lock_keys, namespace=namespace, enable_logging=False
+        sorted(lock_keys), namespace=namespace, enable_logging=False
     ):
         try:
+            # Prefer an exact legacy key when it exists. Otherwise resolve the
+            # caller's spelling to the extraction-normalized identifier.
+            if (
+                requested_entity_name != normalized_entity_name
+                and await chunk_entity_relation_graph.has_node(requested_entity_name)
+            ):
+                entity_name = requested_entity_name
+            elif normalized_entity_name:
+                entity_name = normalized_entity_name
+            else:
+                raise ValueError("Entity name cannot be empty after normalization")
+
+            if has_new_entity_name:
+                if (
+                    requested_new_entity_name != normalized_new_entity_name
+                    and await chunk_entity_relation_graph.has_node(
+                        requested_new_entity_name
+                    )
+                ):
+                    new_entity_name = requested_new_entity_name
+                elif normalized_new_entity_name:
+                    new_entity_name = normalized_new_entity_name
+                else:
+                    raise ValueError("Entity name cannot be empty after normalization")
+                updated_data["entity_name"] = new_entity_name
+            else:
+                new_entity_name = entity_name
+
+            is_renaming = new_entity_name != entity_name
+            operation_summary: dict[str, Any] = {
+                "merged": False,
+                "merge_status": "not_attempted",
+                "merge_error": None,
+                "operation_status": "success",
+                "target_entity": None,
+                "final_entity": new_entity_name if is_renaming else entity_name,
+                "renamed": is_renaming,
+            }
+
             if is_renaming and not allow_rename:
                 raise ValueError(
                     "Entity renaming is not allowed. Set allow_rename=True to enable this feature"
@@ -1009,14 +1063,28 @@ async def acreate_entity(
         entity_data.get("description"), operation="create", object_type="entity"
     )
 
-    # Use keyed lock for entity to ensure atomic graph and vector db operations
+    requested_entity_name = entity_name
+    entity_name = _normalize_manual_entity_name(requested_entity_name)
+    if not entity_name:
+        raise ValueError("Entity name cannot be empty after normalization")
+
+    # Lock both spellings so an existing pre-normalization manual entity cannot
+    # race a canonical create and become a semantic duplicate.
     workspace = entities_vdb.global_config.get("workspace", "")
     namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
     async with get_storage_keyed_lock(
-        [entity_name], namespace=namespace, enable_logging=False
+        sorted({requested_entity_name, entity_name}),
+        namespace=namespace,
+        enable_logging=False,
     ):
         try:
-            # Check if entity already exists
+            if (
+                requested_entity_name != entity_name
+                and await chunk_entity_relation_graph.has_node(requested_entity_name)
+            ):
+                raise ValueError(f"Entity '{requested_entity_name}' already exists")
+
+            # Check if the normalized entity already exists.
             existing_node = await chunk_entity_relation_graph.has_node(entity_name)
             if existing_node:
                 raise ValueError(f"Entity '{entity_name}' already exists")

--- a/lightrag_webui/src/components/graph/EditablePropertyRow.tsx
+++ b/lightrag_webui/src/components/graph/EditablePropertyRow.tsx
@@ -5,6 +5,7 @@ import { updateEntity, updateRelation, checkEntityNameExists } from '@/api/light
 import { useGraphStore } from '@/stores/graph'
 import { useSettingsStore } from '@/stores/settings'
 import { SearchHistoryManager } from '@/utils/SearchHistoryManager'
+import { normalizeEntityName } from '@/utils/entityName'
 import { PropertyName, EditIcon, PropertyValue } from './PropertyRowComponents'
 import PropertyEditDialog from './PropertyEditDialog'
 import MergeDialog from './MergeDialog'
@@ -93,14 +94,36 @@ const EditablePropertyRow = ({
   }
 
   const handleSave = async () => {
-    const value = draftValue.trim()
+    const trimmedValue = draftValue.trim()
     const allowMerge = draftAllowMerge
 
-    if (value === '') {
+    if (trimmedValue === '') {
+      if (name === 'entity_id') {
+        const errorMsg = t('graphPanel.propertiesView.errors.invalidEntityName')
+        setErrorMessage(errorMsg)
+        toast.error(errorMsg)
+      }
       return
     }
 
-    if (isSubmitting || value === String(currentValue)) {
+    if (isSubmitting || trimmedValue === String(currentValue)) {
+      setIsEditing(false)
+      setErrorMessage(null)
+      return
+    }
+
+    const value = name === 'entity_id' ? normalizeEntityName(trimmedValue) : trimmedValue
+    if (name === 'entity_id' && value === '') {
+      const errorMsg = t('graphPanel.propertiesView.errors.invalidEntityName')
+      setErrorMessage(errorMsg)
+      toast.error(errorMsg)
+      return
+    }
+    if (name === 'entity_id' && value !== trimmedValue) {
+      setDraftValue(value)
+    }
+
+    if (value === String(currentValue)) {
       setIsEditing(false)
       setErrorMessage(null)
       return

--- a/lightrag_webui/src/components/graph/PropertyEditDialog.tsx
+++ b/lightrag_webui/src/components/graph/PropertyEditDialog.tsx
@@ -84,10 +84,6 @@ const PropertyEditDialog = ({
     }
   };
 
-  const handleSave = async () => {
-    await onSave()
-  }
-
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="sm:max-w-md">
@@ -170,7 +166,7 @@ const PropertyEditDialog = ({
           </Button>
           <Button
             type="button"
-            onClick={handleSave}
+            onClick={onSave}
             disabled={isSubmitting || disableSave}
           >
             {isSubmitting ? (

--- a/lightrag_webui/src/components/graph/PropertyEditDialog.tsx
+++ b/lightrag_webui/src/components/graph/PropertyEditDialog.tsx
@@ -85,10 +85,7 @@ const PropertyEditDialog = ({
   };
 
   const handleSave = async () => {
-    const trimmedValue = value.trim()
-    if (trimmedValue !== '') {
-      await onSave()
-    }
+    await onSave()
   }
 
   return (

--- a/lightrag_webui/src/locales/ar.json
+++ b/lightrag_webui/src/locales/ar.json
@@ -329,6 +329,7 @@
       "editPropertyDescription": "قم بتحرير قيمة الخاصية في منطقة النص أدناه.",
       "errors": {
         "duplicateName": "اسم العقدة موجود بالفعل",
+        "invalidEntityName": "أدخل اسم عقدة صالحًا",
         "updateFailed": "فشل تحديث العقدة",
         "tryAgainLater": "يرجى المحاولة مرة أخرى لاحقًا",
         "updateSuccessButMergeFailed": "تم تحديث الخصائص، لكن الدمج فشل: {{error}}",

--- a/lightrag_webui/src/locales/de.json
+++ b/lightrag_webui/src/locales/de.json
@@ -329,6 +329,7 @@
       "editPropertyDescription": "Bearbeiten Sie den Eigenschaftswert im Textbereich unten.",
       "errors": {
         "duplicateName": "Knotenname existiert bereits",
+        "invalidEntityName": "Geben Sie einen gültigen Knotennamen ein",
         "updateFailed": "Knoten konnte nicht aktualisiert werden",
         "tryAgainLater": "Bitte versuchen Sie es später erneut",
         "updateSuccessButMergeFailed": "Eigenschaften aktualisiert, aber Zusammenführung fehlgeschlagen: {{error}}",

--- a/lightrag_webui/src/locales/en.json
+++ b/lightrag_webui/src/locales/en.json
@@ -329,6 +329,7 @@
       "editPropertyDescription": "Edit the property value in the text area below.",
       "errors": {
         "duplicateName": "Node name already exists",
+        "invalidEntityName": "Enter a valid node name",
         "updateFailed": "Failed to update node",
         "tryAgainLater": "Please try again later",
         "updateSuccessButMergeFailed": "Properties updated, but merge failed: {{error}}",

--- a/lightrag_webui/src/locales/fr.json
+++ b/lightrag_webui/src/locales/fr.json
@@ -329,6 +329,7 @@
       "editPropertyDescription": "Modifiez la valeur de la propriété dans la zone de texte ci-dessous.",
       "errors": {
         "duplicateName": "Le nom du nœud existe déjà",
+        "invalidEntityName": "Saisissez un nom de nœud valide",
         "updateFailed": "Échec de la mise à jour du nœud",
         "tryAgainLater": "Veuillez réessayer plus tard",
         "updateSuccessButMergeFailed": "Propriétés mises à jour, mais la fusion a échoué : {{error}}",

--- a/lightrag_webui/src/locales/ja.json
+++ b/lightrag_webui/src/locales/ja.json
@@ -329,6 +329,7 @@
       "editPropertyDescription": "下のテキストエリアでプロパティ値を編集してください。",
       "errors": {
         "duplicateName": "ノード名が既に存在します",
+        "invalidEntityName": "有効なノード名を入力してください",
         "updateFailed": "ノードの更新に失敗しました",
         "tryAgainLater": "後でもう一度お試しください",
         "updateSuccessButMergeFailed": "プロパティは更新されましたが、マージに失敗しました: {{error}}",

--- a/lightrag_webui/src/locales/ko.json
+++ b/lightrag_webui/src/locales/ko.json
@@ -329,6 +329,7 @@
       "editPropertyDescription": "아래 텍스트 영역에서 속성 값을 수정하세요.",
       "errors": {
         "duplicateName": "노드 이름이 이미 존재합니다",
+        "invalidEntityName": "올바른 노드 이름을 입력하세요",
         "updateFailed": "노드 업데이트 실패",
         "tryAgainLater": "나중에 다시 시도해주세요",
         "updateSuccessButMergeFailed": "속성이 업데이트되었으나 병합 실패: {{error}}",

--- a/lightrag_webui/src/locales/ru.json
+++ b/lightrag_webui/src/locales/ru.json
@@ -329,6 +329,7 @@
       "editPropertyDescription": "Отредактируйте значение свойства в текстовой области ниже.",
       "errors": {
         "duplicateName": "Имя узла уже существует",
+        "invalidEntityName": "Введите допустимое имя узла",
         "updateFailed": "Не удалось обновить узел",
         "tryAgainLater": "Пожалуйста, попробуйте позже",
         "updateSuccessButMergeFailed": "Свойства обновлены, но слияние не удалось: {{error}}",

--- a/lightrag_webui/src/locales/uk.json
+++ b/lightrag_webui/src/locales/uk.json
@@ -329,6 +329,7 @@
       "editPropertyDescription": "Редагуйте значення властивості в текстовій області нижче.",
       "errors": {
         "duplicateName": "Ім'я вузла вже існує",
+        "invalidEntityName": "Введіть припустиме ім'я вузла",
         "updateFailed": "Не вдалося оновити вузол",
         "tryAgainLater": "Будь ласка, спробуйте пізніше",
         "updateSuccessButMergeFailed": "Властивості оновлено, але об'єднання не вдалося: {{error}}",

--- a/lightrag_webui/src/locales/vi.json
+++ b/lightrag_webui/src/locales/vi.json
@@ -329,6 +329,7 @@
       "editPropertyDescription": "Chỉnh sửa giá trị thuộc tính trong vùng văn bản bên dưới.",
       "errors": {
         "duplicateName": "Tên nút đã tồn tại",
+        "invalidEntityName": "Hãy nhập tên nút hợp lệ",
         "updateFailed": "Cập nhật nút thất bại",
         "tryAgainLater": "Vui lòng thử lại sau",
         "updateSuccessButMergeFailed": "Đã cập nhật thuộc tính, nhưng hợp nhất thất bại: {{error}}",

--- a/lightrag_webui/src/locales/zh.json
+++ b/lightrag_webui/src/locales/zh.json
@@ -329,6 +329,7 @@
       "editPropertyDescription": "在下方文本区域编辑属性值。",
       "errors": {
         "duplicateName": "节点名称已存在",
+        "invalidEntityName": "请输入有效的节点名称",
         "updateFailed": "更新节点失败",
         "tryAgainLater": "请稍后重试",
         "updateSuccessButMergeFailed": "属性已更新，但合并失败：{{error}}",

--- a/lightrag_webui/src/locales/zh_TW.json
+++ b/lightrag_webui/src/locales/zh_TW.json
@@ -329,6 +329,7 @@
       "editPropertyDescription": "在下方文字區域編輯屬性值。",
       "errors": {
         "duplicateName": "節點名稱已存在",
+        "invalidEntityName": "請輸入有效的節點名稱",
         "updateFailed": "更新節點失敗",
         "tryAgainLater": "請稍後重試",
         "updateSuccessButMergeFailed": "屬性已更新，但合併失敗：{{error}}",

--- a/lightrag_webui/src/utils/entityName.test.ts
+++ b/lightrag_webui/src/utils/entityName.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, test } from 'bun:test'
 import { normalizeEntityName } from './entityName'
 
 describe('normalizeEntityName', () => {
+  // Bun runs these unit tests without a DOM, so HTML decoding assertions
+  // exercise the explicit non-browser fallback. Production browsers use a
+  // detached textarea for the full native HTML5 entity decoder.
   test('mirrors extraction cleanup for HTML, full-width characters, quotes and CJK spaces', () => {
     expect(normalizeEntityName('  <p>“Ａ 公 司”</p>  ')).toBe('A公司')
     expect(normalizeEntityName('《北 京》')).toBe('北京')

--- a/lightrag_webui/src/utils/entityName.test.ts
+++ b/lightrag_webui/src/utils/entityName.test.ts
@@ -1,0 +1,32 @@
+/// <reference types="bun" />
+import { describe, expect, test } from 'bun:test'
+import { normalizeEntityName } from './entityName'
+
+describe('normalizeEntityName', () => {
+  test('mirrors extraction cleanup for HTML, full-width characters, quotes and CJK spaces', () => {
+    expect(normalizeEntityName('  <p>“Ａ 公 司”</p>  ')).toBe('A公司')
+    expect(normalizeEntityName('《北 京》')).toBe('北京')
+    expect(normalizeEntityName('"《Ａ 公 司》"')).toBe('A公司')
+    expect(normalizeEntityName('项 目（Ａ－１）')).toBe('项目(A-1)')
+  })
+
+  test('unescapes HTML entities and strips invalid control and surrogate characters', () => {
+    expect(normalizeEntityName('&quot;ACME&amp;Co&quot;')).toBe('ACME&Co')
+    expect(normalizeEntityName('A\u0000B\ud800C')).toBe('ABC')
+  })
+
+  test('preserves meaningful ASCII spacing and inner quotes away from CJK text', () => {
+    expect(normalizeEntityName('Entity "A"')).toBe('Entity "A"')
+    expect(normalizeEntityName('New York')).toBe('New York')
+    expect(normalizeEntityName('C++')).toBe('C++')
+  })
+
+  test('rejects the same short numeric and dotted names as extraction', () => {
+    expect(normalizeEntityName('1')).toBe('')
+    expect(normalizeEntityName('12')).toBe('')
+    expect(normalizeEntityName('1.2')).toBe('')
+    expect(normalizeEntityName('123.4')).toBe('')
+    expect(normalizeEntityName('123')).toBe('123')
+    expect(normalizeEntityName('123.45')).toBe('123.45')
+  })
+})

--- a/lightrag_webui/src/utils/entityName.ts
+++ b/lightrag_webui/src/utils/entityName.ts
@@ -1,0 +1,127 @@
+const BASIC_HTML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  apos: '\'',
+  gt: '>',
+  lt: '<',
+  nbsp: '\u00a0',
+  quot: '"'
+}
+
+const stripInvalidUnicodeAndControls = (value: string): string =>
+  Array.from(value, (character) => {
+    const codePoint = character.codePointAt(0) ?? 0
+    const isInvalidUnicode =
+      (codePoint >= 0xd800 && codePoint <= 0xdfff) ||
+      codePoint === 0xfffe ||
+      codePoint === 0xffff
+    const isControl =
+      codePoint <= 0x08 ||
+      (codePoint >= 0x0b && codePoint <= 0x0c) ||
+      (codePoint >= 0x0e && codePoint <= 0x1f) ||
+      codePoint === 0x7f
+    return isInvalidUnicode || isControl ? '' : character
+  }).join('')
+
+const decodeHtmlEntities = (value: string): string => {
+  if (typeof document !== 'undefined') {
+    const textarea = document.createElement('textarea')
+    textarea.innerHTML = value
+    return textarea.value
+  }
+
+  return value.replace(/&(#(?:x[0-9a-f]+|\d+)|[a-z]+);/gi, (match, entity: string) => {
+    if (entity.startsWith('#')) {
+      const isHex = entity[1]?.toLowerCase() === 'x'
+      const codePoint = Number.parseInt(entity.slice(isHex ? 2 : 1), isHex ? 16 : 10)
+      if (Number.isNaN(codePoint) || codePoint > 0x10ffff) return match
+
+      try {
+        return String.fromCodePoint(codePoint)
+      } catch {
+        return match
+      }
+    }
+
+    return BASIC_HTML_ENTITIES[entity.toLowerCase()] ?? match
+  })
+}
+
+const toHalfWidthEntityCharacters = (value: string): string =>
+  Array.from(value, (character) => {
+    const codePoint = character.codePointAt(0)
+    if (codePoint !== undefined && codePoint >= 0xff10 && codePoint <= 0xff19) {
+      return String.fromCodePoint(codePoint - 0xfee0)
+    }
+    if (codePoint !== undefined && codePoint >= 0xff21 && codePoint <= 0xff3a) {
+      return String.fromCodePoint(codePoint - 0xfee0)
+    }
+    if (codePoint !== undefined && codePoint >= 0xff41 && codePoint <= 0xff5a) {
+      return String.fromCodePoint(codePoint - 0xfee0)
+    }
+
+    return character
+  }).join('')
+
+const stripMatchingOuterQuotes = (value: string): string => {
+  const pairs: ReadonlyArray<readonly [string, string]> = [
+    ['"', '"'],
+    ['\'', '\''],
+    ['“', '”'],
+    ['‘', '’'],
+    ['《', '》']
+  ]
+
+  let result = value
+  for (const [opening, closing] of pairs) {
+    if (!result.startsWith(opening) || !result.endsWith(closing)) continue
+
+    const inner = result.slice(opening.length, -closing.length)
+    if (!inner.includes(opening) && !inner.includes(closing)) result = inner
+  }
+
+  return result
+}
+
+/**
+ * Mirror the backend extraction naming contract for entity names entered in the WebUI.
+ * The backend remains authoritative; this helper provides immediate validation and
+ * makes the duplicate check use the same canonical candidate that will be submitted.
+ */
+export const normalizeEntityName = (input: string): string => {
+  let name = stripInvalidUnicodeAndControls(decodeHtmlEntities(input.trim()))
+  if (!name) return ''
+
+  name = name.replace(/<\/?p\s*>|<p\/>/gi, '')
+  name = name.replace(/<\/?br\s*>|<br\/>/gi, '')
+  name = toHalfWidthEntityCharacters(name)
+    .replaceAll('－', '-')
+    .replaceAll('＋', '+')
+    .replaceAll('／', '/')
+    .replaceAll('＊', '*')
+    .replaceAll('（', '(')
+    .replaceAll('）', ')')
+    .replaceAll('—', '-')
+    .replaceAll('　', ' ')
+
+  name = name.replace(/(?<=[\u4e00-\u9fa5])\s+(?=[\u4e00-\u9fa5])/g, '')
+  name = name.replace(
+    /(?<=[\u4e00-\u9fa5])\s+(?=[a-zA-Z0-9()[\]@#$%!&*\-=+_])/g,
+    ''
+  )
+  name = name.replace(
+    /(?<=[a-zA-Z0-9()[\]@#$%!&*\-=+_])\s+(?=[\u4e00-\u9fa5])/g,
+    ''
+  )
+
+  name = stripMatchingOuterQuotes(name)
+  name = name.replace(/[“”‘’]/g, '')
+  name = name.replace(/['"]+(?=[\u4e00-\u9fa5])/g, '')
+  name = name.replace(/(?<=[\u4e00-\u9fa5])['"]+/g, '')
+  name = name.replaceAll('\u00a0', ' ')
+  name = name.replace(/(?<=[^\d])\u202f/g, ' ').trim()
+
+  if (name.length < 3 && /^[0-9]+$/.test(name)) return ''
+  if (name.length < 6 && name.includes('.') && /^[0-9.]+$/.test(name)) return ''
+
+  return name
+}

--- a/tests/api/routes/test_graph_entity_name_normalization.py
+++ b/tests/api/routes/test_graph_entity_name_normalization.py
@@ -1,0 +1,210 @@
+"""Business-layer normalization for manual entity mutations."""
+
+from copy import deepcopy
+
+import pytest
+
+from lightrag import utils_graph
+from lightrag.utils import compute_mdhash_id
+
+pytestmark = pytest.mark.offline
+
+
+class _NoopLock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Graph:
+    def __init__(self, nodes=None):
+        self.nodes = deepcopy(nodes or {})
+
+    async def has_node(self, entity_name):
+        return entity_name in self.nodes
+
+    async def get_node(self, entity_name):
+        node = self.nodes.get(entity_name)
+        return deepcopy(node) if node is not None else None
+
+    async def upsert_node(self, entity_name, node_data):
+        self.nodes[entity_name] = deepcopy(node_data)
+
+    async def get_node_edges(self, entity_name):
+        return []
+
+    async def delete_node(self, entity_name):
+        self.nodes.pop(entity_name, None)
+
+    async def index_done_callback(self):
+        return None
+
+
+class _VectorStorage:
+    def __init__(self):
+        self.global_config = {"workspace": ""}
+        self.records = {}
+
+    async def upsert(self, data):
+        self.records.update(deepcopy(data))
+
+    async def delete(self, ids):
+        for record_id in ids:
+            self.records.pop(record_id, None)
+
+    async def index_done_callback(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def patch_graph_lock(monkeypatch):
+    monkeypatch.setattr(
+        utils_graph,
+        "get_storage_keyed_lock",
+        lambda *args, **kwargs: _NoopLock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_entity_uses_extraction_name_normalization():
+    graph = _Graph()
+    entities_vdb = _VectorStorage()
+    relationships_vdb = _VectorStorage()
+
+    result = await utils_graph.acreate_entity(
+        graph,
+        entities_vdb,
+        relationships_vdb,
+        "  “Ａ 公 司”  ",
+        {"description": "Company description", "entity_type": "organization"},
+    )
+
+    assert result["entity_name"] == "A公司"
+    assert set(graph.nodes) == {"A公司"}
+    entity_id = compute_mdhash_id("A公司", prefix="ent-")
+    assert entities_vdb.records[entity_id]["entity_name"] == "A公司"
+
+
+@pytest.mark.asyncio
+async def test_create_entity_rejects_name_removed_by_normalization():
+    with pytest.raises(ValueError, match="empty after normalization"):
+        await utils_graph.acreate_entity(
+            _Graph(),
+            _VectorStorage(),
+            _VectorStorage(),
+            "1",
+            {"description": "Invalid numeric identifier"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_edit_resolves_normalized_source_and_normalizes_rename_target():
+    graph = _Graph(
+        {
+            "Source公司": {
+                "entity_id": "Source公司",
+                "description": "old",
+                "entity_type": "organization",
+                "source_id": "manual_creation",
+            }
+        }
+    )
+    entities_vdb = _VectorStorage()
+    relationships_vdb = _VectorStorage()
+    updated_data = {"entity_name": " “Ｔ 目 标” ", "description": "renamed"}
+
+    result = await utils_graph.aedit_entity(
+        graph,
+        entities_vdb,
+        relationships_vdb,
+        "Ｓｏｕｒｃｅ 公 司",
+        updated_data,
+        allow_rename=True,
+    )
+
+    assert updated_data["entity_name"] == " “Ｔ 目 标” "
+    assert "Source公司" not in graph.nodes
+    assert graph.nodes["T目标"]["entity_id"] == "T目标"
+    assert result["entity_name"] == "T目标"
+    assert result["operation_summary"]["final_entity"] == "T目标"
+    assert result["operation_summary"]["renamed"] is True
+
+
+@pytest.mark.asyncio
+async def test_edit_prefers_exact_legacy_entity_key():
+    legacy_name = "“Ａ 公 司”"
+    graph = _Graph(
+        {
+            legacy_name: {
+                "entity_id": legacy_name,
+                "description": "old",
+                "entity_type": "organization",
+                "source_id": "manual_creation",
+            }
+        }
+    )
+
+    result = await utils_graph.aedit_entity(
+        graph,
+        _VectorStorage(),
+        _VectorStorage(),
+        legacy_name,
+        {"description": "updated"},
+        allow_rename=False,
+    )
+
+    assert set(graph.nodes) == {legacy_name}
+    assert graph.nodes[legacy_name]["description"] == "updated"
+    assert result["entity_name"] == legacy_name
+
+
+@pytest.mark.asyncio
+async def test_edit_preserves_exact_legacy_name_that_normalizes_to_empty():
+    legacy_name = "1"
+    graph = _Graph(
+        {
+            legacy_name: {
+                "entity_id": legacy_name,
+                "description": "old",
+                "source_id": "manual_creation",
+            }
+        }
+    )
+
+    result = await utils_graph.aedit_entity(
+        graph,
+        _VectorStorage(),
+        _VectorStorage(),
+        legacy_name,
+        {"description": "updated"},
+        allow_rename=False,
+    )
+
+    assert graph.nodes[legacy_name]["description"] == "updated"
+    assert result["entity_name"] == legacy_name
+
+
+@pytest.mark.asyncio
+async def test_create_refuses_duplicate_exact_legacy_key():
+    legacy_name = "“Ａ 公 司”"
+    graph = _Graph(
+        {
+            legacy_name: {
+                "entity_id": legacy_name,
+                "description": "legacy",
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match="already exists"):
+        await utils_graph.acreate_entity(
+            graph,
+            _VectorStorage(),
+            _VectorStorage(),
+            legacy_name,
+            {"description": "duplicate"},
+        )
+
+    assert set(graph.nodes) == {legacy_name}

--- a/tests/api/routes/test_graph_entity_name_normalization.py
+++ b/tests/api/routes/test_graph_entity_name_normalization.py
@@ -21,6 +21,7 @@ class _NoopLock:
 class _Graph:
     def __init__(self, nodes=None):
         self.nodes = deepcopy(nodes or {})
+        self.deleted_nodes = []
 
     async def has_node(self, entity_name):
         return entity_name in self.nodes
@@ -36,6 +37,7 @@ class _Graph:
         return []
 
     async def delete_node(self, entity_name):
+        self.deleted_nodes.append(entity_name)
         self.nodes.pop(entity_name, None)
 
     async def index_done_callback(self):
@@ -208,3 +210,65 @@ async def test_create_refuses_duplicate_exact_legacy_key():
         )
 
     assert set(graph.nodes) == {legacy_name}
+
+
+@pytest.mark.asyncio
+async def test_merge_normalizes_sources_and_creates_normalized_target_once():
+    graph = _Graph(
+        {
+            "Source公司": {
+                "entity_id": "Source公司",
+                "description": "source",
+                "entity_type": "organization",
+                "source_id": "manual_creation",
+            }
+        }
+    )
+    entities_vdb = _VectorStorage()
+
+    result = await utils_graph.amerge_entities(
+        graph,
+        entities_vdb,
+        _VectorStorage(),
+        ["Ｓｏｕｒｃｅ 公 司", "Source公司"],
+        " “Ｔ 目 标” ",
+    )
+
+    assert result["entity_name"] == "T目标"
+    assert set(graph.nodes) == {"T目标"}
+    assert graph.nodes["T目标"]["entity_id"] == "T目标"
+    assert graph.deleted_nodes == ["Source公司"]
+    target_id = compute_mdhash_id("T目标", prefix="ent-")
+    assert entities_vdb.records[target_id]["entity_name"] == "T目标"
+
+
+@pytest.mark.asyncio
+async def test_merge_preserves_exact_legacy_source_and_target_keys():
+    legacy_source = "1"
+    legacy_target = "“Ａ 公 司”"
+    graph = _Graph(
+        {
+            legacy_source: {
+                "entity_id": legacy_source,
+                "description": "source",
+                "source_id": "manual_creation",
+            },
+            legacy_target: {
+                "entity_id": legacy_target,
+                "description": "target",
+                "source_id": "manual_creation",
+            },
+        }
+    )
+
+    result = await utils_graph.amerge_entities(
+        graph,
+        _VectorStorage(),
+        _VectorStorage(),
+        [legacy_source],
+        legacy_target,
+    )
+
+    assert result["entity_name"] == legacy_target
+    assert set(graph.nodes) == {legacy_target}
+    assert graph.deleted_nodes == [legacy_source]

--- a/tests/api/routes/test_graph_routes_pipeline_busy.py
+++ b/tests/api/routes/test_graph_routes_pipeline_busy.py
@@ -243,6 +243,25 @@ def test_create_entity_message_uses_normalized_result_name(monkeypatch):
     assert response.json()["message"] == "Entity 'A公司' created successfully"
 
 
+def test_merge_entity_message_uses_normalized_result_name(monkeypatch):
+    rag = _make_mock_rag()
+    rag.amerge_entities.return_value = {"entity_name": "T目标"}
+    client = _build_client(rag)
+    _patch_guard(monkeypatch, _noop_guard)
+
+    response = client.post(
+        "/graph/entities/merge",
+        json={
+            "entities_to_change": ["Ｓｏｕｒｃｅ 公 司"],
+            "entity_to_change_into": "“Ｔ 目 标”",
+        },
+        headers=_HEADERS,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["message"] == ("Successfully merged 1 entities into 'T目标'")
+
+
 # ---------------------------------------------------------------------------
 # Part B: helper unit -- against real pipeline_status namespace
 # ---------------------------------------------------------------------------

--- a/tests/api/routes/test_graph_routes_pipeline_busy.py
+++ b/tests/api/routes/test_graph_routes_pipeline_busy.py
@@ -224,6 +224,25 @@ def test_endpoint_passes_through_when_pipeline_idle(monkeypatch):
     rag.aedit_entity.assert_awaited_once()
 
 
+def test_create_entity_message_uses_normalized_result_name(monkeypatch):
+    rag = _make_mock_rag()
+    rag.acreate_entity.return_value = {"entity_name": "A公司"}
+    client = _build_client(rag)
+    _patch_guard(monkeypatch, _noop_guard)
+
+    response = client.post(
+        "/graph/entity/create",
+        json={
+            "entity_name": "“Ａ 公 司”",
+            "entity_data": {"description": "x"},
+        },
+        headers=_HEADERS,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["message"] == "Entity 'A公司' created successfully"
+
+
 # ---------------------------------------------------------------------------
 # Part B: helper unit -- against real pipeline_status namespace
 # ---------------------------------------------------------------------------

--- a/tests/kg/test_batch_graph_operations.py
+++ b/tests/kg/test_batch_graph_operations.py
@@ -424,6 +424,157 @@ class TestAinsertCustomKgBatchPath:
 
     @pytest.mark.offline
     @pytest.mark.asyncio
+    async def test_ainsert_custom_kg_normalizes_names_before_dedup_and_upsert(self):
+        """Graph and vector writes must share extraction-normalized identifiers."""
+        from lightrag import LightRAG
+
+        custom_kg = {
+            "chunks": [],
+            "entities": [
+                {
+                    "entity_name": "  <p>“Ａ 公 司”</p>  ",
+                    "entity_type": "ORGANIZATION",
+                    "description": "first declaration",
+                },
+                {
+                    "entity_name": "A公司",
+                    "entity_type": "ORGANIZATION",
+                    "description": "latest declaration",
+                },
+            ],
+            "relationships": [
+                {
+                    "src_id": "Ａ 公 司",
+                    "tgt_id": "《Ｂ 项 目》",
+                    "description": "old relation",
+                    "keywords": "old",
+                },
+                {
+                    "src_id": "B项目",
+                    "tgt_id": "A公司",
+                    "description": "latest relation",
+                    "keywords": "latest",
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            rag = LightRAG(
+                working_dir=tmp,
+                llm_model_func=AsyncMock(return_value=""),
+                embedding_func=mock_embedding_func,
+            )
+            await rag.initialize_storages()
+
+            rag.entities_vdb.upsert = AsyncMock()
+            rag.relationships_vdb.upsert = AsyncMock()
+            rag.relationships_vdb.delete = AsyncMock()
+
+            await rag.ainsert_custom_kg(custom_kg)
+
+            graph = rag.chunk_entity_relation_graph
+            assert await graph.has_node("A公司")
+            assert await graph.has_node("B项目")
+            assert not await graph.has_node("  <p>“Ａ 公 司”</p>  ")
+            assert await graph.has_edge("A公司", "B项目")
+
+            entity = await graph.get_node("A公司")
+            assert entity is not None
+            assert entity["description"] == "latest declaration"
+
+            edge = await graph.get_edge("A公司", "B项目")
+            assert edge is not None
+            assert edge["description"] == "latest relation"
+
+            entity_vdb_payload = rag.entities_vdb.upsert.await_args.args[0]
+            assert len(entity_vdb_payload) == 1
+            only_entity = next(iter(entity_vdb_payload.values()))
+            assert only_entity["entity_name"] == "A公司"
+
+            relation_vdb_payload = rag.relationships_vdb.upsert.await_args.args[0]
+            assert len(relation_vdb_payload) == 1
+            only_relation = next(iter(relation_vdb_payload.values()))
+            assert only_relation["src_id"] == "A公司"
+            assert only_relation["tgt_id"] == "B项目"
+
+            # The public input remains reusable and unchanged.
+            assert custom_kg["entities"][0]["entity_name"] == ("  <p>“Ａ 公 司”</p>  ")
+            assert custom_kg["relationships"][0]["src_id"] == "Ａ 公 司"
+            assert custom_kg["relationships"][0]["tgt_id"] == "《Ｂ 项 目》"
+
+            await rag.finalize_storages()
+
+    @pytest.mark.offline
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("custom_kg", "invalid_field"),
+        [
+            (
+                {
+                    "chunks": [{"content": "text", "source_id": "s1"}],
+                    "entities": [{"entity_name": "1"}],
+                    "relationships": [],
+                },
+                r"entities\[0\]\.entity_name",
+            ),
+            (
+                {
+                    "chunks": [{"content": "text", "source_id": "s1"}],
+                    "entities": [],
+                    "relationships": [
+                        {
+                            "src_id": "1.2",
+                            "tgt_id": "ValidEntity",
+                            "description": "relation",
+                            "keywords": "keyword",
+                        }
+                    ],
+                },
+                r"relationships\[0\]\.src_id",
+            ),
+        ],
+    )
+    async def test_ainsert_custom_kg_rejects_invalid_names_before_storage_writes(
+        self,
+        custom_kg,
+        invalid_field,
+    ):
+        from lightrag import LightRAG
+
+        with tempfile.TemporaryDirectory() as tmp:
+            rag = LightRAG(
+                working_dir=tmp,
+                llm_model_func=AsyncMock(return_value=""),
+                embedding_func=mock_embedding_func,
+            )
+            await rag.initialize_storages()
+
+            rag.chunks_vdb.upsert = AsyncMock()
+            rag.text_chunks.upsert = AsyncMock()
+            rag.entities_vdb.upsert = AsyncMock()
+            rag.relationships_vdb.upsert = AsyncMock()
+            rag.chunk_entity_relation_graph.upsert_nodes_batch = AsyncMock()
+            rag.chunk_entity_relation_graph.upsert_edges_batch = AsyncMock()
+            rag._insert_done_with_cleanup = AsyncMock()
+
+            with pytest.raises(
+                ValueError,
+                match=rf"Custom KG {invalid_field} cannot be empty after normalization",
+            ):
+                await rag.ainsert_custom_kg(custom_kg)
+
+            rag.chunks_vdb.upsert.assert_not_awaited()
+            rag.text_chunks.upsert.assert_not_awaited()
+            rag.entities_vdb.upsert.assert_not_awaited()
+            rag.relationships_vdb.upsert.assert_not_awaited()
+            rag.chunk_entity_relation_graph.upsert_nodes_batch.assert_not_awaited()
+            rag.chunk_entity_relation_graph.upsert_edges_batch.assert_not_awaited()
+            rag._insert_done_with_cleanup.assert_not_awaited()
+
+            await rag.finalize_storages()
+
+    @pytest.mark.offline
+    @pytest.mark.asyncio
     async def test_ainsert_custom_kg_no_hasattr_needed(self):
         """
         The batch methods are always available on the base class, so no

--- a/tests/pipeline/test_graph_keyed_locks.py
+++ b/tests/pipeline/test_graph_keyed_locks.py
@@ -10,8 +10,9 @@ exclude any concurrent edge write that names the same entity in
 These tests pin:
 - `aedit_entity` locks exact and canonical source/target candidates.
 - `adelete_by_entity` locks {entity_name}.
-- `ainsert_custom_kg` locks every entity name plus every relationship
-  endpoint that the batch will write, sharing the doc-ingest namespace.
+- `ainsert_custom_kg` locks every normalized entity name plus every normalized
+  relationship endpoint that the batch will write, sharing the doc-ingest
+  namespace.
 - An empty `ainsert_custom_kg` batch skips the lock entirely.
 """
 
@@ -290,9 +291,9 @@ async def test_ainsert_custom_kg_locks_every_entity_and_endpoint(
     single_process_shared_data,
 ):
     """ainsert_custom_kg must hold a single coarse-grained keyed lock whose
-    key set covers every entity name plus every relationship endpoint in the
-    batch — sharing the doc-ingest namespace so concurrent callers on
-    overlapping entities serialise instead of racing.
+    key set covers every normalized entity name plus every normalized
+    relationship endpoint in the batch — sharing the doc-ingest namespace so
+    concurrent callers on overlapping entities serialise instead of racing.
     """
     from lightrag import lightrag as lightrag_module
     from lightrag.lightrag import LightRAG
@@ -314,14 +315,14 @@ async def test_ainsert_custom_kg_locks_every_entity_and_endpoint(
         "chunks": [],
         "entities": [
             {
-                "entity_name": "Alice",
+                "entity_name": "Ａｌｉｃｅ",
                 "entity_type": "PERSON",
                 "description": "x",
                 "source_id": "chunk-1",
                 "file_path": "f",
             },
             {
-                "entity_name": "Bob",
+                "entity_name": "“Ｂｏｂ”",
                 "entity_type": "PERSON",
                 "description": "y",
                 "source_id": "chunk-1",
@@ -330,8 +331,8 @@ async def test_ainsert_custom_kg_locks_every_entity_and_endpoint(
         ],
         "relationships": [
             {
-                "src_id": "Alice",
-                "tgt_id": "Bob",
+                "src_id": "Ａｌｉｃｅ",
+                "tgt_id": "“Ｂｏｂ”",
                 "description": "knows",
                 "keywords": "k",
                 "weight": 1.0,
@@ -339,8 +340,8 @@ async def test_ainsert_custom_kg_locks_every_entity_and_endpoint(
                 "file_path": "f",
             },
             {
-                "src_id": "Bob",
-                "tgt_id": "Carol",
+                "src_id": "Ｂｏｂ",
+                "tgt_id": "Ｃａｒｏｌ",
                 "description": "knows",
                 "keywords": "k",
                 "weight": 1.0,
@@ -361,8 +362,8 @@ async def test_ainsert_custom_kg_locks_every_entity_and_endpoint(
     # mutually exclude across paths.
     assert call["namespace"] == "ws1:GraphDB"
 
-    # Union of entity names ({Alice, Bob}) and every relationship endpoint
-    # ({Alice, Bob, Carol}), sorted.
+    # The raw full-width/quoted spellings are normalized before the union is
+    # locked, so keys collide with the extraction pipeline's canonical names.
     assert call["keys"] == ["Alice", "Bob", "Carol"]
 
 

--- a/tests/pipeline/test_graph_keyed_locks.py
+++ b/tests/pipeline/test_graph_keyed_locks.py
@@ -8,7 +8,7 @@ exclude any concurrent edge write that names the same entity in
 `sorted([src, tgt])` — no need to enumerate incident edges here.
 
 These tests pin:
-- `aedit_entity` locks {old, new} on rename, {entity_name} otherwise.
+- `aedit_entity` locks exact and canonical source/target candidates.
 - `adelete_by_entity` locks {entity_name}.
 - `ainsert_custom_kg` locks every entity name plus every relationship
   endpoint that the batch will write, sharing the doc-ingest namespace.
@@ -192,6 +192,34 @@ async def test_aedit_entity_non_rename_locks_single_entity_name():
     # Empty workspace falls back to the bare "GraphDB" namespace.
     assert captured[0]["namespace"] == "GraphDB"
     graph.get_node_edges.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_aedit_entity_locks_exact_and_normalized_name_candidates():
+    """Normalization resolution stays inside the complete candidate lock set."""
+    from lightrag import utils_graph
+
+    spy, captured = _make_keyed_lock_spy()
+    graph = _make_graph_mock(existing_entity="A公司")
+    entities_vdb = _make_vdb_mock(workspace="ws1")
+    relationships_vdb = _make_vdb_mock(workspace="ws1")
+
+    graph.upsert_node.side_effect = RuntimeError("stop after lock acquisition")
+
+    with patch.object(utils_graph, "get_storage_keyed_lock", spy):
+        with pytest.raises(RuntimeError, match="stop after lock acquisition"):
+            await utils_graph.aedit_entity(
+                chunk_entity_relation_graph=graph,
+                entities_vdb=entities_vdb,
+                relationships_vdb=relationships_vdb,
+                entity_name="“Ａ 公 司”",
+                updated_data={"entity_name": "“Ｂ 公 司”", "description": "renamed"},
+                allow_rename=True,
+            )
+
+    assert len(captured) == 1
+    assert captured[0]["keys"] == ["A公司", "B公司", "“Ａ 公 司”", "“Ｂ 公 司”"]
+    assert captured[0]["namespace"] == "ws1:GraphDB"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/test_graph_keyed_locks.py
+++ b/tests/pipeline/test_graph_keyed_locks.py
@@ -9,6 +9,7 @@ exclude any concurrent edge write that names the same entity in
 
 These tests pin:
 - `aedit_entity` locks exact and canonical source/target candidates.
+- `amerge_entities` locks exact and canonical source/target candidates.
 - `adelete_by_entity` locks {entity_name}.
 - `ainsert_custom_kg` locks every normalized entity name plus every normalized
   relationship endpoint that the batch will write, sharing the doc-ingest
@@ -284,6 +285,34 @@ class _AbortOnEnterLock:
 class _LockCaptured(RuntimeError):
     """Sentinel raised from the captured lock context to short-circuit the
     enclosing async with block."""
+
+
+@pytest.mark.asyncio
+async def test_amerge_entities_locks_exact_and_normalized_name_candidates():
+    """Merge resolution stays inside the complete exact/canonical lock set."""
+    from lightrag import utils_graph
+
+    graph = _make_graph_mock(existing_entity="A公司")
+    entities_vdb = _make_vdb_mock(workspace="ws1")
+    relationships_vdb = _make_vdb_mock(workspace="ws1")
+    lock_spy = _AbortOnEnterLock()
+
+    with patch.object(utils_graph, "get_storage_keyed_lock", lock_spy):
+        with pytest.raises(_LockCaptured):
+            await utils_graph.amerge_entities(
+                chunk_entity_relation_graph=graph,
+                entities_vdb=entities_vdb,
+                relationships_vdb=relationships_vdb,
+                source_entities=["“Ａ 公 司”"],
+                target_entity="“Ｔ 目 标”",
+            )
+
+    assert lock_spy.captured == [
+        {
+            "keys": ["A公司", "T目标", "“Ａ 公 司”", "“Ｔ 目 标”"],
+            "namespace": "ws1:GraphDB",
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Manual entity creation, rename, merge, and custom-KG insertion did not consistently apply the same naming cleanup as extraction. This could leave graph and vector storage with non-canonical entity identifiers, while the WebUI checked duplicates using a different spelling from the value ultimately accepted by the backend.

This change establishes one entity-name normalization contract across extraction, manual graph operations, custom-KG insertion, and the WebUI. The backend remains authoritative, while the WebUI provides immediate validation before submission.

## Related Issues

Follow-up to #3555, where storage escaping highlighted that entity-name consistency must be enforced in the business layer.

## Changes Made

- Added a shared `normalize_entity_name` helper that preserves the extraction behavior, including `remove_inner_quotes=True`.
- Applied the shared contract to extracted entity names and relationship endpoints, manual entity creation, rename targets, and entity merges.
- Made entity merge lock and resolve every exact/canonical source and target candidate, preserving existing legacy keys while creating missing targets only under their normalized names.
- Normalized every `ainsert_custom_kg` entity declaration and relationship endpoint before any storage write, then deduplicated and locked canonical identifiers without mutating caller input.
- Preserved exact lookup and editing of legacy non-canonical graph keys while locking both requested and canonical candidates.
- Normalized WebUI rename candidates before duplicate checks and submission, rejected names that become empty, and added localized validation messages for every supported locale.
- Corrected the merge endpoint documentation: merging into a missing target is an intentional spelling-repair operation that creates the normalized target.
- Updated programming documentation and added backend, route, lock, merge, custom-KG, and Bun regression coverage.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Validation completed locally:

- `./scripts/test.sh tests/extraction tests/api/routes tests/pipeline/test_graph_keyed_locks.py`: 589 passed, 4 skipped
- Full API-route, merge consistency, and graph-lock suites: 423 passed, 4 skipped
- All direct `ainsert_custom_kg` caller and boundary suites: 115 passed
- WebUI `bun test`: 92 passed
- WebUI ESLint and production build passed
- Ruff check/format and `git diff --check` passed

The current WebUI has no manual entity-creation form; creation through the public API is normalized by the backend, and the reusable WebUI helper is available for a future form. Bun currently runs without a DOM, so the entity-name unit test explicitly covers the non-DOM HTML-entity fallback; production browsers delegate full HTML5 entity decoding to a detached textarea.
