### PR TITLE
Rank isolated entities in get_popular_labels, stop dropping edges, unify the graph read contract

### DIFF
--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -574,6 +574,19 @@ class BaseGraphStorage(StorageNameSpace, ABC):
         Returns:
             A list of (source_id, target_id) tuples representing edges,
             or None if the node doesn't exist
+
+        Three outcomes, three answers — implementations must not merge them:
+
+        * ``[]``   — the node exists and has no relations.
+        * ``None`` — the node is **confirmed absent**.
+        * raise    — the backend could not answer. A transport/server error is
+          neither of the above; reporting it as ``[]`` or ``None`` turns an
+          unknown into a fact that callers (entity merge/dedup, graph edits)
+          act on. Same rule as :meth:`BaseKVStorage.get_by_id_strict`.
+
+        ``get_nodes_edges_batch`` cannot express the middle case (it returns a
+        dict of lists) and flattens ``None`` to ``[]`` by design; callers that
+        need the distinction must use this single-node form.
         """
 
     async def get_nodes_batch(self, node_ids: list[str]) -> dict[str, dict]:
@@ -820,6 +833,39 @@ class BaseGraphStorage(StorageNameSpace, ABC):
 
         Returns:
             List of labels sorted by degree (highest first)
+
+        Ranks the WHOLE node set: an isolated (degree-0) entity ranks last, but
+        it still ranks. Implementations that derive degrees from their edge
+        store must therefore not let a node absent from that store fall out of
+        the result. Ties break on the label, ascending.
+
+        The expected shape is two phases, because the second one almost never
+        runs. Rank the entities that HAVE edges first — the cheap path, and any
+        graph with more than ``limit`` connected entities fills every slot there
+        — then top the result up from the isolated entities only when that comes
+        up short. The top-up is bounded by the shortfall (never more than
+        ``limit`` rows), which is what keeps it affordable even where it means a
+        sequential scan of the node store. Coming up short also means the
+        connected set is now known in full, so every remaining entity is
+        isolated by definition.
+
+        Driving the whole ranking off the node store instead is simpler to
+        write and gives the same answer, but it pays a full pass over the nodes
+        on every call — on a large graph, to produce a result the first phase
+        already had.
+
+        The result is best-effort about the reverse direction: a backend that
+        derives degrees from its edge store MAY also surface an id that has
+        edges but no node document. Only a data-quality defect produces one —
+        the write paths materialize both endpoints of every edge — and
+        confirming every ranked id against the node store would cost a join or
+        an extra round trip on a hot, interactive endpoint. Callers must
+        therefore tolerate a returned label whose :meth:`get_node` comes back
+        empty, rather than assume every label resolves.
+
+        An empty list means the graph holds no entities. A backend error MUST
+        raise instead — ``/graph/label/popular`` renders both, and the two are
+        indistinguishable to the user once the error is swallowed.
         """
 
     @abstractmethod
@@ -832,6 +878,10 @@ class BaseGraphStorage(StorageNameSpace, ABC):
 
         Returns:
             List of matching labels sorted by relevance
+
+        As with :meth:`get_popular_labels`, an empty list means "nothing
+        matched" — a backend error MUST raise rather than return it. A blank
+        query is a real empty result, not an error.
         """
 
 

--- a/lightrag/kg/memgraph_impl.py
+++ b/lightrag/kg/memgraph_impl.py
@@ -369,7 +369,9 @@ class MemgraphStorage(BaseGraphStorage):
 
         Returns:
             list[tuple[str, str]]: List of (source_label, target_label) tuples representing edges
-            None: If no edges found
+            None: If the node does not exist. An existing node with no relations
+                returns ``[]`` — the BaseGraphStorage contract, as implemented by
+                NetworkXStorage. A query error is neither value: it propagates.
 
         Raises:
             Exception: If there is an error executing the query
@@ -394,7 +396,14 @@ class MemgraphStorage(BaseGraphStorage):
                     results = await session.run(query, entity_id=source_node_id)
 
                     edges = []
+                    # Any row at all means the anchor MATCH bound n, i.e. the
+                    # node exists: an isolated node still yields exactly one row
+                    # (via OPTIONAL MATCH) carrying a NULL connected_entity_id.
+                    # Zero rows is the only "no such node" signal, and it must
+                    # not be reported as an empty edge list.
+                    node_matched = False
                     async for record in results:
+                        node_matched = True
                         node_entity_id = record["node_entity_id"]
                         connected_entity_id = record["connected_entity_id"]
                         start_entity_id = record["start_entity_id"]
@@ -409,7 +418,7 @@ class MemgraphStorage(BaseGraphStorage):
                             edges.append((connected_entity_id, node_entity_id))
 
                     await results.consume()  # Ensure results are consumed
-                    return edges
+                    return edges if node_matched else None
                 except Exception as e:
                     logger.error(
                         f"[{self.workspace}] Error getting edges for node {source_node_id}: {str(e)}"
@@ -1283,10 +1292,14 @@ class MemgraphStorage(BaseGraphStorage):
                 )
                 return labels
         except Exception as e:
+            # Raise, never return []: an empty list here is indistinguishable
+            # from "the graph has no entities". /graph/label/popular already
+            # turns an exception into a 500, so swallowing it handed the WebUI a
+            # 200 with an empty entity picker while the database was down.
             logger.error(f"[{self.workspace}] Error getting popular labels: {str(e)}")
             if result is not None:
                 await result.consume()
-            return []
+            raise
 
     async def search_labels(self, query: str, limit: int = 50) -> list[str]:
         """Search labels(entity names) with fuzzy matching
@@ -1341,7 +1354,9 @@ class MemgraphStorage(BaseGraphStorage):
                 )
                 return labels
         except Exception as e:
+            # Same reasoning as get_popular_labels: "no match" and "the query
+            # failed" must not share a return value.
             logger.error(f"[{self.workspace}] Error searching labels: {str(e)}")
             if result is not None:
                 await result.consume()
-            return []
+            raise

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -2169,8 +2169,27 @@ class MongoGraphStorage(BaseGraphStorage):
 
         Returns:
             list[tuple[str, str]]: List of (source_label, target_label) tuples representing edges
-            None: If no edges found
+            None: If the node does not exist
+
+        An existing node with no relations returns ``[]``, NOT ``None`` — the
+        BaseGraphStorage contract, as implemented by NetworkXStorage. No in-tree
+        caller reads the distinction today (they all guard with ``if edges:``),
+        so this restores the declared contract rather than fixing a live caller;
+        collapsing the two here is what makes the information unrecoverable for
+        a caller that needs it. A backend error is neither value: it propagates.
         """
+        # Existence is decided by the node collection, before the edge scan —
+        # never inferred from the edges. upsert_edge / upsert_edges_batch now
+        # materialize both endpoints, so a dangling target should not arise from
+        # new writes, but rows written before that change still can carry one,
+        # and a read contract must not rest on a write-path invariant anyway.
+        # Inferring existence from the edge scan would make this method
+        # contradict has_node() on the same id, and delete_entity 404s on
+        # has_node(). Checking first also means an absent node costs one indexed
+        # point lookup instead of a full edge scan.
+        if not await self.has_node(source_node_id):
+            return None
+
         cursor = self.edge_collection.find(
             {
                 "$or": [
@@ -2295,8 +2314,24 @@ class MongoGraphStorage(BaseGraphStorage):
         writers race the first insert, the loser hits a ``DuplicateKeyError``; we
         retry once, which now matches the just-inserted doc and updates it.
         """
-        # Ensure source node exists
-        await self.upsert_node(source_node_id, {})
+        # Materialize BOTH endpoints, not just the source. A target-only
+        # endpoint would otherwise carry edges with no node document, and that
+        # dangling state is externally visible: has_node() says absent while the
+        # edge scan says connected, get_popular_labels ranks an id get_node
+        # returns nothing for, and delete_entity 404s on an entity whose edges
+        # are right there. NetworkXStorage.add_edge and PGOpsGraphStorage both
+        # create both ends; this makes the document backends agree.
+        #
+        # One bulk_write instead of two round trips, and $setOnInsert (the form
+        # upsert_edges_batch already uses) so an endpoint that already carries
+        # real properties is never touched. dict.fromkeys collapses a self-loop.
+        await self.collection.bulk_write(
+            [
+                UpdateOne({"_id": nid}, {"$setOnInsert": {"_id": nid}}, upsert=True)
+                for nid in dict.fromkeys((source_node_id, target_node_id))
+            ],
+            ordered=False,
+        )
 
         edge_lo, edge_hi = _canonical_edge_endpoints(source_node_id, target_node_id)
 
@@ -2374,9 +2409,9 @@ class MongoGraphStorage(BaseGraphStorage):
     ) -> None:
         """Batch insert/update multiple edges using a single bulk_write() call.
 
-        Also ensures source nodes exist (matching upsert_edge() behaviour) via a
-        separate bulk_write on the node collection for any source nodes that need
-        to be created as empty placeholders.
+        Also ensures BOTH endpoints of every edge exist (matching upsert_edge()
+        behaviour) via a separate bulk_write on the node collection for any
+        endpoint that needs to be created as an empty placeholder.
 
         Args:
             edges: List of (source_node_id, target_node_id, edge_data) tuples.
@@ -2384,15 +2419,20 @@ class MongoGraphStorage(BaseGraphStorage):
         if not edges:
             return
 
-        # Ensure all source nodes exist (mirrors upsert_edge's upsert_node call)
-        source_node_ids = list(dict.fromkeys(src for src, _tgt, _data in edges))
+        # Both endpoints, not just the source — see upsert_edge for why a
+        # target-only endpoint is externally visible as an inconsistency.
+        endpoint_ids = list(
+            dict.fromkeys(
+                node_id for src, tgt, _data in edges for node_id in (src, tgt)
+            )
+        )
         node_ops: list[tuple[Any, int, str]] = [
             (
-                UpdateOne({"_id": src}, {"$setOnInsert": {"_id": src}}, upsert=True),
-                _estimate_doc_bytes({"_id": src}),
-                src,
+                UpdateOne({"_id": nid}, {"$setOnInsert": {"_id": nid}}, upsert=True),
+                _estimate_doc_bytes({"_id": nid}),
+                nid,
             )
-            for src in source_node_ids
+            for nid in endpoint_ids
         ]
         await _run_batched_bulk_write(
             self.collection,
@@ -2401,7 +2441,7 @@ class MongoGraphStorage(BaseGraphStorage):
             max_records_per_batch=self._max_upsert_records_per_batch,
             ordered=False,
             log_prefix=f"[{self.workspace}] {self.namespace} edges:",
-            what="source-node placeholder upsert",
+            what="edge endpoint placeholder upsert",
         )
 
         # Key every edge by its canonical (edge_lo, edge_hi) pair and dedupe
@@ -3072,9 +3112,22 @@ class MongoGraphStorage(BaseGraphStorage):
 
         Returns:
             List of labels(entity names) sorted by degree (highest first)
+
+        Two phases, and the second one usually does not run. Phase 1 ranks the
+        entities that HAVE edges, straight off the edge collection — the cheap
+        aggregation, and on any graph with more than ``limit`` connected
+        entities it fills every slot on its own. Only when it comes up short
+        does phase 2 top the result up from the isolated (degree-0) entities,
+        which is exactly the case the edge-only ranking got wrong by returning
+        nothing at all for a graph whose entities carry no relations.
+
+        Giving every node a degree-0 baseline row inside the aggregation instead
+        would be simpler, but it forces a full pass over the node collection on
+        every call — on a large graph, to produce a result phase 1 already had.
         """
         try:
