### PR TITLE
Reject unsafe upload filenames and use secure opener to prevent traversal/symlink attacks

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -231,6 +231,9 @@ def sanitize_filename(filename: str, input_dir: Path) -> str:
     return filename
 
 
+_UPLOAD_DIR_FD_SUPPORTED = os.open in os.supports_dir_fd
+
+
 def upload_file_opener(input_dir: Path):
     """Return an opener that creates uploads safely below ``input_dir``.
 
@@ -238,7 +241,23 @@ def upload_file_opener(input_dir: Path):
     creation must also be fail-closed. Opening relative to a directory file
     descriptor with exclusive creation prevents symlink-following overwrites
     and closes the check/write race between duplicate detection and streaming.
+
+    dir_fd-relative opens require openat() (os.supports_dir_fd); Windows has
+    neither that nor a way to os.open() a directory at all, so on platforms
+    without the capability this falls back to opening the full path directly
+    with O_CREAT | O_EXCL (+ O_NOFOLLOW where available) and no directory
+    binding.
     """
+
+    if not _UPLOAD_DIR_FD_SUPPORTED:
+
+        def opener(path: str, flags: int) -> int:
+            open_flags = flags | os.O_CREAT | os.O_EXCL
+            if hasattr(os, "O_NOFOLLOW"):
+                open_flags |= os.O_NOFOLLOW
+            return os.open(path, open_flags, 0o600)
+
+        return opener
 
     directory_flags = os.O_RDONLY
     if hasattr(os, "O_DIRECTORY"):
