### PR TITLE
fix(kg): deep-copy JsonKVStorage read results to prevent aliasing

### DIFF
--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -1,3 +1,4 @@
+import copy
 import os
 from dataclasses import dataclass
 from typing import Any, ClassVar, final
@@ -258,8 +259,13 @@ class JsonKVStorage(BaseKVStorage):
         async with self._storage_lock:
             result = self._data.get(id)
             if result:
-                # Create a copy to avoid modifying the original data
-                result = dict(result)
+                # Deep-copy so nested mutable fields (e.g. text_chunks'
+                # llm_cache_list) don't alias the live storage row — a
+                # shallow copy here only protects top-level keys, letting a
+                # caller that mutates a nested list/dict in place (see
+                # update_chunk_cache_list in utils.py) corrupt persisted
+                # state without going through upsert.
+                result = copy.deepcopy(result)
                 # Ensure time fields are present, provide default values for old data
                 result.setdefault("create_time", 0)
                 result.setdefault("update_time", 0)
@@ -281,8 +287,9 @@ class JsonKVStorage(BaseKVStorage):
             for id in ids:
                 data = self._data.get(id, None)
                 if data:
-                    # Create a copy to avoid modifying the original data
-                    result = {k: v for k, v in data.items()}
+                    # Deep-copy — see get_by_id for why a shallow copy isn't
+                    # enough to protect nested mutable fields.
+                    result = copy.deepcopy(data)
                     # Ensure time fields are present, provide default values for old data
                     result.setdefault("create_time", 0)
                     result.setdefault("update_time", 0)

--- a/tests/kg/json_impl/test_json_kv_copy_on_read.py
+++ b/tests/kg/json_impl/test_json_kv_copy_on_read.py
@@ -1,0 +1,137 @@
+"""Unit tests verifying that JsonKVStorage read methods return deep copies so a
+caller mutating a nested field (e.g. text_chunks' llm_cache_list, updated
+in-place by lightrag.utils.update_chunk_cache_list) cannot corrupt internal
+storage state without going through upsert."""
+
+import pytest
+
+from lightrag.kg.json_kv_impl import JsonKVStorage
+from lightrag.kg.shared_storage import initialize_share_data, finalize_share_data
+from lightrag.namespace import NameSpace
+
+pytestmark = pytest.mark.offline
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
+
+
+@pytest.fixture(autouse=True)
+def setup_shared_data():
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_returns_deep_copy(tmp_path):
+    storage = JsonKVStorage(
+        namespace=NameSpace.KV_STORE_TEXT_CHUNKS,
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace="test",
+    )
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "chunk1": {
+                "content": "hello",
+                "llm_cache_list": ["cache-a"],
+                "metadata": {"key": "original"},
+            }
+        }
+    )
+
+    doc = await storage.get_by_id("chunk1")
+    assert doc is not None
+
+    # Mutate the returned nested list/dict in place, mirroring
+    # update_chunk_cache_list's ``chunk_data["llm_cache_list"].extend(...)``.
+    doc["llm_cache_list"].append("cache-b")
+    doc["metadata"]["key"] = "modified_nested"
+
+    stored = await storage.get_by_id("chunk1")
+    assert stored is not None
+    assert stored["llm_cache_list"] == ["cache-a"]
+    assert stored["metadata"]["key"] == "original"
+
+
+@pytest.mark.asyncio
+async def test_get_by_ids_returns_deep_copy(tmp_path):
+    storage = JsonKVStorage(
+        namespace=NameSpace.KV_STORE_TEXT_CHUNKS,
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace="test",
+    )
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "chunk2": {
+                "content": "hello",
+                "llm_cache_list": ["cache-a"],
+                "metadata": {"key": "original"},
+            }
+        }
+    )
+
+    docs = await storage.get_by_ids(["chunk2"])
+    assert len(docs) == 1 and docs[0] is not None
+    docs[0]["llm_cache_list"].append("cache-b")
+    docs[0]["metadata"]["key"] = "modified_nested"
+
+    stored = await storage.get_by_id("chunk2")
+    assert stored is not None
+    assert stored["llm_cache_list"] == ["cache-a"]
+    assert stored["metadata"]["key"] == "original"
+
+
+@pytest.mark.asyncio
+async def test_update_chunk_cache_list_does_not_corrupt_storage_on_read(tmp_path):
+    """
+    Regression test for the real vulnerable caller: update_chunk_cache_list
+    reads a chunk, appends to its llm_cache_list in place, THEN calls
+    upsert(). Before the deep-copy fix, that in-place append (in
+    single-process mode) mutated the same list object living in
+    JsonKVStorage's internal ``self._data``, bypassing ``_storage_lock``
+    entirely — any concurrent reader holding an earlier ``get_by_id`` result
+    for the same chunk would see the mutation appear underneath it, without
+    ever calling get_by_id again.
+    """
+    from lightrag.utils import update_chunk_cache_list
+
+    storage = JsonKVStorage(
+        namespace=NameSpace.KV_STORE_TEXT_CHUNKS,
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace="test",
+    )
+    await storage.initialize()
+
+    await storage.upsert(
+        {
+            "chunk3": {
+                "content": "hello",
+                "llm_cache_list": ["cache-a"],
+            }
+        }
+    )
+
+    # A snapshot taken before update_chunk_cache_list runs must stay frozen —
+    # it must not observe the later cache-key append just because it holds a
+    # reference to the same (would-be-aliased) list object.
+    snapshot = await storage.get_by_id("chunk3")
+
+    await update_chunk_cache_list("chunk3", storage, ["cache-b"])
+
+    assert snapshot["llm_cache_list"] == ["cache-a"]
+
+    stored = await storage.get_by_id("chunk3")
+    assert stored is not None
+    assert stored["llm_cache_list"] == ["cache-a", "cache-b"]


