### PR TITLE
fix(parser): preserve skipped Markdown heading hierarchy

### DIFF
--- a/lightrag/parser/markdown/extract.py
+++ b/lightrag/parser/markdown/extract.py
@@ -282,7 +282,8 @@ def extract_markdown(
             level = len(heading_match.group(1))
             raw = heading_match.group(2)
             clean = _clean_heading(raw)
-            heading_stack[:] = heading_stack[: max(level - 1, 0)]
+            while heading_stack and heading_stack[-1][0] >= level:
+                heading_stack.pop()
             parents = [h for _, h in heading_stack if h]
             heading_stack.append((level, clean))
             _flush()

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -52,6 +52,16 @@ def test_headings_split_blocks_and_track_parents():
     assert ex.blocks[0]["content"].startswith("# A")
 
 
+def test_skipped_heading_levels_keep_same_level_headings_as_siblings():
+    ex = _extract("# A\n### B\n### C")
+    summary = [(b["heading"], b["parent_headings"]) for b in ex.blocks]
+    assert summary == [
+        ("A", []),
+        ("B", ["A"]),
+        ("C", ["A"]),
+    ]
+
+
 def test_content_before_first_heading_is_preface():
     ex = _extract("loose intro line\n\n# Real")
     assert ex.blocks[0]["heading"] == PREFACE_HEADING


### PR DESCRIPTION
## Description

Markdown headings at the same level should be siblings even when an intermediate heading level was skipped. For `# A` → `### B` → `### C`, the parser currently records `C` under both `A` and `B`, which propagates an incorrect parent path into sidecar metadata and level-aware chunk merging.

The heading stack was truncated by its list length, implicitly assuming contiguous heading levels. This change instead removes stack entries according to their stored heading level.

## Related Issues

No linked issue. Searches across open and closed issues, pull requests, and recent commits found no equivalent fix.

## Changes Made

- Pop same-level and deeper headings before recording a new ATX heading.
- Add a regression test for consecutive level-three headings below a level-one heading.

## Regression evidence

- Before the fix, the new regression test failed because `C` had `parent_headings == ["A", "B"]` instead of `["A"]`.

- After the fix, the same test passes and both level-three headings have `parent_headings == ["A"]`.

## Verification

- Regression: 1 passed
- Markdown parser suite: 79 passed
- Paragraph-semantic merge suite: 23 passed
- Full offline suite: 4,694 passed, 47 skipped, 1 existing warning
- `pre-commit run --all-files --show-diff-on-failure`: passed

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not necessary; no public API change)
- [x] Unit tests added

## Additional Notes

- Scope: 2 files, +12/-1 lines; no dependencies or generated files.
- This fix was developed with AI assistance and validated with the regression and project checks above.