@@ -5117,17 +5136,8 @@ def create_document_routes(
             chunk_size = 1024 * 1024  # 1MB chunks
             needs_cleanup = False
 
-            try:
-                upload_opener = upload_file_opener(doc_manager.input_dir)
-                out_file_context = aiofiles.open(file_path, "xb", opener=upload_opener)
-            except OSError as e:
-                raise HTTPException(
-                    status_code=409,
-                    detail=(
-                        f"Input directory already contains '{safe_filename}' or the "
-                        "upload path is unsafe. Remove it before re-uploading."
-                    ),
-                ) from e
+            upload_opener = upload_file_opener(doc_manager.input_dir)
+            out_file_context = aiofiles.open(file_path, "xb", opener=upload_opener)
 
             try:
                 async with out_file_context as out_file:

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -5139,8 +5139,10 @@ def create_document_routes(
             upload_opener = upload_file_opener(doc_manager.input_dir)
             out_file_context = aiofiles.open(file_path, "xb", opener=upload_opener)
 
+            opened = False
             try:
                 async with out_file_context as out_file:
+                    opened = True
                     while True:
                         # Read chunk from upload stream
                         chunk = await file.read(chunk_size)
@@ -5161,13 +5163,29 @@ def create_document_routes(
                         await out_file.write(chunk)
 
             except OSError as e:
-                raise HTTPException(
-                    status_code=409,
-                    detail=(
-                        f"Input directory already contains '{safe_filename}' or the "
-                        "upload path is unsafe. Remove it before re-uploading."
-                    ),
-                ) from e
+                if not opened:
+                    # Open-time failure: the O_EXCL/O_NOFOLLOW conflict this
+                    # opener exists to enforce. No file was created.
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"Input directory already contains '{safe_filename}' or the "
+                            "upload path is unsafe. Remove it before re-uploading."
+                        ),
+                    ) from e
+                # Failure after the file was already created (e.g. ENOSPC/EIO
+                # during write or close) is a server-side fault, not a
+                # client-fixable conflict -- clean up the partial file so a
+                # retry isn't permanently blocked by the exclusive-create
+                # check, then let it propagate to the endpoint's
+                # internal_server_error(e) path.
+                try:
+                    file_path.unlink()
+                except OSError as cleanup_error:
+                    logger.error(
+                        f"Error cleaning up partially written file {safe_filename}: {cleanup_error}"
+                    )
+                raise
 
             # Cleanup after file is closed
             if needs_cleanup:

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -216,6 +216,14 @@ def sanitize_filename(filename: str, input_dir: Path) -> str:
     if "/" in filename or "\\" in filename:
         raise HTTPException(status_code=400, detail="Unsafe filename detected")
 
+    # ':' lets a name be parsed as an NTFS alternate-data-stream reference
+    # (``safe.pdf:payload``) or a drive-relative path (``C:report.pdf``); the
+    # rest are the other Windows-reserved path characters. Rejecting them
+    # keeps the "single literal basename" invariant this function enforces
+    # true on every platform, not just the one running this process.
+    if any(c in filename for c in '<>:"|?*'):
+        raise HTTPException(status_code=400, detail="Unsafe filename detected")
+
     if filename in {".", ".."}:
         raise HTTPException(status_code=400, detail="Unsafe filename detected")
 

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -5,6 +5,7 @@ This module contains all document-related routes for the LightRAG API.
 import asyncio
 import base64
 import binascii
+import errno
 import math
 import os
 import re
@@ -5164,15 +5165,21 @@ def create_document_routes(
 
             except OSError as e:
                 if not opened:
-                    # Open-time failure: the O_EXCL/O_NOFOLLOW conflict this
-                    # opener exists to enforce. No file was created.
-                    raise HTTPException(
-                        status_code=409,
-                        detail=(
-                            f"Input directory already contains '{safe_filename}' or the "
-                            "upload path is unsafe. Remove it before re-uploading."
-                        ),
-                    ) from e
+                    if isinstance(e, FileExistsError) or e.errno == errno.ELOOP:
+                        # The O_EXCL/O_NOFOLLOW conflict this opener exists to
+                        # enforce (name already taken, or refused to follow a
+                        # symlink). No file was created.
+                        raise HTTPException(
+                            status_code=409,
+                            detail=(
+                                f"Input directory already contains '{safe_filename}' or the "
+                                "upload path is unsafe. Remove it before re-uploading."
+                            ),
+                        ) from e
+                    # A genuine server-side open failure (permission denied,
+                    # ENOSPC/EDQUOT, read-only filesystem, ...) rather than a
+                    # name conflict. No file was created, nothing to clean up.
+                    raise
                 # Failure after the file was already created (e.g. ENOSPC/EIO
                 # during write or close) is a server-side fault, not a
                 # client-fixable conflict -- clean up the partial file so a

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -186,47 +186,82 @@ def is_valid_file_source(file_source: str | None) -> bool:
 
 def sanitize_filename(filename: str, input_dir: Path) -> str:
     """
-    Sanitize uploaded filename to prevent Path Traversal attacks.
+    Validate an uploaded filename and return it unchanged when safe.
+
+    Uploaded filenames are document identifiers as well as on-disk names, so
+    unsafe names must be rejected rather than rewritten. Rewriting values such
+    as ``../report.pdf`` to ``report.pdf`` can hide malicious input, collide
+    with a legitimate document, and make audit logs misleading.
 
     Args:
         filename: The original filename from the upload
         input_dir: The target input directory
 
     Returns:
-        str: Sanitized filename that is safe to use
+        str: The original filename after safety validation
 
     Raises:
         HTTPException: If the filename is unsafe or invalid
     """
-    # Basic validation
     if not filename or not filename.strip():
         raise HTTPException(status_code=400, detail="Filename cannot be empty")
 
-    # Remove path separators and traversal sequences
-    clean_name = filename.replace("/", "").replace("\\", "")
-    clean_name = clean_name.replace("..", "")
+    if filename != filename.strip():
+        raise HTTPException(status_code=400, detail="Invalid filename")
 
-    # Remove control characters and null bytes
-    clean_name = "".join(c for c in clean_name if ord(c) >= 32 and c != "\x7f")
+    if any(ord(c) < 32 or c == "\x7f" for c in filename):
+        raise HTTPException(status_code=400, detail="Invalid filename")
 
-    # Remove leading/trailing whitespace and dots
-    clean_name = clean_name.strip().strip(".")
+    if "/" in filename or "\\" in filename:
+        raise HTTPException(status_code=400, detail="Unsafe filename detected")
 
-    # Check if anything is left after sanitization
-    if not clean_name:
-        raise HTTPException(
-            status_code=400, detail="Invalid filename after sanitization"
-        )
+    if filename in {".", ".."}:
+        raise HTTPException(status_code=400, detail="Unsafe filename detected")
 
-    # Verify the final path stays within the input directory
+    # Verify the final path stays within the input directory. This is a
+    # defense-in-depth check for platform-specific path parsing edge cases.
     try:
-        final_path = (input_dir / clean_name).resolve()
-        if not final_path.is_relative_to(input_dir.resolve()):
+        input_root = input_dir.resolve()
+        final_path = (input_root / filename).resolve()
+        if final_path.parent != input_root or not final_path.is_relative_to(input_root):
             raise HTTPException(status_code=400, detail="Unsafe filename detected")
     except (OSError, ValueError):
         raise HTTPException(status_code=400, detail="Invalid filename")
 
-    return clean_name
+    return filename
+
+
+def upload_file_opener(input_dir: Path):
+    """Return an opener that creates uploads safely below ``input_dir``.
+
+    The upload path is pre-validated as a single basename, but the final file
+    creation must also be fail-closed. Opening relative to a directory file
+    descriptor with exclusive creation prevents symlink-following overwrites
+    and closes the check/write race between duplicate detection and streaming.
+    """
+
+    directory_flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        directory_flags |= os.O_DIRECTORY
+    dir_fd = os.open(input_dir, directory_flags)
+
+    def opener(path: str, flags: int) -> int:
+        nonlocal dir_fd
+        try:
+            open_flags = flags | os.O_CREAT | os.O_EXCL
+            if hasattr(os, "O_NOFOLLOW"):
+                open_flags |= os.O_NOFOLLOW
+            return os.open(
+                os.path.basename(path),
+                open_flags,
+                0o600,
+                dir_fd=dir_fd,
+            )
+        finally:
+            os.close(dir_fd)
+            dir_fd = -1
+
+    return opener
 
 
 class ScanResponse(BaseModel):
@@ -5082,25 +5117,47 @@ def create_document_routes(
             chunk_size = 1024 * 1024  # 1MB chunks
             needs_cleanup = False
 
-            async with aiofiles.open(file_path, "wb") as out_file:
-                while True:
-                    # Read chunk from upload stream
-                    chunk = await file.read(chunk_size)
-                    if not chunk:
-                        break
+            try:
+                upload_opener = upload_file_opener(doc_manager.input_dir)
+                out_file_context = aiofiles.open(file_path, "xb", opener=upload_opener)
+            except OSError as e:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Input directory already contains '{safe_filename}' or the "
+                        "upload path is unsafe. Remove it before re-uploading."
+                    ),
+                ) from e
 
-                    # Check size limit during streaming (if not checked before)
-                    if (
-                        global_args.max_upload_size is not None
-                        and global_args.max_upload_size > 0
-                    ):
-                        bytes_written += len(chunk)
-                        if bytes_written > global_args.max_upload_size:
-                            needs_cleanup = True
+            try:
+                async with out_file_context as out_file:
+                    while True:
+                        # Read chunk from upload stream
+                        chunk = await file.read(chunk_size)
+                        if not chunk:
                             break
 
-                    # Write chunk to file
-                    await out_file.write(chunk)
+                        # Check size limit during streaming (if not checked before)
+                        if (
+                            global_args.max_upload_size is not None
+                            and global_args.max_upload_size > 0
+                        ):
+                            bytes_written += len(chunk)
+                            if bytes_written > global_args.max_upload_size:
+                                needs_cleanup = True
+                                break
+
+                        # Write chunk to file
+                        await out_file.write(chunk)
+
+            except OSError as e:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Input directory already contains '{safe_filename}' or the "
+                        "upload path is unsafe. Remove it before re-uploading."
+                    ),
+                ) from e
 
             # Cleanup after file is closed
             if needs_cleanup:

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -217,11 +217,13 @@ def sanitize_filename(filename: str, input_dir: Path) -> str:
         raise HTTPException(status_code=400, detail="Unsafe filename detected")
 
     # ':' lets a name be parsed as an NTFS alternate-data-stream reference
