### PR TITLE
fix(kg): address PGTableGraphStorage review findings — startup scans, read fan-out, docs, CI reach

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -2,9 +2,9 @@ name: Linting and Formatting
 
 on:
     push:
-        branches: [ main, dev ]
+        branches: [ main, dev, 'dev-*' ]
     pull_request:
-        branches: [ main, dev ]
+        branches: [ main, dev, 'dev-*' ]
         types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:

--- a/.github/workflows/pg-smoke.yml
+++ b/.github/workflows/pg-smoke.yml
@@ -2,9 +2,9 @@ name: PostgreSQL Smoke Tests
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, 'dev-*' ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main, dev, 'dev-*' ]
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:

--- a/.github/workflows/pg-smoke.yml
+++ b/.github/workflows/pg-smoke.yml
@@ -41,7 +41,7 @@ jobs:
       POSTGRES_DATABASE: lightrag_test
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Offline Unit Tests
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main, dev, 'dev-*' ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ main, dev, 'dev-*' ]
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ bun test src/api/lightrag.test.ts  # Single test file
   - `tests/pipeline/` for ingestion pipeline and doc-status behavior (including `test_pipeline_*`, `test_doc_status_*`, `test_multimodal_*`, `test_graph_keyed_locks`).
   - `tests/sidecar/`, `tests/setup/`, `tests/workspace/` for the like-named cross-cutting concerns.
   - When adding a new backend or LLM provider, create a new subdirectory plus an empty `__init__.py` rather than dropping the file in the parent directory root.
-- Markers (see `tests/pytest.ini`): `offline`, `integration`, `requires_db`, `requires_api`. Integration tests are skipped by default via `-m "not integration"`.
+- Markers (registered in `[tool.pytest.ini_options]` in `pyproject.toml`): `offline`, `integration`, `requires_db`, `requires_api`, `pg_smoke`. Integration tests are skipped by default via `-m "not integration"`; opt in with `--run-integration`.
 - Integration env vars: `LIGHTRAG_RUN_INTEGRATION=true`, `LIGHTRAG_KEEP_ARTIFACTS=true`, `LIGHTRAG_TEST_WORKERS=4`, plus storage-specific connection strings.
 
 ### Linting

--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -894,6 +894,13 @@ LightRAG 使用 4 种类型的存储用于不同目的：
 
 在生产环境中，如果希望用单一后端同时承担全部四种存储，可以选择 PostgreSQL、MongoDB 或 OpenSearch；也可以为不同存储类型分别选择专用数据库，例如用 Milvus 或 Qdrant 承担向量存储，用 Neo4j 或 Memgraph 承担图存储。
 
