### PR TITLE
fix(rerank): validate results at query boundary

### DIFF
--- a/lightrag/rerank.py
+++ b/lightrag/rerank.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-from collections import Counter
-from math import isfinite
 import os
+from collections import Counter
+from typing import Any, Dict, List, Optional, Tuple
+
 import aiohttp
-from typing import Any, List, Dict, Optional, Tuple
+from dotenv import load_dotenv
 from tenacity import (
     retry,
+    retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
-    retry_if_exception_type,
 )
-from .utils import logger, run_in_tokenizer_executor
 
-from dotenv import load_dotenv
+from .utils import logger, normalize_rerank_result, run_in_tokenizer_executor
 
 # use the .env that is inside the current folder
 # allows to use different .env file for each lightrag instance
@@ -31,39 +31,6 @@ DEFAULT_RERANK_MAX_TOKENS_PER_DOC = 4096
 # payload and the number of scores to aggregate. Configured values below this are
 # accepted but warned about at startup rather than silently degrading query latency.
 MIN_PRACTICAL_RERANK_MAX_TOKENS = 64
-
-
-def _normalize_rerank_result(
-    result: Any, max_index: int
-) -> tuple[dict[str, int | float] | None, str | None]:
-    """Validate one provider result and return the public rerank shape.
-
-    Providers and compatible proxies occasionally return mixed ``results`` lists.
-    Keeping the validation here lets the HTTP boundary and chunk aggregation reject
-    the same malformed entries without leaking invalid indices or non-finite scores
-    into callers.
-    """
-    if not isinstance(result, dict):
-        return None, "not an object"
-
-    index = result.get("index")
-    if isinstance(index, bool) or not isinstance(index, int):
-        return None, "invalid index"
-    if not 0 <= index < max_index:
-        return None, "index out of range"
-
-    score_value = result.get("relevance_score")
-    if isinstance(score_value, bool):
-        return None, "invalid relevance score"
-
-    try:
-        score = float(score_value)
-    except (TypeError, ValueError, OverflowError):
-        return None, "invalid relevance score"
-    if not isfinite(score):
-        return None, "non-finite relevance score"
-
-    return {"index": index, "relevance_score": score}, None
 
 
 def chunk_documents_for_rerank(
@@ -213,7 +180,7 @@ def aggregate_chunk_scores(
     doc_scores: Dict[int, List[float]] = {i: [] for i in range(num_original_docs)}
 
     for result in chunk_results:
-        normalized_result, _ = _normalize_rerank_result(result, len(doc_indices))
+        normalized_result, _ = normalize_rerank_result(result, len(doc_indices))
         if normalized_result is None:
             continue
 
@@ -429,7 +396,7 @@ async def generic_rerank_api(
             invalid_results = Counter()
             standardized_results = []
             for result in results:
-                normalized_result, invalid_reason = _normalize_rerank_result(
+                normalized_result, invalid_reason = normalize_rerank_result(
                     result, len(documents)
                 )
                 if normalized_result is None:

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -5520,19 +5520,34 @@ async def apply_rerank_if_enabled(
 
         # Process rerank results based on return format
         if rerank_results and len(rerank_results) > 0:
+            first_object = next(
+                (result for result in rerank_results if isinstance(result, dict)),
+                None,
+            )
             # Check if results are in the new index-based format
-            if isinstance(rerank_results[0], dict) and "index" in rerank_results[0]:
+            if first_object is not None and "index" in first_object:
                 # New format: [{"index": 0, "relevance_score": 0.85}, ...]
                 reranked_docs = []
                 for result in rerank_results:
-                    index = result["index"]
-                    relevance_score = result["relevance_score"]
+                    normalized_result, _ = normalize_rerank_result(
+                        result, len(retrieved_docs)
+                    )
+                    if normalized_result is None:
+                        continue
+
+                    index = normalized_result["index"]
+                    relevance_score = normalized_result["relevance_score"]
 
                     # Get original document and add rerank score
-                    if 0 <= index < len(retrieved_docs):
-                        doc = retrieved_docs[index].copy()
-                        doc["rerank_score"] = relevance_score
-                        reranked_docs.append(doc)
+                    doc = retrieved_docs[index].copy()
+                    doc["rerank_score"] = relevance_score
+                    reranked_docs.append(doc)
+
+                if not reranked_docs:
+                    logger.warning(
+                        "Rerank returned no usable results, using original chunks"
+                    )
+                    return retrieved_docs
 
                 logger.info(
                     f"Successfully reranked: {len(reranked_docs)} chunks from {len(retrieved_docs)} original chunks"
@@ -5549,6 +5564,38 @@ async def apply_rerank_if_enabled(
     except Exception as e:
         logger.error(f"Error during reranking: {e}, using original chunks")
         return retrieved_docs
+
+
+def normalize_rerank_result(
+    result: Any, max_index: int
+) -> tuple[dict[str, int | float] | None, str | None]:
+    """Validate one provider result and return the public rerank shape.
+
+    Providers, compatible proxies, and custom rerank functions can return mixed
+    result lists. Centralizing validation keeps provider adapters, chunk score
+    aggregation, and the final query boundary consistent.
+    """
+    if not isinstance(result, dict):
+        return None, "not an object"
+
+    index = result.get("index")
+    if isinstance(index, bool) or not isinstance(index, int):
+        return None, "invalid index"
+    if not 0 <= index < max_index:
+        return None, "index out of range"
+
+    score_value = result.get("relevance_score")
+    if isinstance(score_value, bool):
+        return None, "invalid relevance score"
+
+    try:
+        score = float(score_value)
+    except (TypeError, ValueError, OverflowError):
+        return None, "invalid relevance score"
+    if not math.isfinite(score):
+        return None, "non-finite relevance score"
+
+    return {"index": index, "relevance_score": score}, None
 
 
 async def process_chunks_unified(

--- a/tests/llm/test_apply_rerank_result_validation.py
+++ b/tests/llm/test_apply_rerank_result_validation.py
@@ -1,0 +1,62 @@
+"""Regression tests for validation at the query rerank boundary."""
+
+import pytest
+
+from lightrag.utils import apply_rerank_if_enabled
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.mark.asyncio
+async def test_boolean_index_is_not_treated_as_document_one():
+    async def rerank_func(**_kwargs):
+        return [{"index": True, "relevance_score": 0.9}]
+
+    documents = [{"content": "first"}, {"content": "second"}]
+
+    result = await apply_rerank_if_enabled(
+        query="query",
+        retrieved_docs=documents,
+        global_config={"rerank_model_func": rerank_func},
+    )
+
+    assert result == documents
+
+
+@pytest.mark.asyncio
+async def test_valid_results_survive_malformed_items():
+    async def rerank_func(**_kwargs):
+        return [
+            None,
+            {"index": 1, "relevance_score": "0.8"},
+            {"index": 0},
+        ]
+
+    documents = [{"content": "first"}, {"content": "second"}]
+
+    result = await apply_rerank_if_enabled(
+        query="query",
+        retrieved_docs=documents,
+        global_config={"rerank_model_func": rerank_func},
+    )
+
+    assert result == [{"content": "second", "rerank_score": 0.8}]
+
+
+@pytest.mark.asyncio
+async def test_legacy_documents_are_not_inferred_from_later_index_metadata():
+    legacy_results = [
+        {"content": "ranked first"},
+        {"content": "ranked second", "index": "source-index"},
+    ]
+
+    async def rerank_func(**_kwargs):
+        return legacy_results
+
+    result = await apply_rerank_if_enabled(
+        query="query",
+        retrieved_docs=[{"content": "original"}],
+        global_config={"rerank_model_func": rerank_func},
+    )
+
+    assert result == legacy_results


### PR DESCRIPTION
## Description

Validate index-based rerank results at the final query boundary before mapping them back to retrieved documents.

Custom rerank functions can return mixed or malformed result lists even when built-in HTTP providers normalize their responses. Previously, a boolean index such as `true` selected document 1 because Python treats booleans as integers, while one item missing `relevance_score` caused the entire rerank operation to fall back and discard otherwise valid results. The format check also relied only on the first item.

## Related Issues

No linked issue. This is a focused regression fix discovered while auditing the query rerank path after the recent provider-boundary validation work.

## Changes Made

- move rerank result normalization to `lightrag.utils` so provider adapters, chunk aggregation, and query mapping share one validation rule
- skip leading malformed non-object items when detecting index-based responses without broadening legacy-format detection
- ignore malformed entries while preserving valid rerank results
- retain the existing fallback to original documents when no usable result remains
- add offline regressions for boolean indices and mixed result lists

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not necessary; no public configuration or API change)
- [x] Unit tests added

## Testing

- `python -m pytest -q tests/llm tests/chunker/test_rerank_chunking.py --disable-warnings --maxfail=3` (`371 passed`)
- `python -m ruff check --select E9,F63,F7,F82,I lightrag/rerank.py tests/llm/test_apply_rerank_result_validation.py`
- `git diff --check`

## Additional Notes

The commit is SSH-signed. This does not change provider request behavior or rerank scoring; it only validates the returned mapping before documents are selected.