-    # (``safe.pdf:payload``) or a drive-relative path (``C:report.pdf``); the
-    # rest are the other Windows-reserved path characters. Rejecting them
-    # keeps the "single literal basename" invariant this function enforces
-    # true on every platform, not just the one running this process.
-    if any(c in filename for c in '<>:"|?*'):
+    # (``safe.pdf:payload``) or a drive-relative path (``C:report.pdf``),
+    # breaking the "single literal basename" invariant this function
+    # enforces. The other Windows-reserved path characters don't carry that
+    # same reinterpretation risk in this codebase (filenames are never
+    # shelled out to, and glob() call sites already use glob.escape()), so
+    # they're left alone rather than rejected pre-emptively.
+    if ":" in filename:
         raise HTTPException(status_code=400, detail="Unsafe filename detected")
 
     if filename in {".", ".."}:

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -1272,6 +1272,46 @@ async def test_upload_opener_construction_failure_returns_500_not_409(
     assert not (tmp_path / "safe.pdf").exists()
 
 
+async def test_upload_open_time_permission_error_returns_500_not_409(
+    tmp_path, monkeypatch
+):
+    """A non-conflict OSError raised while the opener actually creates the
+    file (permission denied, ENOSPC, read-only filesystem, ...) is a
+    server-side fault, not the O_EXCL/O_NOFOLLOW name conflict the 409 branch
+    exists for -- only FileExistsError/ELOOP should map to 409."""
+    monkeypatch.setattr(
+        _document_routes, "global_args", SimpleNamespace(max_upload_size=None)
+    )
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _DuplicateUploadRag({})
+    router = create_document_routes(rag, doc_manager)
+    upload_endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "upload_to_input_dir"
+    ][-1]
+    upload_file = _document_routes.UploadFile(
+        filename="safe.pdf", file=BytesIO(b"content")
+    )
+
+    def _permission_denied_opener(_input_dir):
+        def opener(path, flags):
+            raise PermissionError(13, "Permission denied")
+
+        return opener
+
+    monkeypatch.setattr(
+        _document_routes, "upload_file_opener", _permission_denied_opener
+    )
+
+    with pytest.raises(_document_routes.HTTPException) as excinfo:
+        await upload_endpoint(set(), upload_file)
+
+    assert excinfo.value.status_code == 500
+    assert "Permission denied" not in str(excinfo.value.detail)
+    assert not (tmp_path / "safe.pdf").exists()
+
+
 async def test_upload_write_failure_cleans_up_partial_file_and_returns_500(
     tmp_path, monkeypatch
 ):

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -3302,6 +3302,23 @@ def test_sanitize_filename_rejects_separator_and_control_characters(tmp_path):
         assert exc.value.status_code == 400
 
 