### PR DESCRIPTION
## Summary

`JsonKVStorage.get_by_id` / `get_by_ids` only shallow-copy the returned record before handing it to the caller. In single-process mode (`self._data` is a plain dict, not a `multiprocessing.Manager().dict()` proxy), a shallow copy only protects the top-level dict — any nested mutable field (list/dict) in the record still aliases the exact same object living in internal storage. Same bug class as #3556 (`JsonDocStatusStorage`), just not yet fixed on the KV side.

## Problem

```python
chunk = await text_chunks_storage.get_by_id("chunk1")
chunk["llm_cache_list"].append("new-cache-key")  # mutates internal _data in place
```

This isn't hypothetical — `lightrag/utils.py`'s `update_chunk_cache_list()` does exactly this:

```python
chunk_data = await text_chunks_storage.get_by_id(chunk_id)
...
chunk_data["llm_cache_list"].extend(new_keys)   # in-place mutation of a nested list
await text_chunks_storage.upsert({chunk_id: chunk_data})
```

Because `get_by_id`'s shallow copy leaves `llm_cache_list` aliased to the live storage row, this mutation bypasses `_storage_lock` entirely and changes internal state before `upsert()` is ever called. Any other coroutine holding an earlier `get_by_id` snapshot of the same chunk would observe the mutation appear underneath it, breaking the assumption that a read result is a point-in-time snapshot.

## Fix

Return `copy.deepcopy(...)` from both `get_by_id` and `get_by_ids` instead of a shallow copy, mirroring the fix already applied to `JsonDocStatusStorage` in #3556.

## Test plan

- [x] `pytest tests/kg/json_impl/test_json_kv_copy_on_read.py` — covers top-level + nested mutation for both read paths, plus a regression test that drives the real `update_chunk_cache_list` caller and asserts an earlier snapshot stays frozen after it runs.
- [x] Full `tests/kg/json_impl/` and `tests/pipeline/` suites pass (693 tests).
- [x] `pre-commit run ruff` clean.