-            # Use aggregation pipeline to count edges per node and sort by degree
+            # Self-loops count twice (the source and target groups each see the
+            # document), matching the other backends.
             pipeline = [
                 # Count outbound edges
                 {"$group": {"_id": "$source_node_id", "out_degree": {"$sum": 1}}},
@@ -3120,13 +3173,35 @@ class MongoGraphStorage(BaseGraphStorage):
                 if doc.get("_id"):
                     labels.append(doc["_id"])
 
+            if len(labels) < limit:
+                # Phase 1 returned fewer than `limit`, and its aggregation is
+                # exact, so the connected set is now known in full: every node
+                # outside it has no edge at all. Top up in label order, bounded
+                # by the shortfall — the sort rides the _id index, so this stops
+                # as soon as it has enough rather than scanning the collection.
+                # list(labels), not labels: the cursor is consumed below while
+                # appending to the same list, and handing the driver a live
+                # reference makes the filter depend on when it serializes.
+                isolated_cursor = (
+                    self.collection.find({"_id": {"$nin": list(labels)}}, {"_id": 1})
+                    .sort("_id", 1)
+                    .limit(limit - len(labels))
+                )
+                async for doc in isolated_cursor:
+                    if doc.get("_id"):
+                        labels.append(doc["_id"])
+
             logger.debug(
                 f"[{self.workspace}] Retrieved {len(labels)} popular labels (limit: {limit})"
             )
             return labels
         except Exception as e:
+            # Raise, never return []: an empty list here is indistinguishable
+            # from "the graph has no entities". /graph/label/popular already
+            # turns an exception into a 500, so swallowing it handed the WebUI a
+            # 200 with an empty entity picker while the database was down.
             logger.error(f"[{self.workspace}] Error getting popular labels: {str(e)}")
-            return []
+            raise
 
     async def _try_atlas_text_search(self, query_strip: str, limit: int) -> list[str]:
         """Try Atlas Search using simple text search."""
@@ -3278,11 +3353,15 @@ class MongoGraphStorage(BaseGraphStorage):
             return labels
 
         except Exception as e:
+            # Last resort in the progressive chain: the Atlas methods are allowed
+            # to fail (they may simply be unavailable) and fall through to here,
+            # but if the regex scan itself fails the search produced no answer at
+            # all. Returning [] would report that as "nothing matched".
             logger.error(f"[{self.workspace}] Regex fallback search failed: {e}")
             import traceback
 
             logger.error(f"[{self.workspace}] Traceback: {traceback.format_exc()}")
-            return []
+            raise
 
     async def search_labels(self, query: str, limit: int = 50) -> list[str]:
         """
@@ -3305,8 +3384,10 @@ class MongoGraphStorage(BaseGraphStorage):
                 )
                 return []
         except PyMongoError as e:
+            # A failed count is not "the graph is empty" — that shortcut would
+            # report a transport blip as "no labels match".
             logger.error(f"[{self.workspace}] Error counting nodes: {e}")
-            return []
+            raise
 
         # Progressive search strategy
         search_methods = [

--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -921,7 +921,9 @@ class Neo4JStorage(BaseGraphStorage):
 
         Returns:
             list[tuple[str, str]]: List of (source_label, target_label) tuples representing edges
-            None: If no edges found
+            None: If the node does not exist. An existing node with no relations
+                returns ``[]`` — the BaseGraphStorage contract, as implemented by
+                NetworkXStorage. A query error is neither value: it propagates.
 
         Raises:
             ValueError: If source_node_id is invalid
@@ -941,7 +943,14 @@ class Neo4JStorage(BaseGraphStorage):
                     results = await session.run(query, entity_id=source_node_id)
 
                     edges = []
+                    # Any row at all means the anchor MATCH bound n, i.e. the
+                    # node exists: an isolated node still yields exactly one row
+                    # (via OPTIONAL MATCH) carrying a NULL connected node. Zero
+                    # rows is the only "no such node" signal, and it must not be
+                    # reported as an empty edge list.
+                    node_matched = False
                     async for record in results:
+                        node_matched = True
                         source_node = record["n"]
                         connected_node = record["connected"]
 
@@ -964,7 +973,7 @@ class Neo4JStorage(BaseGraphStorage):
                             edges.append((source_label, target_label))
 
                     await results.consume()  # Ensure results are consumed
-                    return edges
+                    return edges if node_matched else None
                 except Exception as e:
                     logger.error(
                         f"[{self.workspace}] Error getting edges for node {source_node_id}: {str(e)}"

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -412,13 +412,25 @@ class NetworkXStorage(BaseGraphStorage):
             limit: Maximum number of labels to return
 
         Returns:
-            List of labels sorted by degree (highest first)
+            List of labels sorted by degree (highest first), ties broken on the
+            label ascending
         """
         graph = await self._get_graph()
 
-        # Get degrees of all nodes and sort by degree descending
+        # Degree descending, then label ascending. The tie-break is not
+        # cosmetic: `sorted(..., key=degree, reverse=True)` is stable, so ties
+        # used to come back in node INSERTION order, and when more labels share
+        # the cutoff degree than fit in `limit` that decided which ones the
+        # caller never sees — a graph that happened to insert "Zeta" before
+        # "Alpha" returned Zeta and dropped Alpha. Every other backend orders
+        # ties by label (SQL `ORDER BY degree DESC, label ASC` / COLLATE "C",
+        # Cypher `ORDER BY degree DESC, label ASC`), and this is the default
+        # backend the contract in BaseGraphStorage points at. Comparing on
+        # str() gives the same code-point order as COLLATE "C".
         degrees = dict(graph.degree())
-        sorted_nodes = sorted(degrees.items(), key=lambda x: x[1], reverse=True)
+        sorted_nodes = sorted(
+            degrees.items(), key=lambda item: (-item[1], str(item[0]))
+        )
 
         # Return top labels limited by the specified limit
         popular_labels = [str(node) for node, _ in sorted_nodes[:limit]]

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -3804,10 +3804,31 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             raise
 
     async def get_node_edges(self, source_node_id: str) -> list[tuple[str, str]] | None:
-        """Get all (source, target) edge tuples connected to a node."""
+        """Get all (source, target) edge tuples connected to a node.
+
+        Returns None if the node does not exist; an existing node with no
+        relations returns ``[]``. Answering ``[]`` for both would make a deleted
+        entity indistinguishable from an isolated one — the BaseGraphStorage
+        contract keeps them apart, even though no in-tree caller reads the
+        distinction today. A transport error is neither value: it propagates,
+        so "no neighbours" stays a positively confirmed fact (see
+        test_opensearch_strict_reads).
+        """
         if not self._indices_ready:
             return None
         try:
+            # Existence is decided by the node index, before the edge scan —
+            # never inferred from the edges. upsert_edge / upsert_edges_batch now
+            # materialize both endpoints, so a dangling target should not arise
+            # from new writes, but documents written before that change still can
+            # carry one, and a read contract must not rest on a write-path
+            # invariant anyway. Inferring existence from the edge scan would make
+            # this method contradict has_node() on the same id, and delete_entity
+            # 404s on has_node(). exists() is a real-time id lookup (no refresh
+            # needed), and checking first skips the PIT scan for an absent node.
+            if not await self.has_node(source_node_id):
+                return None
+
             await self._refresh_graph_indices_if_dirty(refresh_edges=True)
             query = {
                 "bool": {
@@ -4026,6 +4047,33 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             logger.error(f"[{self.workspace}] Error upserting node {node_id}: {e}")
             raise
 
+    async def _create_placeholder_node(self, node_id: str) -> None:
+        """Insert an empty node document for an edge endpoint. Never overwrite.
+
+        ``op_type=create`` is insert-only: a 409 means the endpoint already
+        exists and we keep whatever it holds. ``upsert_node()`` cannot be used
+        for this — it goes through the plain index API, which REPLACES the
+        document, so an endpoint carrying a real description / entity_type /
+        source_ids would be silently reduced to a bare placeholder.
+
+        That matters twice over. The existence probe can only ever be a
+        best-effort hint: a concurrent writer may create the endpoint between
+        the probe and this call. Insert-only makes the placeholder write safe
+        regardless of what the probe concluded, instead of trusting it.
+        """
+        try:
+            await self.client.index(
+                index=self._nodes_index,
+                id=node_id,
+                body={"entity_id": node_id},
+                op_type="create",
+            )
+            self._nodes_dirty = True
+        except ConflictError:
+            # 409: the endpoint already exists. Nothing to do -- and nothing
+            # lost, which is the whole point of create over index.
+            pass
+
     async def upsert_edge(
         self, source_node_id: str, target_node_id: str, edge_data: dict[str, str]
     ) -> None:
@@ -4043,9 +4091,20 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         """
         try:
             await self._ensure_indices_ready()
-            # Ensure source node exists (don't overwrite if it already has data)
-            if not await self.has_node(source_node_id):
-                await self.upsert_node(source_node_id, {})
+            # Materialize BOTH endpoints, not just the source. A target-only
+            # endpoint would otherwise carry edges with no node document, and
+            # that dangling state is externally visible: has_node() says absent
+            # while the edge scan says connected, get_popular_labels ranks an id
+            # get_node returns nothing for, and delete_entity 404s on an entity
+            # whose edges are right there. NetworkXStorage.add_edge and
+            # PGOpsGraphStorage both create both ends; this makes the document
+            # backends agree. One mget for the pair, and existing nodes are left
+            # untouched so real properties are never overwritten by a placeholder.
+            endpoints = list(dict.fromkeys((source_node_id, target_node_id)))
+            existing_endpoints = await self.has_nodes_batch(endpoints)
+            for node_id in endpoints:
+                if node_id not in existing_endpoints:
+                    await self._create_placeholder_node(node_id)
 
             doc = {k: v for k, v in edge_data.items() if k != "_id"}
             doc["source_node_id"] = source_node_id
@@ -4112,7 +4171,16 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             node_ids: List of node IDs to check.
 
         Returns:
-            Set of node_ids that exist in the graph.
+            Set of node_ids CONFIRMED to exist in the graph.
+
+        An id is reported absent only when its mget item says ``found: false``.
+        OpenSearch answers an mget with HTTP 200 even when individual items
+        failed (an unavailable shard yields an ``error`` object and no ``found``
+        flag), and a short or malformed ``docs`` array is not evidence either:
+        those raise, via the same ``_interpret_mget_item`` contract every other
+        mget read in this file uses. Treating them as "absent" is what turns a
+        transient blip into a fact — the edge-endpoint writers act on this set
+        by creating placeholder nodes, and entity merge/dedup act on it too.
         """
         if not node_ids:
             return set()
@@ -4122,7 +4190,18 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             response = await self.client.mget(
                 index=self._nodes_index, body={"ids": node_ids}
             )
-            return {doc["_id"] for doc in response.get("docs", []) if doc.get("found")}
+            docs = response.get("docs")
+            if not isinstance(docs, list) or len(docs) != len(node_ids):
+                raise RuntimeError(
+                    f"OpenSearch mget for {len(node_ids)} node ids returned "
+                    f"{len(docs) if isinstance(docs, list) else 'no'} items, "
+                    f"expected exactly {len(node_ids)}"
+                )
+            return {
+                node_id
+                for node_id, item in zip(node_ids, docs)
+                if _interpret_mget_item(item, node_id, require_source=False) is not None
+            }
         except OpenSearchException as e:
             if _is_missing_index_error(e):
                 self._mark_indices_missing()
@@ -4148,14 +4227,55 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         try:
             await self._ensure_indices_ready()
 
-            # Ensure all source nodes exist (mirrors upsert_edge behaviour)
-            source_ids = list({src for src, _tgt, _data in edges})
-            existing_sources = await self.has_nodes_batch(source_ids)
-            missing_sources = [
-                (nid, {}) for nid in source_ids if nid not in existing_sources
+            # Both endpoints, not just the source — see upsert_edge for why a
+            # target-only endpoint is externally visible as an inconsistency.
+            endpoint_ids = list(
+                dict.fromkeys(
+                    node_id for src, tgt, _data in edges for node_id in (src, tgt)
+                )
+            )
+            existing_endpoints = await self.has_nodes_batch(endpoint_ids)
+            # Insert-only, exactly like _create_placeholder_node on the
+            # single-edge path: upsert_nodes_batch would bulk-INDEX these, and a
+            # replace would strip a real node back to a bare placeholder if the
+            # probe raced a concurrent writer. A 409 here just means the
+            # endpoint already exists, so it is filtered out below rather than
+            # failing the batch.
+            placeholder_actions = [
+                {
+                    "_op_type": "create",
+                    "_index": self._nodes_index,
+                    "_id": nid,
+                    "_source": {"entity_id": nid},
+                }
+                for nid in endpoint_ids
+                if nid not in existing_endpoints
             ]
-            if missing_sources:
-                await self.upsert_nodes_batch(missing_sources)
+            if placeholder_actions:
+                _success, errors = await _run_chunked_async_bulk(
+                    self.client,
+                    placeholder_actions,
+                    max_payload_bytes=self._max_upsert_payload_bytes,
+                    max_records_per_batch=self._max_upsert_records_per_batch,
+                    log_prefix=f"[{self.workspace}] {self.namespace} edges:",
+                    what="edge endpoint placeholder create",
+                    raise_on_error=False,
+                )
+                real_errors = [
+                    e
+                    for e in errors
+                    if not (
+                        isinstance(e, dict)
+                        and isinstance(e.get("create"), dict)
+                        and e["create"].get("status") == 409
+                    )
+                ]
+                if real_errors:
+                    raise RuntimeError(
+                        f"[{self.workspace}] Failed to create edge endpoint "
+                        f"placeholders: {real_errors[:3]}"
+                    )
+                self._nodes_dirty = True
 
             # Key every edge by its canonical id and dedupe within the batch
             # (last-write-wins) so a single bulk request carries one action per
@@ -4975,9 +5095,76 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             logger.error(f"[{self.workspace}] Error getting all edges: {e}")
             raise
 
+    async def _collect_isolated_labels(
+        self, needed: int, connected: set[str]
+    ) -> list[str]:
+        """Scan the node index in label order for entities that have no edges.
+
+        Only reached when the connected entities do not already fill the caller's
+        limit, so a large graph never pays for this pass. The scan stops as soon
+        as ``needed`` labels are collected, which is what makes the scan order
+        load-bearing: these labels all tie at degree 0, so the order they are
+        visited in IS the tie-break, and it must be ``entity_id`` ascending like
+        every other backend's.
+
+        That is why the sort is spelled out here instead of reusing
+        ``_pit_sort_with_field``: that helper is a pagination tiebreaker and
+        collapses to ``_shard_doc`` on OpenSearch >= 3.3, i.e. shard order.
+        ``get_all_labels`` can use it because it reads every page and re-sorts in
+        Python afterwards; an early-exit scan cannot — it would return an
+        arbitrary shard-ordered subset and omit alphabetically earlier labels.
+        ``entity_id`` is unique (it mirrors ``_id``), so it is a total order and
+        needs no extra tiebreaker for ``search_after``.
+        """
+        if needed <= 0:
+            return []
+        await self._refresh_graph_indices_if_dirty(refresh_nodes=True)
+        isolated: list[str] = []
+        pit = await self.client.create_pit(
+            index=self._nodes_index, params={"keep_alive": "1m"}
+        )
+        pit_id = pit["pit_id"]
+        try:
+            search_after = None
+            while len(isolated) < needed:
+                body = {
+                    "query": {"match_all": {}},
+                    "_source": False,
+                    "size": 10000,
+                    "pit": {"id": pit_id, "keep_alive": "1m"},
+                    "sort": [{"entity_id": {"order": "asc"}}],
+                }
+                if search_after:
+                    body["search_after"] = search_after
+                response = await self.client.search(body=body)
+                hits = response["hits"]["hits"]
+                if not hits:
+                    break
+                for hit in hits:
+                    if hit["_id"] not in connected:
+                        isolated.append(hit["_id"])
+                        if len(isolated) >= needed:
+                            break
+                search_after = hits[-1]["sort"]
+                if len(hits) < 10000:
+                    break
+        finally:
+            try:
+                await self.client.delete_pit(body={"pit_id": [pit_id]})
+            except Exception:
+                pass
+        return isolated
+
     async def get_popular_labels(self, limit: int = 300) -> list[str]:
-        """Get node labels ranked by edge degree (most connected first)."""
-        if not self._indices_ready:
+        """Get node labels ranked by edge degree (most connected first).
+
+        Isolated (degree-0) entities rank last but are still returned: the
+        degree aggregation runs on the edge index, where an entity with no
+        relations has no document at all, so ranking from the edge side alone
+        silently excluded them. NetworkXStorage ranks the whole node set, and a
+        graph whose entities carry no relations must not report an empty list.
+        """
+        if not self._indices_ready or limit <= 0:
             return []
         try:
             await self._refresh_graph_indices_if_dirty(refresh_edges=True)
@@ -4989,6 +5176,13 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 },
             }
             response = await self.client.search(index=self._edges_index, body=body)
+            # Keyed on edge ENDPOINTS, so an id with edge documents but no node
+            # document (a dangling endpoint, only reachable as a data-quality
+            # defect — the write path materializes both endpoints) also surfaces
+            # here. Left in deliberately: confirming every ranked id against the
+            # node index costs a round trip on every call, and the worst case is
+            # a picker entry whose entity lookup comes back empty, which the
+            # client reports rather than crashes on.
             degree_map = {}
             for bucket in response["aggregations"]["src"]["buckets"]:
                 degree_map[bucket["key"]] = (
@@ -4998,7 +5192,20 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 degree_map[bucket["key"]] = (
                     degree_map.get(bucket["key"], 0) + bucket["doc_count"]
                 )
-            sorted_labels = sorted(degree_map, key=degree_map.get, reverse=True)[:limit]
+            # Ties break on the label, ascending — the ordering the SQL and
+            # Cypher backends use, rather than aggregation bucket order.
+            sorted_labels = sorted(
+                degree_map, key=lambda label: (-degree_map[label], label)
+            )[:limit]
+            if len(sorted_labels) >= limit:
+                # Every remaining slot would go to a degree-0 node anyway, and
+                # there are none left to fill: skip the node scan entirely.
+                return sorted_labels
+            sorted_labels.extend(
+                await self._collect_isolated_labels(
+                    limit - len(sorted_labels), set(degree_map)
+                )
+            )
             return sorted_labels
         except OpenSearchException as e:
             if _is_missing_index_error(e):

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -6721,6 +6721,52 @@ class PGGraphQueryException(Exception):
         return self.details
 
 
+class PGGraphEdgeWriteLostError(PGGraphQueryException):
+    """Raised when an edge upsert completed without writing an edge.
+
+    The AGE upsert Cypher is ``MATCH (source) ... MATCH (target) ... CREATE``:
+    if either endpoint is absent the whole pattern fails to match, the statement
+    succeeds with zero rows, and the relation is dropped on the floor. Every
+    in-tree caller creates its endpoints first (``merge_nodes_and_edges``,
+    ``ainsert_custom_kg``, the graph-edit flows in ``utils_graph``), so this can
+    only fire on a real defect or a concurrent endpoint deletion — cases where a
+    silent drop is far worse than an error.
+
+    Attributes:
+        source_node_id / target_node_id: the endpoints of the lost edge.
+        missing_endpoints: the endpoint ids found absent, when identifiable.
+    """
+
+    def __init__(
+        self,
+        graph_name: str,
+        source_node_id: str,
+        target_node_id: str,
+        missing_endpoints: Sequence[str] = (),
+    ) -> None:
+        self.graph_name = graph_name
+        self.source_node_id = source_node_id
+        self.target_node_id = target_node_id
+        self.missing_endpoints = tuple(missing_endpoints)
+        if self.missing_endpoints:
+            details = "missing endpoint node(s): " + ", ".join(
+                f"`{node_id}`" for node_id in self.missing_endpoints
+            )
+        else:
+            details = (
+                "both endpoints appear to exist; the edge write was most likely "
+                "lost to a concurrent endpoint deletion"
+            )
+        message = (
+            f"PostgreSQL AGE: edge `{source_node_id}`-`{target_node_id}` was not "
+            f"written to graph {graph_name} ({details})"
+        )
+        super().__init__({"message": message, "details": details})
+        # PGGraphQueryException does not populate Exception.args, which would
+        # make str(exc) empty in logs and test output.
+        self.args = (message,)
+
+
 def _is_transient_graph_write_error(exc: BaseException) -> bool:
     """Return True when a PGGraphQueryException wraps a transient write-time error.
 
@@ -7244,7 +7290,11 @@ class PGGraphStorage(BaseGraphStorage):
     async def get_node_edges(self, source_node_id: str) -> list[tuple[str, str]] | None:
         """
         Retrieves all edges (relationships) for a particular node identified by its label.
-        :return: list of dictionaries containing edge information
+
+        Returns:
+            A list of (source_id, connected_id) tuples, or None if the node does
+            not exist — the BaseGraphStorage contract, as implemented by
+            NetworkXStorage and PGOpsGraphStorage.
         """
         cypher_query = """MATCH (n:base {entity_id: $entity_id})
                       OPTIONAL MATCH (n)-[]-(connected:base)
@@ -7256,6 +7306,19 @@ class PGGraphStorage(BaseGraphStorage):
         }
 
         results = await self._query(query, params=pg_params)
+        if not results:
+            # The anchor MATCH produced no row at all, so no such node exists.
+            # An existing node with no relations is NOT this case: the OPTIONAL
+            # MATCH still yields exactly one row, with connected_id NULL, which
+            # the loop below filters into an empty list. Returning [] here too
+            # would collapse "node absent" into "node isolated" and diverge from
+            # NetworkXStorage/PGOpsGraphStorage. No in-tree caller reads the
+            # distinction today — they all guard with `if edges:` — so this
+            # restores the declared contract rather than fixing a live caller;
+            # collapsing the two here is what makes it unrecoverable for one
+            # that needs it (an error, by contrast, must raise, never return
+            # either value — see get_node_edges on the other backends).
+            return None
         edges = []
         for record in results:
             source_id = record["source_id"]
@@ -7329,6 +7392,53 @@ class PGGraphStorage(BaseGraphStorage):
             ensure_ascii=False,
         )
         return cypher_sql, params_json
+
+    def _build_endpoint_exists_sql(self) -> str:
+        """SQL returning which of the given entity ids have a vertex in the graph.
+
+        Diagnostic-only: used to name the culprit when an edge upsert wrote
+        nothing. Plain SQL over the label table (same access-operator predicate
+        as ``has_node``) so it can run on the caller's connection inside the
+        already-open write transaction.
+        """
+        return f"""
+            SELECT candidate.entity_id AS entity_id
+            FROM unnest($1::text[]) AS candidate(entity_id)
+            WHERE EXISTS (
+                SELECT 1
+                FROM {self.graph_name}.base v
+                WHERE ag_catalog.agtype_access_operator(
+                        VARIADIC ARRAY[v.properties, '"entity_id"'::agtype]
+                      ) = (to_json(candidate.entity_id::text)::text)::agtype
+            )
+        """
+
+    async def _build_edge_write_lost_error(
+        self,
+        connection: asyncpg.Connection,
+        source_node_id: str,
+        target_node_id: str,
+    ) -> PGGraphEdgeWriteLostError:
+        """Build the error for an edge upsert that returned no created edge.
+
+        Probes both endpoints so the message names the one that is missing. The
+        probe is best-effort: it runs on a connection whose transaction is about
+        to be rolled back, so a failure there must not mask the real problem.
+        """
+        endpoints = list(dict.fromkeys((source_node_id, target_node_id)))
+        missing: list[str] = []
+        try:
+            rows = await connection.fetch(self._build_endpoint_exists_sql(), endpoints)
+            present = {row["entity_id"] for row in rows}
+            missing = [node_id for node_id in endpoints if node_id not in present]
+        except Exception as probe_error:  # pragma: no cover - diagnostics only
+            logger.debug(
+                f"[{self.workspace}] Could not probe edge endpoints for "
+                f"`{source_node_id}`-`{target_node_id}`: {probe_error}"
+            )
+        return PGGraphEdgeWriteLostError(
+            self.graph_name, source_node_id, target_node_id, missing
+        )
 
     def _estimate_node_cypher_bytes(
         self, node_id: str, node_data: dict[str, str]
@@ -7470,7 +7580,15 @@ class PGGraphStorage(BaseGraphStorage):
                 await connection.execute(
                     _GRAPH_ADVISORY_LOCK_SHARED_SQL, self.graph_name
                 )
-                await connection.execute(cypher_sql, params_json)
+                # fetch(), not execute(): the Cypher RETURNs the created edge, so
+                # an empty result set is the only signal that the endpoint MATCHes
+                # failed and the edge was silently dropped (see
+                # PGGraphEdgeWriteLostError). AGE reports no error for that.
+                created = await connection.fetch(cypher_sql, params_json)
+                if not created:
+                    raise await self._build_edge_write_lost_error(
+                        connection, source_node_id, target_node_id
+                    )
 
         try:
             await self.db._run_with_retry(
@@ -7642,6 +7760,11 @@ class PGGraphStorage(BaseGraphStorage):
         duplicate DIRECTED rows. Edges are also deduped within the chunk. Retry
         semantics mirror ``upsert_edge``: DELETE + CREATE is idempotent, so a
         full-chunk replay is safe.
+
+        Like the single-edge path, each statement's returned edge is checked: an
+        edge whose endpoints are absent matches nothing and would otherwise be
+        dropped without an error. That raises and rolls the whole chunk back,
+        which is the same all-or-nothing behaviour as any other mid-chunk failure.
         """
         built = [
             self._build_upsert_edge_sql(src, tgt, edge_data)
@@ -7652,8 +7775,14 @@ class PGGraphStorage(BaseGraphStorage):
         async def _operation(connection: asyncpg.Connection) -> None:
             async with connection.transaction():
                 await connection.execute(_GRAPH_ADVISORY_LOCK_SQL, self.graph_name)
-                for cypher_sql, params_json in built:
-                    await connection.execute(cypher_sql, params_json)
+                for (cypher_sql, params_json), (src, tgt, _edge_data) in zip(
+                    built, chunk
+                ):
+                    created = await connection.fetch(cypher_sql, params_json)
+                    if not created:
+                        raise await self._build_edge_write_lost_error(
+                            connection, src, tgt
+                        )
 
         try:
             await self.db._run_with_retry(
@@ -8693,11 +8822,32 @@ class PGGraphStorage(BaseGraphStorage):
         return edges
 
     async def get_popular_labels(self, limit: int = 300) -> list[str]:
-        """Get popular labels by node degree (most connected entities) using native SQL for performance."""
+        """Get popular labels by node degree (most connected entities) using native SQL for performance.
+
+        Two phases, and the second one usually does not run. Phase 1 ranks the
+        entities that HAVE edges, straight off the edge-derived degrees — the
+        cheap plan, and on any graph with more than ``limit`` connected entities
+        it fills every slot on its own. Only when it comes up short does phase 2
+        top the result up from the isolated (degree-0) entities, which is
+        exactly the case the original inner join got wrong by returning nothing
+        at all for a graph whose entities carry no relations.
+
+        Driving the whole ranking off the vertex table instead (one LEFT JOIN)
+        would be simpler, but it forces a full vertex scan on every call — on a
+        large graph, to produce a result phase 1 already had.
+        """
         try:
             # Native SQL query to calculate node degrees directly from AGE's underlying tables
-            # This is significantly faster than using the cypher() function wrapper
-            query = f"""
+            # This is significantly faster than using the cypher() function wrapper.
+            #
+            # Self-loops count twice (start_id and end_id both contribute),
+            # matching node_degree() and the other backends. COLLATE "C" makes
+            # the tie-break a byte-order comparison so it matches Python's
+            # code-point sort. The ranking columns live in a derived table
+            # because ORDER BY cannot apply COLLATE to a bare output alias
+            # (a sub-SELECT, not a CTE: CTEs are an optimization fence before
+            # PostgreSQL 12).
+            connected_query = f"""
             WITH node_degrees AS (
                 SELECT
                     node_id,
@@ -8709,31 +8859,74 @@ class PGGraphStorage(BaseGraphStorage):
                 ) AS all_edges
                 GROUP BY node_id
             )
-            SELECT
-                (ag_catalog.agtype_access_operator(VARIADIC ARRAY[v.properties, '"entity_id"'::agtype]))::text AS label
-            FROM
-                node_degrees d
-            JOIN
-                {self.graph_name}._ag_label_vertex v ON d.node_id = v.id
-            WHERE
-                ag_catalog.agtype_access_operator(VARIADIC ARRAY[v.properties, '"entity_id"'::agtype]) IS NOT NULL
+            SELECT label FROM (
+                SELECT
+                    (ag_catalog.agtype_access_operator(VARIADIC ARRAY[v.properties, '"entity_id"'::agtype]))::text AS label,
+                    d.degree AS degree
+                FROM
+                    node_degrees d
+                JOIN
+                    {self.graph_name}._ag_label_vertex v ON d.node_id = v.id
+                WHERE
+                    ag_catalog.agtype_access_operator(VARIADIC ARRAY[v.properties, '"entity_id"'::agtype]) IS NOT NULL
+            ) AS connected
             ORDER BY
-                d.degree DESC,
-                label ASC
+                degree DESC,
+                label COLLATE "C" ASC
             LIMIT $1;
             """
-            results = await self._query(query, params={"limit": limit})
+            results = await self._query(connected_query, params={"limit": limit})
             labels = [
                 result["label"] for result in results if result and "label" in result
             ]
+
+            if len(labels) < limit:
+                # Phase 1 returned fewer than `limit`, and its aggregate is
+                # exact, so the connected set is now known in full: every
+                # remaining entity has no edge at all. Top up in label order,
+                # bounded by the shortfall — never more than `limit` rows, so
+                # even a sequential vertex scan stays cheap.
+                isolated_query = f"""
+                SELECT label FROM (
+                    SELECT
+                        (ag_catalog.agtype_access_operator(VARIADIC ARRAY[v.properties, '"entity_id"'::agtype]))::text AS label
+                    FROM
+                        {self.graph_name}._ag_label_vertex v
+                    WHERE
+                        ag_catalog.agtype_access_operator(VARIADIC ARRAY[v.properties, '"entity_id"'::agtype]) IS NOT NULL
+                        AND NOT EXISTS (
+                            SELECT 1 FROM {self.graph_name}._ag_label_edge e
+                            WHERE e.start_id = v.id
+                        )
+                        AND NOT EXISTS (
+                            SELECT 1 FROM {self.graph_name}._ag_label_edge e
+                            WHERE e.end_id = v.id
+                        )
+                ) AS isolated
+                ORDER BY
+                    label COLLATE "C" ASC
+                LIMIT $1;
+                """
+                isolated_results = await self._query(
+                    isolated_query, params={"limit": limit - len(labels)}
+                )
+                labels.extend(
+                    result["label"]
+                    for result in isolated_results
+                    if result and "label" in result
+                )
 
             logger.debug(
                 f"[{self.workspace}] Retrieved {len(labels)} popular labels (limit: {limit})"
             )
             return labels
         except Exception as e:
+            # Raise, never return []: an empty list here is indistinguishable
+            # from "the graph has no entities". /graph/label/popular already
+            # turns an exception into a 500, so swallowing it handed the WebUI a
+            # 200 with an empty entity picker while the database was down.
             logger.error(f"[{self.workspace}] Error getting popular labels: {str(e)}")
-            return []
+            raise
 
     async def search_labels(self, query: str, limit: int = 50) -> list[str]:
         """Search labels with fuzzy matching using native, parameterized SQL for performance and security."""
@@ -8794,10 +8987,12 @@ class PGGraphStorage(BaseGraphStorage):
             )
             return labels
         except Exception as e:
+            # Same reasoning as get_popular_labels: "no match" and "the query
+            # failed" must not share a return value.
             logger.error(
                 f"[{self.workspace}] Error searching labels with query '{query}': {str(e)}"
             )
-            return []
+            raise
 
     async def drop(self) -> dict[str, str]:
         """Drop the storage"""

--- a/tests/kg/memgraph_impl/test_memgraph_graph_read_contract.py
+++ b/tests/kg/memgraph_impl/test_memgraph_graph_read_contract.py
@@ -1,0 +1,174 @@
+"""Read-path contracts MemgraphStorage shares with the other graph backends.
+
+Two invariants:
+
+1. ``get_node_edges`` returns None for a node that does not exist and ``[]``
+   for one that exists with no relations. Answering ``[]`` for both makes a
+   deleted entity indistinguishable from an isolated one.
+2. A query failure in the label helpers propagates. Returning ``[]`` there
+   reports a dead database as "this graph has no entities" -- and
+   ``/graph/label/popular`` already turns an exception into a 500, so the
+   swallow was the only thing standing between the user and an accurate error.
+"""
+
+import pytest
+
+from lightrag.kg.memgraph_impl import MemgraphStorage
+
+
+pytestmark = pytest.mark.offline
+
+
+class _FakeResult:
+    """Async-iterable result, optionally raising when iterated."""
+
+    def __init__(self, records, error=None):
+        self._records = list(records)
+        self._error = error
+        self.consumed = False
+
+    def __aiter__(self):
+        self._iter = iter(self._records)
+        return self
+
+    async def __anext__(self):
+        if self._error is not None:
+            raise self._error
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+    async def consume(self):
+        self.consumed = True
+        return None
+
+
+class _FakeSession:
+    def __init__(self, result, run_error=None):
+        self._result = result
+        self._run_error = run_error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def run(self, query, parameters=None, **kwargs):
+        if self._run_error is not None:
+            raise self._run_error
+        return self._result
+
+
+class _FakeDriver:
+    def __init__(self, result, run_error=None):
+        self._result = result
+        self._run_error = run_error
+
+    def session(self, **kwargs):
+        return _FakeSession(self._result, self._run_error)
+
+
+def _make_storage(records=(), run_error=None, iter_error=None):
+    storage = MemgraphStorage(
+        namespace="chunk_entity_relation",
+        global_config={"max_graph_nodes": 1000},
+        embedding_func=None,
+        workspace="test",
+    )
+    storage._driver = _FakeDriver(_FakeResult(records, iter_error), run_error)
+    storage._DATABASE = "memgraph"
+    return storage
+
+
+# ---------------------------------------------------------------------------
+# get_node_edges: absent node vs isolated node
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_node_edges_returns_none_for_missing_node():
+    """Zero rows means the anchor MATCH never bound n."""
+    storage = _make_storage(records=[])
+
+    assert await storage.get_node_edges("NoSuchEntity") is None
+
+
+@pytest.mark.asyncio
+async def test_get_node_edges_returns_empty_list_for_isolated_node():
+    """An existing node with no relations still yields one row from the
+    OPTIONAL MATCH, carrying a NULL connected_entity_id."""
+    storage = _make_storage(
+        records=[
+            {
+                "node_entity_id": "Lonely",
+                "connected_entity_id": None,
+                "start_entity_id": None,
+            }
+        ]
+    )
+
+    assert await storage.get_node_edges("Lonely") == []
+
+
+@pytest.mark.asyncio
+async def test_get_node_edges_preserves_edge_direction():
+    storage = _make_storage(
+        records=[
+            {
+                "node_entity_id": "Alpha",
+                "connected_entity_id": "Beta",
+                "start_entity_id": "Alpha",
+            },
+            {
+                "node_entity_id": "Alpha",
+                "connected_entity_id": "Gamma",
+                "start_entity_id": "Gamma",
+            },
+        ]
+    )
+
+    assert await storage.get_node_edges("Alpha") == [
+        ("Alpha", "Beta"),
+        ("Gamma", "Alpha"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Label helpers: a query failure is not "no labels"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_popular_labels_raises_on_query_error():
+    storage = _make_storage(run_error=RuntimeError("memgraph is down"))
+
+    with pytest.raises(RuntimeError, match="memgraph is down"):
+        await storage.get_popular_labels(limit=10)
+
+
+@pytest.mark.asyncio
+async def test_get_popular_labels_raises_on_iteration_error():
+    """A mid-stream failure loses part of the ranking — that partial result
+    must not be returned as if it were the whole graph."""
+    storage = _make_storage(iter_error=RuntimeError("connection reset"))
+
+    with pytest.raises(RuntimeError, match="connection reset"):
+        await storage.get_popular_labels(limit=10)
+
+
+@pytest.mark.asyncio
+async def test_search_labels_raises_on_query_error():
+    storage = _make_storage(run_error=RuntimeError("memgraph is down"))
+
+    with pytest.raises(RuntimeError, match="memgraph is down"):
+        await storage.search_labels("alpha")
+
+
+@pytest.mark.asyncio
+async def test_search_labels_still_short_circuits_on_blank_query():
+    """An empty query is a real "nothing to match", not an error."""
+    storage = _make_storage(run_error=RuntimeError("must not be reached"))
+
+    assert await storage.search_labels("   ") == []

--- a/tests/kg/mongo_impl/test_mongo_storage.py
+++ b/tests/kg/mongo_impl/test_mongo_storage.py
@@ -40,8 +40,9 @@ class _AsyncCursor:
 
 def _make_node_find_side_effect(real_ids: set):
     """Mock ``collection.find({"_id": {"$in": ids}})``, dropping ids that have
-    no node document -- mirrors a dangling edge endpoint (upsert_edge only
-    guarantees the source node exists, never the target)."""
+    no node document -- mirrors a dangling edge endpoint. Writes now materialize
+    both endpoints, so new data cannot produce one, but rows written before that
+    change still can and the traversal must keep tolerating them."""
 
     def _find(query, projection=None):
         ids = query["_id"]["$in"]
@@ -376,7 +377,8 @@ class TestMongoEdgeKey:
         s._edge_collection_name = "test_edges"
         s._max_upsert_payload_bytes = 16 * 1024 * 1024
         s._max_upsert_records_per_batch = 128
-        s.collection = SimpleNamespace(update_one=AsyncMock())
+        # upsert_edge materializes both endpoints through one bulk_write.
+        s.collection = SimpleNamespace(update_one=AsyncMock(), bulk_write=AsyncMock())
         s.edge_collection = SimpleNamespace()
         return s
 
@@ -409,6 +411,37 @@ class TestMongoEdgeKey:
         assert update["$set"]["target_node_id"] == "A"
         assert update["$set"]["source_ids"] == ["c1", "c2"]
         assert kwargs.get("upsert") is True
+
+    @pytest.mark.asyncio
+    async def test_upsert_edge_materializes_both_endpoints(self):
+        """Both endpoints get a placeholder node, not just the source.
+
+        A target-only endpoint would leave an edge whose target has no node
+        document — externally visible as has_node() and get_node_edges()
+        disagreeing, and as get_popular_labels ranking an id get_node returns
+        nothing for. $setOnInsert so an endpoint that already carries real
+        properties is never overwritten by the placeholder.
+        """
+        s = self._make_storage()
+        s.edge_collection.update_one = AsyncMock()
+        await s.upsert_edge("B", "A", {"weight": 1.0})
+
+        (node_ops,), kwargs = s.collection.bulk_write.call_args
+        assert [op._filter["_id"] for op in node_ops] == ["B", "A"]
+        assert all(
+            op._doc == {"$setOnInsert": {"_id": op._filter["_id"]}} for op in node_ops
+        )
+        assert all(op._upsert for op in node_ops)
+        assert kwargs.get("ordered") is False
+
+    @pytest.mark.asyncio
+    async def test_upsert_edge_self_loop_materializes_one_endpoint(self):
+        s = self._make_storage()
+        s.edge_collection.update_one = AsyncMock()
+        await s.upsert_edge("Loop", "Loop", {"weight": 1.0})
+
+        (node_ops,), _kwargs = s.collection.bulk_write.call_args
+        assert [op._filter["_id"] for op in node_ops] == ["Loop"]
 
     @pytest.mark.asyncio
     async def test_upsert_edge_retries_once_on_duplicate_key(self):
@@ -445,7 +478,13 @@ class TestMongoEdgeKey:
                 [("A", "B", {"weight": 1.0}), ("B", "A", {"weight": 2.0})]
             )
 
-        # Last call is the edge bulk (first is the node-placeholder bulk).
+        # First call is the endpoint-placeholder bulk: BOTH endpoints of every
+        # edge, deduped — not just the sources.
+        node_collection, node_ops = calls[0]
+        assert node_collection is s.collection
+        assert [op._filter["_id"] for op, _bytes, _logid in node_ops] == ["A", "B"]
+
+        # Last call is the edge bulk.
         edge_collection, edge_ops = calls[-1]
         assert edge_collection is s.edge_collection
         assert len(edge_ops) == 1  # reciprocal pair collapsed to one op
@@ -962,3 +1001,240 @@ class TestMongoDocStatusLookup:
 
         with pytest.raises(PyMongoError):
             await storage.get_doc_by_content_hash("abc123")
+
+
+class TestMongoGraphReadContract:
+    """Read-path contracts MongoGraphStorage shares with the other backends.
+
+    Both cases used to answer with a value that means something else:
+    ``get_popular_labels`` ranked only nodes that appear in the edge collection,
+    so isolated entities were missing entirely, and ``get_node_edges`` returned
+    ``[]`` for an entity that does not exist -- indistinguishable from one that
+    exists with no relations.
+    """
+
+    def _make_storage(self):
+        s = MongoGraphStorage.__new__(MongoGraphStorage)
+        s.workspace = "test"
+        s.namespace = "chunk_entity_relation"
+        s._edge_collection_name = "test_edges"
+        s.collection = SimpleNamespace()
+        s.edge_collection = SimpleNamespace()
+        return s
+
+    # -- get_popular_labels -------------------------------------------------
+
+    @staticmethod
+    def _stub_isolated(s, ids):
+        """Stub the phase-2 node-collection top-up (find().sort().limit())."""
+        captured = {}
+
+        def _find(query, projection=None):
+            captured["query"] = query
+            cursor = _AsyncCursor([{"_id": i} for i in ids])
+            cursor.sort = lambda *a, **k: cursor
+            return cursor
+
+        s.collection.find = Mock(side_effect=_find)
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_popular_labels_ranks_from_edges_without_touching_the_nodes(self):
+        """Phase 1 is the cheap edge-side aggregation, and on a graph with
+        enough connected entities it is the ONLY thing that runs.
+
+        The node collection holds far more entities than `limit` in any real
+        graph, so making it drive the ranking would mean a full pass over it on
+        every call to produce a result the edge aggregation already had.
+        """
+        s = self._make_storage()
+        s.edge_collection.aggregate = AsyncMock(
+            return_value=_AsyncCursor([{"_id": f"E{i}"} for i in range(5)])
+        )
+        s.collection.aggregate = AsyncMock()
+        s.collection.find = Mock()
+
+        labels = await s.get_popular_labels(limit=5)
+
+        assert labels == [f"E{i}" for i in range(5)]
+        s.edge_collection.aggregate.assert_awaited_once()
+        # Limit filled by connected entities: the node collection is untouched.
+        s.collection.find.assert_not_called()
+        s.collection.aggregate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_popular_labels_sums_degrees_and_keeps_ranking_stages(self):
+        """Degrees sum across both endpoint groups, ordered and capped."""
+        s = self._make_storage()
+        s.edge_collection.aggregate = AsyncMock(return_value=_AsyncCursor([]))
+        self._stub_isolated(s, [])
+
+        await s.get_popular_labels(limit=42)
+
+        pipeline = s.edge_collection.aggregate.call_args[0][0]
+        assert pipeline[0] == {
+            "$group": {"_id": "$source_node_id", "out_degree": {"$sum": 1}}
+        }
+        union = next(stage for stage in pipeline if "$unionWith" in stage)
+        assert union["$unionWith"]["coll"] == "test_edges"
+        assert union["$unionWith"]["pipeline"][0]["$group"]["_id"] == "$target_node_id"
+        assert {"$sort": {"total_degree": -1, "_id": 1}} in pipeline
+        assert {"$limit": 42} in pipeline
+        assert s.edge_collection.aggregate.call_args.kwargs == {"allowDiskUse": True}
+
+    @pytest.mark.asyncio
+    async def test_popular_labels_tops_up_from_isolated_entities_when_short(self):
+        """Regression: a graph whose entities carry no relations reported an
+        EMPTY picker, because an entity with no edge document has no group to
+        land in. Phase 1 coming up short is exactly that signal -- and since its
+        aggregation is exact, every node outside the result is isolated.
+        """
+        s = self._make_storage()
+        s.edge_collection.aggregate = AsyncMock(
+            return_value=_AsyncCursor([{"_id": "Connected"}])
+        )
+        captured = self._stub_isolated(s, ["Aardvark", "Orphan"])
+
+        labels = await s.get_popular_labels(limit=3)
+
+        # Connected first, then isolated in label order.
+        assert labels == ["Connected", "Aardvark", "Orphan"]
+        # The top-up excludes what phase 1 already returned...
+        assert captured["query"] == {"_id": {"$nin": ["Connected"]}}
+        # ... and asks only for the shortfall, so it can never scan the whole
+        # collection: at most `limit` rows, ordered by the _id index.
+        assert s.collection.find.call_args[0][1] == {"_id": 1}
+
+    @pytest.mark.asyncio
+    async def test_popular_labels_returns_labels_in_ranked_order(self):
+        s = self._make_storage()
+        s.edge_collection.aggregate = AsyncMock(
+            return_value=_AsyncCursor([{"_id": "Alpha"}, {"_id": "Beta"}])
+        )
+        self._stub_isolated(s, ["Orphan"])
+
+        assert await s.get_popular_labels() == ["Alpha", "Beta", "Orphan"]
+
+    # -- get_node_edges -----------------------------------------------------
+
+    def _stub_edges(self, s, docs):
+        s.edge_collection.find = MagicMock(
+            side_effect=lambda query, projection=None: _AsyncCursor(docs)
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_node_edges_returns_none_for_missing_node(self):
+        """Regression: an absent entity answered ``[]``, the same value an
+        existing-but-isolated entity yields. The contract (NetworkXStorage) is
+        ``None``."""
+        s = self._make_storage()
+        self._stub_edges(s, [])
+        s.collection.find_one = AsyncMock(return_value=None)
+
+        assert await s.get_node_edges("NoSuchEntity") is None
+
+    @pytest.mark.asyncio
+    async def test_get_node_edges_returns_empty_list_for_isolated_node(self):
+        s = self._make_storage()
+        self._stub_edges(s, [])
+        s.collection.find_one = AsyncMock(return_value={"_id": "Lonely"})
+
+        assert await s.get_node_edges("Lonely") == []
+
+    @pytest.mark.asyncio
+    async def test_get_node_edges_returns_edges_for_an_existing_node(self):
+        s = self._make_storage()
+        self._stub_edges(
+            s,
+            [
+                {"source_node_id": "Alpha", "target_node_id": "Beta"},
+                {"source_node_id": "Gamma", "target_node_id": "Alpha"},
+            ],
+        )
+        s.collection.find_one = AsyncMock(return_value={"_id": "Alpha"})
+
+        assert await s.get_node_edges("Alpha") == [
+            ("Alpha", "Beta"),
+            ("Gamma", "Alpha"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_node_edges_returns_none_for_a_dangling_target_endpoint(self):
+        """Having edges does NOT prove the node exists in this backend.
+
+        Writes now materialize both endpoints, but rows written before that
+        change can still hold an id that appears only as an edge target with no
+        node document. Inferring existence from the edge scan would make this
+        method answer "exists, here are its edges" for an id that has_node()
+        reports absent — and delete_entity 404s on has_node(). The read must not
+        depend on a write-path invariant that older data does not satisfy.
+        """
+        s = self._make_storage()
+        self._stub_edges(s, [{"source_node_id": "Alpha", "target_node_id": "Target"}])
+        s.collection.find_one = AsyncMock(return_value=None)  # no node document
+
+        assert await s.get_node_edges("Target") is None
+        # The absent node also skips the edge scan entirely.
+        s.edge_collection.find.assert_not_called()
+
+
+class TestMongoLabelHelpersFailLoud:
+    """A database error in the label helpers must propagate.
+
+    Returning [] reports a dead database as "this graph has no entities" --
+    and /graph/label/popular already turns an exception into a 500, so the
+    swallow was the only thing standing between the user and an accurate error.
+    """
+
+    def _make_storage(self):
+        s = MongoGraphStorage.__new__(MongoGraphStorage)
+        s.workspace = "test"
+        s.namespace = "chunk_entity_relation"
+        s._collection_name = "test_nodes"
+        s._edge_collection_name = "test_edges"
+        s.collection = SimpleNamespace()
+        s.edge_collection = SimpleNamespace()
+        return s
+
+    @pytest.mark.asyncio
+    async def test_popular_labels_raises_on_aggregation_error(self):
+        s = self._make_storage()
+        s.edge_collection.aggregate = AsyncMock(side_effect=PyMongoError("boom"))
+
+        with pytest.raises(PyMongoError):
+            await s.get_popular_labels(limit=10)
+
+    @pytest.mark.asyncio
+    async def test_search_labels_raises_when_node_count_fails(self):
+        """The pre-flight count is an optimisation, not a verdict: a failed
+        count is not "the graph is empty"."""
+        s = self._make_storage()
+        s.collection.count_documents = AsyncMock(side_effect=PyMongoError("boom"))
+
+        with pytest.raises(PyMongoError):
+            await s.search_labels("alpha")
+
+    @pytest.mark.asyncio
+    async def test_search_labels_raises_when_regex_fallback_fails(self):
+        """Atlas Search may legitimately be unavailable and fall through to the
+        regex scan -- but if that last resort fails too, no answer was produced.
+        """
+        s = self._make_storage()
+        s.collection.count_documents = AsyncMock(return_value=3)
+        s._try_atlas_text_search = AsyncMock(side_effect=PyMongoError("no atlas"))
+        s._try_atlas_autocomplete_search = AsyncMock(
+            side_effect=PyMongoError("no atlas")
+        )
+        s._try_atlas_compound_search = AsyncMock(side_effect=PyMongoError("no atlas"))
+        s.collection.find = MagicMock(side_effect=PyMongoError("scan failed"))
+
+        with pytest.raises(PyMongoError):
+            await s.search_labels("alpha")
+
+    @pytest.mark.asyncio
+    async def test_search_labels_still_returns_empty_for_an_empty_graph(self):
+        """A confirmed-empty node collection is a real "no labels", not an error."""
+        s = self._make_storage()
+        s.collection.count_documents = AsyncMock(return_value=0)
+
+        assert await s.search_labels("alpha") == []

--- a/tests/kg/neo4j_impl/test_neo4j_graph_read_contract.py
+++ b/tests/kg/neo4j_impl/test_neo4j_graph_read_contract.py
@@ -1,0 +1,118 @@
+"""Read-path contract Neo4JStorage shares with the other graph backends.
+
+``get_node_edges`` must return None for a node that does not exist and ``[]``
+for one that exists with no relations. Answering ``[]`` for both makes a
+deleted entity indistinguishable from an isolated one, which is the whole point
+of the ``list | None`` return type in BaseGraphStorage.
+"""
+
+import pytest
+
+from lightrag.kg.neo4j_impl import Neo4JStorage
+
+
+pytestmark = pytest.mark.offline
+
+
+class _FakeNode(dict):
+    """Neo4j node stand-in: property access via .get(), truthy when populated."""
+
+
+class _FakeResult:
+    def __init__(self, records):
+        self._records = list(records)
+        self.consumed = False
+
+    def __aiter__(self):
+        self._iter = iter(self._records)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+    async def consume(self):
+        self.consumed = True
+        return None
+
+
+class _FakeSession:
+    def __init__(self, result, calls):
+        self._result = result
+        self._calls = calls
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def run(self, query, **params):
+        self._calls.append((query, params))
+        return self._result
+
+
+class _FakeDriver:
+    def __init__(self, result, calls):
+        self._result = result
+        self._calls = calls
+
+    def session(self, **kwargs):
+        return _FakeSession(self._result, self._calls)
+
+
+def _make_storage(records):
+    calls = []
+    storage = Neo4JStorage(
+        namespace="chunk_entity_relation",
+        global_config={"max_graph_nodes": 1000},
+        embedding_func=None,
+        workspace="test",
+    )
+    storage._driver = _FakeDriver(_FakeResult(records), calls)
+    storage._DATABASE = "neo4j"
+    return storage, calls
+
+
+@pytest.mark.asyncio
+async def test_get_node_edges_returns_none_for_missing_node():
+    """Zero rows means the anchor MATCH never bound n: no such node."""
+    storage, _ = _make_storage([])
+
+    assert await storage.get_node_edges("NoSuchEntity") is None
+
+
+@pytest.mark.asyncio
+async def test_get_node_edges_returns_empty_list_for_isolated_node():
+    """An existing node with no relations still yields one row from the
+    OPTIONAL MATCH, with a NULL connected node."""
+    storage, _ = _make_storage(
+        [{"n": _FakeNode(entity_id="Lonely"), "r": None, "connected": None}]
+    )
+
+    assert await storage.get_node_edges("Lonely") == []
+
+
+@pytest.mark.asyncio
+async def test_get_node_edges_returns_connected_pairs():
+    storage, _ = _make_storage(
+        [
+            {
+                "n": _FakeNode(entity_id="Alpha"),
+                "r": object(),
+                "connected": _FakeNode(entity_id="Beta"),
+            },
+            {
+                "n": _FakeNode(entity_id="Alpha"),
+                "r": object(),
+                "connected": _FakeNode(entity_id="Gamma"),
+            },
+        ]
+    )
+
+    assert await storage.get_node_edges("Alpha") == [
+        ("Alpha", "Beta"),
+        ("Alpha", "Gamma"),
+    ]

--- a/tests/kg/networkx_impl/test_networkx_popular_labels.py
+++ b/tests/kg/networkx_impl/test_networkx_popular_labels.py
@@ -1,0 +1,86 @@
+"""NetworkXStorage.get_popular_labels ranking contract.
+
+NetworkX is the default backend and the reference implementation the
+BaseGraphStorage contract points at, so the two things the other backends were
+fixed to do must hold here first:
+
+* every node is ranked, including isolated (degree-0) entities;
+* ties break on the label ascending, NOT on node insertion order.
+"""
+
+import networkx as nx
+import pytest
+
+from lightrag.kg.networkx_impl import NetworkXStorage
+
+
+pytestmark = pytest.mark.offline
+
+
+def _make_storage(graph: nx.Graph) -> NetworkXStorage:
+    storage = NetworkXStorage.__new__(NetworkXStorage)
+    storage.workspace = "test"
+    storage.namespace = "chunk_entity_relation"
+
+    async def _get_graph():
+        return graph
+
+    storage._get_graph = _get_graph
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_ties_break_on_label_not_insertion_order():
+    """Regression: ties used to come back in node insertion order.
+
+    ``sorted(..., key=degree, reverse=True)`` is stable, so equal degrees kept
+    the order the nodes were added in. With more tied labels than ``limit``,
+    that decided which ones the caller never sees: inserting "Zeta" before
+    "Alpha" made /graph/label/popular?limit=1 answer Zeta and drop Alpha.
+    """
+    graph = nx.Graph()
+    # Insertion order is deliberately the reverse of alphabetical order, and
+    # every node has the same degree.
+    for name in ["Zeta", "Mu", "Alpha"]:
+        graph.add_node(name)
+    graph.add_edge("Hub", "Zeta")
+    graph.add_edge("Hub", "Mu")
+    graph.add_edge("Hub", "Alpha")
+
+    storage = _make_storage(graph)
+
+    # Hub has degree 3; the three leaves all tie at 1 and must come back
+    # alphabetically, not Zeta-first.
+    assert await storage.get_popular_labels() == ["Hub", "Alpha", "Mu", "Zeta"]
+
+    # And the tie-break decides truncation, which is the part that actually
+    # loses data for the caller.
+    assert await storage.get_popular_labels(limit=2) == ["Hub", "Alpha"]
+
+
+@pytest.mark.asyncio
+async def test_isolated_nodes_are_ranked_last_but_still_ranked():
+    graph = nx.Graph()
+    graph.add_edge("Connected", "Peer")
+    graph.add_node("Orphan")
+    graph.add_node("Aardvark")  # inserted last, must still sort before Orphan
+
+    storage = _make_storage(graph)
+
+    labels = await storage.get_popular_labels()
+    assert set(labels) == {"Connected", "Peer", "Orphan", "Aardvark"}
+    # Both degree-0 entities are present, in label order.
+    assert labels[-2:] == ["Aardvark", "Orphan"]
+
+
+@pytest.mark.asyncio
+async def test_limit_truncates_after_ranking():
+    graph = nx.Graph()
+    graph.add_edge("A", "B")
+    graph.add_edge("A", "C")
+    graph.add_node("Z")
+
+    storage = _make_storage(graph)
+
+    assert await storage.get_popular_labels(limit=1) == ["A"]
+    assert len(await storage.get_popular_labels(limit=99)) == 4

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -23,6 +23,7 @@ from opensearchpy.exceptions import (  # type: ignore
     OpenSearchException,
     ConflictError,
 )
+import lightrag.kg.opensearch_impl
 from lightrag.kg.opensearch_impl import (
     OpenSearchKVStorage,
     OpenSearchDocStatusStorage,
@@ -161,6 +162,29 @@ def global_config():
 def embed_func():
     """Mock embedding function fixture."""
     return MockEmbeddingFunc()
+
+
+def _node_mget_side_effect(existing: set[str]):
+    """Well-formed node ``mget``: echo every requested id, found iff in `existing`.
+
+    ``has_nodes_batch`` reads items through ``_interpret_mget_item``, which
+    raises on an id mismatch, an item-level error, or a short ``docs`` array —
+    an ambiguous item must never be reported as a confirmed miss, because the
+    edge writers turn "absent" into a placeholder node. A canned fixed-id
+    response therefore no longer stands in for a real one.
+    """
+
+    async def _mget(index=None, body=None, **kwargs):
+        return {
+            "docs": [
+                {"_id": node_id, "found": True, "_source": {"entity_id": node_id}}
+                if node_id in existing
+                else {"_id": node_id, "found": False}
+                for node_id in body["ids"]
+            ]
+        }
+
+    return _mget
 
 
 def _make_client():
@@ -2218,6 +2242,10 @@ class TestGraphStorage:
                 },
             }
         )
+        # get_node_edges confirms the node exists before scanning edges (an id
+        # that only appears as an edge target may have no node document), and
+        # the shared fixture defaults exists() to False.
+        mock_client.exists = AsyncMock(return_value=True)
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
@@ -2285,20 +2313,29 @@ class TestGraphStorage:
 
     @pytest.mark.asyncio
     async def test_upsert_edge(self, global_config, embed_func, mock_client):
-        mock_client.exists = AsyncMock(return_value=False)
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect(set()))
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
             await s.upsert_edge("A", "B", {"weight": "1.0", "description": "knows"})
-            # Should call index twice: once for ensuring source node, once for edge
-            assert mock_client.index.await_count == 2
+            # Three index calls: a placeholder for BOTH endpoints (neither
+            # exists here), then the edge. Materializing only the source would
+            # leave B with edges but no node document.
+            assert mock_client.index.await_count == 3
+            placeholder_ids = [
+                c.kwargs["id"]
+                for c in mock_client.index.await_args_list
+                if c.kwargs["index"] == s._nodes_index
+            ]
+            assert placeholder_ids == ["A", "B"]
 
     @pytest.mark.asyncio
     async def test_upsert_edge_uses_canonical_id_without_reverse_lookup(
         self, global_config, embed_func, mock_client
     ):
         """Reciprocal writes land on the same canonical _id, no exists(reverse)."""
-        mock_client.exists = AsyncMock(return_value=True)  # source node already exists
+        # Both endpoints already exist, so no placeholder writes.
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect({"A", "B"}))
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
@@ -2323,7 +2360,7 @@ class TestGraphStorage:
     ):
         """No per-write reverse-orientation cleanup — the fail-fast migration
         already guarantees the index is canonical before any write."""
-        mock_client.exists = AsyncMock(return_value=True)  # source exists
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect({"A", "B"}))
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
@@ -2343,6 +2380,7 @@ class TestGraphStorage:
     ):
         """Reciprocal edges in one batch collapse to a single canonical action,
         with no extra self-heal delete bulk."""
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect(set()))
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
@@ -2375,6 +2413,16 @@ class TestGraphStorage:
             assert index_actions[0]["_id"] == _canonical_edge_id("A", "B")
             # last-write-wins within the batch
             assert index_actions[0]["_source"]["weight"] == "2.0"
+
+            # BOTH endpoints get a placeholder node, not just the sources: a
+            # target-only endpoint would carry edges with no node document.
+            node_ids = sorted(
+                a["_id"]
+                for call in bulk_calls
+                for a in call
+                if a["_index"] == s._nodes_index
+            )
+            assert node_ids == ["A", "B"]
 
     @pytest.mark.asyncio
     async def test_migrate_edges_to_canonical_id_reindexes_legacy_docs(
@@ -2998,7 +3046,7 @@ class TestGraphStorage:
     async def test_upsert_after_drop_recreates_indices(
         self, global_config, embed_func, mock_client
     ):
-        mock_client.exists = AsyncMock(return_value=False)
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect(set()))
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             with patch.object(
@@ -3009,7 +3057,8 @@ class TestGraphStorage:
                 await s.drop()
                 await s.upsert_edge("A", "B", {"weight": "1.0"})
                 mock_create.assert_awaited_once()
-                assert mock_client.index.await_count == 2
+                # Placeholder for both endpoints, then the edge.
+                assert mock_client.index.await_count == 3
 
     @pytest.mark.asyncio
     async def test_reads_short_circuit_after_drop(
@@ -3146,6 +3195,9 @@ class TestGraphStorage:
                 },
             }
         )
+        # Ranked endpoints are confirmed against the node index before they can
+        # occupy a slot (an edge endpoint is not proof of an entity).
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect({"A", "B"}))
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
@@ -3312,7 +3364,7 @@ class TestGraphStorage:
     async def test_drop_partial_error_marks_indices_not_ready_and_next_upsert_recreates_indices(
         self, global_config, embed_func, mock_client
     ):
-        mock_client.exists = AsyncMock(return_value=False)
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect(set()))
         mock_client.indices.delete = AsyncMock(
             side_effect=[None, OpenSearchException("edges drop failed")]
         )
@@ -5286,3 +5338,458 @@ class TestEmbeddingBatchNumDiagnosis:
         assert embed16.call_count == math.ceil(100 / 16) == 7
         assert embed32.call_count == math.ceil(100 / 32) == 4
         assert embed16.call_count != embed32.call_count
+
+
+# ---------------------------------------------------------------------------
+# Graph read contracts shared with the other backends
+# ---------------------------------------------------------------------------
+
+
+class TestGraphReadContract:
+    """Isolated entities must still be ranked, and an absent node must be
+    distinguishable from an isolated one.
+
+    Both used to answer with a value that means something else: the degree
+    ranking was derived purely from the edge index (where an entity with no
+    relations has no document at all), and get_node_edges returned ``[]`` for a
+    node that does not exist -- the same value an existing isolated node yields.
+    """
+
+    def _make(self, global_config, embed_func, workspace="test"):
+        return OpenSearchGraphStorage(
+            namespace="chunk_entity_relation",
+            global_config=global_config,
+            embedding_func=embed_func,
+            workspace=workspace,
+        )
+
+    @staticmethod
+    def _aggs(src_buckets, tgt_buckets):
+        return {
+            "hits": {"hits": [], "total": {"value": 0}},
+            "aggregations": {
+                "src": {"buckets": src_buckets},
+                "tgt": {"buckets": tgt_buckets},
+                "status_counts": {"buckets": []},
+            },
+        }
+
+    @staticmethod
+    def _node_page(ids):
+        return {
+            "hits": {
+                "hits": [{"_id": i, "sort": [i]} for i in ids],
+                "total": {"value": len(ids)},
+            }
+        }
+
+    # -- get_popular_labels -------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_popular_labels_backfills_isolated_nodes(
+        self, global_config, embed_func, mock_client
+    ):
+        """Degree-0 entities fill the remaining slots instead of vanishing.
+
+        Regression: the ranking came only from the edge index aggregation, so a
+        graph of entities with no relations reported an empty popular-label
+        list even though every one of those entities exists.
+        """
+        mock_client.search = AsyncMock(
+            side_effect=[
+                self._aggs(
+                    [{"key": "A", "doc_count": 5}], [{"key": "B", "doc_count": 2}]
+                ),
+                self._node_page(["A", "B", "Orphan1", "Orphan2"]),
+            ]
+        )
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect({"A", "B"}))
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            labels = await s.get_popular_labels(limit=10)
+
+        # Connected entities first (by degree), then the isolated ones in label
+        # order -- and the already-ranked ids are not repeated.
+        assert labels == ["A", "B", "Orphan1", "Orphan2"]
+        mock_client.create_pit.assert_awaited_once()
+        mock_client.delete_pit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("shard_doc_supported", [False, True])
+    async def test_isolated_backfill_sorts_by_label_not_shard_order(
+        self, global_config, embed_func, mock_client, shard_doc_supported
+    ):
+        """The isolated-node scan must sort on entity_id explicitly.
+
+        Every degree-0 label ties, so the scan order IS the tie-break — and the
+        scan exits as soon as it has enough labels. Reusing the pagination
+        helper ``_pit_sort_with_field`` would collapse to ``_shard_doc`` on
+        OpenSearch >= 3.3, making the backfill return an arbitrary shard-ordered
+        subset and omit alphabetically earlier entities.
+        ``get_all_labels`` tolerates that helper only because it reads every page
+        and re-sorts in Python afterwards.
+        """
+        mock_client.search = AsyncMock(
+            side_effect=[
+                self._aggs([{"key": "A", "doc_count": 1}], []),
+                self._node_page(["A", "Orphan"]),
+            ]
+        )
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect({"A"}))
+        with patch.object(
+            lightrag.kg.opensearch_impl, "_shard_doc_supported", shard_doc_supported
+        ):
+            with patch.object(ClientManager, "get_client", return_value=mock_client):
+                s = self._make(global_config, embed_func)
+                await s.initialize()
+                await s.get_popular_labels(limit=10)
+
+        # The PRIMARY sort key must be entity_id ascending on every cluster
+        # version — an added tiebreaker would be harmless, a _shard_doc primary
+        # is the bug.
+        scan_body = mock_client.search.call_args_list[-1].kwargs["body"]
+        assert scan_body["sort"][0] == {"entity_id": {"order": "asc"}}, (
+            f"isolated backfill must sort on entity_id "
+            f"(_shard_doc_supported={shard_doc_supported}), got {scan_body['sort']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_popular_labels_skips_node_scan_when_limit_already_filled(
+        self, global_config, embed_func, mock_client
+    ):
+        """A large graph must not pay for the isolated-node scan: every slot is
+        already taken by an entity with degree >= 1."""
+        mock_client.search = AsyncMock(
+            return_value=self._aggs(
+                [{"key": "A", "doc_count": 5}, {"key": "B", "doc_count": 2}], []
+            )
+        )
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect({"A", "B"}))
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            labels = await s.get_popular_labels(limit=2)
+
+        assert labels == ["A", "B"]
+        mock_client.create_pit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_popular_labels_breaks_degree_ties_on_label(
+        self, global_config, embed_func, mock_client
+    ):
+        """Equal degrees sort by label ascending, like the SQL/Cypher backends,
+        instead of falling back to aggregation bucket order."""
+        mock_client.search = AsyncMock(
+            return_value=self._aggs(
+                [{"key": "Zeta", "doc_count": 1}, {"key": "Alpha", "doc_count": 1}], []
+            )
+        )
+        mock_client.mget = AsyncMock(
+            side_effect=_node_mget_side_effect({"Zeta", "Alpha"})
+        )
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            assert await s.get_popular_labels(limit=2) == ["Alpha", "Zeta"]
+
+    # -- get_node_edges -----------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_get_node_edges_returns_none_for_missing_node(
+        self, global_config, embed_func, mock_client
+    ):
+        mock_client.search = AsyncMock(
+            return_value={"hits": {"hits": [], "total": {"value": 0}}}
+        )
+        mock_client.exists = AsyncMock(return_value=False)
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            assert await s.get_node_edges("NoSuchEntity") is None
+
+    @pytest.mark.asyncio
+    async def test_get_node_edges_returns_empty_list_for_isolated_node(
+        self, global_config, embed_func, mock_client
+    ):
+        mock_client.search = AsyncMock(
+            return_value={"hits": {"hits": [], "total": {"value": 0}}}
+        )
+        mock_client.exists = AsyncMock(return_value=True)
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            assert await s.get_node_edges("Lonely") == []
+
+    @pytest.mark.asyncio
+    async def test_get_node_edges_returns_edges_for_an_existing_node(
+        self, global_config, embed_func, mock_client
+    ):
+        mock_client.search = AsyncMock(
+            return_value={
+                "hits": {
+                    "hits": [
+                        {
+                            "_id": "e1",
+                            "_source": {"source_node_id": "A", "target_node_id": "B"},
+                            "sort": [1],
+                        }
+                    ],
+                    "total": {"value": 1},
+                }
+            }
+        )
+        mock_client.exists = AsyncMock(return_value=True)
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            assert await s.get_node_edges("A") == [("A", "B")]
+
+    @pytest.mark.asyncio
+    async def test_get_node_edges_returns_none_for_a_dangling_target_endpoint(
+        self, global_config, embed_func, mock_client
+    ):
+        """Having edges does NOT prove the node exists in this backend.
+
+        Writes now materialize both endpoints, but documents indexed before that
+        change can still hold an id that appears only as an edge target with no
+        node document. Inferring existence from the edge scan would make this
+        method answer "exists, here are its edges" for an id that has_node()
+        reports absent — and delete_entity 404s on has_node(). The read must not
+        depend on a write-path invariant that older data does not satisfy.
+        """
+        mock_client.search = AsyncMock(
+            return_value={
+                "hits": {
+                    "hits": [
+                        {
+                            "_id": "e1",
+                            "_source": {
+                                "source_node_id": "A",
+                                "target_node_id": "Target",
+                            },
+                            "sort": [1],
+                        }
+                    ],
+                    "total": {"value": 1},
+                }
+            }
+        )
+        mock_client.exists = AsyncMock(return_value=False)  # no node document
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            assert await s.get_node_edges("Target") is None
+            # The absent node also skips the PIT scan entirely.
+            mock_client.create_pit.assert_not_awaited()
+
+
+class TestGraphEndpointPlaceholderSafety:
+    """A placeholder write for an edge endpoint must never destroy a real node.
+
+    Two independent guards, because either one alone leaves a hole:
+
+    1. ``has_nodes_batch`` must not report an ambiguous mget item as absent —
+       an item-level error or a short ``docs`` array is "unknown", and the edge
+       writers turn "absent" into a placeholder write.
+    2. The placeholder write itself is insert-only, so even a probe that raced
+       a concurrent writer cannot cost the node its properties.
+    """
+
+    def _make(self, global_config, embed_func, workspace="test"):
+        return OpenSearchGraphStorage(
+            namespace="chunk_entity_relation",
+            global_config=global_config,
+            embedding_func=embed_func,
+            workspace=workspace,
+        )
+
+    @pytest.mark.asyncio
+    async def test_has_nodes_batch_raises_on_item_level_error(
+        self, global_config, embed_func, mock_client
+    ):
+        """An mget item carrying an `error` is UNKNOWN, never "absent".
+
+        OpenSearch answers mget with HTTP 200 even when an individual item
+        failed (unavailable shard). Reading the missing `found` flag as absent
+        would make upsert_edge overwrite a live node with a bare placeholder.
+        """
+        mock_client.mget = AsyncMock(
+            return_value={
+                "docs": [
+                    {"_id": "A", "found": True, "_source": {"entity_id": "A"}},
+                    {"_id": "B", "error": {"type": "shard_unavailable"}},
+                ]
+            }
+        )
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            with pytest.raises(RuntimeError, match="mget item error"):
+                await s.has_nodes_batch(["A", "B"])
+
+    @pytest.mark.asyncio
+    async def test_has_nodes_batch_raises_on_short_docs_array(
+        self, global_config, embed_func, mock_client
+    ):
+        """A response with fewer items than ids requested is malformed, not a
+        set of confirmed misses for the ids that fell off the end."""
+        mock_client.mget = AsyncMock(
+            return_value={
+                "docs": [{"_id": "A", "found": True, "_source": {"entity_id": "A"}}]
+            }
+        )
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            with pytest.raises(RuntimeError, match="expected exactly 2"):
+                await s.has_nodes_batch(["A", "B"])
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_probe_never_reaches_the_placeholder_write(
+        self, global_config, embed_func, mock_client
+    ):
+        """End to end: upsert_edge fails loudly instead of placeholdering.
+
+        This is the actual data-loss path — an ambiguous probe result feeding a
+        placeholder write that would replace a node's description/source_ids.
+        """
+        mock_client.mget = AsyncMock(
+            return_value={
+                "docs": [
+                    {"_id": "A", "error": {"type": "shard_unavailable"}},
+                    {"_id": "B", "found": False},
+                ]
+            }
+        )
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            with pytest.raises(RuntimeError, match="mget item error"):
+                await s.upsert_edge("A", "B", {"weight": "1.0"})
+            # Nothing was written: not the placeholder, not the edge.
+            assert mock_client.index.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_placeholder_write_is_insert_only(
+        self, global_config, embed_func, mock_client
+    ):
+        """op_type=create, not a plain index.
+
+        The index API REPLACES the document, so a placeholder written over an
+        endpoint that already carries a real description / entity_type /
+        source_ids would silently strip them. Insert-only makes the write safe
+        even when the probe raced a concurrent writer that created the node.
+        """
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect(set()))
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            await s.upsert_edge("A", "B", {"weight": "1.0"})
+
+        node_writes = [
+            c
+            for c in mock_client.index.await_args_list
+            if c.kwargs["index"] == s._nodes_index
+        ]
+        assert [c.kwargs["id"] for c in node_writes] == ["A", "B"]
+        assert all(c.kwargs.get("op_type") == "create" for c in node_writes), (
+            "placeholder writes must be insert-only so they cannot replace a "
+            "node that already holds real properties"
+        )
+        # The edge itself is still a plain index (last-write-wins by design).
+        edge_writes = [
+            c
+            for c in mock_client.index.await_args_list
+            if c.kwargs["index"] == s._edges_index
+        ]
+        assert len(edge_writes) == 1
+        assert edge_writes[0].kwargs.get("op_type") is None
+
+    @pytest.mark.asyncio
+    async def test_placeholder_conflict_is_not_an_error(
+        self, global_config, embed_func, mock_client
+    ):
+        """A 409 means the endpoint was created between probe and write —
+        exactly the race insert-only exists to survive, so the edge write must
+        carry on rather than fail the document."""
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect(set()))
+
+        async def _index(index=None, id=None, body=None, **kwargs):
+            if kwargs.get("op_type") == "create":
+                raise ConflictError(409, "version_conflict_engine_exception", {})
+            return {"result": "created"}
+
+        mock_client.index = AsyncMock(side_effect=_index)
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            await s.upsert_edge("A", "B", {"weight": "1.0"})
+
+        # Both placeholders 409'd, and the edge was still written.
+        edge_writes = [
+            c
+            for c in mock_client.index.await_args_list
+            if c.kwargs["index"] == s._edges_index
+        ]
+        assert len(edge_writes) == 1
+
+    @pytest.mark.asyncio
+    async def test_batch_placeholders_are_insert_only_and_tolerate_conflicts(
+        self, global_config, embed_func, mock_client
+    ):
+        """The batch path uses the same insert-only semantics, and a per-item
+        409 is filtered out instead of failing the whole batch."""
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect(set()))
+        bulk_calls = []
+
+        async def capture_bulk(_client, actions, *args, **kwargs):
+            acts = list(actions)
+            bulk_calls.append(acts)
+            node_acts = [a for a in acts if a["_index"].endswith("-nodes")]
+            if node_acts:
+                # One endpoint lost the race and 409s — must not abort.
+                return (
+                    len(acts) - 1,
+                    [{"create": {"_id": node_acts[0]["_id"], "status": 409}}],
+                )
+            return (len(acts), [])
+
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk",
+                new=AsyncMock(side_effect=capture_bulk),
+            ):
+                await s.upsert_edges_batch([("A", "B", {"weight": "1.0"})])
+
+        node_acts = [
+            a for call in bulk_calls for a in call if a["_index"] == s._nodes_index
+        ]
+        assert sorted(a["_id"] for a in node_acts) == ["A", "B"]
+        assert all(a["_op_type"] == "create" for a in node_acts)
+
+    @pytest.mark.asyncio
+    async def test_batch_placeholder_non_conflict_error_fails_the_write(
+        self, global_config, embed_func, mock_client
+    ):
+        """A non-409 placeholder failure must not be swallowed: the edge would
+        otherwise land against an endpoint that was never created."""
+        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect(set()))
+
+        async def capture_bulk(_client, actions, *args, **kwargs):
+            acts = list(actions)
+            if any(a["_index"].endswith("-nodes") for a in acts):
+                return (0, [{"create": {"_id": "A", "status": 503}}])
+            return (len(acts), [])
+
+        with patch.object(ClientManager, "get_client", return_value=mock_client):
+            s = self._make(global_config, embed_func)
+            await s.initialize()
+            with patch(
+                "lightrag.kg.opensearch_impl.helpers.async_bulk",
+                new=AsyncMock(side_effect=capture_bulk),
+            ):
+                with pytest.raises(RuntimeError, match="endpoint placeholder"):
+                    await s.upsert_edges_batch([("A", "B", {"weight": "1.0"})])

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -3195,9 +3195,6 @@ class TestGraphStorage:
                 },
             }
         )
-        # Ranked endpoints are confirmed against the node index before they can
-        # occupy a slot (an edge endpoint is not proof of an entity).
-        mock_client.mget = AsyncMock(side_effect=_node_mget_side_effect({"A", "B"}))
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()

--- a/tests/kg/opensearch_impl/test_opensearch_strict_reads.py
+++ b/tests/kg/opensearch_impl/test_opensearch_strict_reads.py
@@ -627,8 +627,10 @@ async def test_bfs_subgraph_transient_error_raises_not_reports_false_complete(
 def _bfs_mget_side_effect(real_nodes: dict):
     """Mock ``client.mget`` for both the single-id start-node lookup and the
     batched per-level neighbor resolution. Ids absent from `real_nodes` come
-    back ``found: False``, mirroring a dangling edge endpoint (upsert_edge
-    only guarantees the source node exists, never the target)."""
+    back ``found: False``, mirroring a dangling edge endpoint. Writes now
+    materialize both endpoints, so new data cannot produce one, but documents
+    written before that change still can and the traversal must keep tolerating
+    them."""
 
     async def _mget(index=None, body=None, **kwargs):
         docs = []
@@ -787,10 +789,12 @@ async def test_vector_query_missing_index_still_returns_empty(global_config):
 # ---------------------------------------------------------------------------
 
 
-async def test_upsert_edge_raises_when_has_node_check_fails(global_config):
+async def test_upsert_edge_raises_when_endpoint_existence_check_fails(global_config):
+    # upsert_edge materializes BOTH endpoints and probes them with one mget
+    # (has_nodes_batch), like upsert_edges_batch does.
     client = _make_graph_client()
     storage = await _make_graph(global_config, client)
-    client.exists = AsyncMock(side_effect=_transient_error())
+    client.mget = AsyncMock(side_effect=_transient_error())
     with pytest.raises(TransportError):
         await storage.upsert_edge("A", "B", {})
 

--- a/tests/kg/postgres_impl/test_postgres_cypher_injection.py
+++ b/tests/kg/postgres_impl/test_postgres_cypher_injection.py
@@ -42,6 +42,12 @@ class _FakeConnection:
         self.calls.append({"sql": sql, "args": args})
         return ""
 
+    async def fetch(self, sql, *args):
+        # upsert_edge runs its Cypher through fetch() and raises when the result
+        # is empty (endpoints missing -> edge silently dropped), so return a row.
+        self.calls.append({"sql": sql, "args": args})
+        return [{"r": "edge"}]
+
 
 class _FakeTransaction:
     async def __aenter__(self):

--- a/tests/kg/postgres_impl/test_postgres_graph_batch.py
+++ b/tests/kg/postgres_impl/test_postgres_graph_batch.py
@@ -44,6 +44,12 @@ class _FakeConnection:
         self._capture.calls.append({"sql": sql, "args": args})
         return ""
 
+    async def fetch(self, sql, *args):
+        # The edge chunk path runs each Cypher through fetch() and raises when a
+        # statement returns no created edge (missing endpoints), so return a row.
+        self._capture.calls.append({"sql": sql, "args": args})
+        return [{"r": "edge"}]
+
 
 def make_graph_storage(
     *,

--- a/tests/kg/postgres_impl/test_postgres_graph_read_contract.py
+++ b/tests/kg/postgres_impl/test_postgres_graph_read_contract.py
@@ -1,0 +1,230 @@
+"""Unit tests for PGGraphStorage read-path contracts shared with the other
+graph backends.
+
+Covers two divergences from ``BaseGraphStorage`` / ``NetworkXStorage``:
+
+1. ``get_popular_labels`` ranked nodes purely from edge-derived degrees, so an
+   entity with no relations (degree 0) had no row to join against and vanished
+   from the ranking entirely — a graph of unconnected entities reported an
+   empty picker. It now tops the result up from the isolated entities, but only
+   when the connected ones come up short of ``limit``.
+2. ``get_node_edges`` returned ``[]`` for a node that does not exist, which is
+   the same value an existing-but-isolated node yields — collapsing "no such
+   node" into "no edges". The contract (and NetworkX/PGOps) is ``None``.
+"""
+
+import re
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from lightrag.kg.postgres_impl import PGGraphQueryException, PGGraphStorage
+
+
+def make_graph_storage() -> PGGraphStorage:
+    """Construct a PGGraphStorage instance with a mocked db."""
+    storage = PGGraphStorage.__new__(PGGraphStorage)
+    storage.workspace = "test_ws"
+    storage.namespace = "test_graph"
+    storage.graph_name = "test_graph"
+    storage.__post_init__()
+    storage.db = MagicMock()
+    return storage
+
+
+def _normalize(sql: str) -> str:
+    """Collapse whitespace so multi-line SQL can be matched as one string."""
+    return re.sub(r"\s+", " ", sql).strip()
+
+
+# ---------------------------------------------------------------------------
+# get_popular_labels: connected first, isolated (degree-0) nodes to top up
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_popular_labels_ranks_from_edges_without_scanning_the_vertices():
+    """Phase 1 is the cheap edge-derived ranking, and on a graph with enough
+    connected entities it is the ONLY query that runs.
+
+    Any real graph holds far more entities than `limit`, so driving the whole
+    ranking off the vertex table (one LEFT JOIN) would mean a full vertex scan
+    on every call to produce a result phase 1 already had.
+    """
+    storage = make_graph_storage()
+    storage._query = AsyncMock(return_value=[{"label": f"E{i}"} for i in range(7)])
+
+    labels = await storage.get_popular_labels(limit=7)
+
+    assert labels == [f"E{i}" for i in range(7)]
+    assert storage._query.await_count == 1, "the limit was filled; no second query"
+
+    sql = _normalize(storage._query.await_args.args[0])
+    # Degrees drive the join, and the vertex table is only probed for the ids
+    # that actually have edges.
+    assert "FROM node_degrees d JOIN test_graph._ag_label_vertex v" in sql, sql
+    assert "LIMIT $1" in sql
+    assert storage._query.await_args.kwargs["params"] == {"limit": 7}
+
+
+@pytest.mark.asyncio
+async def test_popular_labels_tops_up_from_isolated_when_short():
+    """Regression: a graph whose entities carry no relations reported ZERO
+    popular labels, because an entity with no edge has no row in node_degrees
+    and the inner join dropped it.
+
+    Phase 1 coming up short is exactly that signal — its aggregate is exact, so
+    every remaining vertex is isolated — and the top-up is bounded by the
+    shortfall, so even a sequential vertex scan stays cheap.
+    """
+    storage = make_graph_storage()
+    storage._query = AsyncMock(
+        side_effect=[
+            [{"label": "Connected"}],
+            [{"label": "Aardvark"}, {"label": "Orphan"}],
+        ]
+    )
+
+    labels = await storage.get_popular_labels(limit=3)
+
+    # Connected first, then isolated in label order.
+    assert labels == ["Connected", "Aardvark", "Orphan"]
+    assert storage._query.await_count == 2
+
+    isolated_sql = _normalize(storage._query.await_args_list[1].args[0])
+    # Isolated == no edge names it, at either end.
+    assert (
+        "NOT EXISTS ( SELECT 1 FROM test_graph._ag_label_edge e WHERE e.start_id = v.id )"
+        in isolated_sql
+    ), isolated_sql
+    assert (
+        "NOT EXISTS ( SELECT 1 FROM test_graph._ag_label_edge e WHERE e.end_id = v.id )"
+        in isolated_sql
+    ), isolated_sql
+    # Only the shortfall is requested.
+    assert storage._query.await_args_list[1].kwargs["params"] == {"limit": 2}
+
+
+@pytest.mark.asyncio
+async def test_popular_labels_orders_by_degree_then_bytewise_label():
+    """Ties break on a byte-order label sort, matching Python's code-point sort.
+
+    With degree-0 entities able to fill the tail, ties at the cutoff decide
+    which labels survive the LIMIT — so the tie-break has to agree with the
+    other backends instead of following the database's locale collation.
+    """
+    storage = make_graph_storage()
+    storage._query = AsyncMock(return_value=[{"label": f"E{i}"} for i in range(3)])
+
+    await storage.get_popular_labels(limit=3)
+
+    sql = _normalize(storage._query.await_args.args[0])
+    assert 'ORDER BY degree DESC, label COLLATE "C" ASC' in sql
+    # The isolated top-up orders on the label alone (every row is degree 0).
+    storage._query = AsyncMock(side_effect=[[], []])
+    await storage.get_popular_labels(limit=3)
+    isolated_sql = _normalize(storage._query.await_args_list[1].args[0])
+    assert 'ORDER BY label COLLATE "C" ASC' in isolated_sql
+
+
+@pytest.mark.asyncio
+async def test_get_popular_labels_returns_labels_in_query_order():
+    """Rows are passed through in the order the database ranked them."""
+    storage = make_graph_storage()
+    storage._query = AsyncMock(
+        return_value=[{"label": "Alpha"}, {"label": "Beta"}, {"label": "Isolated"}]
+    )
+
+    assert await storage.get_popular_labels(limit=3) == ["Alpha", "Beta", "Isolated"]
+
+
+# ---------------------------------------------------------------------------
+# Label helpers: a database error is not "no labels"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_popular_labels_raises_on_query_error():
+    """A failed query must not be reported as an empty graph.
+
+    Regression: the handler logged and returned []. The
+    ``/graph/label/popular`` route already converts an exception into a 500, so
+    swallowing it here handed the WebUI a 200 with an empty entity picker while
+    the database was unreachable — indistinguishable from a graph that really
+    holds no entities.
+    """
+    storage = make_graph_storage()
+    boom = PGGraphQueryException({"message": "connection reset"})
+    storage._query = AsyncMock(side_effect=boom)
+
+    with pytest.raises(PGGraphQueryException):
+        await storage.get_popular_labels(limit=10)
+
+
+@pytest.mark.asyncio
+async def test_search_labels_raises_on_query_error():
+    """Same reasoning: "no match" and "the query failed" are different answers."""
+    storage = make_graph_storage()
+    storage._query = AsyncMock(side_effect=PGGraphQueryException({"message": "boom"}))
+
+    with pytest.raises(PGGraphQueryException):
+        await storage.search_labels("alpha")
+
+
+@pytest.mark.asyncio
+async def test_search_labels_still_short_circuits_on_blank_query():
+    """An empty query is a real "nothing to match", not an error."""
+    storage = make_graph_storage()
+    storage._query = AsyncMock(side_effect=AssertionError("must not be reached"))
+
+    assert await storage.search_labels("   ") == []
+
+
+# ---------------------------------------------------------------------------
+# get_node_edges: absent node vs isolated node
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_node_edges_returns_none_for_missing_node():
+    """No rows at all means the anchor MATCH failed: the node does not exist.
+
+    Regression: PGGraphStorage returned ``[]`` here while NetworkXStorage and
+    PGOpsGraphStorage return ``None``, so callers could not tell a missing
+    entity from an isolated one.
+    """
+    storage = make_graph_storage()
+    storage._query = AsyncMock(return_value=[])
+
+    assert await storage.get_node_edges("NoSuchEntity") is None
+
+
+@pytest.mark.asyncio
+async def test_get_node_edges_returns_empty_list_for_isolated_node():
+    """An existing node with no relations still yields one row (OPTIONAL MATCH).
+
+    That row carries a NULL connected_id and must degrade to ``[]`` — not to
+    ``None``, which would now mean "the node is gone".
+    """
+    storage = make_graph_storage()
+    storage._query = AsyncMock(
+        return_value=[{"source_id": "Lonely", "connected_id": None}]
+    )
+
+    assert await storage.get_node_edges("Lonely") == []
+
+
+@pytest.mark.asyncio
+async def test_get_node_edges_returns_connected_pairs():
+    """Connected nodes come back as (source, connected) tuples."""
+    storage = make_graph_storage()
+    storage._query = AsyncMock(
+        return_value=[
+            {"source_id": "Alpha", "connected_id": "Beta"},
+            {"source_id": "Alpha", "connected_id": "Gamma"},
+        ]
+    )
+
+    assert await storage.get_node_edges("Alpha") == [
+        ("Alpha", "Beta"),
+        ("Alpha", "Gamma"),
+    ]

--- a/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
+++ b/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
@@ -15,6 +15,7 @@ import asyncpg
 from tenacity import wait_none
 
 from lightrag.kg.postgres_impl import (
+    PGGraphEdgeWriteLostError,
     PGGraphQueryException,
     PGGraphStorage,
     _is_transient_graph_write_error,
@@ -38,10 +39,16 @@ def make_graph_storage() -> PGGraphStorage:
 
 
 class _FakeConnection:
-    """Captures statements + args passed to a fake asyncpg connection."""
+    """Captures statements + args passed to a fake asyncpg connection.
 
-    def __init__(self):
+    ``fetch`` returns one row by default: the edge upsert runs its Cypher via
+    fetch() and treats an empty result as "the edge was not written" (see
+    PGGraphEdgeWriteLostError), so the happy path must hand back a row.
+    """
+
+    def __init__(self, edge_rows: list | None = None):
         self.calls: list[dict] = []
+        self._edge_rows = [{"r": "edge"}] if edge_rows is None else edge_rows
 
     def transaction(self):
         return _FakeTransaction()
@@ -49,6 +56,10 @@ class _FakeConnection:
     async def execute(self, sql, *args):
         self.calls.append({"sql": sql, "args": args})
         return ""
+
+    async def fetch(self, sql, *args):
+        self.calls.append({"sql": sql, "args": args})
+        return self._edge_rows
 
 
 class _FakeTransaction:
@@ -391,3 +402,168 @@ async def test_upsert_edges_batch_dedupes_last_write_wins():
     assert '"first"' not in cypher_calls[0]["sql"]
     params_json = cypher_calls[0]["args"][0]
     assert json.loads(params_json) == {"src_id": "B", "tgt_id": "A"}
+
+
+# ---------------------------------------------------------------------------
+# Missing endpoints: the edge must not be dropped silently
+# ---------------------------------------------------------------------------
+
+
+class _MissingEndpointConnection(_FakeConnection):
+    """Fake connection where the edge CREATE matches nothing.
+
+    Mirrors AGE's behaviour when an endpoint is absent: ``MATCH (source) ...
+    MATCH (target)`` fails to match, so the whole pattern -- including the
+    CREATE -- produces no rows, and the statement still succeeds. The endpoint
+    probe that follows reports whichever ids were asked for as absent.
+    """
+
+    def __init__(self, present: set[str] | None = None):
+        super().__init__(edge_rows=[])
+        self._present = present or set()
+
+    async def fetch(self, sql, *args):
+        self.calls.append({"sql": sql, "args": args})
+        if "unnest(" in sql:  # the endpoint-existence probe
+            return [
+                {"entity_id": node_id}
+                for node_id in args[0]
+                if node_id in self._present
+            ]
+        return []  # the edge upsert: nothing created
+
+
+async def _run_upsert_edge(storage: PGGraphStorage, conn, src, tgt, edge_data=None):
+    async def fake_run_with_retry(operation, **_kwargs):
+        return await operation(conn)
+
+    storage.db._run_with_retry = AsyncMock(side_effect=fake_run_with_retry)
+    await storage.upsert_edge(src, tgt, edge_data or {"weight": "1.0"})
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_raises_when_no_edge_was_created(monkeypatch):
+    """An edge whose endpoints are missing must raise, not vanish.
+
+    Regression: the Cypher is ``MATCH (source) ... MATCH (target) ... CREATE``.
+    If either endpoint does not exist the pattern matches nothing, AGE reports
+    success with zero rows, and the relation was silently lost -- no exception,
+    no log line, and the caller believed the write landed.
+    """
+    monkeypatch.setattr(PGGraphStorage.upsert_edge.retry, "wait", wait_none())
+    storage = make_graph_storage()
+    conn = _MissingEndpointConnection(present={"Alice"})
+
+    with pytest.raises(PGGraphEdgeWriteLostError) as excinfo:
+        await _run_upsert_edge(storage, conn, "Alice", "Bob")
+
+    error = excinfo.value
+    # The message names the endpoint that is actually missing.
+    assert error.missing_endpoints == ("Bob",)
+    assert "`Bob`" in str(error)
+    assert "Alice" in str(error) and "test_graph" in str(error)
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_write_lost_error_is_not_retried(monkeypatch):
+    """A missing endpoint is deterministic — retrying it just wastes time."""
+    monkeypatch.setattr(PGGraphStorage.upsert_edge.retry, "wait", wait_none())
+    storage = make_graph_storage()
+    conn = _MissingEndpointConnection()
+
+    call_count = 0
+
+    async def fake_run_with_retry(operation, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        return await operation(conn)
+
+    storage.db._run_with_retry = AsyncMock(side_effect=fake_run_with_retry)
+
+    with pytest.raises(PGGraphEdgeWriteLostError):
+        await storage.upsert_edge("Alice", "Bob", {"weight": "1.0"})
+
+    assert call_count == 1
+    # It is a PGGraphQueryException subclass, so the existing except-clauses in
+    # upsert_edge re-raise it unchanged instead of re-wrapping it...
+    assert issubclass(PGGraphEdgeWriteLostError, PGGraphQueryException)
+    # ... and the transient-error predicate does not classify it as retryable.
+    assert _is_transient_graph_write_error(
+        PGGraphEdgeWriteLostError("g", "A", "B")
+    ) is (False)
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_reports_both_endpoints_when_neither_exists(monkeypatch):
+    monkeypatch.setattr(PGGraphStorage.upsert_edge.retry, "wait", wait_none())
+    storage = make_graph_storage()
+    conn = _MissingEndpointConnection(present=set())
+
+    with pytest.raises(PGGraphEdgeWriteLostError) as excinfo:
+        await _run_upsert_edge(storage, conn, "Alice", "Bob")
+
+    assert excinfo.value.missing_endpoints == ("Alice", "Bob")
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_still_raises_when_probe_finds_both_endpoints(monkeypatch):
+    """Zero created edges is an error even when the endpoints look present.
+
+    A concurrent endpoint deletion can land between the CREATE and the probe.
+    Nothing was written either way, so the caller must still hear about it.
+    """
+    monkeypatch.setattr(PGGraphStorage.upsert_edge.retry, "wait", wait_none())
+    storage = make_graph_storage()
+    conn = _MissingEndpointConnection(present={"Alice", "Bob"})
+
+    with pytest.raises(PGGraphEdgeWriteLostError) as excinfo:
+        await _run_upsert_edge(storage, conn, "Alice", "Bob")
+
+    assert excinfo.value.missing_endpoints == ()
+    assert "concurrent" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_upsert_edges_batch_raises_and_rolls_back_the_chunk(monkeypatch):
+    """One dropped edge fails the whole chunk transaction.
+
+    The chunk is a single transaction, so this matches the existing
+    all-or-nothing behaviour for any mid-chunk failure -- and the edges that did
+    CREATE are rolled back rather than left as a partial write.
+    """
+    monkeypatch.setattr(PGGraphStorage._upsert_edge_chunk.retry, "wait", wait_none())
+    storage = make_graph_storage()
+    conn = _MissingEndpointConnection(present={"A"})
+
+    async def fake_run_with_retry(operation, **_kwargs):
+        return await operation(conn)
+
+    storage.db._run_with_retry = AsyncMock(side_effect=fake_run_with_retry)
+
+    with pytest.raises(PGGraphEdgeWriteLostError) as excinfo:
+        await storage.upsert_edges_batch(
+            [("A", "B", {"weight": "1"}), ("A", "C", {"weight": "2"})]
+        )
+
+    # Fails on the first edge of the chunk; the second never runs.
+    assert (excinfo.value.source_node_id, excinfo.value.target_node_id) == ("A", "B")
+    cypher_calls = [c for c in conn.calls if "CREATE (source)-[r:DIRECTED" in c["sql"]]
+    assert len(cypher_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_edge_endpoint_probe_failure_does_not_mask_the_error(monkeypatch):
+    """The diagnostic probe is best-effort: its failure must not hide the drop."""
+    monkeypatch.setattr(PGGraphStorage.upsert_edge.retry, "wait", wait_none())
+    storage = make_graph_storage()
+
+    class _ProbeExplodes(_MissingEndpointConnection):
+        async def fetch(self, sql, *args):
+            if "unnest(" in sql:
+                raise RuntimeError("transaction is aborted")
+            return await super().fetch(sql, *args)
+
+    with pytest.raises(PGGraphEdgeWriteLostError) as excinfo:
+        await _run_upsert_edge(storage, _ProbeExplodes(), "Alice", "Bob")
+
+    assert excinfo.value.missing_endpoints == ()

--- a/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
+++ b/tests/kg/postgres_impl/test_postgres_upsert_edge_cypher.py
@@ -488,9 +488,7 @@ async def test_upsert_edge_write_lost_error_is_not_retried(monkeypatch):
     # upsert_edge re-raise it unchanged instead of re-wrapping it...
     assert issubclass(PGGraphEdgeWriteLostError, PGGraphQueryException)
     # ... and the transient-error predicate does not classify it as retryable.
-    assert _is_transient_graph_write_error(
-        PGGraphEdgeWriteLostError("g", "A", "B")
-    ) is (False)
+    assert not _is_transient_graph_write_error(PGGraphEdgeWriteLostError("g", "A", "B"))
 
 
 @pytest.mark.asyncio

--- a/tests/kg/test_batch_graph_operations.py
+++ b/tests/kg/test_batch_graph_operations.py
@@ -943,6 +943,13 @@ class TestPostgresBatchOrdering:
                 calls.append({"sql": sql, "args": args})
                 return ""
 
+            async def fetch(self, sql, *args):
+                # Edge upserts run through fetch(); an empty result means the
+                # endpoints were missing and the edge was dropped, which now
+                # raises — so hand back a created-edge row.
+                calls.append({"sql": sql, "args": args})
+                return [{"r": "edge"}]
+
         conn = _Conn()
 
         async def fake_run_with_retry(operation, **_kwargs):
@@ -1065,7 +1072,7 @@ class TestMongoBatchOrdering:
 
     @pytest.mark.offline
     @pytest.mark.asyncio
-    async def test_upsert_edges_batch_deduplicates_source_node_upserts(self):
+    async def test_upsert_edges_batch_materializes_and_dedupes_endpoint_upserts(self):
         pytest.importorskip("pymongo")
         from lightrag.kg.mongo_impl import (
             MongoGraphStorage,
@@ -1091,9 +1098,16 @@ class TestMongoBatchOrdering:
             ],
         )
 
+        # Every endpoint of every edge gets a placeholder node — both ends, not
+        # just the sources, so no edge is left pointing at a node document that
+        # does not exist. EntityA appears as the source of both edges and must
+        # still collapse to a single op.
         node_ops = storage.collection.bulk_write.await_args.args[0]
-        assert len(node_ops) == 1
-        assert node_ops[0]._filter == {"_id": "EntityA"}
+        assert [op._filter["_id"] for op in node_ops] == [
+            "EntityA",
+            "EntityB",
+            "EntityC",
+        ]
 
 
 class TestPGTableBatchOrdering:

--- a/tests/kg/test_graph_storage.py
+++ b/tests/kg/test_graph_storage.py
@@ -1035,12 +1035,22 @@ async def test_graph_query_helpers(storage):
     Cover the whole-graph query helpers that the other tests don't touch:
     1. get_all_nodes  - every node as a dict carrying its "id".
     2. get_all_edges  - every edge as a dict carrying "source"/"target".
-    3. get_popular_labels - labels ordered by degree (highest first).
+    3. get_popular_labels - labels ordered by degree (highest first), INCLUDING
+       isolated (degree-0) entities, ties broken on the label ascending.
     4. search_labels  - substring/fuzzy label search.
+    5. get_node_edges - None for a node that does not exist, [] for one that
+       exists with no relations.
     """
     try:
-        # Star topology so degrees are distinct: Alpha=3, others=1.
-        node_ids = ["Alpha", "Beta", "Gamma", "Alphabet"]
+        # Star topology so degrees are distinct: Alpha=3, others=1. "Orphan" and
+        # "Aardvark" stay unconnected (degree 0) to pin two things at once:
+        #   * isolated entities are still ranked -- a backend deriving degrees
+        #     from its edge store has no row for them, and joining/aggregating
+        #     from that side alone drops them;
+        #   * their tie is broken on the LABEL, not on insertion order --
+        #     "Aardvark" is inserted last on purpose, so a backend that keeps
+        #     insertion order for ties returns it after "Orphan".
+        node_ids = ["Alpha", "Beta", "Gamma", "Alphabet", "Orphan", "Aardvark"]
         for nid in node_ids:
             await storage.upsert_node(
                 nid,
@@ -1082,6 +1092,21 @@ async def test_graph_query_helpers(storage):
             f"highest-degree label should be 'Alpha', got {popular}"
         )
 
+        # 3.1 Isolated entities must still be ranked (last, at degree 0) rather
+        # than excluded — they are entities the user can select in the WebUI —
+        # and their tie must break on the label, not on insertion order. The
+        # tie-break is what decides which labels survive a `limit`, so getting
+        # it wrong silently hides entities from the picker.
+        all_popular = await storage.get_popular_labels(limit=len(node_ids) + 5)
+        assert set(all_popular) == set(node_ids), (
+            f"get_popular_labels must rank every node, got {all_popular}"
+        )
+        assert all_popular[0] == "Alpha"
+        assert all_popular[-2:] == ["Aardvark", "Orphan"], (
+            "degree-0 nodes should rank last, ordered by label ascending "
+            f"(NOT insertion order), got {all_popular}"
+        )
+
         # 4. search_labels - substring / prefix match, and a clear miss
         print("== Testing search_labels")
         gamma_hits = await storage.search_labels("Gam")
@@ -1092,6 +1117,18 @@ async def test_graph_query_helpers(storage):
         )
         misses = await storage.search_labels("NoSuchEntityXYZ")
         assert "Alpha" not in misses and "Gamma" not in misses
+
+        # 5. get_node_edges - "no such node" and "node with no edges" are
+        # different answers: None vs []. A backend that returns an empty list
+        # for both makes a deleted entity indistinguishable from an isolated
+        # one. (A backend ERROR is neither value — it must raise.)
+        print("== Testing get_node_edges on absent vs isolated nodes")
+        assert await storage.get_node_edges("NoSuchEntityXYZ") is None, (
+            "get_node_edges must return None for a node that does not exist"
+        )
+        assert await storage.get_node_edges("Orphan") == [], (
+            "get_node_edges must return [] for an existing node with no edges"
+        )
 
         print("\nQuery helper tests completed.")
 


### PR DESCRIPTION
> Supersedes #3577 — same change, squashed to one commit and rebased on current `main`, with the description reorganised by theme rather than by the order things were found.

## Description

Two problems, both reported against `PGGraphStorage` and both found in other backends once looked for.

**1. `get_popular_labels` lost entities that have no relations.** Every backend that derives degrees from its edge store had the same hole — an entity with no edge has no row to rank, so it never appeared. A graph whose entities carry no relations reported an **empty entity picker**.

**2. Edge writes could leave the graph inconsistent.** On AGE a missing endpoint made the upsert silently write nothing; on Mongo and OpenSearch only the *source* endpoint was materialized, so a target-only id could end up with edge documents and no node document.

Fixing those surfaced three consistency defects on the same read paths (§3), and the resulting contract is now written down in `BaseGraphStorage` (§4) so the seven backends cannot drift again.

## Related Issues

Reported against `PGGraphStorage`:

1. `get_popular_labels` excluded every entity with degree 0.
2. `_build_upsert_edge_sql` silently dropped an edge when an endpoint was missing — no exception, no log line.
3. `get_node_edges` returned `[]` for a node that does not exist, where NetworkX returns `None`.

Defect 1 was then found in `mongo_impl` and `opensearch_impl`; defect 3 in `mongo_impl`, `neo4j_impl` and `memgraph_impl`.

## Changes Made

### 1. Popular labels: rank connected entities, top up from isolated ones only when short

Two phases, and the second almost never runs:

- **Phase 1** ranks the entities that *have* edges, from the edge-derived degrees. Any real graph holds far more than `limit` (default 300) connected entities, so this fills every slot on its own and the node store is never touched.
- **Phase 2** runs only when phase 1 comes up short — a small graph, which is exactly the case that used to return nothing. Its aggregate is exact, so coming up short also means the connected set is now known in full and every remaining entity is isolated by definition. The top-up is bounded by the shortfall (at most `limit` rows), which keeps it affordable even where it means a sequential scan of the node store.

| backend | phase 1 | phase 2 |
|---|---|---|
| PG/AGE | `node_degrees` ⨝ vertex table (index probes for ids that have edges) | second query, `NOT EXISTS` per endpoint column so both halves can use an index, `LIMIT` = shortfall |
| Mongo | aggregation on the edge collection | `find({_id: {$nin: …}}).sort(_id).limit(shortfall)` — rides the `_id` index, stops as soon as it has enough |
| OpenSearch | terms aggregation on the edges index | PIT scan of the node index in `entity_id` order, stops at the shortfall |

Driving the whole ranking off the node store instead is simpler to write and gives the same answer, but pays a full node-store pass on every call to produce a result phase 1 already had.

**Ties break on the label, ascending, everywhere.** `COLLATE "C"` on PG so it matches Python's code-point sort; an explicit sort key on OpenSearch, which had been falling back to aggregation bucket order; and `(-degree, label)` on **NetworkX**, the default backend, whose stable sort left ties in node insertion order — a graph that inserted `Zeta` before `Alpha` answered `?limit=1` with Zeta and dropped Alpha. With degree-0 entities now able to fill the tail, a tie at the cutoff decides which labels the caller never sees.

### 2. Edge writes

**AGE no longer loses edges silently.** The Cypher is `MATCH (source) … MATCH (target) … CREATE`: if either endpoint is absent the whole pattern fails to match, the statement **succeeds with zero rows**, and the relation is gone. Both write paths now run it through `fetch()` and check that an edge came back, raising `PGGraphEdgeWriteLostError` (a `PGGraphQueryException` subclass) otherwise. The error probes both endpoints so the message names the missing one; the probe is best-effort and can never mask the write loss. The batch path rolls the whole chunk back — same all-or-nothing behaviour as any other mid-chunk failure. Not retried: a missing endpoint is deterministic.

**Mongo and OpenSearch materialize both endpoints.** A target-only endpoint is a state where `has_node()` says absent while the edge scan says connected, and `delete_entity` 404s on an entity whose edges are right there. `NetworkXStorage.add_edge` and `PGOpsGraphStorage` create both ends; the document backends now do too. Mongo uses one `bulk_write` of `$setOnInsert` ops for the pair (deduped, so a self-loop writes one) — same round-trip count as the single `upsert_node` it replaces. OpenSearch covers the pair with one `has_nodes_batch` mget, then writes a placeholder for whichever endpoints are missing.

**That placeholder can never overwrite a real node** — two independent guards, because either alone leaves a hole:

- `has_nodes_batch` read `if doc.get("found")` straight off each mget item, so anything that was not an explicit `found: true` counted as absent, including an item-level `error` object (OpenSearch answers mget with HTTP 200 even when individual items fail on an unavailable shard) and a short or malformed `docs` array. It now goes through `_interpret_mget_item`, like every other mget read in that file, and rejects a `docs` array whose length does not match the request. This fixes every caller — entity merge/dedup read the same set.
- `upsert_node` goes through the plain index API, which **replaces** the document, so a placeholder written over a live endpoint would strip its description / entity_type / source_ids. Endpoint placeholders now use `op_type=create` with 409 tolerated, so the write is safe regardless of what the probe concluded — a concurrent writer can create the endpoint between probe and write. Non-409 bulk failures still fail the batch.

### 3. Read-path consistency defects found along the way

- **`get_node_edges` conflated "absent" with "no edges".** It returned `[]` for a node that does not exist — the same value an existing-but-isolated node yields. AGE, Neo4j and Memgraph now key on the anchor `MATCH` binding (an isolated node still yields exactly one row via `OPTIONAL MATCH`, so zero rows is the only "no such node" signal); Mongo and OpenSearch decide existence from the node store before the edge scan, which also makes an absent node cost one indexed point lookup instead of a full scan.
- **Backend errors were reported as "no labels".** `get_popular_labels` / `search_labels` logged and returned `[]` on any exception in AGE, Mongo and Memgraph. `/graph/label/popular` already turns an exception into a 500, so the swallow was the only thing between the user and an accurate error: the WebUI received 200 with an empty picker while the database was unreachable. They raise now. Deliberately preserved as real empty results: Mongo's progressive Atlas→regex fallback (a missing Atlas Search index is a capability gap, not a failure — only a failure of the final regex scan raises), blank queries, and a confirmed-empty node collection.

### 4. The contract, in `base.py`

`get_node_edges`: the three outcomes (`[]` / `None` / raise), and that `get_nodes_edges_batch` cannot express the middle one and flattens it by design. `get_popular_labels` / `search_labels`: the two-phase shape and why, the label tie-break, that errors raise, and that callers must tolerate a ranked label whose `get_node()` comes back empty (see *Scope* below).

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

**Scope — dangling endpoints are not filtered out of the ranking.** On Mongo and OpenSearch the degree ranking is keyed on edge endpoints, so an id with edge documents but no node document can appear in the picker. That is left alone on purpose:

- No in-tree path produces one. All six `upsert_edge`/`upsert_edges_batch` callers create both endpoints first; `delete_node`/`remove_nodes` delete edges **before** the node in both backends, so an interrupted delete leaves an isolated node rather than a dangling edge; and the purge path clears incident edges before removing an entity. §2 closes the remaining API-level hole going forward.
- The consequence is bounded and already handled: selecting such a label makes `get_knowledge_graph` log a warning and return an empty `KnowledgeGraph`, and the WebUI renders its "Graph Is Empty" placeholder. No crash, no silent wrong answer.
- Filtering for it would cost a join or an extra round trip on an interactive endpoint, every call, to prevent a client-side empty result. Repairing such data is `audit_kg_integrity`'s job.

**Behaviour changes reviewers should weigh.**

1. On PG/AGE, Mongo and Memgraph, `/graph/label/popular` and `/graph/label/search` now return **500 instead of 200 with an empty list** when the backend is down. Any client treating an empty list as "fine" will now see an error.
2. On Mongo and OpenSearch, an edge write also materializes the target endpoint. Existing dangling targets are not backfilled.
3. On OpenSearch, `has_nodes_batch` raises on an ambiguous mget item instead of reporting the id absent — a strictness increase shared with every other read in that file.

**No current caller is affected by the `None` change.** Every in-tree caller of `get_node_edges` guards with `if edges:` / `len(edges) if edges else 0`, and the batch sibling flattens `None` to `[]` by design. Returning `None` restores the declared contract and keeps the information recoverable; it does not change any existing call site's behaviour today.

**Tests.** Per-backend read-contract suites for AGE, Mongo, OpenSearch, Neo4j, Memgraph and NetworkX; edge-write-loss cases; `TestGraphEndpointPlaceholderSafety` covering both guards, including the end-to-end path (ambiguous probe → `upsert_edge` raises and writes nothing) and the 409 race. The popular-label tests assert behaviour rather than SQL/pipeline text: filling the limit must issue exactly one query and leave the node store untouched; coming up short must request only the shortfall.

The cross-backend integration suite `tests/kg/test_graph_storage.py` pins both contracts for every backend — two unconnected entities (`Orphan`, and `Aardvark` inserted last) must both be ranked, last, in label order rather than insertion order, and absent vs isolated must answer `None` vs `[]`. These assertions were held back until all seven backends conformed, so the shared suite never carried known-failing cases.

`tests/kg`: **1570 passed**. The 10 failures in `tests/kg/test_batch_graph_operations.py` reproduce on `main` unchanged (blocked tiktoken/pip downloads in the sandbox); the full-suite failure set is identical file-for-file with and without this branch.

https://claude.ai/code/session_01W3Y1u6KcuYQ8GLpToBMK7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3Y1u6KcuYQ8GLpToBMK7B)_