+def test_sanitize_filename_rejects_windows_reserved_path_characters(tmp_path):
+    for filename in (
+        "safe.pdf:payload.pdf",  # NTFS alternate-data-stream reference
+        "C:report.pdf",  # drive-relative, not a literal basename
+        'bad"name.pdf',
+        "bad|name.pdf",
+        "bad?name.pdf",
+        "bad*name.pdf",
+        "bad<name.pdf",
+        "bad>name.pdf",
+    ):
+        with pytest.raises(_document_routes.HTTPException) as exc:
+            _document_routes.sanitize_filename(filename, tmp_path)
+
+        assert exc.value.status_code == 400
+
+
 def test_sanitize_filename_allows_non_traversal_dot_sequences(tmp_path):
     filename = "report..final.pdf"
 

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -3302,21 +3302,30 @@ def test_sanitize_filename_rejects_separator_and_control_characters(tmp_path):
         assert exc.value.status_code == 400
 
 
-def test_sanitize_filename_rejects_windows_reserved_path_characters(tmp_path):
+def test_sanitize_filename_rejects_colon(tmp_path):
     for filename in (
         "safe.pdf:payload.pdf",  # NTFS alternate-data-stream reference
         "C:report.pdf",  # drive-relative, not a literal basename
-        'bad"name.pdf',
-        "bad|name.pdf",
-        "bad?name.pdf",
-        "bad*name.pdf",
-        "bad<name.pdf",
-        "bad>name.pdf",
     ):
         with pytest.raises(_document_routes.HTTPException) as exc:
             _document_routes.sanitize_filename(filename, tmp_path)
 
         assert exc.value.status_code == 400