+**PostgreSQL 图存储推荐使用 `PGTableGraphStorage`：** 对于新建的 PostgreSQL 部署，`PGTableGraphStorage` 是推荐的 `GRAPH_STORAGE` 实现，用于替代 `PGGraphStorage`。它不经由 Apache AGE，而是把实体关系图直接存放在普通表中（JSONB 属性配合 B-tree 索引），由此带来两点实际优势：
+
+* **无需安装扩展。** `PGGraphStorage` 依赖 Apache AGE 扩展，而多数托管 PostgreSQL 服务（Amazon RDS、Cloud SQL、Supabase、Neon）并不提供该扩展，导致图存储往往无法与其余三类存储共用同一个数据库。`PGTableGraphStorage` 可运行在任意原生 PostgreSQL 14 及以上版本，所需的表在 `initialize()` 阶段自动创建。
+* **性能大幅提升。** 查询是带索引的普通 SQL，而非基于 `agtype` 的 Cypher；`get_knowledge_graph` 采用受 `max_nodes` 约束的前沿限幅 BFS。根据 [PR #3103](https://github.com/HKUDS/LightRAG/pull/3103) 随附的实测数据（PostgreSQL 18，8k 节点 / 约 40k 边的图，两个后端在测量前均已执行 `VACUUM ANALYZE`）：`get_knowledge_graph` p50 为 **39 ms 对 1,099 ms（约 28 倍）**，图数据批量装载 **3.0 s 对 434 s**，混合负载吞吐 **1,431 对 73 RPS**。
+
+两种实现读取相同的 `POSTGRES_*` 环境变量，但图数据的存放位置不同 —— `PGTableGraphStorage` 使用自己的 `lightrag_graph_nodes` / `lightrag_graph_edges` 表，`PGGraphStorage` 则存放在 AGE 图内部。因此对已有部署而言，切换实现并不是原地迁移：此前抽取的图将不可见，文档需要重新索引（LLM 缓存可以沿用，参见下文*在不同存储类型之间迁移LLM缓存*）。对于已经运行在 AGE 上的部署，`PGGraphStorage` 仍继续支持。
+
 各存储实现启动时必须配置的环境变量如下（未列出的实现无需额外配置，仅依赖 WORKING_DIR 下的文件持久化）：
 
 | 存储实现 | 必需的环境变量 |
@@ -918,7 +925,7 @@ LightRAG 使用 4 种类型的存储用于不同目的：
 ```
 LIGHTRAG_KV_STORAGE=PGKVStorage
 LIGHTRAG_VECTOR_STORAGE=PGVectorStorage
-LIGHTRAG_GRAPH_STORAGE=PGGraphStorage
+LIGHTRAG_GRAPH_STORAGE=PGTableGraphStorage
 LIGHTRAG_DOC_STATUS_STORAGE=PGDocStatusStorage
 ```
 

--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -889,7 +889,7 @@ LightRAG 使用 4 种类型的存储用于不同目的：
 |---|---|
 | KV_STORAGE | `JsonKVStorage`、`RedisKVStorage`、`PGKVStorage`、`MongoKVStorage`、`OpenSearchKVStorage` |
 | VECTOR_STORAGE | `NanoVectorDBStorage`、`MilvusVectorDBStorage`、`PGVectorStorage`、`FaissVectorDBStorage`、`QdrantVectorDBStorage`、`MongoVectorDBStorage`、`OpenSearchVectorDBStorage` |
-| GRAPH_STORAGE | `NetworkXStorage`、`Neo4JStorage`、`PGGraphStorage`、`PGTableGraphStorage`、`MongoGraphStorage`、`MemgraphStorage`、`OpenSearchGraphStorage` |
+| GRAPH_STORAGE | `NetworkXStorage`、`Neo4JStorage`、`PGTableGraphStorage`、`PGGraphStorage`、`MongoGraphStorage`、`MemgraphStorage`、`OpenSearchGraphStorage` |
 | DOC_STATUS_STORAGE | `JsonDocStatusStorage`、`RedisDocStatusStorage`、`PGDocStatusStorage`、`MongoDocStatusStorage`、`OpenSearchDocStatusStorage` |
 
 在生产环境中，如果希望用单一后端同时承担全部四种存储，可以选择 PostgreSQL、MongoDB 或 OpenSearch；也可以为不同存储类型分别选择专用数据库，例如用 Milvus 或 Qdrant 承担向量存储，用 Neo4j 或 Memgraph 承担图存储。

--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -889,7 +889,7 @@ LightRAG 使用 4 种类型的存储用于不同目的：
 |---|---|
 | KV_STORAGE | `JsonKVStorage`、`RedisKVStorage`、`PGKVStorage`、`MongoKVStorage`、`OpenSearchKVStorage` |
 | VECTOR_STORAGE | `NanoVectorDBStorage`、`MilvusVectorDBStorage`、`PGVectorStorage`、`FaissVectorDBStorage`、`QdrantVectorDBStorage`、`MongoVectorDBStorage`、`OpenSearchVectorDBStorage` |
-| GRAPH_STORAGE | `NetworkXStorage`、`Neo4JStorage`、`PGGraphStorage`、`MongoGraphStorage`、`MemgraphStorage`、`OpenSearchGraphStorage` |
+| GRAPH_STORAGE | `NetworkXStorage`、`Neo4JStorage`、`PGGraphStorage`、`PGTableGraphStorage`、`MongoGraphStorage`、`MemgraphStorage`、`OpenSearchGraphStorage` |
 | DOC_STATUS_STORAGE | `JsonDocStatusStorage`、`RedisDocStatusStorage`、`PGDocStatusStorage`、`MongoDocStatusStorage`、`OpenSearchDocStatusStorage` |
 
 在生产环境中，如果希望用单一后端同时承担全部四种存储，可以选择 PostgreSQL、MongoDB 或 OpenSearch；也可以为不同存储类型分别选择专用数据库，例如用 Milvus 或 Qdrant 承担向量存储，用 Neo4j 或 Memgraph 承担图存储。
@@ -898,7 +898,7 @@ LightRAG 使用 4 种类型的存储用于不同目的：
 
 | 存储实现 | 必需的环境变量 |
 |---|---|
-| `PGKVStorage` / `PGVectorStorage` / `PGGraphStorage` / `PGDocStatusStorage` | `POSTGRES_USER`、`POSTGRES_PASSWORD`、`POSTGRES_DATABASE`（另需 `POSTGRES_HOST`、`POSTGRES_PORT`） |
+| `PGKVStorage` / `PGVectorStorage` / `PGGraphStorage` / `PGTableGraphStorage` / `PGDocStatusStorage` | `POSTGRES_USER`、`POSTGRES_PASSWORD`、`POSTGRES_DATABASE`（另需 `POSTGRES_HOST`、`POSTGRES_PORT`） |
 | `Neo4JStorage` | `NEO4J_URI`、`NEO4J_USERNAME`、`NEO4J_PASSWORD` |
 | `MongoKVStorage` / `MongoVectorDBStorage` / `MongoGraphStorage` / `MongoDocStatusStorage` | `MONGO_URI`、`MONGO_DATABASE`（`MongoVectorDBStorage` 要求该 Mongo 实例支持 Atlas Search / Vector Search） |
 | `RedisKVStorage` / `RedisDocStatusStorage` | `REDIS_URI` |

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -894,6 +894,13 @@ Each storage type offers multiple implementations. By default, LightRAG Server u
 
 For production deployments, PostgreSQL, MongoDB, or OpenSearch can provide all four storage types through a single backend. You can also select a specialized database for each storage type, such as Milvus or Qdrant for vector storage and Neo4j or Memgraph for graph storage.
 
+**PostgreSQL Graph Storage — prefer `PGTableGraphStorage`:** For new PostgreSQL deployments, `PGTableGraphStorage` is the recommended `GRAPH_STORAGE` implementation and supersedes `PGGraphStorage`. It keeps the entity-relation graph in ordinary tables — JSONB properties plus B-tree indexes — instead of going through Apache AGE, which brings two practical advantages:
+
+* **No extension to install.** `PGGraphStorage` requires the Apache AGE extension, which most managed PostgreSQL services (Amazon RDS, Cloud SQL, Supabase, Neon) do not offer — so the graph layer frequently could not run on the same database as the other three storage types. `PGTableGraphStorage` runs on any stock PostgreSQL 14+ and creates the tables it needs during `initialize()`.
+* **Substantially faster.** Queries are plain indexed SQL rather than Cypher over `agtype`, and `get_knowledge_graph` uses a frontier-capped BFS bounded by `max_nodes`. From the measurements published with [PR #3103](https://github.com/HKUDS/LightRAG/pull/3103) (PostgreSQL 18, an 8k-node / ~40k-edge graph, both backends `VACUUM ANALYZE`d before measuring): `get_knowledge_graph` p50 **39 ms vs 1,099 ms (~28×)**, bulk graph load **3.0 s vs 434 s**, mixed-workload throughput **1,431 vs 73 RPS**.
+
+Both implementations read the same `POSTGRES_*` environment variables, but they store the graph in different places — `PGTableGraphStorage` in its own `lightrag_graph_nodes` / `lightrag_graph_edges` tables, `PGGraphStorage` inside an AGE graph. Switching an existing deployment is therefore not an in-place migration: the previously extracted graph will not be visible and the documents have to be re-indexed (the LLM cache can be carried over — see *LLM Cache Migration Between Storage Types* below). `PGGraphStorage` remains supported for deployments already running on AGE.
+
 The environment variables required at startup for each storage implementation are listed below. Implementations not listed require no additional configuration and rely only on file persistence under WORKING_DIR.
 
 | Storage Implementation | Required Environment Variables |
@@ -918,7 +925,7 @@ You can select the storage implementation by configuring environment variables. 
 ```
 LIGHTRAG_KV_STORAGE=PGKVStorage
 LIGHTRAG_VECTOR_STORAGE=PGVectorStorage
-LIGHTRAG_GRAPH_STORAGE=PGGraphStorage
+LIGHTRAG_GRAPH_STORAGE=PGTableGraphStorage
 LIGHTRAG_DOC_STATUS_STORAGE=PGDocStatusStorage
 ```
 

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -889,7 +889,7 @@ Each storage type offers multiple implementations. By default, LightRAG Server u
 |---|---|
 | KV_STORAGE | `JsonKVStorage`, `RedisKVStorage`, `PGKVStorage`, `MongoKVStorage`, `OpenSearchKVStorage` |
 | VECTOR_STORAGE | `NanoVectorDBStorage`, `MilvusVectorDBStorage`, `PGVectorStorage`, `FaissVectorDBStorage`, `QdrantVectorDBStorage`, `MongoVectorDBStorage`, `OpenSearchVectorDBStorage` |
-| GRAPH_STORAGE | `NetworkXStorage`, `Neo4JStorage`, `PGGraphStorage`, `PGTableGraphStorage`, `MongoGraphStorage`, `MemgraphStorage`, `OpenSearchGraphStorage` |
+| GRAPH_STORAGE | `NetworkXStorage`, `Neo4JStorage`, `PGTableGraphStorage`, `PGGraphStorage`, `MongoGraphStorage`, `MemgraphStorage`, `OpenSearchGraphStorage` |
 | DOC_STATUS_STORAGE | `JsonDocStatusStorage`, `RedisDocStatusStorage`, `PGDocStatusStorage`, `MongoDocStatusStorage`, `OpenSearchDocStatusStorage` |
 
 For production deployments, PostgreSQL, MongoDB, or OpenSearch can provide all four storage types through a single backend. You can also select a specialized database for each storage type, such as Milvus or Qdrant for vector storage and Neo4j or Memgraph for graph storage.

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -889,7 +889,7 @@ Each storage type offers multiple implementations. By default, LightRAG Server u
 |---|---|
 | KV_STORAGE | `JsonKVStorage`, `RedisKVStorage`, `PGKVStorage`, `MongoKVStorage`, `OpenSearchKVStorage` |
 | VECTOR_STORAGE | `NanoVectorDBStorage`, `MilvusVectorDBStorage`, `PGVectorStorage`, `FaissVectorDBStorage`, `QdrantVectorDBStorage`, `MongoVectorDBStorage`, `OpenSearchVectorDBStorage` |
-| GRAPH_STORAGE | `NetworkXStorage`, `Neo4JStorage`, `PGGraphStorage`, `MongoGraphStorage`, `MemgraphStorage`, `OpenSearchGraphStorage` |
+| GRAPH_STORAGE | `NetworkXStorage`, `Neo4JStorage`, `PGGraphStorage`, `PGTableGraphStorage`, `MongoGraphStorage`, `MemgraphStorage`, `OpenSearchGraphStorage` |
 | DOC_STATUS_STORAGE | `JsonDocStatusStorage`, `RedisDocStatusStorage`, `PGDocStatusStorage`, `MongoDocStatusStorage`, `OpenSearchDocStatusStorage` |
 
 For production deployments, PostgreSQL, MongoDB, or OpenSearch can provide all four storage types through a single backend. You can also select a specialized database for each storage type, such as Milvus or Qdrant for vector storage and Neo4j or Memgraph for graph storage.
@@ -898,7 +898,7 @@ The environment variables required at startup for each storage implementation ar
 
 | Storage Implementation | Required Environment Variables |
 |---|---|
-| `PGKVStorage` / `PGVectorStorage` / `PGGraphStorage` / `PGDocStatusStorage` | `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DATABASE` (plus `POSTGRES_HOST` and `POSTGRES_PORT`) |
+| `PGKVStorage` / `PGVectorStorage` / `PGGraphStorage` / `PGTableGraphStorage` / `PGDocStatusStorage` | `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DATABASE` (plus `POSTGRES_HOST` and `POSTGRES_PORT`) |
 | `Neo4JStorage` | `NEO4J_URI`, `NEO4J_USERNAME`, `NEO4J_PASSWORD` |
 | `MongoKVStorage` / `MongoVectorDBStorage` / `MongoGraphStorage` / `MongoDocStatusStorage` | `MONGO_URI`, `MONGO_DATABASE` (`MongoVectorDBStorage` requires a MongoDB deployment that supports Atlas Search / Vector Search) |
 | `RedisKVStorage` / `RedisDocStatusStorage` | `REDIS_URI` |

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -71,7 +71,7 @@ Notes:
 | **workspace** | str | Workspace name for data isolation between different LightRAG Instances | |
 | **kv_storage** | `str` | Storage type for documents and text chunks. Supported types: `JsonKVStorage`,`PGKVStorage`,`RedisKVStorage`,`MongoKVStorage`,`OpenSearchKVStorage` | `JsonKVStorage` |
 | **vector_storage** | `str` | Storage type for embedding vectors. Supported types: `NanoVectorDBStorage`,`PGVectorStorage`,`MilvusVectorDBStorage`,`ChromaVectorDBStorage`,`FaissVectorDBStorage`,`MongoVectorDBStorage`,`QdrantVectorDBStorage`,`OpenSearchVectorDBStorage` | `NanoVectorDBStorage` |
-| **graph_storage** | `str` | Storage type for graph edges and nodes. Supported types: `NetworkXStorage`,`Neo4JStorage`,`PGGraphStorage`,`AGEStorage`,`OpenSearchGraphStorage` | `NetworkXStorage` |
+| **graph_storage** | `str` | Storage type for graph edges and nodes. Supported types: `NetworkXStorage`,`Neo4JStorage`,`PGGraphStorage`,`PGTableGraphStorage`,`AGEStorage`,`OpenSearchGraphStorage` | `NetworkXStorage` |
 | **doc_status_storage** | `str` | Storage type for documents process status. Supported types: `JsonDocStatusStorage`,`PGDocStatusStorage`,`MongoDocStatusStorage`,`OpenSearchDocStatusStorage` | `JsonDocStatusStorage` |
 | **chunk_token_size** | `int` | Maximum token size per chunk when splitting documents | `1200` |
 | **chunk_overlap_token_size** | `int` | Overlap token size between two chunks when splitting documents | `100` |
@@ -655,11 +655,18 @@ OpenSearchKVStorage  OpenSearch
 NetworkXStorage          NetworkX (default)
 Neo4JStorage             Neo4J
 PGGraphStorage           PostgreSQL with AGE plugin
+PGTableGraphStorage      PostgreSQL, plain tables (no AGE, no extensions)
 MemgraphStorage          Memgraph
 OpenSearchGraphStorage   OpenSearch
 ```
 
 > Testing has shown that Neo4J delivers superior performance in production environments compared to PostgreSQL with AGE plugin.
+>
+> `PGTableGraphStorage` implements the graph layer on ordinary indexed tables plus
+> JSONB, so it runs on any stock PostgreSQL 14+ — including managed instances
+> (RDS, Cloud SQL, Supabase, Neon) where the AGE extension cannot be installed.
+> It shares the same `POSTGRES_*` configuration and connection pool as the other
+> PG storages. Choose `PGGraphStorage` only if you specifically need AGE/Cypher.
 
 **VECTOR_STORAGE**
 ```
@@ -921,7 +928,7 @@ The `workspace` parameter ensures data isolation between different LightRAG inst
 | `JsonKVStorage`, `JsonDocStatusStorage`, `NetworkXStorage`, `NanoVectorDBStorage`, `FaissVectorDBStorage` | Workspace subdirectories |
 | `RedisKVStorage`, `MilvusVectorDBStorage`, `MongoKVStorage`, `MongoVectorDBStorage`, `MongoGraphStorage`, `PGGraphStorage` | Workspace prefix on collection name |
 | `QdrantVectorDBStorage` | Payload-based partitioning (Qdrant multitenancy) |
-| `PGKVStorage`, `PGVectorStorage`, `PGDocStatusStorage` | `workspace` field in tables |
+| `PGKVStorage`, `PGVectorStorage`, `PGDocStatusStorage`, `PGTableGraphStorage` | `workspace` field in tables |
 | `Neo4JStorage` | Labels |
 | `OpenSearch*` | Index name prefixes |
 

--- a/env.example
+++ b/env.example
@@ -1142,6 +1142,11 @@ OLLAMA_EMBEDDING_NUM_CTX=8192
 ### Data storage selection
 ############################
 ### Default storage: JSON/Nano/NetworkX (Recommended for test deployment)
+### LIGHTRAG_GRAPH_STORAGE options: NetworkXStorage, Neo4JStorage, PGGraphStorage,
+###   PGTableGraphStorage, MongoGraphStorage, MemgraphStorage, OpenSearchGraphStorage
+### PGTableGraphStorage runs the graph on plain PostgreSQL 14+ tables with no
+###   Apache AGE and no extensions, so it works on managed PostgreSQL
+###   (RDS / Cloud SQL / Supabase / Neon). Use PGGraphStorage only if you need AGE.
 LIGHTRAG_KV_STORAGE=JsonKVStorage
 LIGHTRAG_DOC_STATUS_STORAGE=JsonDocStatusStorage
 LIGHTRAG_GRAPH_STORAGE=NetworkXStorage

--- a/lightrag/kg/pgtable_impl.py
+++ b/lightrag/kg/pgtable_impl.py
@@ -314,11 +314,10 @@ class PGTableGraphStorage(BaseGraphStorage):
         semantics the pre-chunking single statement had.
 
     Configuration note:
-        global_config["vector_storage"] selects the pool's vector support. An
-        absent/empty value falls back to this class's own name rather than None,
-        because ClientManager treats None as "enable pgvector" and this backend
-        must stay installable on stock PostgreSQL. See initialize() for the
-        pool-signature tradeoff that buys.
+        global_config["vector_storage"] is forwarded to ClientManager verbatim,
+        like every other PG storage. Only "PGVectorStorage" enables pgvector on the
+        shared pool, so this backend needs no extension whether the caller names a
+        non-PostgreSQL vector backend or names none at all.
     """
 
     db: Any | None = field(default=None, init=False, repr=False)
@@ -514,29 +513,13 @@ class PGTableGraphStorage(BaseGraphStorage):
             if self.db is None:
                 from .postgres_impl import ClientManager
 
-                # Substitute this class's own name when no vector backend is
-                # configured, instead of forwarding None like the sibling PG
-                # storages do. This is deliberate and load-bearing: ClientManager
-                # maps vector_storage=None to enable_vector=True, which makes the
-                # pool require pgvector — and a graph backend whose entire purpose
-                # is running on stock PostgreSQL must not demand an extension just
-                # because the caller left the vector backend unspecified. Callers
-                # with a bare global_config are real: tests/kg/test_graph_storage.py
-                # (the cross-backend contract suite) is one.
-                #
-                # The cost is that the process-wide pool signature records this
-                # name, so a sibling PG storage in the same process that forwarded
-                # None would disagree and whichever initialized second would be
-                # rejected. That is acceptable because (a) LightRAG always
-                # populates global_config["vector_storage"], so both sides compute
-                # the identical value and the fallback never fires, and (b) when it
-                # does fire the mismatch surfaces as an explicit RuntimeError from
-                # _assert_compatible_vector_signature, not as silent corruption.
-                vector_storage = (
-                    self.global_config.get("vector_storage") or "PGTableGraphStorage"
-                )
+                # Forwarded unchanged, exactly like the sibling PG storages. An
+                # unspecified vector backend resolves to None, which ClientManager
+                # maps to enable_vector=False — so a bare global_config no longer
+                # demands pgvector and this backend stays installable on stock
+                # PostgreSQL without passing a sentinel backend name.
                 self.db = await ClientManager.get_client(
-                    vector_storage=vector_storage,
+                    vector_storage=self.global_config.get("vector_storage")
                 )
                 # Workspace priority: POSTGRES_WORKSPACE env > self.workspace > "default"
                 if self.db.workspace:

--- a/lightrag/kg/pgtable_impl.py
+++ b/lightrag/kg/pgtable_impl.py
@@ -295,7 +295,20 @@ class PGTableGraphStorage(BaseGraphStorage):
         PGGraphStorage); edge properties are replaced, node properties merged.
       - get_knowledge_graph uses a frontier-capped iterative BFS (see
         _bfs_frontier) whose cost is bounded by max_nodes, not by the number of
-        simple paths in the reachable subgraph.
+        simple paths in the reachable subgraph. Each hop's unvisited filter,
+        degree ranking and budget cap run in SQL, so rows returned and JSONB
+        decoded per hop are bounded by the remaining budget.
+      - search_labels scores and truncates in SQL (like PGGraphStorage) using the
+        NetworkXStorage scoring rules, so the wire cost is O(limit) rather than
+        O(every id matching the query). _search_score is the reference definition
+        and the pg_smoke suite pins the SQL to it.
+
+    Configuration note:
+        global_config["vector_storage"] selects the pool's vector support. An
+        absent/empty value falls back to this class's own name rather than None,
+        because ClientManager treats None as "enable pgvector" and this backend
+        must stay installable on stock PostgreSQL. See initialize() for the
+        pool-signature tradeoff that buys.
     """
 
     db: Any | None = field(default=None, init=False, repr=False)
@@ -399,6 +412,24 @@ class PGTableGraphStorage(BaseGraphStorage):
             if self.db is None:
                 from .postgres_impl import ClientManager
 
+                # Substitute this class's own name when no vector backend is
+                # configured, instead of forwarding None like the sibling PG
+                # storages do. This is deliberate and load-bearing: ClientManager
+                # maps vector_storage=None to enable_vector=True, which makes the
+                # pool require pgvector — and a graph backend whose entire purpose
+                # is running on stock PostgreSQL must not demand an extension just
+                # because the caller left the vector backend unspecified. Callers
+                # with a bare global_config are real: tests/kg/test_graph_storage.py
+                # (the cross-backend contract suite) is one.
+                #
+                # The cost is that the process-wide pool signature records this
+                # name, so a sibling PG storage in the same process that forwarded
+                # None would disagree and whichever initialized second would be
+                # rejected. That is acceptable because (a) LightRAG always
+                # populates global_config["vector_storage"], so both sides compute
+                # the identical value and the fallback never fires, and (b) when it
+                # does fire the mismatch surfaces as an explicit RuntimeError from
+                # _assert_compatible_vector_signature, not as silent corruption.
                 vector_storage = (
                     self.global_config.get("vector_storage") or "PGTableGraphStorage"
                 )
@@ -835,22 +866,64 @@ class PGTableGraphStorage(BaseGraphStorage):
         q = query.strip().lower()
         if not q:
             return []
+        escaped = self._escape_like(q)
+        # Score, rank and truncate server-side, like PGGraphStorage does. Scoring
+        # in Python instead meant transferring EVERY id matching %q% just to
+        # return `limit` of them — on a large graph that is most of the node
+        # table over the wire per search. The LIKE filter is unindexable either
+        # way, but the transfer is now O(limit).
+        #
+        # The CASE mirrors _search_score / NetworkXStorage.search_labels exactly:
+        # the +50 word-boundary bonus is nested INSIDE the ELSE branch so it can
+        # never apply to an exact or prefix match (AGE's SQL adds it
+        # unconditionally, which is the divergent one). LENGTH() counts
+        # characters like Python len(), not octets. ORDER BY id COLLATE "C"
+        # reproduces Python's code-point tie-break on the original,
+        # non-lowercased id. _search_score stays the reference definition and the
+        # pg_smoke suite asserts this SQL agrees with it.
+        #
+        # $3 is the RAW lowercased query (compared with =, so it must not carry
+        # LIKE escapes); $4..$7 are LIKE patterns built from the escaped form.
         # ESCAPE uses an E'' literal so the backslash escape char is unambiguously
         # one character regardless of standard_conforming_strings; a plain '\'
         # literal is a syntax error when that (deprecated, non-default) setting is
         # off. E'\\' is one backslash under both settings.
         rows = await self._fetch(
             """
-            SELECT id FROM lightrag_graph_nodes
-            WHERE workspace=$1 AND namespace=$2 AND LOWER(id) LIKE $3 ESCAPE E'\\\\'
+            SELECT id
+            FROM (
+                SELECT id,
+                       CASE
+                           WHEN LOWER(id) = $3 THEN 1000
+                           WHEN LOWER(id) LIKE $4 ESCAPE E'\\\\' THEN 500
+                           ELSE 100 - LENGTH(id)
+                                + CASE
+                                      WHEN LOWER(id) LIKE $5 ESCAPE E'\\\\'
+                                        OR LOWER(id) LIKE $6 ESCAPE E'\\\\'
+                                      THEN 50
+                                      ELSE 0
+                                  END
+                       END AS score
+                FROM lightrag_graph_nodes
+                WHERE workspace = $1
+                  AND namespace = $2
+                  AND LOWER(id) LIKE $7 ESCAPE E'\\\\'
+            ) scored
+            ORDER BY score DESC, id COLLATE "C" ASC
+            LIMIT $8
             """,
             self.workspace,
             self.namespace,
-            f"%{self._escape_like(q)}%",
+            q,
+            f"{escaped}%",
+            f"% {escaped}%",
+            # Literal underscore: '_' is a LIKE wildcard, so the word-boundary
+            # probe for "_query" must escape it or it would match any character.
+            rf"%\_{escaped}%",
+            f"%{escaped}%",
+            limit,
         )
-        labels = [r["id"] for r in rows]
-        labels.sort(key=lambda label: (-self._search_score(label, q), label))
-        return labels[:limit]
+        return [r["id"] for r in rows]
 
     @staticmethod
     def _escape_like(value: str) -> str:
@@ -900,11 +973,16 @@ class PGTableGraphStorage(BaseGraphStorage):
         CTE with a path-local visited array does — that re-materializes shared
         nodes per path and blows up on dense/cyclic graphs.
 
-        NOTE on cost: the per-hop *work* is bounded by the size of the frontier's
-        neighbourhood, NOT by ``node_budget``. A single very high-degree node
-        still pulls (and degree-ranks) its entire neighbour set on the hop that
-        expands it, before the budget truncates the result. Pushing the
-        degree-rank + cap down into SQL is tracked as a follow-up optimization.
+        NOTE on cost: the unvisited-filter, degree ranking and budget cap all run
+        inside the per-hop SQL, so the rows returned, the JSONB payloads decoded
+        and the round trips per hop are bounded by the remaining budget — a hub
+        with a million edges no longer ships a million property blobs to Python
+        to have all but ``node_budget`` of them discarded. What is NOT bounded is
+        the server-side edge enumeration: ranking a hub's neighbours by degree
+        requires visiting that hub's edges, which is a lower bound for any
+        correct top-k-by-degree. Those scans are index-driven (see the UNION
+        note below) and no longer duplicated by a second node_degrees_batch
+        round trip.
 
         Within each depth level the highest-degree unvisited neighbours are
         admitted first, so when the budget cuts a level the retained nodes are
@@ -941,48 +1019,84 @@ class PGTableGraphStorage(BaseGraphStorage):
             # "src_id = ANY OR tgt_id = ANY" predicate cannot use either index and
             # degrades to a seq scan of the whole edge table on every level —
             # which made traversal O(edges) per hop on large sparse graphs.
+            #
+            # The hop admits at most (node_budget - collected + 1) nodes: one
+            # past the budget, so get_knowledge_graph still sees the overfetched
+            # row that distinguishes "exactly full" from "truncated". This is the
+            # SQL equivalent of the previous admit-then-break-on-overflow loop.
+            level_cap = node_budget - len(collected) + 1
             rows = await self._fetch(
                 """
-                SELECT n.id AS id, n.properties AS properties
-                FROM lightrag_graph_nodes n
-                JOIN (
+                WITH nb AS (
                     SELECT tgt_id AS nid FROM lightrag_graph_edges
                     WHERE workspace = $1 AND namespace = $2 AND src_id = ANY($3)
                   UNION
                     SELECT src_id AS nid FROM lightrag_graph_edges
                     WHERE workspace = $1 AND namespace = $2 AND tgt_id = ANY($3)
-                ) nb ON n.id = nb.nid
-                WHERE n.workspace = $1 AND n.namespace = $2
+                ),
+                -- Anti-join against the visited set rather than "nid <> ALL($4)":
+                -- a scalar <> ALL over a ~node_budget-element array is evaluated
+                -- per candidate row, i.e. O(neighbours x visited), which on a hub
+                -- is worse than the Python-side set lookup this replaces. The
+                -- NOT EXISTS form lets the planner hash the visited set once.
+                visited AS (
+                    SELECT unnest($4::text[]) AS vid
+                ),
+                candidates AS (
+                    SELECT nb.nid FROM nb
+                    WHERE NOT EXISTS (
+                        SELECT 1 FROM visited v WHERE v.vid = nb.nid
+                    )
+                ),
+                -- Same UNION ALL + GROUP BY shape as node_degrees_batch, so
+                -- self-loops count twice here exactly as they do there and in
+                -- node_degree. Each arm is index-served: src_id via the PK
+                -- prefix, tgt_id via idx_..._namespace_tgt.
+                candidate_degrees AS (
+                    SELECT id, COUNT(*) AS degree
+                    FROM (
+                        SELECT src_id AS id FROM lightrag_graph_edges
+                        WHERE workspace = $1 AND namespace = $2
+                          AND src_id IN (SELECT nid FROM candidates)
+                        UNION ALL
+                        SELECT tgt_id AS id FROM lightrag_graph_edges
+                        WHERE workspace = $1 AND namespace = $2
+                          AND tgt_id IN (SELECT nid FROM candidates)
+                    ) sub
+                    GROUP BY id
+                )
+                SELECT n.id AS id,
+                       n.properties AS properties,
+                       COALESCE(d.degree, 0) AS degree
+                FROM candidates c
+                JOIN lightrag_graph_nodes n
+                  ON n.workspace = $1 AND n.namespace = $2 AND n.id = c.nid
+                LEFT JOIN candidate_degrees d ON d.id = c.nid
+                -- Reproduces the previous Python key=(-degree, nid) exactly;
+                -- COLLATE "C" makes the tie-break a code-point sort like Python's.
+                ORDER BY COALESCE(d.degree, 0) DESC, n.id COLLATE "C" ASC
+                LIMIT $5
                 """,
                 self.workspace,
                 self.namespace,
                 frontier,
+                list(collected),
+                level_cap,
             )
-            # Gather this level's unvisited neighbours, then admit the
-            # highest-degree ones first so a budget cut keeps high-degree nodes
-            # (degree-priority truncation), rather than whatever order the DB
-            # happened to return rows in.
-            candidates: dict[str, Any] = {}
-            for r in rows:
-                if r["id"] not in collected and r["id"] not in candidates:
-                    candidates[r["id"]] = r["properties"]
-            if not candidates:
+            if not rows:
                 break
-            level_degrees = await self.node_degrees_batch(list(candidates))
-            degrees.update(level_degrees)
-            ordered = sorted(
-                candidates, key=lambda nid: (-level_degrees.get(nid, 0), nid)
-            )
+            # Rows arrive already unvisited-filtered, degree-ranked and capped,
+            # so admission is a straight walk in the order the DB returned.
             next_frontier: list[str] = []
-            for nid in ordered:
+            for r in rows:
+                nid = r["id"]
+                degrees[nid] = int(r["degree"] or 0)
                 collected[nid] = {
                     "id": nid,
-                    "properties": candidates[nid],
+                    "properties": r["properties"],
                     "depth": depth,
                 }
                 next_frontier.append(nid)
-                if len(collected) > node_budget:
-                    break
             frontier = next_frontier
         # The seed is never a candidate (it seeds the frontier), so its degree
         # was never gathered in the loop — fetch it once for the ordering

--- a/lightrag/kg/pgtable_impl.py
+++ b/lightrag/kg/pgtable_impl.py
@@ -174,28 +174,73 @@ END $$;
 CREATE INDEX IF NOT EXISTS idx_lightrag_graph_edges_namespace_tgt
     ON lightrag_graph_edges (workspace, namespace, tgt_id);
 
-DELETE FROM lightrag_graph_edges e
-WHERE NOT EXISTS (
-        SELECT 1 FROM lightrag_graph_nodes n
-        WHERE n.workspace = e.workspace
-          AND n.namespace = e.namespace
-          AND n.id = e.src_id
-    )
-   OR NOT EXISTS (
-        SELECT 1 FROM lightrag_graph_nodes n
-        WHERE n.workspace = e.workspace
-          AND n.namespace = e.namespace
-          AND n.id = e.tgt_id
-    );
+-- Partial index serving _normalize_legacy_edges' fast-path guard. Its predicate
+-- IS the non-canonical condition, so in the steady state the index is empty and
+-- the guard becomes an index-only probe instead of a sequential scan of the
+-- whole edge table on every process start (the guard cannot use a plain index:
+-- EXISTS can only short-circuit when it FINDS a row, and after the one-time
+-- migration there are none, so it used to scan to completion forever).
+--
+-- Measured on PostgreSQL 14.15, 200k canonical edges: Seq Scan 28.6 ms /
+-- 2273 buffers -> Index Only Scan 0.04 ms / empty 8 kB index. Canonical writes
+-- never satisfy the predicate, so they create no index entries and pay only the
+-- predicate evaluation. If the planner ever declines the index the guard simply
+-- degrades to the previous full scan, so this is an optimization, not a
+-- correctness dependency.
+CREATE INDEX IF NOT EXISTS idx_lightrag_graph_edges_noncanonical
+    ON lightrag_graph_edges (workspace, namespace)
+    WHERE src_id COLLATE "C" > tgt_id COLLATE "C";
 
 DO $$
+DECLARE
+    has_src_fk BOOLEAN;
+    has_tgt_fk BOOLEAN;
 BEGIN
-    IF NOT EXISTS (
+    SELECT EXISTS (
         SELECT 1
         FROM pg_constraint
         WHERE conname = 'fk_lightrag_graph_edges_src'
           AND conrelid = 'lightrag_graph_edges'::regclass
-    ) THEN
+    ) INTO has_src_fk;
+
+    SELECT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_lightrag_graph_edges_tgt'
+          AND conrelid = 'lightrag_graph_edges'::regclass
+    ) INTO has_tgt_fk;
+
+    -- Steady state: both constraints already exist, so there is nothing to
+    -- create and — because they are enforced — no orphan edge can exist either.
+    -- Returning here keeps the table-wide orphan sweep below off the startup
+    -- path, which matters because every process pays it: it runs inside the
+    -- transaction holding pg_advisory_xact_lock('lightrag_pgtable_schema'), so
+    -- N gunicorn workers used to pay N *serialized* full scans of the entire
+    -- edge table (all workspaces) before serving traffic.
+    IF has_src_fk AND has_tgt_fk THEN
+        RETURN;
+    END IF;
+
+    -- Only reachable on first install, or immediately after the namespace PK
+    -- migration above dropped the constraints. ADD CONSTRAINT fails outright if
+    -- any edge references a missing endpoint, so orphans must be removed first.
+    -- The sweep is table-wide because the FK is a global composite constraint
+    -- and cannot be validated per workspace.
+    DELETE FROM lightrag_graph_edges e
+    WHERE NOT EXISTS (
+            SELECT 1 FROM lightrag_graph_nodes n
+            WHERE n.workspace = e.workspace
+              AND n.namespace = e.namespace
+              AND n.id = e.src_id
+        )
+       OR NOT EXISTS (
+            SELECT 1 FROM lightrag_graph_nodes n
+            WHERE n.workspace = e.workspace
+              AND n.namespace = e.namespace
+              AND n.id = e.tgt_id
+        );
+
+    IF NOT has_src_fk THEN
         ALTER TABLE lightrag_graph_edges
             ADD CONSTRAINT fk_lightrag_graph_edges_src
             FOREIGN KEY (workspace, namespace, src_id)
@@ -203,12 +248,7 @@ BEGIN
             ON DELETE CASCADE;
     END IF;
 
-    IF NOT EXISTS (
-        SELECT 1
-        FROM pg_constraint
-        WHERE conname = 'fk_lightrag_graph_edges_tgt'
-          AND conrelid = 'lightrag_graph_edges'::regclass
-    ) THEN
+    IF NOT has_tgt_fk THEN
         ALTER TABLE lightrag_graph_edges
             ADD CONSTRAINT fk_lightrag_graph_edges_tgt
             FOREIGN KEY (workspace, namespace, tgt_id)
@@ -394,12 +434,19 @@ class PGTableGraphStorage(BaseGraphStorage):
         # UTF-8). Using the DB's default collation here could diverge on
         # non-ASCII ids and either skip rows that still need normalizing or
         # rescan already-canonical data forever.
+        #
+        # The predicate is written to match idx_lightrag_graph_edges_noncanonical's
+        # partial-index predicate verbatim (see _DDL) so the planner can prove
+        # implication and serve this as an index-only probe on a normally-empty
+        # index. Keep the two in sync: any change to the COLLATE spelling here
+        # silently turns this back into a full scan on every process start.
         needs_normalize = await self._fetchval(
             """
             SELECT EXISTS (
                 SELECT 1 FROM lightrag_graph_edges
                 WHERE workspace = $1 AND namespace = $2
                   AND src_id COLLATE "C" > tgt_id COLLATE "C"
+                LIMIT 1
             )
             """,
             self.workspace,
@@ -511,9 +558,13 @@ class PGTableGraphStorage(BaseGraphStorage):
             # one statement (hence one implicit transaction), so a mid-drop
             # failure can never leave nodes stripped of their edges or vice versa
             # — the two-statement version committed the edge delete independently.
-            # Edges are deleted explicitly rather than relying solely on FK
-            # CASCADE so the drop stays correct even on a legacy table whose FK
-            # was never (re)created.
+            #
+            # Edges are named explicitly to keep the delete set unambiguous and
+            # the statement self-describing, NOT because the FK might be missing:
+            # _DDL either creates both fk_lightrag_graph_edges_{src,tgt} or raises
+            # and aborts initialize(), so after a successful init the CASCADE is
+            # guaranteed. delete_node / remove_nodes rely on exactly that
+            # guarantee instead of repeating the edge delete.
             await self._execute(
                 """
                 WITH deleted_edges AS (
@@ -583,6 +634,9 @@ class PGTableGraphStorage(BaseGraphStorage):
         )
 
     async def delete_node(self, node_id: str) -> None:
+        # Incident edges go via ON DELETE CASCADE on
+        # fk_lightrag_graph_edges_{src,tgt}. _DDL creates both or raises and
+        # aborts initialize(), so the cascade is guaranteed here — see drop().
         await self._execute(
             "DELETE FROM lightrag_graph_nodes WHERE workspace = $1 AND namespace = $2 AND id = $3",
             self.workspace,
@@ -593,6 +647,7 @@ class PGTableGraphStorage(BaseGraphStorage):
     async def remove_nodes(self, nodes: list[str]) -> None:
         if not nodes:
             return
+        # Incident edges cascade — same guarantee as delete_node().
         await self._execute(
             "DELETE FROM lightrag_graph_nodes WHERE workspace = $1 AND namespace = $2 AND id = ANY($3)",
             self.workspace,

--- a/lightrag/kg/pgtable_impl.py
+++ b/lightrag/kg/pgtable_impl.py
@@ -303,6 +303,16 @@ class PGTableGraphStorage(BaseGraphStorage):
         O(every id matching the query). _search_score is the reference definition
         and the pg_smoke suite pins the SQL to it.
 
+    Flush-time batching:
+        upsert_nodes_batch / upsert_edges_batch split their payload by
+        POSTGRES_UPSERT_MAX_PAYLOAD_BYTES (primary) and
+        POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH; remove_nodes / remove_edges split by
+        POSTGRES_DELETE_MAX_RECORDS_PER_BATCH. Same variables, same defaults and
+        same splitter as every other PostgreSQL write path. Upsert chunks are
+        separate statements (bounded lock/WAL footprint, idempotent on replay);
+        delete chunks all share ONE transaction, preserving the all-or-nothing
+        semantics the pre-chunking single statement had.
+
     Configuration note:
         global_config["vector_storage"] selects the pool's vector support. An
         absent/empty value falls back to this class's own name rather than None,
@@ -312,6 +322,11 @@ class PGTableGraphStorage(BaseGraphStorage):
     """
 
     db: Any | None = field(default=None, init=False, repr=False)
+    # Populated on first use by _batch_limits(); see that method for why it is not
+    # resolved in __post_init__ like the sibling PG storages do.
+    _cached_batch_limits: tuple[int, int, int] | None = field(
+        default=None, init=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         validate_workspace(self.workspace)
@@ -323,6 +338,93 @@ class PGTableGraphStorage(BaseGraphStorage):
                 "PGTableGraphStorage not initialized — call initialize() first"
             )
         return self.db
+
+    # ------------------------------------------------------------------
+    # Flush-time batching limits
+    # ------------------------------------------------------------------
+
+    def _batch_limits(self) -> tuple[int, int, int]:
+        """``(upsert_payload_bytes, upsert_records, delete_records)`` from env.
+
+        Uses the same ``_resolve_pg_batch_limits`` helper — hence the same
+        POSTGRES_UPSERT_MAX_PAYLOAD_BYTES / POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH /
+        POSTGRES_DELETE_MAX_RECORDS_PER_BATCH variables and the same defaults — as
+        every other PostgreSQL write path, so one deployment-wide setting bounds
+        them all.
+
+        Resolved on first use and cached, rather than in __post_init__ like the
+        sibling storages, for two reasons: postgres_impl must stay lazily imported
+        (importing it installs and imports asyncpg at module scope — see
+        _is_transient_error), and batch writes only run after initialize(), which
+        imports postgres_impl anyway, so this is a cache hit there. getattr()
+        rather than a plain attribute read because callers legitimately build this
+        storage without __init__ (object.__new__ in the offline test suites).
+        """
+        limits = getattr(self, "_cached_batch_limits", None)
+        if limits is None:
+            from .postgres_impl import _resolve_pg_batch_limits
+
+            limits = _resolve_pg_batch_limits()
+            self._cached_batch_limits = limits
+        return limits
+
+    @staticmethod
+    def _chunk_writes(
+        items: list[Any], size_of: Callable[[Any], int], limits: tuple[int, int, int]
+    ) -> list[list[Any]]:
+        """Split an upsert payload with the shared byte/record budget splitter.
+
+        Delegates to postgres_impl._chunk_by_budget so the byte accounting (JSON
+        array overhead, separator overhead, oversized-single-item passthrough) is
+        identical to the other PG storages instead of a second approximation.
+        """
+        from .postgres_impl import _chunk_by_budget
+
+        payload_bytes, records, _delete_records = limits
+        return [
+            chunk
+            for chunk, _bytes in _chunk_by_budget(
+                items, size_of, payload_bytes, records
+            )
+        ]
+
+    async def _chunked_delete(
+        self,
+        sql: str,
+        items: list[Any],
+        to_args: Callable[[list[Any]], tuple[Any, ...]],
+        label: str,
+    ) -> None:
+        """Run one DELETE per POSTGRES_DELETE_MAX_RECORDS_PER_BATCH-sized chunk.
+
+        Unlike the upsert paths, every chunk runs inside ONE transaction: the
+        pre-chunking implementation was a single statement, so it was
+        all-or-nothing, and a caller deleting a set of nodes must not be left with
+        half of them gone. This mirrors PGGraphStorage's delete batching exactly.
+        _run_with_retry replays the whole closure on transient errors, which is
+        safe because DELETE is idempotent.
+
+        ``to_args`` maps a chunk to the positional parameters after
+        (workspace, namespace) — one array for nodes, two parallel arrays for edge
+        pairs. A non-positive cap disables chunking.
+        """
+        _payload_bytes, _records, delete_records = self._batch_limits()
+        chunk_size = delete_records if delete_records > 0 else len(items)
+        if len(items) > chunk_size:
+            logger.info(
+                f"[{self.workspace}] {self.namespace}: {label} delete of "
+                f"{len(items)} items split into chunks (chunk={chunk_size})"
+            )
+
+        async def _batch_delete(conn: Any) -> None:
+            async with conn.transaction():
+                for start in range(0, len(items), chunk_size):
+                    chunk = items[start : start + chunk_size]
+                    await conn.execute(
+                        sql, self.workspace, self.namespace, *to_args(chunk)
+                    )
+
+        await self._with_retry(lambda: self._db._run_with_retry(_batch_delete))
 
     # ------------------------------------------------------------------
     # Query helpers — thin wrappers over PostgreSQLDB.query / execute
@@ -679,11 +781,12 @@ class PGTableGraphStorage(BaseGraphStorage):
         if not nodes:
             return
         # Incident edges cascade — same guarantee as delete_node().
-        await self._execute(
-            "DELETE FROM lightrag_graph_nodes WHERE workspace = $1 AND namespace = $2 AND id = ANY($3)",
-            self.workspace,
-            self.namespace,
+        await self._chunked_delete(
+            "DELETE FROM lightrag_graph_nodes "
+            "WHERE workspace = $1 AND namespace = $2 AND id = ANY($3)",
             nodes,
+            lambda chunk: (chunk,),
+            label="node",
         )
 
     # ------------------------------------------------------------------
@@ -753,19 +856,17 @@ class PGTableGraphStorage(BaseGraphStorage):
             return
         if not all(isinstance(e[0], str) and isinstance(e[1], str) for e in edges):
             raise ValueError("Edge node IDs must be non-None strings")
-        srcs = [min(e[0], e[1]) for e in edges]
-        tgts = [max(e[0], e[1]) for e in edges]
-        await self._execute(
+        pairs = [(min(e[0], e[1]), max(e[0], e[1])) for e in edges]
+        await self._chunked_delete(
             """
             DELETE FROM lightrag_graph_edges
             WHERE workspace = $1
               AND namespace = $2
               AND (src_id, tgt_id) IN (SELECT * FROM unnest($3::text[], $4::text[]))
             """,
-            self.workspace,
-            self.namespace,
-            srcs,
-            tgts,
+            pairs,
+            lambda chunk: ([p[0] for p in chunk], [p[1] for p in chunk]),
+            label="edge",
         )
 
     async def get_node_edges(self, source_node_id: str) -> list[tuple[str, str]] | None:
@@ -1355,25 +1456,42 @@ class PGTableGraphStorage(BaseGraphStorage):
             node_props = dict(node_data)
             node_props["entity_id"] = node_id
             deduped[node_id] = node_props
-        sorted_ids = sorted(deduped)
-        props = [json.dumps(deduped[node_id]) for node_id in sorted_ids]
-        await self._execute(
-            """
-            INSERT INTO lightrag_graph_nodes (workspace, namespace, id, properties, updated_at)
-            SELECT $1, $2, u.id, u.props::jsonb, now()
-            FROM unnest($3::text[], $4::text[]) AS u(id, props)
-            ORDER BY u.id
-            ON CONFLICT (workspace, namespace, id)
-            DO UPDATE SET
-                -- Merge (not replace), same as upsert_node — see note there.
-                properties = lightrag_graph_nodes.properties || EXCLUDED.properties,
-                updated_at = now()
-            """,
-            self.workspace,
-            self.namespace,
-            sorted_ids,
-            props,
+        # (id, props_json) pairs in id order, then split so no single statement
+        # carries an unbounded payload. Chunks are applied sequentially and each is
+        # its own statement (hence its own implicit transaction), matching
+        # PGGraphStorage.upsert_nodes_batch — deliberately NOT one transaction over
+        # all chunks, which would reintroduce the unbounded lock/WAL footprint the
+        # chunking exists to avoid. Node upsert is idempotent (jsonb merge to the
+        # same payload), so a partially-applied batch is safe to replay.
+        items = [(node_id, json.dumps(deduped[node_id])) for node_id in sorted(deduped)]
+        chunks = self._chunk_writes(
+            items,
+            lambda pair: len(pair[0].encode("utf-8")) + len(pair[1].encode("utf-8")),
+            self._batch_limits(),
         )
+        if len(chunks) > 1:
+            logger.info(
+                f"[{self.workspace}] {self.namespace}: node upsert split into "
+                f"{len(chunks)} chunks for {len(items)} nodes"
+            )
+        for chunk in chunks:
+            await self._execute(
+                """
+                INSERT INTO lightrag_graph_nodes (workspace, namespace, id, properties, updated_at)
+                SELECT $1, $2, u.id, u.props::jsonb, now()
+                FROM unnest($3::text[], $4::text[]) AS u(id, props)
+                ORDER BY u.id
+                ON CONFLICT (workspace, namespace, id)
+                DO UPDATE SET
+                    -- Merge (not replace), same as upsert_node — see note there.
+                    properties = lightrag_graph_nodes.properties || EXCLUDED.properties,
+                    updated_at = now()
+                """,
+                self.workspace,
+                self.namespace,
+                [item[0] for item in chunk],
+                [item[1] for item in chunk],
+            )
 
     async def upsert_edges_batch(
         self, edges: list[tuple[str, str, dict[str, str]]]
@@ -1385,35 +1503,53 @@ class PGTableGraphStorage(BaseGraphStorage):
         for src, tgt, edge_data in edges:
             key = (min(src, tgt), max(src, tgt))
             deduped[key] = edge_data
-        sorted_keys = sorted(deduped.keys())
-        srcs = [k[0] for k in sorted_keys]
-        tgts = [k[1] for k in sorted_keys]
-        props = [json.dumps(deduped[k]) for k in sorted_keys]
-        endpoint_ids = sorted({nid for key in sorted_keys for nid in key})
-        await self._execute(
-            """
-            WITH endpoints AS (
-                INSERT INTO lightrag_graph_nodes (workspace, namespace, id, properties, updated_at)
-                SELECT $1, $2, u.id, jsonb_build_object('entity_id', u.id), now()
-                FROM unnest($6::text[]) AS u(id)
-                ON CONFLICT (workspace, namespace, id) DO NOTHING
-                RETURNING id
+        # (src, tgt, props_json) triples in canonical pair order, then split so no
+        # single statement carries an unbounded payload. Per-chunk statements, like
+        # upsert_nodes_batch and PGGraphStorage — see the note there.
+        #
+        # Each chunk stays self-consistent under the FK: it creates the endpoints
+        # for its OWN edges inside the same statement, so no chunk can insert an
+        # edge whose endpoint another chunk was going to create.
+        items = [(key[0], key[1], json.dumps(deduped[key])) for key in sorted(deduped)]
+        chunks = self._chunk_writes(
+            items,
+            lambda triple: (
+                len(triple[0].encode("utf-8"))
+                + len(triple[1].encode("utf-8"))
+                + len(triple[2].encode("utf-8"))
             ),
-            endpoint_write AS (
-                SELECT COUNT(*) AS inserted_count FROM endpoints
-            )
-            INSERT INTO lightrag_graph_edges (workspace, namespace, src_id, tgt_id, properties, updated_at)
-            SELECT $1, $2, u.src, u.tgt, u.props::jsonb, now()
-            FROM unnest($3::text[], $4::text[], $5::text[]) AS u(src, tgt, props)
-            CROSS JOIN endpoint_write
-            ORDER BY u.src, u.tgt
-            ON CONFLICT (workspace, namespace, src_id, tgt_id)
-            DO UPDATE SET properties = EXCLUDED.properties, updated_at = now()
-            """,
-            self.workspace,
-            self.namespace,
-            srcs,
-            tgts,
-            props,
-            endpoint_ids,
+            self._batch_limits(),
         )
+        if len(chunks) > 1:
+            logger.info(
+                f"[{self.workspace}] {self.namespace}: edge upsert split into "
+                f"{len(chunks)} chunks for {len(items)} edges"
+            )
+        for chunk in chunks:
+            await self._execute(
+                """
+                WITH endpoints AS (
+                    INSERT INTO lightrag_graph_nodes (workspace, namespace, id, properties, updated_at)
+                    SELECT $1, $2, u.id, jsonb_build_object('entity_id', u.id), now()
+                    FROM unnest($6::text[]) AS u(id)
+                    ON CONFLICT (workspace, namespace, id) DO NOTHING
+                    RETURNING id
+                ),
+                endpoint_write AS (
+                    SELECT COUNT(*) AS inserted_count FROM endpoints
+                )
+                INSERT INTO lightrag_graph_edges (workspace, namespace, src_id, tgt_id, properties, updated_at)
+                SELECT $1, $2, u.src, u.tgt, u.props::jsonb, now()
+                FROM unnest($3::text[], $4::text[], $5::text[]) AS u(src, tgt, props)
+                CROSS JOIN endpoint_write
+                ORDER BY u.src, u.tgt
+                ON CONFLICT (workspace, namespace, src_id, tgt_id)
+                DO UPDATE SET properties = EXCLUDED.properties, updated_at = now()
+                """,
+                self.workspace,
+                self.namespace,
+                [item[0] for item in chunk],
+                [item[1] for item in chunk],
+                [item[2] for item in chunk],
+                sorted({nid for item in chunk for nid in (item[0], item[1])}),
+            )

--- a/lightrag/kg/pgtable_impl.py
+++ b/lightrag/kg/pgtable_impl.py
@@ -1496,9 +1496,19 @@ class PGTableGraphStorage(BaseGraphStorage):
         items = [(key[0], key[1], json.dumps(deduped[key])) for key in sorted(deduped)]
         chunks = self._chunk_writes(
             items,
+            # Endpoint ids are charged TWICE, because the statement sends them
+            # twice: once as the $3/$4 edge arrays and again as the chunk's
+            # distinct endpoint list in $6. Deduplication inside the chunk can
+            # only make the second copy smaller, never larger, and a per-item
+            # size_of cannot see how much it will save — so charge the worst case
+            # (every endpoint distinct). Counting them once let a chunk whose
+            # estimate fit under POSTGRES_UPSERT_MAX_PAYLOAD_BYTES bind close to
+            # twice that, which is exactly the unbounded single statement the cap
+            # exists to prevent, and it under-counted most on the graphs where it
+            # matters: long entity-name ids with small edge payloads.
             lambda triple: (
-                len(triple[0].encode("utf-8"))
-                + len(triple[1].encode("utf-8"))
+                2 * len(triple[0].encode("utf-8"))
+                + 2 * len(triple[1].encode("utf-8"))
                 + len(triple[2].encode("utf-8"))
             ),
             self._batch_limits(),

--- a/lightrag/kg/pgtable_impl.py
+++ b/lightrag/kg/pgtable_impl.py
@@ -300,8 +300,11 @@ class PGTableGraphStorage(BaseGraphStorage):
         decoded per hop are bounded by the remaining budget.
       - search_labels scores and truncates in SQL (like PGGraphStorage) using the
         NetworkXStorage scoring rules, so the wire cost is O(limit) rather than
-        O(every id matching the query). _search_score is the reference definition
-        and the pg_smoke suite pins the SQL to it.
+        O(every id matching the query). _search_score is the reference for the
+        rules and the pg_smoke suite pins the SQL to it; case folding is the
+        database's LOWER(), not Python str.lower(), which is a documented
+        PostgreSQL-family divergence on the few code points where the two
+        disagree — see the comment in search_labels.
 
     Flush-time batching:
         upsert_nodes_batch / upsert_edges_batch split their payload by
@@ -494,6 +497,10 @@ class PGTableGraphStorage(BaseGraphStorage):
         # Mirror NetworkXStorage.search_labels scoring exactly: the
         # word-boundary bonus applies ONLY to the contains branch, not to
         # exact/prefix matches.
+        #
+        # Reference for the RULES only. search_labels evaluates them in SQL and
+        # folds case with the database's LOWER(), which is not Python
+        # str.lower() on every code point — see the comment there.
         lowered = label.lower()
         if lowered == query:
             return 1000
@@ -957,14 +964,35 @@ class PGTableGraphStorage(BaseGraphStorage):
         # table over the wire per search. The LIKE filter is unindexable either
         # way, but the transfer is now O(limit).
         #
-        # The CASE mirrors _search_score / NetworkXStorage.search_labels exactly:
-        # the +50 word-boundary bonus is nested INSIDE the ELSE branch so it can
-        # never apply to an exact or prefix match (AGE's SQL adds it
+        # The CASE mirrors _search_score / NetworkXStorage.search_labels' scoring
+        # RULES: the +50 word-boundary bonus is nested INSIDE the ELSE branch so
+        # it can never apply to an exact or prefix match (AGE's SQL adds it
         # unconditionally, which is the divergent one). LENGTH() counts
         # characters like Python len(), not octets. ORDER BY id COLLATE "C"
         # reproduces Python's code-point tie-break on the original,
-        # non-lowercased id. _search_score stays the reference definition and the
-        # pg_smoke suite asserts this SQL agrees with it.
+        # non-lowercased id.
+        #
+        # Case folding, however, is the DATABASE's — LOWER() is not Python
+        # str.lower(). LOWER() maps one character to one character, while Python
+        # applies full Unicode case mapping, so the two disagree on a small set
+        # of code points: LOWER('İ') = 'i' but 'İ'.lower() == 'i̇', and
+        # LOWER('ΟΣ') = 'οσ' but 'ΟΣ'.lower() == 'ος' (final sigma). Where they
+        # disagree, a label can land in a different score tier than
+        # _search_score would give it. That is deliberate and unchanged in
+        # authority: the pre-scoring version already folded with LOWER() in this
+        # same WHERE clause, so which labels MATCH has always been the
+        # database's call — this only extends it to which tier they match in.
+        # PGGraphStorage scores with LOWER() the same way, so the whole
+        # PostgreSQL family shares one folding authority while NetworkX/JSON
+        # storages use Python's;
+        # test_search_labels_folds_case_with_the_database_not_python in the
+        # pg_smoke suite pins it.
+        #
+        # _search_score remains the reference for the rules, and
+        # test_search_labels_sql_scoring_matches_search_score_reference asserts
+        # the SQL agrees with it over a corpus whose folding is identical on both
+        # sides (which is every label whose characters fold 1:1 — i.e. all but
+        # that handful).
         #
         # $3 is the RAW lowercased query (compared with =, so it must not carry
         # LIKE escapes); $4..$7 are LIKE patterns built from the escaped form.

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -2483,10 +2483,20 @@ class ClientManager:
                 config.get("postgres", "ssl_crl", fallback=None),
             ),
             # Vector configuration: derived from the vector storage backend in use.
-            # PGVectorStorage requires pgvector; all other backends do not.
-            "enable_vector": vector_storage == "PGVectorStorage"
-            if vector_storage is not None
-            else True,
+            # PGVectorStorage requires pgvector; all other backends — and an
+            # unspecified one — do not.
+            #
+            # There is deliberately NO `None -> True` special case. That was the
+            # last surviving default of the removed POSTGRES_ENABLE_VECTOR env var
+            # (which defaulted to "true"), and it meant "I don't know which vector
+            # backend is in use" was answered with the most demanding option:
+            # require an extension nobody asked for. It cost two workarounds
+            # elsewhere in the tree — PGTableGraphStorage had to pass a sentinel
+            # backend name to avoid demanding pgvector on stock PostgreSQL, and
+            # tools/rebuild_vdb.py had to populate vector_storage defensively — so
+            # an unspecified backend now means no pgvector. A storage that does
+            # need it says so itself: see PGVectorStorage.initialize.
+            "enable_vector": vector_storage == "PGVectorStorage",
             "vector_index_type": os.environ.get(
                 "POSTGRES_VECTOR_INDEX_TYPE",
                 config.get("postgres", "vector_index_type", fallback="HNSW"),
@@ -3886,8 +3896,23 @@ class PGVectorStorage(BaseVectorStorage):
     async def initialize(self):
         async with get_data_init_lock():
             if self.db is None:
+                # Declare this class's OWN requirement rather than asking
+                # global_config what the vector backend is. This storage IS the
+                # pgvector backend, so it always needs the extension and the
+                # asyncpg codec — even when constructed directly with a
+                # global_config that never named a vector backend. Reading the
+                # ambient value would resolve to None there and, since an
+                # unspecified backend no longer implies pgvector (see get_config),
+                # hand back a pool with no vector codec that only fails later.
+                #
+                # In every LightRAG-driven path the two are identical: this class
+                # is only instantiated because global_config["vector_storage"] is
+                # "PGVectorStorage". A caller that hand-builds this storage
+                # alongside another PG storage under a bare global_config now gets
+                # an explicit signature-mismatch RuntimeError instead, which is the
+                # correct answer for a config that never said it wanted pgvector.
                 self.db = await ClientManager.get_client(
-                    vector_storage=self.global_config.get("vector_storage")
+                    vector_storage="PGVectorStorage"
                 )
 
             # Implement workspace priority: PostgreSQLDB.workspace > self.workspace > "default"

--- a/lightrag/tools/rebuild_vdb.py
+++ b/lightrag/tools/rebuild_vdb.py
@@ -624,11 +624,10 @@ class RebuildTool:
         global_config: Dict[str, Any] = {
             "working_dir": os.getenv("WORKING_DIR", "./rag_storage"),
             # Backend selection, mirroring LightRAG._build_global_config. PG
-            # storages derive enable_vector from global_config["vector_storage"]
-            # (ClientManager.get_config defaults enable_vector=True when it is
-            # absent), so a legal mixed config like PGGraphStorage +
-            # QdrantVectorDBStorage would otherwise make the tool wrongly try to
-            # initialize pgvector. Keep all three names for parity.
+            # storages derive enable_vector from global_config["vector_storage"],
+            # so this must carry the real backend name for a mixed config like
+            # PGGraphStorage + QdrantVectorDBStorage to resolve correctly. Keep all
+            # three names for parity.
             "kv_storage": self.storage_names["kv"],
             "vector_storage": self.storage_names["vector"],
             "graph_storage": self.storage_names["graph"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,8 @@ python_functions = ["test_*"]
 markers = [
     "offline: tests that run without any external service (default CI gate)",
     "integration: tests requiring external services; skipped by default, opt in with --run-integration",
+    "requires_db: test needs a reachable database backend",
+    "requires_api: test needs a reachable external API endpoint",
     "pg_smoke: integration tests that require a live PostgreSQL instance (POSTGRES_PASSWORD must be set)",
 ]
 

--- a/scripts/setup/lib/storage_requirements.sh
+++ b/scripts/setup/lib/storage_requirements.sh
@@ -12,11 +12,11 @@ declare -ag KV_STORAGE_OPTIONS=(
 declare -ag GRAPH_STORAGE_OPTIONS=(
   "NetworkXStorage"
   "PGGraphStorage"
-  "PGTableGraphStorage"
   "MongoGraphStorage"
   "OpenSearchGraphStorage"
   "MemgraphStorage"
   "Neo4JStorage"
+  "PGTableGraphStorage"
 )
 
 declare -ag VECTOR_STORAGE_OPTIONS=(

--- a/scripts/setup/lib/storage_requirements.sh
+++ b/scripts/setup/lib/storage_requirements.sh
@@ -11,12 +11,12 @@ declare -ag KV_STORAGE_OPTIONS=(
 
 declare -ag GRAPH_STORAGE_OPTIONS=(
   "NetworkXStorage"
-  "PGGraphStorage"
+  "PGTableGraphStorage"
   "MongoGraphStorage"
   "OpenSearchGraphStorage"
   "MemgraphStorage"
   "Neo4JStorage"
-  "PGTableGraphStorage"
+  "PGGraphStorage"
 )
 
 declare -ag VECTOR_STORAGE_OPTIONS=(

--- a/tests/kg/pgtable_impl/test_pgtable_graph_storage.py
+++ b/tests/kg/pgtable_impl/test_pgtable_graph_storage.py
@@ -1193,6 +1193,62 @@ async def test_upsert_edges_batch_chunk_carries_its_own_endpoints(monkeypatch):
         assert set(endpoint_ids) == set(srcs) | set(tgts)
 
 
+def _edge_statement_bytes(call) -> int:
+    """UTF-8 bytes an edge-upsert statement actually binds for its chunk.
+
+    All four text arrays, including the $6 endpoint list — the point being that
+    $6 is real bound data, not free, so the chunk splitter has to have paid for
+    it.
+    """
+    srcs, tgts, props, endpoint_ids = call.args[3:7]
+    return sum(
+        len(value.encode("utf-8"))
+        for array in (srcs, tgts, props, endpoint_ids)
+        for value in array
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_edges_batch_payload_cap_accounts_for_the_endpoint_array(
+    monkeypatch,
+):
+    """No edge chunk may bind more bytes than POSTGRES_UPSERT_MAX_PAYLOAD_BYTES.
+
+    The chunk splitter used to size an edge by src + tgt + properties, but the
+    statement also sends the chunk's endpoint ids again in $6. With distinct
+    endpoints and small properties — long entity names, thin edges, i.e. the
+    normal shape — the id bytes went over the wire twice while being budgeted
+    once, so a chunk that "fit" bound close to double the cap.
+
+    Long ids and tiny properties here so the id bytes dominate and the
+    under-count is the whole difference: at this cap the old accounting emitted a
+    4-edge chunk binding 1660 bytes.
+    """
+    cap = 1000
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_PAYLOAD_BYTES", str(cap))
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH", "1000")
+    storage = make_storage()
+    edges = [
+        (f"s{i}" + "x" * 98, f"t{i}" + "y" * 98, {"weight": 1.0}) for i in range(6)
+    ]
+
+    with patch.object(storage, "_execute", new=AsyncMock()) as execute:
+        await storage.upsert_edges_batch(edges)
+
+    sizes = [_edge_statement_bytes(call) for call in execute.await_args_list]
+    counts = [len(call.args[3]) for call in execute.await_args_list]
+    for size, count in zip(sizes, counts):
+        # A single item over budget is passed through by design (the server is the
+        # final arbiter); a multi-item chunk over budget is an accounting bug.
+        assert count == 1 or size <= cap, (
+            f"chunk of {count} edges bound {size} bytes against a {cap}-byte cap"
+        )
+    # Guard against the assertion above passing vacuously through the
+    # oversized-single-item exemption.
+    assert max(counts) > 1, "expected multi-edge chunks at this cap"
+    assert sum(counts) == len(edges)
+
+
 @pytest.mark.asyncio
 async def test_remove_nodes_chunks_inside_one_transaction(monkeypatch):
     """Delete chunking must stay all-or-nothing across chunks."""

--- a/tests/kg/pgtable_impl/test_pgtable_graph_storage.py
+++ b/tests/kg/pgtable_impl/test_pgtable_graph_storage.py
@@ -54,17 +54,15 @@ def test_constructor_validates_workspace_like_other_backends():
 @pytest.mark.parametrize(
     ("global_config", "expected_vector_storage"),
     [
-        # No vector backend configured -> this class's own name, NOT None.
-        # ClientManager maps None to enable_vector=True, which would make the pool
-        # require pgvector and break the whole point of this backend. Callers with
-        # a bare global_config are real: tests/kg/test_graph_storage.py, the
-        # cross-backend contract suite, is one, and it runs against a plain
-        # postgres image in CI.
-        ({}, "PGTableGraphStorage"),
-        ({"vector_storage": None}, "PGTableGraphStorage"),
-        # Whenever the key IS set, the value must be forwarded verbatim so the
-        # pool signature agrees with the sibling PG storages. LightRAG always sets
-        # it, so this is the path that actually runs in production.
+        # Forwarded verbatim in every case, exactly like the sibling PG storages,
+        # so the process-wide pool signature can never diverge. An unspecified
+        # backend stays None: ClientManager maps that to enable_vector=False, so a
+        # bare global_config does not demand pgvector and this backend needs no
+        # sentinel name to stay installable on stock PostgreSQL. Bare configs are
+        # real — tests/kg/test_graph_storage.py, the cross-backend contract suite,
+        # is one, and CI runs it against a plain postgres image.
+        ({}, None),
+        ({"vector_storage": None}, None),
         ({"vector_storage": "NanoVectorDBStorage"}, "NanoVectorDBStorage"),
         ({"vector_storage": "PGVectorStorage"}, "PGVectorStorage"),
     ],

--- a/tests/kg/pgtable_impl/test_pgtable_graph_storage.py
+++ b/tests/kg/pgtable_impl/test_pgtable_graph_storage.py
@@ -1080,3 +1080,188 @@ async def test_get_all_edges_returns_source_target_keys():
     assert edges[0]["weight"] == 1.0
     assert "src_id" not in edges[0]
     assert "tgt_id" not in edges[0]
+
+
+# ---------------------------------------------------------------------------
+# flush-time batching — POSTGRES_UPSERT_* / POSTGRES_DELETE_* caps
+# ---------------------------------------------------------------------------
+
+
+class _FakeConn:
+    """Records execute() calls and the transaction nesting they ran under."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, tuple, int]] = []
+        self.depth = 0
+        self.max_depth = 0
+
+    def transaction(self):
+        outer = self
+
+        class _Txn:
+            async def __aenter__(self):
+                outer.depth += 1
+                outer.max_depth = max(outer.max_depth, outer.depth)
+
+            async def __aexit__(self, *exc):
+                outer.depth -= 1
+                return False
+
+        return _Txn()
+
+    async def execute(self, sql, *args):
+        self.calls.append((sql, args, self.depth))
+
+
+def _wire_delete_capture(storage) -> _FakeConn:
+    """Record every statement a delete path emits, whichever route it takes.
+
+    Both the transactional `_run_with_retry` route and a plain `_execute` land in
+    the same recorder, so the assertions are about observable behaviour — how many
+    statements, and whether they ran inside a transaction — rather than about which
+    private helper happens to exist. A single-statement implementation shows up as
+    one call at depth 0.
+    """
+    conn = _FakeConn()
+
+    async def _run(fn):
+        return await fn(conn)
+
+    async def _execute(sql, *args):
+        await conn.execute(sql, *args)
+
+    storage.db._run_with_retry = _run
+    storage._execute = _execute
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_upsert_nodes_batch_splits_by_record_cap(monkeypatch):
+    """A large node batch must not go out as one unbounded statement."""
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH", "3")
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_PAYLOAD_BYTES", "16777216")
+    storage = make_storage()
+    nodes = [(f"n{i:02d}", {"entity_id": f"n{i:02d}"}) for i in range(7)]
+
+    with patch.object(storage, "_execute", new=AsyncMock()) as execute:
+        await storage.upsert_nodes_batch(nodes)
+
+    assert execute.await_count == 3, "7 nodes at cap 3 must be 3 statements"
+    per_chunk_ids = [call.args[3] for call in execute.await_args_list]
+    assert [len(ids) for ids in per_chunk_ids] == [3, 3, 1]
+    # Every node written exactly once, in id order, with parallel props arrays.
+    assert [nid for ids in per_chunk_ids for nid in ids] == [n[0] for n in nodes]
+    for call in execute.await_args_list:
+        assert len(call.args[3]) == len(call.args[4])
+
+
+@pytest.mark.asyncio
+async def test_upsert_nodes_batch_splits_by_payload_bytes(monkeypatch):
+    """The byte budget is the primary limiter, independent of the record cap."""
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH", "1000")
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_PAYLOAD_BYTES", "400")
+    storage = make_storage()
+    # ~300 bytes of properties each, so only one fits per chunk.
+    nodes = [
+        (f"n{i}", {"entity_id": f"n{i}", "description": "x" * 300}) for i in range(4)
+    ]
+
+    with patch.object(storage, "_execute", new=AsyncMock()) as execute:
+        await storage.upsert_nodes_batch(nodes)
+
+    assert execute.await_count == 4, "byte cap must split even under the record cap"
+
+
+@pytest.mark.asyncio
+async def test_upsert_edges_batch_chunk_carries_its_own_endpoints(monkeypatch):
+    """Each edge chunk must create the endpoints for its OWN edges.
+
+    Chunks are separate statements, so an edge whose endpoint node was only going
+    to be created by a different chunk would violate the FK.
+    """
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH", "2")
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_PAYLOAD_BYTES", "16777216")
+    storage = make_storage()
+    edges = [(f"s{i}", f"t{i}", {"weight": 1.0}) for i in range(5)]
+
+    with patch.object(storage, "_execute", new=AsyncMock()) as execute:
+        await storage.upsert_edges_batch(edges)
+
+    assert execute.await_count == 3
+    for call in execute.await_args_list:
+        srcs, tgts, props, endpoint_ids = call.args[3:7]
+        assert len(srcs) == len(tgts) == len(props)
+        # endpoint_ids is exactly this chunk's endpoint set — no more, no less.
+        assert set(endpoint_ids) == set(srcs) | set(tgts)
+
+
+@pytest.mark.asyncio
+async def test_remove_nodes_chunks_inside_one_transaction(monkeypatch):
+    """Delete chunking must stay all-or-nothing across chunks."""
+    monkeypatch.setenv("POSTGRES_DELETE_MAX_RECORDS_PER_BATCH", "2")
+    storage = make_storage()
+    conn = _wire_delete_capture(storage)
+
+    await storage.remove_nodes([f"n{i}" for i in range(5)])
+
+    assert len(conn.calls) == 3, "5 ids at cap 2 must be 3 statements"
+    assert conn.max_depth == 1, "all chunks must run in ONE transaction"
+    for sql, args, depth in conn.calls:
+        assert depth == 1, "every chunk must execute inside the transaction"
+        assert args[0] == "test" and args[1] == GRAPH_NAMESPACE
+    assert [len(args[2]) for _sql, args, _d in conn.calls] == [2, 2, 1]
+    assert [nid for _s, args, _d in conn.calls for nid in args[2]] == [
+        f"n{i}" for i in range(5)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_remove_edges_chunks_canonically_inside_one_transaction(monkeypatch):
+    monkeypatch.setenv("POSTGRES_DELETE_MAX_RECORDS_PER_BATCH", "2")
+    storage = make_storage()
+    conn = _wire_delete_capture(storage)
+
+    # Mixed orientation: canonicalization must survive chunking.
+    await storage.remove_edges([("z", "a"), ("b", "y"), ("m", "c")])
+
+    assert len(conn.calls) == 2
+    assert conn.max_depth == 1
+    pairs = [pair for _sql, args, _d in conn.calls for pair in zip(args[2], args[3])]
+    assert pairs == [("a", "z"), ("b", "y"), ("c", "m")]
+
+
+@pytest.mark.asyncio
+async def test_non_positive_caps_disable_chunking(monkeypatch):
+    """A non-positive cap means "one statement", matching the sibling storages."""
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH", "0")
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_PAYLOAD_BYTES", "0")
+    monkeypatch.setenv("POSTGRES_DELETE_MAX_RECORDS_PER_BATCH", "0")
+
+    storage = make_storage()
+    with patch.object(storage, "_execute", new=AsyncMock()) as execute:
+        await storage.upsert_nodes_batch(
+            [(f"n{i}", {"entity_id": f"n{i}"}) for i in range(50)]
+        )
+    assert execute.await_count == 1
+
+    delete_storage = make_storage()
+    conn = _wire_delete_capture(delete_storage)
+    await delete_storage.remove_nodes([f"n{i}" for i in range(50)])
+    assert len(conn.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_batch_limits_come_from_the_shared_pg_resolver(monkeypatch):
+    """The caps must be the shared POSTGRES_* ones, not a private re-read.
+
+    Guards against this backend growing its own env names or defaults and
+    drifting from the rest of the PostgreSQL write paths.
+    """
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_PAYLOAD_BYTES", "12345")
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH", "67")
+    monkeypatch.setenv("POSTGRES_DELETE_MAX_RECORDS_PER_BATCH", "89")
+
+    from lightrag.kg.postgres_impl import _resolve_pg_batch_limits
+
+    assert make_storage()._batch_limits() == _resolve_pg_batch_limits()
+    assert make_storage()._batch_limits() == (12345, 67, 89)

--- a/tests/kg/pgtable_impl/test_pgtable_graph_storage.py
+++ b/tests/kg/pgtable_impl/test_pgtable_graph_storage.py
@@ -54,12 +54,23 @@ def test_constructor_validates_workspace_like_other_backends():
 @pytest.mark.parametrize(
     ("global_config", "expected_vector_storage"),
     [
+        # No vector backend configured -> this class's own name, NOT None.
+        # ClientManager maps None to enable_vector=True, which would make the pool
+        # require pgvector and break the whole point of this backend. Callers with
+        # a bare global_config are real: tests/kg/test_graph_storage.py, the
+        # cross-backend contract suite, is one, and it runs against a plain
+        # postgres image in CI.
         ({}, "PGTableGraphStorage"),
+        ({"vector_storage": None}, "PGTableGraphStorage"),
+        # Whenever the key IS set, the value must be forwarded verbatim so the
+        # pool signature agrees with the sibling PG storages. LightRAG always sets
+        # it, so this is the path that actually runs in production.
         ({"vector_storage": "NanoVectorDBStorage"}, "NanoVectorDBStorage"),
+        ({"vector_storage": "PGVectorStorage"}, "PGVectorStorage"),
     ],
 )
 @pytest.mark.asyncio
-async def test_initialize_passes_pgtable_safe_vector_storage_to_client_manager(
+async def test_initialize_forwards_configured_vector_storage_verbatim(
     global_config, expected_vector_storage
 ):
     storage = make_uninitialized_storage(global_config=global_config)
@@ -210,6 +221,51 @@ def test_ddl_adds_cascading_edge_foreign_keys():
     assert "ON DELETE CASCADE" in _DDL
     assert "DELETE FROM lightrag_graph_edges e" in _DDL
     assert "n.namespace = e.namespace" in _DDL
+
+
+def test_ddl_gates_orphan_sweep_behind_missing_foreign_keys():
+    """The table-wide orphan sweep must not run once both FKs already exist.
+
+    It is an anti-join over the WHOLE edge table (all workspaces — the FK is a
+    global composite constraint), it runs inside the transaction holding
+    pg_advisory_xact_lock, and with the FKs enforced it can never match a row.
+    As a top-level statement every process paid it, serialized, on every start.
+    """
+    from lightrag.kg.pgtable_impl import _DDL
+
+    # The sweep must live inside the *second* DO block (the FK creator), after
+    # its both-present early return and before the first ADD CONSTRAINT.
+    fk_block = _DDL.split("DO $$", 2)[2]
+    early_return = fk_block.index("RETURN;")
+    sweep = fk_block.index("DELETE FROM lightrag_graph_edges e")
+    add_src_fk = fk_block.index("ADD CONSTRAINT fk_lightrag_graph_edges_src")
+    assert early_return < sweep < add_src_fk, (
+        "orphan sweep must sit between the early return and ADD CONSTRAINT"
+    )
+    assert "IF has_src_fk AND has_tgt_fk THEN" in fk_block
+    # ...and must not additionally exist as an ungated top-level statement.
+    assert _DDL.count("DELETE FROM lightrag_graph_edges e") == 1
+
+
+def test_normalize_guard_predicate_matches_the_partial_index():
+    """The guard and its partial index must share one predicate, verbatim.
+
+    The planner can only serve the guard from
+    idx_lightrag_graph_edges_noncanonical if it can prove the query predicate
+    implies the index predicate. Any drift between the two spellings silently
+    turns a ~0.04 ms index-only probe back into a full scan of the edge table on
+    every process start, with no error to notice.
+    """
+    import inspect
+
+    from lightrag.kg.pgtable_impl import _DDL, PGTableGraphStorage
+
+    predicate = 'src_id COLLATE "C" > tgt_id COLLATE "C"'
+
+    assert "idx_lightrag_graph_edges_noncanonical" in _DDL
+    assert predicate in _DDL
+    guard_src = inspect.getsource(PGTableGraphStorage._normalize_legacy_edges)
+    assert predicate in guard_src
 
 
 def test_postgres_impl_loads_pgvector_lazily_for_vector_connections():
@@ -699,12 +755,100 @@ async def test_get_knowledge_graph_bfs_depth_beats_degree_on_truncation():
 
 
 # ---------------------------------------------------------------------------
+# _bfs_frontier — per-hop work bounded in SQL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bfs_hop_ranks_and_caps_in_sql_without_per_level_degree_roundtrip():
+    """Each hop must rank + cap server-side and cost ONE query.
+
+    Previously a hop fetched every neighbour (full JSONB properties included),
+    then issued a second node_degrees_batch round trip over that whole
+    neighbourhood, then ranked and truncated in Python. On a hub that meant
+    shipping the entire neighbour set just to discard all but `node_budget` of
+    it. node_degrees_batch must now be called exactly once — for the seed's
+    ordering tie-break — no matter how many levels are walked.
+    """
+    storage = make_storage()
+
+    seed_row = {"id": "seed", "properties": json.dumps({"entity_id": "seed"})}
+    # Two levels, each already degree-ranked and capped by the DB.
+    hop_rows = [
+        [
+            {"id": "a", "properties": json.dumps({"entity_id": "a"}), "degree": 9},
+            {"id": "b", "properties": json.dumps({"entity_id": "b"}), "degree": 4},
+        ],
+        [{"id": "c", "properties": json.dumps({"entity_id": "c"}), "degree": 1}],
+        [],
+    ]
+    fetch = AsyncMock(side_effect=hop_rows)
+    degrees_batch = AsyncMock(return_value={"seed": 7})
+
+    with (
+        patch.object(storage, "_fetchrow", new=AsyncMock(return_value=seed_row)),
+        patch.object(storage, "_fetch", new=fetch),
+        patch.object(storage, "node_degrees_batch", new=degrees_batch),
+    ):
+        rows, degrees = await storage._bfs_frontier("seed", max_depth=3, node_budget=10)
+
+    # Seed only — NOT once per level.
+    degrees_batch.assert_awaited_once_with(["seed"])
+    # Degrees come from the hop query itself.
+    assert degrees == {"a": 9, "b": 4, "c": 1, "seed": 7}
+    assert [r["id"] for r in rows] == ["seed", "a", "b", "c"]
+    assert [r["depth"] for r in rows] == [0, 1, 1, 2]
+
+    # Every hop must push the unvisited filter, the degree ranking and the
+    # remaining-budget cap into SQL.
+    first_sql = fetch.await_args_list[0].args[0]
+    assert "ORDER BY COALESCE(d.degree, 0) DESC" in first_sql
+    assert "LIMIT $5" in first_sql
+    assert "NOT EXISTS" in first_sql
+
+    # The cap is the remaining budget + 1, so the caller still sees the one
+    # overfetched row that distinguishes "exactly full" from "truncated".
+    # collected grows 1 -> 3 -> 4, so the cap is 10-1+1, 10-3+1, 10-4+1.
+    caps = [call.args[5] for call in fetch.await_args_list]
+    assert caps == [10, 8, 7]
+    # The visited set is passed so the DB can anti-join it.
+    visited_per_hop = [call.args[4] for call in fetch.await_args_list]
+    assert visited_per_hop[0] == ["seed"]
+    assert visited_per_hop[1] == ["seed", "a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_bfs_hop_cap_never_exceeds_remaining_budget():
+    """A hop must not admit more than budget+1 nodes even if SQL returned more."""
+    storage = make_storage()
+    seed_row = {"id": "seed", "properties": json.dumps({"entity_id": "seed"})}
+    fetch = AsyncMock(
+        return_value=[
+            {"id": "a", "properties": json.dumps({"entity_id": "a"}), "degree": 3},
+        ]
+    )
+
+    with (
+        patch.object(storage, "_fetchrow", new=AsyncMock(return_value=seed_row)),
+        patch.object(storage, "_fetch", new=fetch),
+        patch.object(
+            storage, "node_degrees_batch", new=AsyncMock(return_value={"seed": 0})
+        ),
+    ):
+        await storage._bfs_frontier("seed", max_depth=5, node_budget=1)
+
+    # budget 1, seed already collected -> cap 1, and the loop stops after it.
+    assert fetch.await_args_list[0].args[5] == 1
+    assert fetch.await_count == 1
+
+
+# ---------------------------------------------------------------------------
 # search_labels — literal SQL pattern semantics
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_search_labels_strips_and_relevance_orders():
+async def test_search_labels_strips_and_ranks_and_limits_in_sql():
     storage = make_storage()
     fetch = AsyncMock(return_value=[])
 
@@ -712,11 +856,24 @@ async def test_search_labels_strips_and_relevance_orders():
         assert await storage.search_labels("   ") == []
         await storage.search_labels(" Foo ", limit=7)
 
-    sql, workspace, namespace, contains = fetch.call_args.args
+    sql, workspace, namespace, exact, prefix, space_bnd, us_bnd, contains, limit = (
+        fetch.call_args.args
+    )
     assert workspace == "test"
     assert namespace == GRAPH_NAMESPACE
+    # $3 is compared with '=', so it must be the raw lowercased query with no
+    # LIKE escaping applied.
+    assert exact == "foo"
+    assert prefix == "foo%"
+    assert space_bnd == "% foo%"
+    # '_' is a LIKE wildcard: the "_query" word-boundary probe must escape it.
+    assert us_bnd == r"%\_foo%"
     assert contains == "%foo%"
-    assert "ORDER BY" not in sql
+    # Ranking and truncation must happen server-side, not after transferring the
+    # whole match set (that was the point of the change).
+    assert limit == 7
+    assert "ORDER BY score DESC" in sql
+    assert "LIMIT $8" in sql
     # E'' escape literal: unambiguous one-char escape regardless of
     # standard_conforming_strings (see search_labels).
     assert "ESCAPE E'\\\\'" in sql
@@ -730,29 +887,32 @@ async def test_search_labels_escapes_like_wildcards():
     with patch.object(storage, "_fetch", new=fetch):
         await storage.search_labels(r"a_%\b")
 
-    _sql, _workspace, namespace, contains = fetch.call_args.args
+    args = fetch.call_args.args
+    namespace, exact, prefix, space_bnd, us_bnd, contains = args[2:8]
     assert namespace == GRAPH_NAMESPACE
+    assert exact == r"a_%\b"
+    assert prefix == r"a\_\%\\b%"
+    assert space_bnd == r"% a\_\%\\b%"
+    assert us_bnd == r"%\_a\_\%\\b%"
     assert contains == r"%a\_\%\\b%"
 
 
 @pytest.mark.asyncio
-async def test_search_labels_relevance_sorted_in_python():
-    storage = make_storage()
-    with patch.object(
-        storage,
-        "_fetch",
-        new=AsyncMock(
-            return_value=[
-                {"id": "xx_foo"},
-                {"id": "foo"},
-                {"id": "bar foo"},
-                {"id": "foobar"},
-            ]
-        ),
-    ):
-        result = await storage.search_labels("foo", limit=3)
+async def test_search_labels_preserves_sql_row_order():
+    """Ordering is the DB's job now; the method must not re-sort or re-slice.
 
-    assert result == ["foo", "foobar", "xx_foo"]
+    Rows are handed back in the order SQL returned them (the equivalence of that
+    SQL ordering to _search_score is proven against a live PostgreSQL by
+    tests/kg/pgtable_impl/test_pgtable_smoke.py).
+    """
+    storage = make_storage()
+    # Deliberately NOT in _search_score order: a lingering Python sort would
+    # reorder these, and a lingering [:limit] would drop the last one.
+    sql_order = [{"id": "zz"}, {"id": "aa"}, {"id": "mm"}]
+    with patch.object(storage, "_fetch", new=AsyncMock(return_value=sql_order)):
+        result = await storage.search_labels("a", limit=1)
+
+    assert result == ["zz", "aa", "mm"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/kg/pgtable_impl/test_pgtable_smoke.py
+++ b/tests/kg/pgtable_impl/test_pgtable_smoke.py
@@ -58,6 +58,11 @@ async def store():
     storage = PGTableGraphStorage(
         namespace="graph",
         workspace=workspace,
+        # Deliberately no "vector_storage" key: this exercises the
+        # no-vector-backend-configured fallback in initialize(), which is what
+        # keeps the pool from requiring pgvector. CI runs these against a plain
+        # postgres image, so a regression here fails loudly rather than silently
+        # depending on an extension.
         global_config={"max_graph_nodes": 1000},
         embedding_func=None,
     )
@@ -626,3 +631,212 @@ async def test_get_node_edges_self_loop_appears_once(store):
 
     edges = await store.get_node_edges("A")
     assert edges == [("A", "A")], f"self-loop must appear exactly once: {edges}"
+
+
+# ---------------------------------------------------------------------------
+# SQL-vs-Python equivalence — the SQL rewrites must match their references
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_labels_sql_scoring_matches_search_score_reference(store):
+    """The SQL CASE must score/rank exactly like the _search_score reference.
+
+    Scoring moved from Python into SQL so the LIMIT could be applied server-side
+    (the Python version transferred every id matching %q% to return `limit` of
+    them). _search_score stays the definition of NetworkXStorage's semantics, so
+    the two must agree — including the subtle part: the +50 word-boundary bonus
+    applies ONLY to the contains branch, never to an exact or prefix match.
+    """
+    labels = [
+        "foo",
+        "FOO",
+        "foobar",
+        "foo foo",  # prefix match that ALSO has a boundary hit -> must stay 500
+        "xx_foo",
+        "bar foo",
+        "barfoo",
+        "foo_bar",
+        "prefix_foo_suffix",
+        "x" * 120 + "foo",  # negative score (100 - len)
+        "_foo",
+        "café foo",
+        "北京 foo",
+        "foo%bar",  # literal % must not act as a wildcard
+        "a_foo",  # literal _ must not act as a wildcard
+        "zzfoo",
+    ]
+    await store.upsert_nodes_batch([(lbl, _node(lbl)) for lbl in labels])
+
+    for query in ("foo", "f", "oo", "bar", "%", "_", "FOO"):
+        normalized = query.strip().lower()
+        for limit in (1, 3, 50):
+            got = await store.search_labels(query, limit=limit)
+
+            matched = [lbl for lbl in labels if normalized in lbl.lower()]
+            expected = sorted(
+                matched, key=lambda lbl: (-store._search_score(lbl, normalized), lbl)
+            )[:limit]
+
+            assert got == expected, (
+                f"SQL scoring diverged from _search_score for "
+                f"query={query!r} limit={limit}: {got} != {expected}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_bfs_matches_degree_ordered_reference_traversal(store):
+    """SQL-side rank+cap BFS must equal the Python reference on a hub graph.
+
+    The per-hop unvisited filter, degree ranking and budget cap all moved into
+    SQL. This pins the observable result — which nodes are retained at which BFS
+    depth, and their degrees — against a plain in-memory reference walk, on a
+    graph with a hub whose degree far exceeds the node budget (the case the
+    rewrite targets).
+    """
+    nodes = [f"n{i:03d}" for i in range(120)]
+    hub = nodes[0]
+    edges = {(min(hub, n), max(hub, n)) for n in nodes[1:80]}
+    # A second, lower-degree cluster reachable only at depth 2.
+    edges |= {(min(nodes[80], n), max(nodes[80], n)) for n in nodes[81:100]}
+    edges.add((min(hub, nodes[80]), max(hub, nodes[80])))
+    edges.add((nodes[5], nodes[5]))  # self-loop: counts twice, like node_degree
+
+    await store.upsert_nodes_batch([(n, _node(n)) for n in nodes])
+    await store.upsert_edges_batch([(s, t, _edge()) for s, t in sorted(edges)])
+
+    adjacency: dict[str, set[str]] = {}
+    degree: dict[str, int] = {}
+    for src, tgt in edges:
+        adjacency.setdefault(src, set()).add(tgt)
+        adjacency.setdefault(tgt, set()).add(src)
+        degree[src] = degree.get(src, 0) + 1
+        degree[tgt] = degree.get(tgt, 0) + 1
+
+    def reference(seed, max_depth, budget):
+        """Degree-ordered BFS, admitting one past the budget like the real one."""
+        collected = {seed: 0}
+        frontier, depth = [seed], 0
+        while frontier and depth < max_depth and len(collected) <= budget:
+            depth += 1
+            candidates = {
+                nb
+                for node in frontier
+                for nb in adjacency.get(node, ())
+                if nb not in collected
+            }
+            if not candidates:
+                break
+            ordered = sorted(candidates, key=lambda n: (-degree.get(n, 0), n))
+            nxt = []
+            for node in ordered:
+                collected[node] = depth
+                nxt.append(node)
+                if len(collected) > budget:
+                    break
+            frontier = nxt
+        return collected
+
+    for seed, max_depth, budget in [
+        (hub, 1, 1000),
+        (hub, 2, 1000),
+        (hub, 3, 25),
+        (hub, 2, 10),
+        (nodes[80], 2, 1000),
+        (nodes[99], 3, 40),
+        (nodes[5], 2, 1000),
+    ]:
+        rows, degrees = await store._bfs_frontier(seed, max_depth, budget)
+        expected = reference(seed, max_depth, budget)
+
+        assert {r["id"] for r in rows} == set(expected), (
+            f"node set diverged for seed={seed} depth={max_depth} budget={budget}"
+        )
+        assert {r["id"]: r["depth"] for r in rows} == expected, (
+            f"BFS depths diverged for seed={seed} depth={max_depth} budget={budget}"
+        )
+        for row in rows:
+            assert degrees[row["id"]] == degree.get(row["id"], 0), (
+                f"degree diverged for {row['id']}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_reinitialize_is_idempotent_and_keeps_data(store):
+    """Re-running the DDL must not disturb existing rows.
+
+    The orphan sweep is now gated behind "an FK is missing", so a second
+    initialize() must skip it entirely — and must certainly not delete live
+    edges. Guards the gating change against a regression that would make
+    startup destructive.
+    """
+    await store.upsert_node("A", _node("A"))
+    await store.upsert_node("B", _node("B"))
+    await store.upsert_edge("A", "B", _edge(weight=3.5))
+
+    from lightrag.kg.pgtable_impl import _DDL
+
+    # Second pass over the schema DDL + legacy normalization.
+    await store._db.execute(_DDL)
+    await store._normalize_legacy_edges()
+
+    assert await store.get_node("A") is not None
+    assert await store.get_node("B") is not None
+    edge = await store.get_edge("A", "B")
+    assert edge is not None, "re-running the DDL must not delete live edges"
+    assert edge["weight"] == 3.5
+
+
+@pytest.mark.asyncio
+async def test_orphan_sweep_still_runs_when_foreign_keys_are_missing(store):
+    """Gating the sweep must not break the legacy migration it exists for.
+
+    Drop both FKs, plant an orphan edge that the constraints would have
+    forbidden, then re-run the DDL: the sweep must remove the orphan and both
+    constraints must come back. Without the sweep, ADD CONSTRAINT would fail and
+    initialize() would abort.
+    """
+    from lightrag.kg.pgtable_impl import _DDL
+
+    await store.upsert_node("A", _node("A"))
+    await store.upsert_node("B", _node("B"))
+    await store.upsert_edge("A", "B", _edge())
+
+    async def _plant_orphan(conn):
+        await conn.execute(
+            "ALTER TABLE lightrag_graph_edges "
+            "DROP CONSTRAINT IF EXISTS fk_lightrag_graph_edges_src"
+        )
+        await conn.execute(
+            "ALTER TABLE lightrag_graph_edges "
+            "DROP CONSTRAINT IF EXISTS fk_lightrag_graph_edges_tgt"
+        )
+        await conn.execute(
+            "INSERT INTO lightrag_graph_edges "
+            "(workspace, namespace, src_id, tgt_id, properties) "
+            "VALUES ($1, $2, 'A', 'GHOST', '{}'::jsonb)",
+            store.workspace,
+            store.namespace,
+        )
+
+    await store._db._run_with_retry(_plant_orphan)
+    assert await store.has_edge("A", "GHOST") is True
+
+    await store._db.execute(_DDL)
+
+    assert await store.has_edge("A", "GHOST") is False, (
+        "orphan edge must be swept before the FKs are recreated"
+    )
+    assert await store.get_edge("A", "B") is not None, "live edge must survive"
+
+    async def _count_fks(conn):
+        return await conn.fetchval(
+            "SELECT COUNT(*) FROM pg_constraint "
+            "WHERE conrelid = 'lightrag_graph_edges'::regclass "
+            "AND conname IN ('fk_lightrag_graph_edges_src', "
+            "'fk_lightrag_graph_edges_tgt')"
+        )
+
+    assert await store._db._run_with_retry(_count_fks) == 2, (
+        "both foreign keys must be recreated after the sweep"
+    )

--- a/tests/kg/pgtable_impl/test_pgtable_smoke.py
+++ b/tests/kg/pgtable_impl/test_pgtable_smoke.py
@@ -647,6 +647,13 @@ async def test_search_labels_sql_scoring_matches_search_score_reference(store):
     them). _search_score stays the definition of NetworkXStorage's semantics, so
     the two must agree — including the subtle part: the +50 word-boundary bonus
     applies ONLY to the contains branch, never to an exact or prefix match.
+
+    Scope: every label below folds identically under SQL LOWER() and Python
+    str.lower(), which is true of all but a handful of code points. Those are a
+    separate, documented divergence — see
+    test_search_labels_folds_case_with_the_database_not_python. Keep this corpus
+    free of them, or this test stops testing the scoring rules and starts
+    testing case folding.
     """
     labels = [
         "foo",
@@ -682,6 +689,47 @@ async def test_search_labels_sql_scoring_matches_search_score_reference(store):
                 f"SQL scoring diverged from _search_score for "
                 f"query={query!r} limit={limit}: {got} != {expected}"
             )
+
+
+@pytest.mark.asyncio
+async def test_search_labels_folds_case_with_the_database_not_python(store):
+    """Pin the one place SQL scoring is allowed to disagree with _search_score.
+
+    SQL LOWER() folds one character to one character; Python str.lower() applies
+    full Unicode case mapping. So LOWER('İ') is 'i' — an EXACT match for query
+    'i', worth 1000 — while 'İ'.lower() is 'i̇', only a prefix match worth
+    500, which the code-point tie-break then puts behind 'ia'.
+
+    This is not new authority: the pre-scoring implementation already folded with
+    LOWER() in the same WHERE clause, so which labels match has always been the
+    database's call. PGGraphStorage folds the same way, so the divergence is
+    against the NetworkX/JSON storages, not between the PostgreSQL ones. Asserted
+    explicitly here so it stays a decision rather than drifting into a surprise —
+    if a future change unifies the folding, this test is the one to update.
+    """
+    # LOWER() is lc_ctype-dependent: a server initdb'd with the pure "C" locale
+    # does not fold non-ASCII at all, so there is no divergence to pin there.
+    # Ask this server rather than hard-coding one libc's answer.
+    server_lower = await store._fetchval("SELECT LOWER($1)", "İ")
+    if server_lower != "i":
+        pytest.skip(
+            f"server folds 'İ' to {server_lower!r}, not 'i' "
+            "(lc_ctype=C?) — nothing to diverge from Python here"
+        )
+
+    labels = ["İ", "ia"]
+    await store.upsert_nodes_batch([(lbl, _node(lbl)) for lbl in labels])
+
+    # What the database's folding produces, in full and truncated to one.
+    assert await store.search_labels("i", limit=50) == ["İ", "ia"]
+    assert await store.search_labels("i", limit=1) == ["İ"]
+
+    # ... and that this is a real divergence from the Python reference, not an
+    # accident of ordering: the reference disagrees on both the tier and the rank.
+    assert store._search_score("İ", "i") == 500
+    assert store._search_score("ia", "i") == 500
+    reference = sorted(labels, key=lambda lbl: (-store._search_score(lbl, "i"), lbl))
+    assert reference == ["ia", "İ"]
 
 
 @pytest.mark.asyncio

--- a/tests/kg/pgtable_impl/test_pgtable_smoke.py
+++ b/tests/kg/pgtable_impl/test_pgtable_smoke.py
@@ -840,3 +840,99 @@ async def test_orphan_sweep_still_runs_when_foreign_keys_are_missing(store):
     assert await store._db._run_with_retry(_count_fks) == 2, (
         "both foreign keys must be recreated after the sweep"
     )
+
+
+# ---------------------------------------------------------------------------
+# flush-time batching against a real server
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chunked_batch_writes_and_deletes_round_trip(store, monkeypatch):
+    """Multi-chunk upserts and deletes must be indistinguishable from single ones.
+
+    Caps are set absurdly low so every batch path splits, then the full data set is
+    read back. This is the live counterpart to the offline chunking tests: it proves
+    the per-chunk statements are valid SQL, that each edge chunk satisfies the
+    endpoint foreign keys on its own, and that a chunked delete removes exactly the
+    requested set.
+    """
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH", "4")
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_PAYLOAD_BYTES", "512")
+    monkeypatch.setenv("POSTGRES_DELETE_MAX_RECORDS_PER_BATCH", "3")
+    # The fixture may already have cached the default caps.
+    store._cached_batch_limits = None
+
+    nodes = [f"n{i:03d}" for i in range(37)]
+    # Chain plus a few cross edges, all endpoints among `nodes`.
+    edges = [(nodes[i], nodes[i + 1]) for i in range(len(nodes) - 1)]
+    edges += [(nodes[0], nodes[20]), (nodes[5], nodes[30])]
+
+    await store.upsert_nodes_batch([(n, _node(n)) for n in nodes])
+    await store.upsert_edges_batch([(s, t, _edge()) for s, t in edges])
+
+    fetched = await store.get_nodes_batch(nodes)
+    assert set(fetched) == set(nodes), "every node must survive chunked upsert"
+    for n in nodes:
+        assert fetched[n]["description"] == f"smoke node {n}"
+
+    all_edges = await store.get_all_edges()
+    expected_pairs = {(min(s, t), max(s, t)) for s, t in edges}
+    assert {(e["source"], e["target"]) for e in all_edges} == expected_pairs
+
+    # Chunked edge delete removes exactly the requested pairs.
+    to_drop = edges[:7]
+    await store.remove_edges(list(to_drop))
+    remaining = {(e["source"], e["target"]) for e in await store.get_all_edges()}
+    assert remaining == expected_pairs - {(min(s, t), max(s, t)) for s, t in to_drop}
+
+    # Chunked node delete removes exactly the requested nodes (and cascades edges).
+    await store.remove_nodes(nodes[:11])
+    still_there = await store.get_nodes_batch(nodes)
+    assert set(still_there) == set(nodes[11:])
+    for edge in await store.get_all_edges():
+        assert edge["source"] in still_there and edge["target"] in still_there, (
+            "cascade must not leave an edge pointing at a deleted node"
+        )
+
+
+@pytest.mark.asyncio
+async def test_failed_upsert_chunk_leaves_no_edge_without_endpoints(store, monkeypatch):
+    """A chunk failure mid-batch must not strand an edge without its endpoints.
+
+    Upsert chunks are separate statements, so a crash between them leaves earlier
+    chunks committed. That is acceptable only because each chunk creates its own
+    endpoints in the same statement: the partial result must still satisfy the
+    foreign keys, and replaying the whole batch must converge (upsert is
+    idempotent). Without the per-chunk endpoint set, a later chunk's edge could
+    reference a node an earlier failed chunk never wrote.
+    """
+    monkeypatch.setenv("POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH", "2")
+    store._cached_batch_limits = None
+
+    edges = [(f"s{i}", f"t{i}", _edge()) for i in range(6)]
+    real_execute = store._execute
+    seen = {"count": 0}
+
+    async def _flaky(sql, *args):
+        seen["count"] += 1
+        if seen["count"] == 2:
+            raise RuntimeError("injected chunk failure")
+        return await real_execute(sql, *args)
+
+    store._execute = _flaky
+    with pytest.raises(RuntimeError, match="injected chunk failure"):
+        await store.upsert_edges_batch(edges)
+    store._execute = real_execute
+
+    persisted_nodes = {n["id"] for n in await store.get_all_nodes()}
+    partial = await store.get_all_edges()
+    assert partial, "the chunk before the failure must have committed"
+    for edge in partial:
+        assert (
+            edge["source"] in persisted_nodes and edge["target"] in persisted_nodes
+        ), "a committed chunk left an edge whose endpoint node is missing"
+
+    # Replaying the full batch converges on the complete edge set.
+    await store.upsert_edges_batch(edges)
+    assert len(await store.get_all_edges()) == len(edges)

--- a/tests/kg/postgres_impl/test_postgres_client_manager.py
+++ b/tests/kg/postgres_impl/test_postgres_client_manager.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -39,16 +40,31 @@ def test_qdrant_storage_disables_vector() -> None:
     assert config["enable_vector"] is False
 
 
-def test_none_vector_storage_defaults_to_true() -> None:
-    # Backward compatibility: when vector_storage is unknown (None), default to True.
+def test_none_vector_storage_disables_vector() -> None:
+    """An unspecified vector backend must NOT demand pgvector.
+
+    This used to default to True — the last surviving default of the removed
+    POSTGRES_ENABLE_VECTOR env var. It made "I don't know which vector backend is
+    in use" mean "require an extension", which is why PGTableGraphStorage had to
+    pass a sentinel backend name to stay installable on stock PostgreSQL and why
+    tools/rebuild_vdb.py had to populate vector_storage defensively.
+    """
     config = ClientManager.get_config(None)
-    assert config["enable_vector"] is True
+    assert config["enable_vector"] is False
 
 
-def test_no_args_defaults_to_true() -> None:
-    # Backward compatibility: calling without arguments preserves prior behavior.
+def test_no_args_disables_vector() -> None:
     config = ClientManager.get_config()
-    assert config["enable_vector"] is True
+    assert config["enable_vector"] is False
+
+
+def test_only_pg_vector_storage_enables_vector() -> None:
+    """Exhaustive: pgvector is enabled for exactly one backend name."""
+    from lightrag.kg import STORAGE_IMPLEMENTATIONS
+
+    for name in STORAGE_IMPLEMENTATIONS["VECTOR_STORAGE"]["implementations"]:
+        expected = name == "PGVectorStorage"
+        assert ClientManager.get_config(name)["enable_vector"] is expected, name
 
 
 @pytest.mark.asyncio
@@ -80,3 +96,47 @@ async def test_get_client_rejects_conflicting_vector_storage_settings() -> None:
 
         with pytest.raises(RuntimeError, match="process-wide"):
             await ClientManager.get_client("PGVectorStorage")
+
+
+@pytest.mark.asyncio
+async def test_pg_vector_storage_declares_its_own_pgvector_requirement() -> None:
+    """PGVectorStorage must not ask global_config whether it needs pgvector.
+
+    It IS the pgvector backend, so it always does. Since an unspecified vector
+    backend no longer implies pgvector, reading the ambient value would resolve to
+    None under a bare global_config and hand back a pool with no vector codec that
+    only fails later, on the first vector query.
+    """
+    from lightrag.kg.postgres_impl import PGVectorStorage
+
+    storage = object.__new__(PGVectorStorage)
+    storage.db = None
+    storage.workspace = "test"
+    storage.namespace = "chunks"
+    storage.global_config = {}  # deliberately names no vector backend
+    # Only needed so setup_table's argument list can be evaluated; the call itself
+    # is patched out below.
+    storage.table_name = "LIGHTRAG_VDB_CHUNKS"
+    storage.legacy_table_name = "LIGHTRAG_VDB_CHUNKS"
+    storage.embedding_func = MagicMock(embedding_dim=8)
+    storage._flush_lock = MagicMock()
+
+    db = MagicMock()
+    db.workspace = None
+
+    @asynccontextmanager
+    async def _lock():
+        yield
+
+    with (
+        patch(
+            "lightrag.kg.postgres_impl.ClientManager.get_client",
+            new=AsyncMock(return_value=db),
+        ) as get_client,
+        patch("lightrag.kg.postgres_impl.get_data_init_lock", return_value=_lock()),
+        patch.object(PGVectorStorage, "setup_table", new=AsyncMock(), create=True),
+    ):
+        await PGVectorStorage.initialize(storage)
+
+    get_client.assert_awaited_once_with(vector_storage="PGVectorStorage")
+    assert ClientManager.get_config("PGVectorStorage")["enable_vector"] is True

--- a/tests/setup/_helpers.py
+++ b/tests/setup/_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import os
 import re
 import shutil
@@ -31,7 +32,19 @@ def _bash_version_major(candidate: str) -> int | None:
     return int(match.group(1)) if match else None
 
 
-def _resolve_bash() -> str:
+@functools.cache
+def bash_bin() -> str:
+    """Path to a bash >= 4 interpreter, resolved once per process.
+
+    ``scripts/setup/setup.sh`` uses associative arrays (``declare -A``), which
+    need bash 4+. macOS still ships bash 3.2 as ``/bin/bash``, so a plain
+    ``"bash"`` picks an interpreter that cannot source the wizard at all.
+
+    Deliberately lazy (and cached): resolution shells out to ``bash --version``
+    once per candidate, and a module-level constant made every test session that
+    merely imports this helper pay those forks — including sessions that run no
+    setup test. Override with ``LIGHTRAG_TEST_BASH``.
+    """
     candidates = [
         os.environ.get("LIGHTRAG_TEST_BASH"),
         "/opt/homebrew/bin/bash",
@@ -39,19 +52,20 @@ def _resolve_bash() -> str:
         shutil.which("bash"),
         "/bin/bash",
     ]
+    seen: set[str] = set()
     for candidate in candidates:
-        if not candidate:
+        if not candidate or candidate in seen:
             continue
+        seen.add(candidate)
         candidate_path = Path(candidate)
         if candidate_path.is_absolute() and not candidate_path.exists():
             continue
         major = _bash_version_major(candidate)
         if major is not None and major >= 4:
             return candidate
+    # No bash 4+ found. Return the best available so the caller fails with the
+    # script's own error rather than a confusing FileNotFoundError.
     return shutil.which("bash") or "bash"
-
-
-BASH_BIN = _resolve_bash()
 
 
 def run_bash_process(
@@ -59,7 +73,7 @@ def run_bash_process(
 ) -> subprocess.CompletedProcess[str]:
     """Run a bash snippet and return the completed process."""
     return subprocess.run(
-        [BASH_BIN, "--norc", "--noprofile", "-c", script],
+        [bash_bin(), "--norc", "--noprofile", "-c", script],
         cwd=cwd or REPO_ROOT,
         input=stdin,
         capture_output=True,

--- a/tests/setup/test_validate.py
+++ b/tests/setup/test_validate.py
@@ -9,8 +9,8 @@ from pathlib import Path
 import pytest
 
 from tests.setup._helpers import (
-    BASH_BIN,
     REPO_ROOT,
+    bash_bin,
     parse_lines,
     run_bash,
     run_bash_lines,
@@ -40,7 +40,7 @@ def test_validate_env_file_rejects_missing_ssl_files(tmp_path: Path) -> None:
     )
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "-lc",
             f"""
 source "{REPO_ROOT}/scripts/setup/setup.sh"
@@ -99,7 +99,7 @@ def test_validate_env_file_rejects_container_ssl_paths_for_host_target(
     )
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "-lc",
             f"""
 source "{REPO_ROOT}/scripts/setup/setup.sh"
@@ -143,7 +143,7 @@ def test_validate_env_file_rejects_container_ssl_paths_for_default_host_target(
     )
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "-lc",
             f"""
 source "{REPO_ROOT}/scripts/setup/setup.sh"
@@ -188,7 +188,7 @@ def test_validate_env_file_accepts_container_ssl_paths_for_compose_target(
     )
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "-lc",
             f"""
 source "{REPO_ROOT}/scripts/setup/setup.sh"
@@ -244,7 +244,7 @@ def test_validate_env_file_allows_predictable_auth_passwords_and_leaves_them_to_
     write_text_lines(tmp_path / "env.example", ["LLM_BINDING=openai"])
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -268,7 +268,7 @@ fi
     assert values["VALID"] == "yes"
     audit_result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -397,7 +397,7 @@ def test_validate_env_file_handles_supported_and_unsupported_uri_schemes(
         write_text_lines(case_dir / "env.example", ["LLM_BINDING=openai"])
         result = subprocess.run(
             [
-                BASH_BIN,
+                bash_bin(),
                 "--norc",
                 "--noprofile",
                 "-c",
@@ -438,7 +438,7 @@ def test_validate_env_file_rejects_invalid_runtime_target(tmp_path: Path) -> Non
     write_text_lines(tmp_path / "env.example", ["LLM_BINDING=openai"])
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -505,7 +505,7 @@ def test_validate_env_file_rejects_invalid_opensearch_index_settings(
     write_text_lines(tmp_path / "env.example", ["LLM_BINDING=openai"])
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -550,7 +550,7 @@ def test_validate_env_file_rejects_blank_opensearch_index_settings(
     write_text_lines(tmp_path / "env.example", ["LLM_BINDING=openai"])
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -595,7 +595,7 @@ def test_validate_env_file_rejects_mongo_vector_storage_without_atlas_capable_ur
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -643,7 +643,7 @@ def test_validate_env_file_allows_mongo_vector_storage_with_wizard_managed_atlas
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -689,7 +689,7 @@ def test_validate_env_file_allows_external_atlas_local_for_mongo_vector_storage(
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -736,7 +736,7 @@ def test_validate_env_file_rejects_remote_mongo_uri_with_docker_marker(
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -787,7 +787,7 @@ def test_validate_env_file_rejects_stale_local_mongo_uri_without_direct_connecti
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -838,7 +838,7 @@ def test_validate_env_file_rejects_wrong_local_mongo_port_with_docker_marker(
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -885,7 +885,7 @@ def test_validate_env_file_rejects_empty_opensearch_hosts(tmp_path: Path) -> Non
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -933,7 +933,7 @@ def test_validate_env_file_rejects_whitespace_only_opensearch_hosts(
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -981,7 +981,7 @@ def test_validate_env_file_rejects_docker_opensearch_without_password(
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -1033,7 +1033,7 @@ def test_validate_env_file_rejects_weak_docker_opensearch_password(
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -1081,7 +1081,7 @@ def test_validate_env_file_rejects_weak_host_opensearch_password(
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -1127,7 +1127,7 @@ def test_validate_env_file_rejects_unauthenticated_host_opensearch(
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -1173,7 +1173,7 @@ def test_validate_env_file_rejects_partial_host_opensearch_auth(tmp_path: Path) 
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -1221,7 +1221,7 @@ def test_validate_env_file_rejects_opensearch_hosts_with_uri_scheme(
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -1275,7 +1275,7 @@ def test_validate_env_file_ignores_invalid_unused_storage_settings(
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",
@@ -1327,7 +1327,7 @@ def test_validate_env_file_allows_empty_opensearch_hosts_when_unused(
     (tmp_path / "env.example").write_text("LLM_BINDING=openai\n", encoding="utf-8")
     result = subprocess.run(
         [
-            BASH_BIN,
+            bash_bin(),
             "--norc",
             "--noprofile",
             "-c",


### PR DESCRIPTION
## Summary

Addresses the review findings on #3103 (`PGTableGraphStorage`), on top of `dev-pgtable`. The storage contract and the schema shape are unchanged; what changes is startup cost, read fan-out, write batching, test coverage, docs and CI reach — plus one fix in shared PostgreSQL infrastructure that turned out to be a latent bug for *every* PG storage, not just this one.

One finding I raised was refuted by testing, then re-established by fixing its actual root cause. That is section 4, and it is the part most worth reviewing.

## What's changed

### 1. Startup no longer does two full scans of the edge table

`initialize()` paid two unindexable full scans of `lightrag_graph_edges` on **every process start**, both one-time-migration checks that can never find anything once the migration has run.

**Orphan-edge sweep** was an ungated top-level DDL statement: a table-wide anti-join (the FK is a global composite constraint, so it cannot be scoped per workspace) running inside the transaction that holds `pg_advisory_xact_lock('lightrag_pgtable_schema')`. With `lightrag-gunicorn` and N workers that was N **serialized** scans of the whole edge table before serving traffic — and with both FKs enforced it cannot match a row. It now lives inside the DO block that creates the constraints, behind an early return taken when both already exist, so it runs only when a constraint is genuinely missing (first install, or right after the namespace PK migration drops them).

**`_normalize_legacy_edges`' fast-path guard** could not use an index: `EXISTS` only short-circuits when it *finds* a row, and after normalization there are none, so it scanned to completion forever. Added a partial index whose predicate *is* the non-canonical condition, making the guard an index-only probe on a normally-empty index.

Measured on PostgreSQL 14.15 with 200k canonical edges:

| | plan | time | buffers |
|---|---|--:|--:|
| before | Seq Scan | 28.6 ms | 2273 |
| after | Index Only Scan | 0.04 ms | — |

The index is 8 kB while every edge stays canonical. Canonical writes never satisfy the predicate, so they create no index entries. If the planner ever declines the index the guard degrades to the previous scan — an optimization, not a correctness dependency.

### 2. Read paths no longer fetch far more than they return

**`search_labels`** transferred every id matching `%query%`, then scored/sorted/sliced in Python — on a large graph, most of the node table over the wire to return `limit` rows. Scoring now runs in SQL with `ORDER BY ... LIMIT`, as `PGGraphStorage` already does, so the wire cost is O(limit). The `CASE` reproduces `_search_score`'s scoring **rules**, including the easy-to-break part: the `+50` word-boundary bonus is nested **inside** the `ELSE` branch so it can never apply to an exact or prefix match. (AGE's SQL adds it unconditionally — AGE is the divergent one here, not this.) `_search_score` stays the reference for the rules.

It is *not* equivalent in case folding, and the first version of this description said it was. SQL `LOWER()` folds one character to one character; Python `str.lower()` applies full Unicode case mapping. Verified on PostgreSQL 14.15 and 18.4:

| | `İ` | `ΟΣ` |
|---|---|---|
| `LOWER()` | `i` | `οσ` |
| `str.lower()` | `i̇` (U+0069 U+0307) | `ος` (final sigma) |

So for query `i`, SQL scores `İ` 1000 (exact) where the reference scores it 500 (prefix), reversing its rank against `ia`. **Which authority folds case is unchanged by this PR** — the pre-scoring version already used `LOWER()` in the same `WHERE` clause, so which labels *match* has always been the database's call; this only extends that to which tier they match in. `PGGraphStorage` folds the same way, so the divergence is between the PostgreSQL family and the NetworkX/JSON storages, not among the PostgreSQL ones. Now stated where the claim is made and pinned by a smoke test, so it stays a decision rather than drifting into a surprise.

**`_bfs_frontier`** fetched a hop's entire neighbourhood — full JSONB properties included — then issued a *second* `node_degrees_batch` round trip over that whole set, then ranked and capped in Python. Expanding one hub shipped its complete neighbour list just to discard all but `node_budget` of it. The unvisited anti-join, degree ranking and remaining-budget cap now run inside the hop query. `node_degrees_batch` is called once per traversal (the seed's tie-break) instead of once per level. The visited set is passed for a hash anti-join rather than a scalar `<> ALL`, which would have been O(neighbours × visited) — worse than the Python lookup it replaces.

What is still unbounded is the server-side edge enumeration, which is a lower bound for any correct top-k-by-degree. The docstring now says that plainly instead of describing the whole thing as a follow-up.

### 3. Batch writes now honour the shared PostgreSQL batching caps

Every batch write path sent its whole payload as one statement, so a single `unnest()` array was bounded only by whatever the caller happened to pass. `PGKVStorage`, `PGVectorStorage`, `PGDocStatusStorage` and `PGGraphStorage` all bound theirs with `POSTGRES_UPSERT_MAX_PAYLOAD_BYTES`, `POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH` and `POSTGRES_DELETE_MAX_RECORDS_PER_BATCH` — this backend honoured **none** of them. An operator who had tuned those caps to fit their server got no protection on the graph tables, and a large ingest could push a multi-hundred-megabyte statement.

Now chunked, reusing `postgres_impl`'s own `_resolve_pg_batch_limits` and `_chunk_by_budget` rather than re-deriving either, so one deployment-wide setting bounds every PG write path with identical byte accounting:

| path | bounded by |
|---|---|
| `upsert_nodes_batch` / `upsert_edges_batch` | byte budget (primary) + record cap |
| `remove_nodes` / `remove_edges` | delete record cap |

Transaction semantics deliberately differ between the two, matching `PGGraphStorage`:

- **Upsert chunks are separate statements.** Wrapping them all in one transaction would reintroduce exactly the unbounded lock/WAL footprint the chunking exists to avoid. Safe because each chunk is self-consistent under the FKs — an edge chunk creates the endpoints for its **own** edges in the same statement — and because upsert is idempotent, so replaying the batch after a mid-batch failure converges.
- **Delete chunks all share ONE transaction.** The pre-chunking version was a single statement and therefore all-or-nothing; a caller removing a set of nodes must not end up with half of them gone.

One accounting detail the first version of this got wrong: the edge statement binds its endpoint ids **twice** — `$3`/`$4` carry the edge arrays and `$6` carries the chunk's distinct endpoint list for the endpoint-creating CTE — but the splitter sized an edge as `src + tgt + properties`. With distinct endpoints the id bytes crossed the wire twice while being budgeted once, so a chunk whose estimate fit under the cap could bind close to **twice** it, which is the unbounded statement the cap exists to prevent. Worst on the most common shape: long entity-name ids with thin edge payloads. Endpoints are now charged twice, i.e. the worst case where none are shared — in-chunk deduplication can only shrink the second copy, and a per-item `size_of` cannot see how much it will save.

Verified on live PostgreSQL by injecting a failure into the second chunk: earlier chunks commit, **no edge is left without its endpoints**, and a full replay reaches the complete set.

### 4. An unspecified vector backend no longer demands pgvector

*This is the one that started as a bad review finding.* I flagged that `PGTableGraphStorage` substituted its own class name when `global_config["vector_storage"]` was absent, instead of forwarding the value like the four sibling PG storages. I changed it to a passthrough — and the cross-backend contract suite immediately died:

```
ERROR: Failed to connect database: unknown type: public.vector
```

`ClientManager.get_config` derived `enable_vector` as:

```python
vector_storage == "PGVectorStorage" if vector_storage is not None else True
```

That `else True` is the last surviving default of the `POSTGRES_ENABLE_VECTOR` env var removed in 5d70309f (whose fallback was `"true"`). It answered *"I don't know which vector backend is in use"* with the **most demanding** option: require an extension nobody asked for. So the sentinel was load-bearing — but only because the shared default was wrong.

**This was never specific to the new backend.** Every sibling forwards `global_config.get("vector_storage")`, so *any* caller whose config never named a vector backend got a pool that tries `CREATE EXTENSION vector` and then fails registering the codec. Reproduced with a bare-config `PGKVStorage` against a plain PostgreSQL 14:

| | bare-config `PGKVStorage` on stock PG 14 |
|---|---|
| before | ❌ `unknown type: public.vector` — fails to initialize |
| after | ✅ initializes |

The same default had already forced **two** workarounds in-tree — the `PGTableGraphStorage` sentinel, and `tools/rebuild_vdb.py` populating `vector_storage` defensively with a comment explaining why. Both are now deleted.

So rather than documenting the sentinel, this fixes the cause:

- `enable_vector = vector_storage == "PGVectorStorage"` — no `None` special case; unspecified means no pgvector.
- `PGVectorStorage` passes `"PGVectorStorage"` **literally** rather than asking `global_config` what the vector backend is. It *is* the pgvector backend, so the ambient value could only agree or be wrong — and under the new default a bare config would have handed it a pool with no vector codec that fails later, on the first vector query. In every LightRAG-driven path the two are identical, because that class is only instantiated when `global_config["vector_storage"]` is `"PGVectorStorage"`.
- `PGTableGraphStorage` now forwards `vector_storage` unchanged like every other PG storage — so the pool signature can no longer diverge between PG storages in one process. That was the concern that motivated the sentinel, which the sentinel itself created — the fallback and the comment block defending it are both gone.

**Residual behaviour change**, stated plainly: hand-building `PGVectorStorage` alongside another PG storage under a bare `global_config` now raises an explicit signature-mismatch `RuntimeError` instead of silently working. That is the correct answer for a config that never said it wanted pgvector, and it cannot arise through `LightRAG`.

Verified on a PostgreSQL 14 instance **with pgvector absent** — the bare-config contract suite and `pg_smoke` both pass, which is precisely what failed before the root-cause fix.

### 5. `drop()` / `delete_node` FK invariant made consistent

`drop()` claimed to delete edges explicitly in case the FK "was never (re)created", while `delete_node` / `remove_nodes` relied on `ON DELETE CASCADE`. `_DDL` either creates both constraints or raises and aborts `initialize()`, so the cascade is guaranteed. The comments now state that one invariant in all three places.

### 6. Tests

**Offline fix-proofs** — each verified to fail on the pre-change implementation by running the new tests against the old file:

- orphan sweep is inside the FK-creating DO block, after the early return, and exists nowhere as a top-level statement
- the guard predicate matches the partial index predicate verbatim — drift silently restores the full scan with no error, so it needs pinning
- a BFS hop pushes filter/ranking/cap into SQL; `node_degrees_batch` awaited once for the seed, not once per level; per-hop cap is remaining-budget + 1 so the overfetched row that distinguishes "exactly full" from "truncated" survives
- `search_labels` ranks and truncates server-side and passes SQL row order through untouched, with the raw query bound for `=` and the literal underscore escaped in the word-boundary probe
- batch writes split by record cap and by byte budget; each edge chunk carries its own endpoint set; both delete paths chunk **inside one transaction**; non-positive caps disable chunking; the caps come from the shared resolver rather than a private re-read
- no edge chunk binds more bytes than the cap — measured over all four arrays the statement actually sends, `$6` included, and asserted non-vacuously (the oversized-single-item exemption cannot satisfy it). Against the old accounting it reports a 4-edge chunk binding 1660 bytes at a 1000-byte cap
- an unspecified vector backend disables pgvector; an exhaustive pass over all seven registered vector backends asserts pgvector is enabled for exactly one name; `PGVectorStorage` declares its own requirement

The delete fix-proofs record whichever statement route the code takes, so they fail on the old single-statement behaviour rather than on a missing symbol.

**Live-PostgreSQL proofs** (`pg_smoke`) — each rewrite compared against a plain-Python reference over the same data, rather than restating the SQL:

- the `search_labels` CASE matches `_search_score` over labels covering every branch: exact, case variants, prefix-that-also-has-a-boundary-hit, both boundary forms, negative scores, CJK, accents, literal `%` and `_` — a corpus whose folding is identical on both sides, which the docstring now says so nobody widens it into the folding divergence by accident
- the case-folding divergence itself is pinned separately: `İ` vs `ia` for query `i`, asserting both the SQL result and that the Python reference disagrees on tier *and* rank. The expectation is derived from the server's own `LOWER()` and skips where that does not fold non-ASCII at all (`lc_ctype=C`) rather than hard-coding one libc's answer; CI's `postgres:18` runs `en_US.utf8` and exercises it
- the SQL-ranked BFS matches a degree-ordered reference walk on a graph whose hub degree exceeds the node budget — same node sets, same per-node depths, same degrees, across hub seeds, budget cuts, self-loops and depth limits
- re-running the DDL is idempotent and does not delete live edges (the sweep is now skipped), while dropping the FKs and planting an orphan still triggers the sweep and recreates both constraints
- a 37-node / 38-edge graph written and deleted under deliberately tiny caps round-trips exactly, and an injected mid-batch chunk failure leaves no edge without endpoints and converges on replay

### 7. Docs

`PGTableGraphStorage` was registered in the storage registry and the setup wizard but appeared in **no** documentation, making the deployment it exists for undiscoverable. Added to the `graph_storage` type list and backend table in `ProgramingWithCore`, the `GRAPH_STORAGE` and PostgreSQL env-requirement tables in both API-server guides, and the storage-selection block in `env.example`. Also moved to the *"`workspace` field in tables"* row of the data-isolation table, which is how it actually isolates workspaces (a column filter, not a collection prefix).

Being *listed* still did not say when to pick it, and the sample configuration immediately below selected `PGGraphStorage`. Both API-server guides now recommend `PGTableGraphStorage` for new PostgreSQL deployments, with the two reasons stated: no AGE extension to install (most managed PostgreSQL services do not offer it, which is why the graph layer often could not share a database with the other three storage types), and substantially better performance — citing the measurements published with #3103 (`get_knowledge_graph` p50 39 ms vs 1,099 ms, bulk load 3.0 s vs 434 s, 1,431 vs 73 RPS) rather than asserting it in the abstract. It also says what switching costs an existing deployment: the two keep the graph in different places, so it is not an in-place migration and the documents have to be re-indexed. `PGGraphStorage` stays supported for AGE deployments, and the sample `LIGHTRAG_GRAPH_STORAGE` value now matches the recommendation.

### 8. CI reach

`tests.yml`, `linting.yaml` and `pg-smoke.yml` all filtered on `branches: [ main, dev ]`, and for `pull_request` that matches the **base** branch. Since new storage backends land on long-lived `dev-<backend>` branches, **every PR into one of them ran no CI at all** — including `pg-smoke`, whose entire purpose is guarding the PostgreSQL backend developed there. Added a `'dev-*'` glob. Push triggers widen too, intentionally: the push runs are what keep a long-lived branch honest between PRs.

Also aligned `pg-smoke.yml` on `actions/checkout@v7` (every other workflow already uses it), and registered the last two unregistered pytest markers (`requires_db`, `requires_api` — 17 and 16 uses, still emitting `PytestUnknownMarkWarning`). `AGENTS.md` pointed at a non-existent `tests/pytest.ini`; the markers live in `pyproject.toml`.

### 9. Unrelated, isolated commit

`test(setup): resolve a bash>=4 interpreter lazily` — `scripts/setup/setup.sh` uses `declare -A`, which needs bash 4+, and macOS ships bash 3.2 as `/bin/bash`, so every `tests/setup` test fails locally on macOS. This arrived bundled into #3103; it is kept as its own commit here and can be reverted alone. Resolution is now a `functools.cache`d function rather than a module-level constant, which was forking up to five `bash --version` subprocesses at **import** time for every session that merely imported the helper.

## Tests

- Full offline suite: **4680 passed, 2 skipped** (`./scripts/test.sh tests -m offline`) — no other test depended on the removed `enable_vector` default
- `pg_smoke` on live PostgreSQL **14.15**: **32 passed**
- Shared cross-backend graph contract suite with `LIGHTRAG_GRAPH_STORAGE=PGTableGraphStorage`: **8 passed**
- `pg_smoke` and the contract suite re-run with `POSTGRES_UPSERT_MAX_PAYLOAD_BYTES=256 POSTGRES_UPSERT_MAX_RECORDS_PER_BATCH=3 POSTGRES_DELETE_MAX_RECORDS_PER_BATCH=2`, forcing every batch path to split: same results as the single-chunk run
- `ruff check` clean; formatted with the repo's pinned pre-commit ruff

Verified against PostgreSQL 14 specifically, since that is the declared floor — including that the partial-index predicate is accepted and chosen there in the cold-statistics state right after `CREATE INDEX` as well as after `ANALYZE`, and that the `enable_vector` change behaves correctly on an instance where **pgvector is not installed at all**.

## Not addressed

`get_knowledge_graph`'s server-side edge enumeration for very high-degree hubs is still O(hub degree); as noted in section 2 that is a lower bound for correct top-k-by-degree ranking, and it is now documented rather than left implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