+
+
+def test_sanitize_filename_allows_other_windows_reserved_characters(tmp_path):
+    """Unlike ':', these don't let the name be reinterpreted as a different
+    path (no shell-out or unescaped glob() call site uses upload filenames in
+    this codebase), so they're accepted rather than pre-emptively rejected."""
+    for filename in (
+        'quoted"name.pdf',
+        "piped|name.pdf",
+        "glob?name.pdf",
+        "glob*name.pdf",
+        "less<than.pdf",
+        "greater>than.pdf",
+    ):
+        assert _document_routes.sanitize_filename(filename, tmp_path) == filename
 
 
 def test_sanitize_filename_allows_non_traversal_dot_sequences(tmp_path):

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -1235,6 +1235,43 @@ async def test_upload_rejects_parser_hinted_filesystem_duplicate(tmp_path, monke
     assert not (tmp_path / "existing.[native].docx").exists()
 
 
+async def test_upload_opener_construction_failure_returns_500_not_409(
+    tmp_path, monkeypatch
+):
+    """upload_file_opener() raising means the input directory itself could
+    not be opened (permissions, removed mid-request, etc.) -- a server-side
+    fault, not a client-fixable name conflict. Before the fix this hit the
+    same try/except as the real O_EXCL conflict and returned a misleading
+    409; it must now propagate to the endpoint's internal_server_error(e)
+    500 path instead."""
+    monkeypatch.setattr(
+        _document_routes, "global_args", SimpleNamespace(max_upload_size=None)
+    )
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _DuplicateUploadRag({})
+    router = create_document_routes(rag, doc_manager)
+    upload_endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "upload_to_input_dir"
+    ][-1]
+    upload_file = _document_routes.UploadFile(
+        filename="safe.pdf", file=BytesIO(b"content")
+    )
+
+    def _raise_oserror(_input_dir):
+        raise OSError("input directory unavailable")
+
+    monkeypatch.setattr(_document_routes, "upload_file_opener", _raise_oserror)
+
+    with pytest.raises(_document_routes.HTTPException) as excinfo:
+        await upload_endpoint(set(), upload_file)
+
+    assert excinfo.value.status_code == 500
+    assert "input directory unavailable" not in str(excinfo.value.detail)
+    assert not (tmp_path / "safe.pdf").exists()
+
+
 async def test_upload_rejects_malformed_hint_with_detail(tmp_path, monkeypatch):
     """A malformed filename hint fails the upload synchronously with the
     detailed hint error in the 400 body (it used to be accepted and only
@@ -3212,6 +3249,37 @@ def test_upload_file_opener_creates_new_file_with_private_permissions(tmp_path):
 
     assert path.read_bytes() == b"content"
     assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_upload_file_opener_falls_back_when_dir_fd_unsupported(tmp_path, monkeypatch):
+    """Simulates Windows: os.open() cannot bind a directory fd there at all,
+    so the opener must skip that step entirely rather than crash on it."""
+    monkeypatch.setattr(_document_routes, "_UPLOAD_DIR_FD_SUPPORTED", False)
+
+    real_open = _document_routes.os.open
+    directory_open_attempts = []
+
+    def spying_open(path, flags, mode=0o777, *, dir_fd=None):
+        if dir_fd is not None or str(path) == str(tmp_path):
+            directory_open_attempts.append((str(path), dir_fd))
+        if dir_fd is None:
+            return real_open(path, flags, mode)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(_document_routes.os, "open", spying_open)
+
+    path = tmp_path / "safe.pdf"
+    opener = _document_routes.upload_file_opener(tmp_path)
+    with open(path, "xb", opener=opener) as fh:
+        fh.write(b"content")
+
+    assert path.read_bytes() == b"content"
+    assert (path.stat().st_mode & 0o777) == 0o600
+    assert directory_open_attempts == []
+
+    with pytest.raises(FileExistsError):
+        with open(path, "xb", opener=_document_routes.upload_file_opener(tmp_path)):
+            pass
 
 
 def test_sanitize_filename_preserves_safe_parser_hint_filename(tmp_path):

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -1272,6 +1272,48 @@ async def test_upload_opener_construction_failure_returns_500_not_409(
     assert not (tmp_path / "safe.pdf").exists()
 
 
+async def test_upload_write_failure_cleans_up_partial_file_and_returns_500(
+    tmp_path, monkeypatch
+):
+    """An OSError raised after the exclusive-create opener already succeeded
+    (e.g. ENOSPC mid-stream) is a server-side fault, not the O_EXCL/O_NOFOLLOW
+    conflict the 409 branch exists for. It must delete the partial file (so a
+    retry isn't permanently blocked by the exact-file precheck) and surface as
+    a 500 that doesn't echo the raw OSError text."""
+    monkeypatch.setattr(
+        _document_routes, "global_args", SimpleNamespace(max_upload_size=None)
+    )
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _DuplicateUploadRag({})
+    router = create_document_routes(rag, doc_manager)
+    upload_endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "upload_to_input_dir"
+    ][-1]
+    upload_file = _document_routes.UploadFile(
+        filename="safe.pdf", file=BytesIO(b"content")
+    )
+
+    call_count = 0
+
+    async def _read_then_fail(_size):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return b"partial content"
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(upload_file, "read", _read_then_fail)
+
+    with pytest.raises(_document_routes.HTTPException) as excinfo:
+        await upload_endpoint(set(), upload_file)
+
+    assert excinfo.value.status_code == 500
+    assert "No space left on device" not in str(excinfo.value.detail)
+    assert not (tmp_path / "safe.pdf").exists()
+
+
 async def test_upload_rejects_malformed_hint_with_detail(tmp_path, monkeypatch):
     """A malformed filename hint fails the upload synchronously with the
     detailed hint error in the 400 body (it used to be accepted and only

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -3168,6 +3168,58 @@ def test_lightrag_document_reprocess_uses_full_docs_without_reparse():
     assert engine == "reuse"
 
 
+def test_sanitize_filename_rejects_traversal_instead_of_rewriting(tmp_path):
+    with pytest.raises(_document_routes.HTTPException) as exc:
+        _document_routes.sanitize_filename("../report.pdf", tmp_path)
+
+    assert exc.value.status_code == 400
+
+
+def test_sanitize_filename_rejects_separator_and_control_characters(tmp_path):
+    for filename in ("nested/report.pdf", "nested\\report.pdf", "report.pdf\x00"):
+        with pytest.raises(_document_routes.HTTPException) as exc:
+            _document_routes.sanitize_filename(filename, tmp_path)
+
+        assert exc.value.status_code == 400
+
+
+def test_sanitize_filename_allows_non_traversal_dot_sequences(tmp_path):
+    filename = "report..final.pdf"
+
+    assert _document_routes.sanitize_filename(filename, tmp_path) == filename
+
+
+def test_upload_file_opener_refuses_existing_symlink(tmp_path):
+    outside = tmp_path / "outside.txt"
+    outside.write_text("keep", encoding="utf-8")
+    link = tmp_path / "safe.pdf"
+    link.symlink_to(outside)
+
+    opener = _document_routes.upload_file_opener(tmp_path)
+    with pytest.raises(FileExistsError):
+        with open(link, "xb", opener=opener):
+            pass
+
+    assert outside.read_text(encoding="utf-8") == "keep"
+
+
+def test_upload_file_opener_creates_new_file_with_private_permissions(tmp_path):
+    path = tmp_path / "safe.pdf"
+
+    opener = _document_routes.upload_file_opener(tmp_path)
+    with open(path, "xb", opener=opener) as fh:
+        fh.write(b"content")
+
+    assert path.read_bytes() == b"content"
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+def test_sanitize_filename_preserves_safe_parser_hint_filename(tmp_path):
+    filename = "report.[native].docx"
+
+    assert _document_routes.sanitize_filename(filename, tmp_path) == filename
+
+
 def test_default_allowlist_equals_local_engine_suffixes(tmp_path, monkeypatch):
     """With no external endpoints and no routing rules, the registry-derived
     allowlist must equal the local engines' (legacy ∪ native) suffixes —


### PR DESCRIPTION
### Motivation

- Prevent silent rewriting of malicious upload filenames and close race/TOCTOU and symlink-following vulnerabilities when creating uploaded files on disk.

### Description

- Replace permissive filename sanitization with strict validation in `sanitize_filename` that rejects leading/trailing whitespace, path separators, traversal atoms like `..`, control characters, and returns the original name when safe.  
- Add `upload_file_opener` which opens files relative to a directory file descriptor with `O_CREAT | O_EXCL` and `O_NOFOLLOW` where available to prevent symlink-following and ensure exclusive creation.  
- Use the secure opener with `aiofiles.open(..., opener=upload_file_opener(...))` and handle `OSError` to surface a `409` when the upload path is unsafe or already exists.  
- Keep a defense-in-depth check that the resolved target stays within the intended `input_dir` and enforce size-check cleanup on streamed uploads.

### Testing

- Added unit tests in `tests/api/routes/test_document_routes_docx_archive.py` for `sanitize_filename` and `upload_file_opener` including `test_sanitize_filename_rejects_traversal_instead_of_rewriting`, `test_sanitize_filename_rejects_separator_and_control_characters`, `test_sanitize_filename_allows_non_traversal_dot_sequences`, `test_upload_file_opener_refuses_existing_symlink`, `test_upload_file_opener_creates_new_file_with_private_permissions`, and `test_sanitize_filename_preserves_safe_parser_hint_filename`.  
- Ran the updated test module containing the new cases and the tests passed.  
- Existing upload-related behavior is covered by the streaming and size-check tests which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a727cc63a4c8323ba57259cc7b1d244)