### PR TITLE
docs(pipeline): rewrite the dedup and concurrency chapters from a user's view

### DIFF
--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -18,8 +18,8 @@ LightRAG Server引入了一个文件处理的中间格式： `LightRAG Document`
 - [4. 多模态分析（VLM）](#4-多模态分析vlm)
 - [5. 分块器参数配置（chunk_options）](#5-分块器参数配置chunk_options)
 - [6. 存储与目录布局](#6-存储与目录布局)
-- [7. 文档重复判定规则](#7-文档重复判定规则)
-- [8. 流水线并发与重入约束](#8-流水线并发与重入约束)
+- [7. 同名与重复文档](#7-同名与重复文档)
+- [8. 运行控制：边跑边传、停止与重试](#8-运行控制边跑边传停止与重试)
 - [9. 流水线启动时的续跑规则](#9-流水线启动时的续跑规则)
 - [10. 常见问题排查](#10-常见问题排查)
 - [11. Python SDK 调用](#11-python-sdk-调用)
@@ -555,7 +555,7 @@ LIGHTRAG_PARSER=pdf:mineru(language=en);*:legacy-R                       # 规�
 
 ### 4.5 图片限制与吞吐
 
-`VLM_MAX_IMAGE_BYTES`（缺省 5 MB）与 `VLM_MIN_IMAGE_PIXEL`（缺省 64）界定什么值得送出去：下限的存在是为了跳过图标和分隔线，而不是为它们付一次 VLM 调用。分析阶段的并发是 `MAX_PARALLEL_ANALYZE`（§8.10），与解析、入库阶段互不影响。
+`VLM_MAX_IMAGE_BYTES`（缺省 5 MB）与 `VLM_MIN_IMAGE_PIXEL`（缺省 64）界定什么值得送出去：下限的存在是为了跳过图标和分隔线，而不是为它们付一次 VLM 调用。分析阶段的并发是 `MAX_PARALLEL_ANALYZE`（§8.6），与解析、入库阶段互不影响。
 
 ### 4.6 模型配置不在本章
 
@@ -571,7 +571,7 @@ MinerU 自己也有一轮 VLM，由 `MINERU_LOCAL_IMAGE_ANALYSIS` 开启。它�
 2. 确认 sidecar item 的 `llm_analyze_result.status == "success"`。
 3. 再把 `i` 与 `VLM_PROCESS_ENABLE=true` 以及一个支持视觉的 binding **一起**加上。
 
-把第 3 步拆成两半，就会撞上 §4.3 第 4 行那种失败。而且因为处理选项在入队时已冻结，已经这样失败的文档无法靠改配置重试救回来：`/documents/reprocess_failed` 会按原来的 `i` 重跑。要么把 VLM 配好再重试，要么删除该文档、以不带 `i` 的配置重新上传。
+把第 3 步拆成两半，就会撞上 §4.3 第 4 行那种失败。而且因为处理选项在入队时已冻结，已经这样失败的文档无法靠改配置重试救回来：`/documents/reprocess_failed` 会按原来的 `i` 重跑。要么把 VLM 配好再重试，要么删除该文档、以不带 `i` 的配置重新上传（§8.3）。
 
 ## 5. 分块器参数配置（chunk_options）
 
@@ -843,163 +843,184 @@ __parsed__/<base>.docling_raw/
 
 > **"任一侧为空即跳过"** 适用于两个外部引擎的 `engine_version` 与 `endpoint_signature`。若写 manifest 时该字段为空（例如首次解析时未配置 `MINERU_ENGINE_VERSION`），或当前环境变量未设置，则跳过该项检查。因此，在产物包已经存在**之后**才设置版本号变量，并不会追溯性地让它失效——这种情况需要用对应的 `LIGHTRAG_FORCE_REPARSE_*` 标志。
 
-## 7. 文档重复判定规则
+## 7. 同名与重复文档
 
-文件上传、文件解析入队和文本接口会按照「文件名 + 内容 hash」两道关卡判断是否重复，命中任一即视为重复并写入一条 `FAILED` 记录，不会覆盖已有的 `full_docs`。`/documents/scan` 目录扫描也使用同一套索引，但为了便于自动重试未完成文件，对文件名重复有单独的归档与重处理规则。
+文件上传、目录扫描和文本接口都会查重。同一份内容重复入库会浪费 LLM 配额，还会在知识图谱里造出重复实体，所以 LightRAG 用文件名和内容两条规则查重：命中任一即判为重复，本次记录写为 `FAILED`，**已有文档永远不会被覆盖**。所有查重都在分块、实体抽取和图谱写入**之前**完成——但这不等于"落库之前"：`native` / `mineru` / `docling` 必须先持久化待解析记录、再持久化解析结果，才拿得到内容 hash，所以这条路径上会短暂存在一条随后被撤销的记录（见 §7.1、§7.2）。
 
-### 7.1 文件名（basename）查重
+### 7.1 两条查重规则
 
-- 判断粒度为 basename，不包含目录路径和 workspace 路径。例如 `/data/a.pdf`、`inputs/a.pdf` 和 `a.pdf` 都视为同一个文件名 `a.pdf`。
-- 文件名查重以 `canonical_basename` 为索引：将文件名末尾的支持引擎处理提示 hint 剥离后再比对，因此 `abc.docx`、`abc.[native].docx`、`abc.[native-iet].docx` 之间互相视为同名；不支持的 hint 不会被剥离，例如 `abc.[draft].docx` 仍按原文件名处理。
-- 对普通上传、文本接口和核心入队 API，只要 `doc_status` 中已经存在同名文件记录，无论该记录当前处于 `PENDING`、`PARSING`、`ANALYZING`、`PROCESSING`、`FAILED` 还是 `PROCESSED`，同名文件都会被视为重复。
-- 对 `/documents/scan` 目录扫描：canonical basename 只用于**定位**候选记录，不假设唯一（custom ID 插入、legacy id、历史碰撞都可能共享同一个 canonical）。扫描对每个物理文件算出 canonical source key，用 `resolve_doc_source_strict` 做一次 typed 解析，再按固定的互斥顺序落到七类出口之一。分类阶段**只读**：入队、归档、删 stub 等破坏性动作都在分类之后执行，因此每个决策都能先记日志、计数和采样。
+**规则一：文件名重复。** 只比对文件名本身（不含目录，也不含 workspace 路径），因此 `/data/a.pdf`、`inputs/a.pdf` 和 `a.pdf` 是同一个名字。比对前会先剥掉能识别的 `[引擎-选项]` hint，所以 `abc.docx`、`abc.[native].docx`、`abc.[native-iet].docx` 互相视为同名；无法识别的 hint 不剥离，`abc.[draft].docx` 仍是另一个名字。只要 `doc_status` 里已有同名记录，**无论它处于 `PENDING`、`PARSING`、`ANALYZING`、`PROCESSING`、`FAILED` 还是 `PROCESSED`**，本次都算重复。
 
-  | 出口 | 条件 | 动作 |
-  | --- | --- | --- |
-  | `CLAIMED_NEW` | 无同 canonical 记录（`SourceAbsent`） | 在扫描期可丢弃的磁盘 spool 中取得 canonical 首次 claim，之后按全局 `st_mtime` 顺序入队；`metadata.source_file` 保存带 hint 的原始 basename |
-  | `SOURCE_CONFLICT` | 同 canonical 有多条主记录（`SourceConflict`，历史遗留） | 不入队、不删任何记录、**也不归档文件**（operator 需要现场文件）；job 记录有界的候选 doc ID 摘要，等按 doc ID 修复后再扫。修复入口：`GET /documents/source_conflicts` 列出冲突，`POST /documents/source_conflicts/repair` 指定保留的 `primary_doc_id`（默认 dry-run，拿到 `candidate_count`/`fingerprint` 后回填提交；候选集有变动则 409），或离线用 `python -m lightrag.tools.source_conflict_repair` |
-  | `PROCESSED` | 唯一记录已 `PROCESSED` | 输出 warning，源文件归档到 `__parsed__`，跳过入队 |
-  | `STALE_STUB` | 唯一记录为 `FAILED`，且 strict point read **确认** `full_docs` 不存在 | 视为 `apipeline_enqueue_error_documents` 写下的提取错误 stub（一致性检查会保留它供人工 review）：删掉 stub 后把当前文件按 `CLAIMED_NEW` 重新入队。这是唯一会重新提取的出口，让"修好源文件再 scan 一次"自动生效。point read 能力缺失或读取失败时**不删**，转下面的非破坏性出口 |
-  | `SOURCE_IDENTITY_UNKNOWN` | 唯一记录缺 `metadata.source_file`（custom ID / legacy / 非 scan 来源的 RAW 行） | 保留文件、不入队、记录有界告警；缺失**不**等于"不同的物理文件" |
-  | `RESUME_SAME_PHYSICAL_SOURCE` | 物理 basename == `source_file` | **resume 路径**：doc_status 现状保留，源文件留在 `INPUT/`，由处理循环按状态查询接走（不重新提取、不覆盖既有状态） |
-  | `ALIAS_DUPLICATE` | 物理 basename != `source_file` | 同 canonical 的另一个物理文件：归档 alias 并输出 warning，不走普通入队（避免制造 `dup-*` FAILED 行） |
+**规则二：内容重复。** 比对的是**抽取之后的正文**，不是原始文件的字节。所以换个文件名、甚至换成另一种格式，只要抽出来的内容一致就算重复。取值口径按内容格式区分：
 
-  发现阶段仍是单遍无序流，但精确的全局 mtime 顺序必然需要在某处保存 O(文件数) 的排序状态。因此新候选写入可丢弃的 SQLite spool：UNIQUE canonical-key 索引在任何新行进入 doc_status 前维持整次扫描的 first-physical-claim-wins；`(mtime, path, discovery sequence)` 索引再通过 `fetchmany(SCAN_ENQUEUE_BATCH_SIZE)` 分批读取，使 Python 内存保持 O(K)。每个候选还携带发现阶段已经 stat 到的文件大小，入队阶段因此不再重复读一次元数据。
-
-  **spool 的落点**：依次取 `SCAN_SPOOL_DIR`、`WORKING_DIR/scan_spool`，两者都再按 workspace 分子目录。它必须落在真实、可写的本地磁盘上：spool 的全部意义就是把 O(文件数) 的状态挪出内存，而很多 Linux 主机上 `/tmp` 是 RAM 支撑的 tmpfs，落在那里等于把内存又还回去。`WORKING_DIR` 本身是网络卷时应显式设置 `SCAN_SPOOL_DIR`。INPUT_DIR 被有意排除：它经常是网络挂载（全流程唯一一处批量写入落在最慢的卷上）、存在合法的只读挂载方式、且被同步工具共管，可能在扫描中途把 spool 复制走或删掉。
-
-  **落点失败是 fail-closed**：目录不可用时扫描直接失败，错误信息点名 `SCAN_SPOOL_DIR`，且一条都不入队；输入文件原封不动，改完配置重扫不丢任何东西。它**不会**改落到系统临时目录 —— 那不是"降级但仍正确"，在 tmpfs 主机上它恰好把 spool 要消除的内存开销原样还回来，而运维只会在大扫描跑到一半时以 OOM 被杀的形式发现。
-
-  **崩溃残留上限为一份**：spool 落在持久卷上，`kill -9` 留下的东西没人回收，因此它在 workspace 子目录里用**固定文件名**而非随机名：下次扫描在打开自己的之前先删掉残留。残留因此恒为一份，而不是每崩一次多一份。固定名是安全的，因为 `scanning_exclusive` 本就只允许每个 workspace 同时跑一次扫描（也正是这个保证让两次扫描不会争抢 INPUT_DIR）；而 workspace 子目录保证共用同一个 `WORKING_DIR` 的两个 workspace 不会复用彼此的文件。
-
-  正因为固定名让这个子目录成为承重结构，workspace → 目录的映射在构造上就是**单射**的：
-
-  ```text
-  <base>/unnamed/candidates.sqlite3           # 未设置 WORKSPACE
-  <base>/named/<workspace>/candidates.sqlite3 # 每个具名 workspace
-  ```
-
-  用一个裸哨兵名做不到单射 —— workspace 名只被校验、不被限制，所以一个真的叫 `_default` 的 workspace 会和未命名的落到同一个目录。这两者持有**不同**的 per-workspace 扫描锁、可以并发扫描，后启动的那个会删掉前者正在使用的数据库。
-
-  **精确全局排序的代价**：发现阶段结束前没有任何行进入 doc_status，因此扫描被中断（取消、崩溃、重启）时**一条都不会入队** —— 源文件仍在 INPUT_DIR，下次扫描重新发现即可。唯一回不来的是发现阶段已删除的 `STALE_STUB` 行：文件下次会作为新文档重新入队，但那条"保留供人工 review"的 FAILED stub 已经没了。spool 本身不属于 LightRAG 持久存储，扫描结束即删除。
-- 普通上传和核心入队 API 中，同名文件即使内容已经变化，也需要先删除旧文档记录后再重新上传或入队；上述自动恢复（`STALE_STUB` / `RESUME_SAME_PHYSICAL_SOURCE`）仅用于目录扫描场景。
-- 文件系统时间只在持久化前充当扫描优先级：spool 按全局从旧到新吐出候选，随后逐条入队，并在真正首次落库时写 `doc_status.created_at=now()`。文件一旦进入 doc_status，调度只认普通的不可变 `(created_at, id)`，文件 mtime 随即丢弃。mtime 不可读的候选排在所有可读时间之后，但不会因此丢失；文件消失或不可读仍由入队路径正常报错。
-- 文本接口必须提供有效的 `file_source`，并按 `file_source` 的 basename 判断重复；缺少有效 `file_source` 时直接返回 400。
-- SDK 路径调用 `insert` / `ainsert` / `apipeline_enqueue_documents` 时不传 `file_paths` 是被允许的，相关行为详见 §11.4。这类无来源文档的 `file_path` 保存为 `unknown_source`。
-- 空字符串、`no-file-path` 和 `unknown_source` 都会被视为未知来源；它们不会阻止新的无来源文本入队，也不会作为同名文件互相去重。
-
-存储后端通过 `get_doc_by_file_basename` 提供 basename 直查能力，内部按 `canonical_basename` 字段比对（传入参数会先经 `canonicalize_parser_hinted_basename` 规范化）。`JsonDocStatusStorage` 已经实现了内存级遍历；其它后端目前回落到默认实现（扫描全部状态后比对 `canonical_basename`），将在后续 PR 中补齐原生索引。
-
-### 7.2 内容 hash 查重
-
-- 文件名不同但抽取后的内容完全相同的文档同样视为重复。这里的 hash 是按配置的抽取引擎得到最终文本或 LightRAG Document 后计算的内容 hash，不是原始文件字节 hash。
-- `full_docs` 与 `doc_status` 会按内容格式写入或补齐 `content_hash` 字段：
-  - `parse_format=raw`：取经过 `sanitize_text_for_encoding` 之后的文本 MD5。
-  - `parse_format=lightrag`：取 `lightrag_document_path` 解析出的 `*.blocks.jsonl` 文件 MD5。相对路径按 `INPUT_DIR` 解析。
-  - `parse_format=pending_parse`：暂不写入 hash，等到真正完成解析后由后续步骤补上（避免按空内容误判）。
-- `legacy` 路径会在本地提取文本后、入队时进行内容 hash 查重；命中重复时，本次记录写为 `FAILED duplicate`，不会生成新的 `full_docs`、chunks 或图数据。
-- `native` / `mineru` / `docling` 路径会先以 `pending_parse` 入队；真正完成解析并补齐 `content_hash` 后，如果发现其它文档已有相同 hash，本次记录会在进入分析、切块、实体抽取和图写入前停止。
-- 重复记录会在 `metadata.duplicate_kind` 中标记为 `filename` 或 `content_hash`，便于排查。内容 hash 重复还会记录 `metadata.is_duplicate=true`、`metadata.original_doc_id` 和 `metadata.original_track_id`；解析后才发现的重复会删除本次临时写入的 `full_docs`。
-- 相关 warning 会尽量减少重复噪音：扫描发现已 `PROCESSED` 的同名文件时会写入日志和 pipeline status；入队阶段重复使用 LightRAG 层的 `Duplicate document detected (...)` 日志；解析完成后才发现的内容重复使用 `Duplicate content skipped after parsing`，并写入 pipeline status。扫描归档不会额外输出 `[File Extraction]Duplicate skipped`。
-- 存储后端通过 `get_doc_by_content_hash` 进行 hash 直查；命名约定与 `get_doc_by_file_basename` 一致。
-
-> 入队批次内（同一次 `apipeline_enqueue_documents` 调用）也会做 basename 与 content_hash 去重，命中时把后续条目直接写为 `FAILED` 并标记 `existing_status=batch_duplicate`。其中 basename 去重只对有效文件名生效；`unknown_source`、`no-file-path` 和空来源只参与内容 hash 去重。
->
-> **跨调用并发去重**也由 workspace 级串行锁保证（详见 [§8.8 enqueue 串行锁（防并发去重穿透）](#88-enqueue-串行锁防并发去重穿透)）：两次相同内容、不同文件名的并发入队不会双双穿透 `content_hash` 检查。
-
-## 8. 流水线并发与重入约束
-
-为防止 `scan` / `upload` / `insert` 与运行中的流水线相互覆盖 `doc_status` / `full_docs` 记录，所有写入入口在 `pipeline_status` 共享字典上协调。同一 workspace 下的 `pipeline_status_lock` 保证下表所有 transition 都在锁内原子完成。
-
-### 8.1 `pipeline_status` 字段
-
-| 字段 | 语义 |
+| `parse_format` | 内容 hash 取自 |
 | --- | --- |
-| `busy` | 流水线繁忙的笼统标志。处理循环和破坏性作业（clear/delete）都会设它。**仅有 `busy=True`（处理循环）不阻塞 enqueue**——循环按 batch 拉取 `doc_status` 快照处理，运行中到达的新工作经 workspace ingress mailbox 接入（批内 feeder + 批边界静默决策）。 |
-| `destructive_busy` | `busy` 的破坏性子集：`/documents/clear` 或 `/documents/delete_document`正在 drop 存储 / 删源文件。reservation 和 enqueue last-line guard 都会拒绝——并发 enqueue 会写入正被 drop 的存储，已接受的文档会静默丢失。处理循环不会设此字段。 |
-| `scanning` | `/documents/scan` 后台任务运行中（整个生命周期：分类阶段 + 处理阶段）。仅 `/scan` 端点用它拒绝重叠 scan，本身**不**阻塞 upload/insert。 |
-| `scanning_exclusive` | `scanning` 的独占子集：只在 scan 的**分类阶段**为 True——run_scanning_process 在读 doc_status 分类（已处理 / 续跑 / 删 stub / 归档），不能与并发写者交错。reservation 和 enqueue last-line guard 都会拒绝。分类完成后会立即清旗，scan 进入处理阶段后允许并发 upload。 |
-| `pending_enqueues` | 已通过 `_reserve_enqueue_slot` 但 bg task 未完成的 upload/insert 数。仅给 scan 端点参考——决定是否能拿独占。bg task 在 `finally` 里释放 slot。 |
+| `raw` | 编码规范化之后的正文文本 MD5 |
+| `lightrag` | sidecar 中 `*.blocks.jsonl` 文件的 MD5（相对路径按 `INPUT_DIR` 解析） |
+| `pending_parse` | 暂不计算，等真正解析完成后补上（避免按空内容误判） |
 
-唤醒信号**不在** `pipeline_status` 里，而在 workspace 级 **pipeline ingress mailbox**（`lightrag/kg/pipeline_ingress.py`，三通道：逐文档 document 消息 / auto-rescan 脏标志 / sticky 人工重试请求）。enqueue 写完 `doc_status` 后在 `pipeline_status_lock` 下发布 document 消息；被 busy 拒绝的 processing 请求在 reservation 同一临界区内置 auto-rescan 标志；运行中的循环在批内（feeder）与每个批边界（原子静默决策，三通道全空时在同一临界区释放 `busy`）消费这些信号。`doc_status` 仍是事实来源——丢失的通知由下一次 run 的初始 strict 扫描兜底。
+这也决定了内容查重发生在什么时候：`legacy` 在本地抽完文本、入队时就能判；`native` / `mineru` / `docling` 要等解析真正完成才判，此时本次记录会**停在建库之前**——不分块、不抽实体、不写图谱，并删掉本次临时写入的 `full_docs`。
 
-### 8.2 入口行为
+两条补充规则：
 
-| 入口 | 条件 | 行为 |
+- **文本接口**（`/documents/text`、`/documents/texts`）必须提供有效的 `file_source`，并按它的 basename 判定同名；缺失时直接返回 400。
+- **无来源文档**（SDK 调用 `insert` / `ainsert` 时不传 `file_paths`，`file_path` 记为 `unknown_source`）不参与同名查重——`unknown_source` 只是占位名，两份无来源文档不会因为它互相冲突——但**仍然按正文内容查重**：重复插入同一段正文依旧会被判为重复。空字符串与 `no-file-path` 同理。
+
+同一批入队内部、以及并发发起的两次入队，都不会双双穿透查重：后到的那条一定会被识别为重复并写为 `FAILED`。
+
+### 7.2 你会看到什么
+
+| 症状 | 含义 |
+| --- | --- |
+| 上传返回 409 `Document storage already contains '<name>' (Status: …)` | `doc_status` 里已有同名记录（任何状态，包括 `FAILED`） |
+| 上传返回 409 `Input directory already contains a file with the same canonical basename …` | 库里没有记录，但 `INPUT_DIR` 里还留着同名文件 |
+| 文档列表多出一条 `FAILED`，`error_msg` 为 `File name already exists. Original doc_id: …, Status: …` | 批量入队或扫描时命中了文件名重复 |
+| `FAILED`，`error_msg` 为 `Identical content already exists under another filename. Original doc_id: …` | 命中了内容重复 |
+| `FAILED`，`error_msg` 为 `N existing documents already share this file name …` | 历史遗留的"一个文件名对应多条主记录"冲突，需要先按 doc id 修复 |
+
+上传路径是 **fail-fast** 的：前两种情况直接 409，不写文件、也不在 `doc_status` 里留下任何痕迹。后三种会在文档列表里留下记录，但**记录形态不同**——运维时不能只按 `dup-` 前缀查找：
+
+- **入队时发现的重复**（同名，或 `legacy` 路径上正文 hash 已存在）：新建一条 doc id 以 `dup-` 开头的 `FAILED` 记录，原文档不受影响。`metadata` 带 `duplicate_kind`（`filename` / `content_hash`）、`original_doc_id` 和 `original_track_id`，指向保留下来的那份正本。
+- **解析完成后才发现的内容重复**（`native` / `mineru` / `docling` 入队时还没有正文 hash）：**不会**新建 `dup-*` 记录，而是把本文档原有的 `doc-*` 记录就地改成 `FAILED`，写入 `metadata.is_duplicate=true` 与 `duplicate_kind=content_hash`，删掉本次临时写入的 `full_docs`，并把源文件归档到 `__parsed__`。
+- **`filename_conflict`**：库里已有多条主记录占用同一个文件名，系统**故意不替你选正本**，因此这条记录上的 `original_doc_id` 并不指向某个"保留下来的正本"——必须先按 [§7.3](#73-怎么处理) 修复冲突。
+
+### 7.3 怎么处理
+
+- **想用新内容替换同名文档**：先删除（`POST /documents/delete_document`，或 WebUI 文档列表里的删除对话框），再上传。上传永远不会覆盖已有记录。
+- **想清掉重复记录**：`dup-*` 记录、以及解析后被就地改成 `FAILED` 的那条原记录，都是**惰性记录**——没有正文内容，`/documents/scan` 与 `/documents/reprocess_failed` 都会跳过它们，既不会重跑，也不会再失败一次。要清掉只能显式删除；留着不管也不影响检索。
+- **只是想换引擎或换处理选项重跑同一份文件**：查重不是障碍，被冻结的配置才是——见 [§8.3](#83-出错后如何重试) 与 [§9.3](#93-分支-b已抽取)，这种情况必须删除后重新上传。
+- **`filename_conflict`（一名多记录）**：用 `GET /documents/source_conflicts` 列出冲突，`POST /documents/source_conflicts/repair` 指定要保留的 `primary_doc_id`（默认 dry-run，拿到 `candidate_count` / `fingerprint` 后回填提交；候选集有变动则返回 409），或离线执行 `python -m lightrag.tools.source_conflict_repair`。修好之后再扫描。
+
+### 7.4 目录扫描的特殊处理
+
+`/documents/scan` 用的是同一套查重口径，但它同时面对"磁盘上的文件"和"库里的记录"两侧，所以对同名文件有额外的自动处理——目的就是让"改好配置、修好源文件，再扫一次"能直接生效，而不必逐个手工删除：
+
+| 库里的记录 | 扫描时的动作 |
+| --- | --- |
+| 没有同名记录 | 作为新文档入队；整批按文件修改时间从旧到新排序 |
+| 已 `PROCESSED` | 不重复处理；源文件归档到 `__parsed__`，并落一条 warning |
+| `FAILED`，且确认从未成功抽取出内容 | 删掉这条失败记录，把文件当作新文档重新走一遍——"修好源文件再扫一次"靠的就是它 |
+| 处理到一半被中断（`PENDING` / `PARSING` / `ANALYZING` / `PROCESSING`） | 记录和源文件都原样保留，由流水线接着跑，不重新抽取 |
+| 同名的另一个物理文件 / 记录来源不明 / 一名多记录 | 既不入队也不删记录，只归档或告警——这几类需要人工判断，见 [§7.3](#73-怎么处理) |
+
+两点运维须知：
+
+- **扫描被中断（取消、崩溃、重启）时一条都不会入队。** 发现与入队分两步走，源文件始终留在 `INPUT_DIR`，下次扫描重新发现即可。唯一回不来的是上表第三行已经删掉的失败记录——文件会作为新文档重跑，但那条留作人工复核的记录没了。
+- **`SCAN_SPOOL_DIR` 必须指向真实可写的本地磁盘。** 扫描期间的候选清单落在 `SCAN_SPOOL_DIR`，未设置时取 `WORKING_DIR/scan_spool`，两者都再按 workspace 分子目录。不要指向 tmpfs（很多 Linux 主机上 `/tmp` 是内存盘）；`WORKING_DIR` 本身是网络卷时应显式设置这个变量。目录不可用时扫描**直接失败且一条都不入队**，错误信息会点名该变量，输入文件原封不动，改完配置重扫不丢任何东西。
+
+## 8. 运行控制：边跑边传、停止与重试
+
+本章回答三个运行期问题：流水线跑起来之后还能不能继续上传、怎么把它停下来、以及文档失败之后该怎么重试。并发调优参数与请求准入限制放在本章末尾两节。
+
+### 8.1 处理进行中还能做什么
+
+| 你想做的事 | 正在处理文档 | 扫描的分类阶段 | 正在清空 / 删除 | 手动重试正在排空 |
+| --- | :-: | :-: | :-: | :-: |
+| 上传文件 / 插入文本 | ✅ 允许 | ❌ 409 | ❌ 409 | ❌ 409 |
+| `/documents/scan` | ⛔ 拒绝 | ⛔ 拒绝 | ⛔ 拒绝 | ⛔ 拒绝 |
+| 删除文档 / 清空 | ⛔ 拒绝 | ⛔ 拒绝 | ⛔ 拒绝 | ⛔ 拒绝 |
+| 检索 / 查询 | ✅ 不被拒绝 | ✅ 不被拒绝 | ⚠️ 不被拒绝，但结果不保证 | ✅ 不被拒绝 |
+
+要点：
+
+- **长批次处理期间可以继续上传，不用等。** 这是最常被误解的一点：文档处理本身**不**阻塞上传。新文档写完记录后由运行中的流水线自动接手——可能被并进当前批次，也可能在批次边界被接上，两种都不需要你做任何额外操作。
+- **扫描、删除、清空需要流水线空闲。** 扫描要一边读库一边决定每个磁盘文件的去向（[§7.4](#74-目录扫描的特殊处理)），删除和清空会直接拆掉存储，这两类都不能和并发写入交错。被拒时 `/documents/scan` 返回 HTTP 200 但 `status="scanning_skipped_pipeline_busy"`，删除 / 清空返回 `status="busy"`——都不是报错，等空闲后重试即可。
+- **查询不受流水线准入约束，但清空 / 删除期间不保证结果。** 查询接口不检查流水线状态，所以不会像上传那样被 409 拒绝；但 `/documents/clear` 会用 `asyncio.gather` 并发 drop 文本分块、实体 / 关系 / chunk 向量、知识图谱、`full_docs` 与 `doc_status` 等十余个存储，而查询既不持有一致性快照，也不会等它结束——中途发起的查询可能拿到空结果、部分结果或存储报错。"请求会被受理"和"能返回一致结果"是两回事：破坏性操作期间应当等它跑完再查。
+- **上传被拒时按报错文案定位原因**，三种 409 各自对应一种状态：
+  - `Document scan is classifying files. …` —— 扫描正在分类阶段。
+  - `Pipeline is clearing or deleting documents. …` —— 正在清空或删除文档。
+  - `A retry of failed documents is draining the pipeline. …` —— 手动重试正在排空流水线（[§8.3](#83-出错后如何重试)）。
+- 上传返回 **413 / 429** 与流水线是否繁忙无关，那是请求准入限制，见 [§8.7](#87-准入与请求限制)；返回 **503** 见 [§8.5](#85-所有接口都返回-503recovery_required-栅栏)。
+
+### 8.2 如何停止正在运行的流水线
+
+```text
+POST /documents/cancel_pipeline      # 无请求体
+```
+
+WebUI 入口是文档管理页「流水线状态」对话框里的**「中断」**按钮，仅在流水线运行中且尚未请求中断时可点。接口返回 `{"status": "cancellation_requested" | "not_busy", "message": …}`：`not_busy` 表示当前没有在跑，无需中断。
+
+**返回 200 不代表已经停了。** 它只是置了一个中断请求标志。中断是**协作式**的：只在阶段之间、批次边界、以及多模态分析每 0.5 秒的轮询点生效，**不会打断已经发出的 LLM 调用**。所以点完之后还要等当前这一步跑完，`GET /documents/pipeline_status` 上的 `cancellation_requested` 可以确认请求已经收到。
+
+停下来之后，文档会落在这几种状态：
+
+| 文档当时的位置 | 停止后的状态 |
+| --- | --- |
+| 已经处理完 | `PROCESSED`，正常保留，不受影响 |
+| 已被本批取走（正在解析 / 分析 / 抽取，或在队列里排队） | `FAILED`，`error_msg` 形如 `User cancelled during parse: <文件名>` |
+| 还没被本批取走 | 保持 `PENDING`，下一次触发时继续 |
+
+几点补充：
+
+- **已完成的部分工作不会浪费。** LLM 缓存和已经分析成功的多模态条目都会落盘，之后重试会命中缓存，不会重复花钱。
+- ⚠️ **被标成 `FAILED` 的文档不会自动重试**，必须用 [§8.3](#83-出错后如何重试) 的显式重试手段捞回来。
+- **中断期间仍可继续上传。** 新上传的文档会在这一轮退出之后，由下一轮自动接上。
+- **什么时候它不管用**：扫描的分类阶段不算"流水线繁忙"，此时调用会返回 `not_busy`，而且目前没有中断扫描任务的接口——等它跑完即可。删除 / 清空作业**可以**被中断，粒度是逐个文档：已删除的保持删除，剩余的会在响应里报告为未删除。
+
+**直接重启或杀掉服务**是另一种停法，后果不同：
+
+- 进行中的文档会停在 `PARSING` / `ANALYZING` / `PROCESSING`，**不会**被写成 `FAILED`。
+- 这些中断态在下一次流水线启动时会**自动恢复为 `PENDING` 重跑**，不需要手工干预。
+- 但**服务启动本身不会自动开跑**：需要一次上传，或调一次 `POST /documents/scan` 来触发。所以重启后看到文档卡在 `PROCESSING` 不必惊慌，触发一次即可。
+
+### 8.3 出错后如何重试
+
+失败文档有三种捞回方式，按覆盖面从大到小：
+
+| 手段 | 做什么 | 什么时候用 |
 | --- | --- | --- |
-| `/documents/upload` / `/documents/text` / `/documents/texts` | `scanning_exclusive=True` 或 `destructive_busy=True` | 抛 HTTP 409，不写文件、不调入队 |
-| 同上 | 否则（含纯 `busy=True`、scan 处理阶段 `scanning=True` 但 `scanning_exclusive=False`） | 锁内 `pending_enqueues++` 预留 slot → 严格名字预检 → 保存文件 → schedule bg task；bg task 在 `finally` 释放 slot |
-| `/documents/scan` | `busy=True` 或 `scanning=True` 或 `pending_enqueues>0` | 落 warning 后立即返回 `scanning_skipped_pipeline_busy`，不 schedule 后台任务 |
-| 同上 | 全部 idle | 锁内设 `scanning=True` 后 schedule，task 结束在 `finally` 清旗 |
-| `/documents/clear` / `/documents/delete_document` | `busy=True` 或 `scanning=True` 或 `pending_enqueues>0` | 端点同步返回 `status="busy"`，不 schedule 后台任务 |
-| 同上 | 全部 idle | 端点**同步**在锁内设 `busy=True` + `destructive_busy=True`（`delete_document` 在返回 `deletion_started` 之前），bg task 的 finally 一并清旗 |
-| `apipeline_enqueue_documents` 内部 (last-line guard) | `scanning_exclusive=True` 且 `from_scan=False`，或 `destructive_busy=True` | 抛 `RuntimeError("Cannot enqueue while scan is classifying / clearing or deleting")` |
-| 同上 | 任何其它情况（含纯 `busy=True`、scan 处理阶段） | 正常入队；写完 `doc_status` 后向 ingress mailbox 发布逐文档消息（运行中的循环在批内或批边界接手） |
+| `POST /documents/scan`（WebUI「扫描/重试」按钮） | 先把所有可恢复的 `FAILED` 重置为 `PENDING`，再扫描 `INPUT_DIR` 里的新文件；还能处理"从未成功抽取出内容"的失败记录（删记录 + 把文件当新文档重跑） | **首选**，覆盖面最广 |
+| `POST /documents/reprocess_failed` | 只按存储里的记录重试 `FAILED`，不做目录发现；但解析阶段就失败的文档会**重新解析**，那时仍要读取记录指向的源文件 | 不想顺带触发一次全目录扫描时 |
+| 删除 + 重新上传 | 彻底重来一遍 | 需要换引擎 / 换处理选项，或上面两种都救不回来 |
 
-`from_scan=True` 是 scan 后台任务自身入队时的旁路：scan 已持有 `scanning` 旗标，必须允许它把扫到的文件入队。
+四条必须知道的口径：
 
-### 8.3 为什么 `busy` 不再阻塞 enqueue
+1. **每次重试请求对每个文档只给一次机会。** 再失败就停在 `FAILED`，等下一次显式重试，不会自旋。
+2. **自动续跑不碰 `FAILED`。** 上传新文件触发的那一轮只会恢复中断态（`PENDING` / `PARSING` / `ANALYZING` / `PROCESSING`）；`FAILED` 只能靠上表前两个显式入口。
+3. **是否重新解析，取决于正文有没有抽取成功。** 已经抽出正文的文档不会重解析：重试从多模态分析阶段起跑，先清掉上一轮写进去的 chunks 与图谱贡献再重做（细节见 [§9.3](#93-分支-b已抽取)），所以"修好 VLM 配置 / 等限流恢复之后重试"是有效的。而**在解析阶段就失败的文档**（`full_docs` 里只留着 `pending_parse` 占位记录）会被重置为 `PENDING` 后重新进入解析阶段，再次读取 `INPUT_DIR` 里的源文件、再次调用对应引擎——修好 MinerU / Docling 后重试因此有效，但源文件已被删除时这类重试会再次失败。
+4. **重试不会改引擎与处理选项。** `parse_engine`、`process_options`、`chunk_options` 在入队那一刻就冻结进记录了；改 `.env` 或改文件名 hint 只对新上传生效。
 
-旧版本里 `busy=True` 一律拒绝任何新入队，理由是"修改 `doc_status` 会与流水线工作线程交错"。但实际上：
+哪些情况重试有效、哪些必须删除重传：
 
-1. **写入顺序保证一致性**：`apipeline_enqueue_documents` 总是先 upsert `full_docs`、再 upsert `doc_status`。处理循环开头的 consistency check 仅删除"`doc_status` 行没有对应 `full_docs`"的孤儿——这种状态在并发 enqueue 中不可能出现。
-2. **批次级快照**：处理循环每个 batch 拉一次 `get_docs_by_statuses` 快照，新写入的 `PENDING` 行不会破坏当前 batch——它们的 document 消息由批内 feeder 直接路由进当前 batch，剩余的在批边界重拉快照接上。
-3. **ingress mailbox 设计本就为此**：enqueue 为"运行中又有新工作"这一场景逐文档发布通知；循环的静默决策在同一临界区内消费信号并释放 `busy`，信号不会落进缝隙。
+| 失败原因 | 就地重试？ |
+| --- | --- |
+| LLM / VLM / 存储 / 网络临时故障，或撞上限流 | ✅ 直接重试 |
+| 被用户中断（`User cancelled during …`） | ✅ 直接重试 |
+| VLM 没配好（`VLM analysis required but VLM role is not available`） | ⚠️ 把 VLM 配好后重试有效；若想改成不做图片分析（去掉 `i`），必须删除重传 |
+| 外部解析服务没起来 / 端点写错 | ⚠️ 修好配置后重试；命中原始产物包缓存时不会重复调用外部服务（§6.3） |
+| 想换解析引擎、换分块策略、改 `i/t/e/!` | ❌ 删除后重新上传（[§9.3](#93-分支-b已抽取)） |
+| 文件名 hint 写错、分块参数非法（`[File Extraction]` 开头、从未抽出正文的记录） | ❌ `reprocess_failed` 会跳过它；改好文件名后用 `/documents/scan`，或删掉记录后重传 |
+| 扫描版 PDF 走了 `legacy`，抽不出文字 | ❌ 先把该后缀路由到 `mineru` / `docling`，再删除重传（[§3.2](#32-使用-legacy-内容抽取器)） |
+| 重复文档 `dup-*` | ❌ 惰性记录，重试不会动它，直接删除（[§7.3](#73-怎么处理)） |
+| 删除文档时报 409（缺少 recovery anchor） | ❌ 原样重试仍会被拒；先跑 `audit_kg_integrity(..., apply=True)` 修复 |
 
-新契约把这个机制启用起来后，**用户在长批次处理过程中仍可继续上传新文档**，bg task 写完 `doc_status` 后由运行中的循环自动接管。
+`/documents/reprocess_failed` 还有两点值得知道。它会先冻结入口、把流水线排空到空闲——这段时间上传返回 409、`/documents/scan` 被拒——再在没有任何 worker 运行的前提下把 `FAILED` 改回 `PENDING`，然后恢复正常处理；文档数量多时这个过程需要一点时间。它可能返回 429（未确认的重试请求过多，上限由 `MAX_UNACKED_MANUAL_RETRIES` 控制）或 503（栅栏已升起，或正在清空 / 删除）；排空迟迟到不了空闲时会升起栅栏，见 [§8.5](#85-所有接口都返回-503recovery_required-栅栏)。
 
-### 8.4 为什么 scan 仍是独占写者
+### 8.4 删除文档：两个勾选项的区别
 
-scan 不仅 enqueue 自己扫到的新文件，还会读 `doc_status` 决定每个文件去向（`PROCESSED` 归档、resume 保留、stale stub 删除重入队等，七类出口见 [§7.1](#71-文件名basename查重)）。
+删除对话框里的两个复选框默认都不勾，它们决定磁盘上的东西是否一起清掉：
 
-这些"读—决策—写"组合不能与其它写者交错，否则分类决策会基于过期视图。所以分类阶段必须独占（`scanning_exclusive`），且 scan 端点会在 `busy` / `scanning` / `pending_enqueues>0` / 独占 reset 冻结（`manual_freeze_requested`）/ 有更早未处理的人工重试请求 任一成立时拒绝——最后一条保证 scan 不会插队到人工重试请求之前。
+- **都不勾**：只删存储里的状态——chunks、向量、图谱贡献、`doc_status`、`full_docs`。磁盘上的源文件、`__parsed__` 里的归档件与 `.parsed/` sidecar、外部引擎的原始产物缓存**全部保留**。
+- **勾「同时删除上传文件」**（API 参数 `delete_file=true`）：连同 `INPUT_DIR` 里的源文件、`__parsed__` 下的归档件与 `<base>.parsed/` sidecar，以及 `<base>.mineru_raw/` / `<base>.docling_raw/` / `<base>.native_raw/` 原始产物缓存一起删除。**想换引擎重跑、或想让外部引擎真的重新解析一次，必须勾这个**，否则重新上传会命中缓存拿回旧结果（[§3.7](#37-解析缓存与强制重解析)、§6.3）。
+- **勾「同时删除实体关系抽取 LLM 缓存」**：额外清掉该文档抽取阶段的 LLM 缓存，重传时会真实重跑 LLM 而不是命中缓存。想验证换了模型或提示词之后的效果，需要勾它。
 
-### 8.5 严格名字预检（upload 路径）
+### 8.5 所有接口都返回 503：`recovery_required` 栅栏
 
-upload 通过 reservation 后、保存文件前必须双道检查：
+有些故障会让 workspace 处于"继续下去只能靠猜"的状态。管线不做这种猜测，而是升起 `recovery_required` 栅栏：此后**所有**写操作（upload / text / scan / 手动重试 / delete / clear）一律返回 **HTTP 503**，直到运维显式解除。三种情况会升起它——其中 1 和 3 依赖跨进程的死进程检测，只在 **Linux + Gunicorn 多 worker** 部署下才会发生（单进程 uvicorn 的协调状态随进程一起消失）：
 
-1. **INPUT 目录扫描**：把要保存的 basename 经 `canonicalize_parser_hinted_basename` 规范化，遍历 INPUT 目录里现有任何同 canonical 变体（含 hint / 不含 hint），命中即 409。
-2. **doc_status 查重**：用规范化 basename 调 `get_existing_doc_by_file_path_candidates`，命中即 409。
+1. **worker 在 `custom_chunks` / `delete` / `clear` 执行途中死亡。** 这些操作可能已经半提交，不能简单重跑。（`processing` / `scan` 的执行者死亡是可重跑的，会被静默回收，不设栅栏。）
+2. **手动重试的排空无法到达空闲。** 有两种卡法：同一批文档反复回来且状态毫无变化（再重扫只会自旋），以及排空根本无法推进的文档——持有**未完成 custom-chunk 操作**的行，只有 `/documents/scan` 的回滚能处理它们。两种情况下重置都不执行，重试请求保持未确认（那一次机会仍然欠着），栅栏消息里带阻塞文档 ID 的有界样本。`recovery_kind` 区分二者：`manual_drain_stalled` 和 `manual_drain_blocked`。
+3. **无法判定某个执行者是否已经死亡。** 回收一个执行权必须先证明其所属进程确已死亡；不带进程身份的记录永远无法证明，管线不靠猜回收，改由栅栏提供出口。
 
-两道都过 → 保存文件 → schedule bg task → bg task 调 `apipeline_enqueue_documents` 写库 + 调 `apipeline_process_enqueue_documents` 触发处理。
-
-> 旧版本曾允许 upload 在已有同名记录时悄悄写入 FAILED 重复条目；新规则改为 fail-fast，不在 doc_status 留下任何重复痕迹。如需替换同名文档，请先调用 `/documents/delete_document` 接口。
-
-### 8.6 多 reservation 并发的协调
-
-两个 upload 同时进来时（scan 此时拿不到独占）：
-
-1. A `_reserve_enqueue_slot` → `pending_enqueues=1`，写文件，schedule bg task A，返回 success。
-2. B `_reserve_enqueue_slot` → `pending_enqueues=2`，写文件，schedule bg task B，返回 success。
-3. bg task A `apipeline_enqueue_documents` → 写 `doc_status` → 调 `apipeline_process_enqueue_documents` → 设 `busy=True` 处理 A 的文档。
-4. bg task B `apipeline_enqueue_documents` → 看到 `scanning=False`，正常写入；写完后向 ingress mailbox 发布 B 的 document 消息。
-5. bg task B 调 `apipeline_process_enqueue_documents` → reservation 看到 `busy=True`，同一临界区内置 auto-rescan 标志后立即返回。
-6. A 的运行循环经批内 feeder 把 B 的 document 消息直接路由进当前 batch——若消息落在批边界，则由静默决策消费信号后重拉快照——B 的 `PENDING` 行被接上处理。
-7. 全部完成后 `busy=False`、`pending_enqueues=0`。
-
-任何一个 bg task 都不会因为 busy 被误拒——因为 enqueue 不再检查 busy；处理循环也不会重复处理同一份文档——批内准入按 routing/inflight 登记去重，auto-rescan 标志每个静默决策恰好消费一次。
-
-### 8.7 `recovery_required` 栅栏
-
-有些故障会让 workspace 处于"继续下去只能靠猜"的状态。管线不做这种猜测，而是设置 `recovery_required` 栅栏：此后**所有**写操作（upload / text / scan / manual retry / delete / clear）一律返回 **HTTP 503**，直到运维显式解除。三种情况会设置它：
-
-1. **worker 在 `custom_chunks` / `delete` / `clear` 执行途中死亡。** 这些操作可能已经半提交，因此不能简单重跑。（`processing` / `scan` 的 owner 死亡是可重跑的，会被静默回收，不设栅栏。）
-2. **manual retry 的排空无法到达空闲。** `/documents/reprocess_failed` 会先把管线排空到空闲，再执行独占的 `FAILED → PENDING` 重置；有两种情况会卡住排空：同一批 active 文档反复回来且状态毫无变化（再重扫只会自旋），以及排空**根本无法推进**的 active 文档——持有**未完成 custom-chunk 操作**的行，只有 `/documents/scan` 的回滚能处理它们。两种情况下重置都不执行，重试请求保持未 ACK（那一次机会仍然欠着），栅栏消息带阻塞文档 ID 的**有界样本**。`recovery_kind` 区分二者：`manual_drain_stalled` 和 `manual_drain_blocked`。
-
-   （`/documents/scan` 不做这个排空——见 §8.4：它只在管线空闲时才获得 reservation，分类阶段持有 `scanning_exclusive`，且其重置不启动任何 worker，所以残留的 `PENDING` 行是惰性的，不是生产者。）
-3. **reservation 持有者的生死无法判定。** 回收一个 reservation 必须先证明其所属进程已死亡。不带进程身份的持有者记录永远无法证明，因此它的 reservation 保持原样（绝不靠猜回收），由栅栏提供出口。
-
-`GET /documents/pipeline_status` 返回净化后的投影——`recovery_required`（布尔）、`recovery_kind`（粗粒度原因）和 `recovery_message`（与 503 相同的文案，某些原因还带有界的阻塞样本）。原始栅栏记录永不外露：它与携带 PID 和 reservation token 的 owner 记录并存，而 token 可以用来释放 reservation。
+`GET /documents/pipeline_status` 会返回 `recovery_required`（布尔）、`recovery_kind`（粗粒度原因）和 `recovery_message`（与 503 相同的文案，某些原因还带阻塞文档的有界样本）。
 
 解除栅栏：
 
-```
+```text
 POST /documents/recovery/force_reset
 ```
 
-这是**不安全的人工覆盖**——它不修复任何东西。除栅栏之外，它还会**取消该 workspace 排队中的 manual retry 请求**，这一点是必需的而非附带：只要存在排队请求，`/documents/scan` 就会拒绝自己的 reservation（scan 自己要跑独占 `FAILED` 重置，不能跳 manual FIFO，见 §8.4），所以只清栅栏会让恢复路径照样被堵。响应里返回 `cancelled_manual_retries`。不会丢文档——失败文档仍是 `FAILED`，由下一次请求或 scan 自己的重置处理。
-
-由于两半都是必需的，这个调用是**全有或全无**的：如果排队请求无法取消，接口返回 **503** 且栅栏保持不变——这样可以重试来完成恢复，而不是让 API 报告一次并未发生的恢复。
+这是**不安全的人工覆盖**——它不修复任何东西。除栅栏之外，它还会**取消该 workspace 排队中的手动重试请求**，这一点是必需的而非附带：只要还有排队请求，`/documents/scan` 就会拒绝执行（scan 自己也要跑独占的 `FAILED` 重置，不能插队），所以只清栅栏会让恢复路径照样被堵。响应里返回 `cancelled_manual_retries`。不会丢文档——失败文档仍是 `FAILED`，由下一次重试请求或 scan 自己的重置处理。由于两半都是必需的，这个调用是**全有或全无**的：如果排队请求无法取消，接口返回 **503** 且栅栏保持不变，这样可以重试来完成恢复，而不是让 API 报告一次并未发生的恢复。
 
 恢复顺序：
 
@@ -1007,42 +1028,50 @@ POST /documents/recovery/force_reset
 |---|---|
 | `manual_drain_blocked` | `POST /documents/recovery/force_reset`，然后 `POST /documents/scan` —— scan 会回滚未完成的操作**并且**自己执行 `FAILED` 重置，无需再单独调重试。 |
 | `manual_drain_stalled` | `POST /documents/recovery/force_reset`，然后排查 `recovery_message` 中列出的文档——它们卡住的原因这个栅栏无法给出。处理完后重新调 `POST /documents/reprocess_failed`。 |
-| worker 死于 `custom_chunks` / `delete` / `clear` 途中 | 先确认受影响的存储一致，再 `POST /documents/recovery/force_reset`。 |
+| worker 死于 `custom_chunks` / `delete` / `clear` 途中 | 不要直接 `force_reset`——按下面「半提交存储怎么修」处理。 |
 
-整体重启服务同样会清除栅栏和排队请求，二者都是运行时协调状态，都不做持久化。
+**能不能直接重启服务了事？** 判断标准只有一条——**堵塞源在内存里还是在存储里**。重启清掉的只有运行时协调状态（`pipeline_status` 里的栅栏与 owner 记录、ingress 里排队的手动重试请求，都不持久化），写进 `doc_status` / `full_docs` / 存储的东西一样都清不掉。
 
-### 8.8 enqueue 串行锁（防并发去重穿透）
+| 成因 | 重启能否解决 | 说明 |
+| --- | :-: | --- |
+| owner 生死无法判定 | ✅ 能 | 卡住的 reservation 记录本身就活在跨进程共享状态里，进程组一起重启就没了，且没有任何存储被动过——这是最干净的办法 |
+| `manual_drain_stalled` | ⚠️ 多半能 | 栅栏与排队请求随重启消失；那些"反复回来又不变状态"的活跃行若是死进程遗留的 `PROCESSING` / `PARSING` / `ANALYZING` 孤儿，重启后会被自动重置为 `PENDING` 并在下次触发时重跑，堵塞源自然消失。但重启不诊断根因：若它们是因别的原因每轮都停在同一状态，下一次 `/documents/reprocess_failed` 会再次 stall |
+| `manual_drain_blocked` | ❌ 不能 | 阻塞源是 `doc_status.metadata` 里未完成的 custom-chunk 操作日志，它**是持久化的**，重启原样还在。重启只清掉栅栏和排队请求（这一步仍是必要的，否则排队请求会让 `/scan` 拒绝自己的 reservation），真正的回滚必须由 `POST /documents/scan` 执行 |
+| worker 死于 `custom_chunks` / `delete` / `clear` | ❌ 不能 | 半提交的是存储本身，见下 |
 
-`apipeline_enqueue_documents` 内部"读 doc_status 做去重 → 写 `full_docs` / `doc_status`"这一段在 workspace 级 `enqueue_serialize` 锁内串行执行。原因：放开 busy/scan-processing 阶段允许并发 enqueue 之后，两次相同内容、不同文件名的入队（典型场景：scan 处理阶段的 enqueue 与 upload 同时进来）若在没有锁的情况下并发执行——
+所以重启相当于一次"温和版 `force_reset`"：两者都清栅栏与排队请求、都不修复任何东西，区别是重启还会顺带把中断态文档重置为 `PENDING`（这正是 stalled 常能自愈的原因），代价是一次服务中断。能停服务就优先重启；不能停、且已确认存储未被动过（成因 2 / 3）才用 `force_reset`。
 
-1. A 读 `doc_status` 查 `content_hash`：未命中。
-2. B 读 `doc_status` 查 `content_hash`：仍未命中（A 还没 upsert）。
-3. A upsert `full_docs` + `doc_status`。
-4. B upsert `full_docs` + `doc_status`。
+#### 半提交存储怎么修：两个离线工具与 `force_reset` 的分工
 
-结果：同 `content_hash` 的两条 `PENDING` 都进入流水线后续处理，原本应当被识别为 `duplicate_kind=content_hash` 的那条**没**被识别。
+栅栏本身**不持久化**（它活在 `pipeline_status` 里），**整体重启服务就会清掉它和排队请求**。这一点决定了 `force_reset` 该用在哪：
 
-加上串行锁后第二次 enqueue 一定能在去重读时看到第一次已 upsert 的行，正常走"无新唯一文档"的早返回路径并把本次记为 `duplicate_kind=content_hash` 的 FAILED 行。锁的作用范围**只覆盖**：
+- **成因 2 / 3 用它。** 这两种情况下重置根本没执行、存储一字未动，卡住的只是调度——为此停服务不值得。
+- **成因 1 尽量别用它。** 它只清标志、不修任何东西；清完之后所有写入（包括并发上传）立刻在一个可能半提交的存储上重新开工。而下面两个离线工具本来就要求先停服务——停下来栅栏自然消失，`force_reset` 根本不必出场。
 
-- `filter_keys`（按 doc_id 排除已存在）
-- 文件名 / 内容 hash 去重读
-- 重复 FAILED 行的 upsert
-- `full_docs.upsert` + `doc_status.upsert`
+两个离线工具能修什么、修不了什么：
 
-锁**不**覆盖 ingress document 发布（在锁外，只取一下 `pipeline_status_lock`），也**不**阻塞处理循环的 `get_docs_by_statuses` 读（处理循环走的是 `doc_status` 自身的并发读，与 enqueue 写是 KV 级原子，不抢同一把锁）。锁顺序：`enqueue_serialize → pipeline_status_lock`，无死锁路径。
+| 工具 | 真相源与修复对象 | 修不了 | 成本 |
+| --- | --- | --- | --- |
+| `python -m lightrag.tools.kg_integrity_repair` | 沿 graph → chunk `source_id` → `text_chunks` → `full_doc_id` 反查，重建缺失或不可用的 `full_entities` / `full_relations` 锚点行；也能给确实什么都不拥有的文档写空锚点行 | 图↔向量漂移、`doc_status` / `full_docs` 自身、custom-chunk 日志、栅栏本身 | 不调 LLM / embedder，近乎免费 |
+| `lightrag-rebuild-vdb` | drop 后按图重建 `entities_vdb` / `relationships_vdb`、按 `text_chunks` 重建 `chunks_vdb`；能清掉反向孤儿（向量里有、图里没有），这是增量修复做不到的 | 锚点行、`doc_status`、图本身的正确性、栅栏本身 | 全量重新嵌入，真金白银 |
 
-### 8.9 分块在哪里执行
+两个顺序陷阱，弄反了会把可修复的数据变成不可修复的：
 
-分块的开销取决于调用方提供的文档，对递归策略还取决于随之提供的分隔符级联，因此它在一个专用的**单 worker** 线程池中执行，而不是在 asyncio 事件循环上就地运行。就地运行会导致时间循环被阻塞，导致异步操作出现延迟。从"拿到正文"到"写出分块"之间所有 CPU 密集的步骤都在该池内：四种分块策略、语义分块器对超尺寸片段的二次切分、多模态分块构建、嵌入前的硬切分，以及 `surrounding` 回填。
+- **`kg_integrity_repair` 必须在任何进一步删除之前跑。** 它只能从**幸存的** chunk provenance 重建锚点；半截的 delete 若已经删掉 `text_chunks`，那部分贡献就成了不可恢复孤儿，工具只能报告、绝不自动改。先跑一次报告模式（不加 `--apply`）没有任何理由不跑。
+- **`lightrag-rebuild-vdb` 必须最后跑。** 它把图与 `text_chunks` 当作真相：半截 delete 留下的、本该删掉的图对象，会被它忠实地重新嵌入回向量库。它保证的是向量与图**一致**，而不是图本身**正确**。所以先把图这一侧的真相定下来，再考虑重建向量。
 
-有两点需要知悉：
+因此成因 1 的完整顺序是：
 
-- **并发度不变，而非提升。** 单 worker 正是事件循环原本施加的并发度——一篇文档分块期间，其它文档的协程根本轮不到。该池释放的是事件循环，并不会让分块并行，也不随 `MAX_PARALLEL_INSERT` 增长。
-- **自定义 `chunking_func` 仍在事件循环上执行。** 它的契约是"同步或异步"，因此一个在被调用时触碰运行中事件循环的实现是受支持的，放进工作线程会直接失败。只有内置默认实现会被派发到该池；CPU 密集的自定义分块器应自行 `asyncio.to_thread`。
+1. **停服务**（栅栏随之消失，别急着 `force_reset`）。
+2. `python -m lightrag.tools.kg_integrity_repair --verbose` 先看报告：锚点缺口、以及已经救不回来的不可恢复孤儿。有缺口再 `--apply`。
+3. 起服务，把没做完的那次操作重跑一遍——whole-document purge 带 journal，会从已完成的阶段之后接着做；`clear` 直接重跑；`custom_chunks` 的回滚由 `POST /documents/scan` 触发。
+4. 稳定之后若怀疑图↔向量漂移，再停服务跑 `lightrag-rebuild-vdb`，先用菜单里的只读一致性检查决定值不值得付嵌入成本。
 
-### 8.10 流水线并发参数
+两个工具都必须在服务已停止、workspace 空闲时运行（并发写入会让它们读到移动的目标）；`lightrag-rebuild-vdb` 还必须使用与服务相同的 `.env`，否则重建出的向量落在另一个嵌入空间里。详见 [README_KG_INTEGRITY_REPAIR.md](../lightrag/tools/README_KG_INTEGRITY_REPAIR.md) 与 [README_REBUILD_VDB.md](../lightrag/tools/README_REBUILD_VDB.md)。
 
-`pipeline_status` 相关的锁解决的是"谁能写"的正确性问题，本节这一组参数解决的是"同时跑几个 worker"的吞吐量问题。流水线分为 3 个阶段，每个阶段的 worker 池数量独立可调：
+### 8.6 流水线并发参数
+
+上面几节讲的是"谁能写"的正确性问题，本节这一组参数解决的是"同时跑几个 worker"的吞吐量问题。流水线分为 3 个阶段，每个阶段的 worker 池数量独立可调：
 
 ```
           ┌─ parse_queues["native"]  ─► [native 池  × N1] ─┐   ← legacy 共享此池
@@ -1051,7 +1080,7 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼�
           └─ parse_queues[<第三方组>] ─► [自定义并发池]  ──┘   ← 按 ParserSpec.queue_group 动态创建
 ```
 
-解析队列**按注册表的 `ParserSpec.queue_group` 动态创建**（每批取一次注册表快照）：内置 native/mineru/docling 各占一组，legacy 共享 native 池（本地、无网络），第三方引擎可声明独立组与自定义并发数（见 [ThirdPartyParser-zh.md](./ThirdPartyParser-zh.md)）。入队时 `resolve_stored_document_parser_engine` 根据每个文档的 `parser_engine`（来自 `LIGHTRAG_PARSER` 默认值或文件 hint）把它放入对应解析队列；各解析队列**完全互不阻塞**——mineru 占满不会拖慢 docling 或 native。解析完成后统一进入 `q_analyze`（多模态分析），再进入 `q_process`（实体/关系抽取 + 入库）。
+解析队列**按注册表的 `ParserSpec.queue_group` 动态创建**（每批取一次注册表快照）：内置 native/mineru/docling 各占一组，legacy 共享 native 池（本地、无网络），第三方引擎可声明独立组与自定义并发数（见 [ThirdPartyParser-zh.md](./ThirdPartyParser-zh.md)）。入队时根据每个文档的解析引擎（来自 `LIGHTRAG_PARSER` 默认值或文件 hint）把它放入对应解析队列；各解析队列**完全互不阻塞**——mineru 占满不会拖慢 docling 或 native。解析完成后统一进入 `q_analyze`（多模态分析），再进入 `q_process`（实体/关系抽取 + 入库）。
 
 | 环境变量 | 默认值 | 作用 | 调优建议 |
 | --- | --- | --- | --- |
@@ -1071,6 +1100,7 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼�
 3. **`MAX_PARALLEL_INSERT` 兼任 worker 池大小和信号量上限**：流水线创建 `Semaphore(max_parallel_insert)`，每个 process worker 在抽取入库前还要拿一次信号量。所以哪怕你把 worker 数手动改大，实际并发上限仍由这个值决定——直接调它就够了。
 4. **queue size 与背压**：`QUEUE_SIZE_INSERT=4` 这个偏小的默认值是有意为之——process 阶段慢且占内存，让 analyze 阶段在队列写满时阻塞、再反压到 parse 阶段，避免一次性把成千上万份解析结果堆在内存里。
 5. **改后生效方式**：所有参数通过 `.env`（或环境变量）传入，仅在 `LightRAG` 实例构造时读取一次；改完需要重启服务。
+6. **分块不随并发增长**：分块在一个专用的单 worker 线程池里执行，目的是不阻塞事件循环，并发度不随 `MAX_PARALLEL_INSERT` 提高，调大并发不会让分块更快。自定义 `chunking_func` 仍在事件循环上执行（它的契约允许触碰运行中的事件循环），CPU 密集的实现应自行 `asyncio.to_thread`。
 
 **典型调优场景：**
 
@@ -1079,7 +1109,7 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼�
 - 纯 docx / txt（仅走 native）：`MAX_PARALLEL_PARSE_NATIVE=10`、`MAX_PARALLEL_INSERT` 按 `MAX_ASYNC_LLM/3` 推算。
 - LLM 限流明显：先降 `MAX_PARALLEL_INSERT`（process 阶段每文档多次 LLM 调用），再降 `MAX_PARALLEL_ANALYZE`（VLM 是独立配额）。
 
-### 8.11 准入与请求限制
+### 8.7 准入与请求限制
 
 在文档触及上述任何机制之前，服务端就可能直接拒收。下面这些变量决定一次上传是被拒绝还是被排队：
 
@@ -1097,14 +1127,14 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼�
 | 变量 | 缺省 | 含义 |
 | --- | --- | --- |
 | `PIPELINE_SCHEDULING_PAGE_SIZE` | `500` | doc_status 积压扫描的 keyset 分页大小；`0` 关闭分页 |
-| `PIPELINE_REQUIRE_STRICT_STORAGE_READS` | `false` | doc_status 后端无法提供严格读时拒绝启动。它直接决定 §7.1 的 `STALE_STUB` 出口能否工作——没有可靠的点读，就什么都不会删 |
-| `MAX_UNACKED_MANUAL_RETRIES` | `64` | 每个 workspace 已发布但未确认的手动重试请求上限（§8.7） |
+| `PIPELINE_REQUIRE_STRICT_STORAGE_READS` | `false` | doc_status 后端无法提供严格读时拒绝启动。它直接决定 [§7.4](#74-目录扫描的特殊处理) 里"删掉失败记录、把文件当新文档重跑"那一行能否生效——没有可靠的点读，就什么都不会删 |
+| `MAX_UNACKED_MANUAL_RETRIES` | `64` | 每个 workspace 已发布但未确认的手动重试请求上限（[§8.3](#83-出错后如何重试)） |
 
 ## 9. 流水线启动时的续跑规则
 
 每次 `apipeline_process_enqueue_documents` 起步时，会拉取所有处于 `PARSING` / `ANALYZING` / `PROCESSING` / `PENDING` / `FAILED` 状态的文档继续处理。续跑路径**根据"内容是否已抽取"分流**，保证同一个文档无论之前进度如何，按当前 `process_options` 续跑都有幂等结果。
 
-续跑规则只对 `doc_id` 已经存在于 `doc_status` 的文档生效。新文件入队需要"并发与重入约束"中的文件查重逻辑，避免新文件挤掉旧的已经成功提取内容的文件记录。
+续跑规则只对 `doc_id` 已经存在于 `doc_status` 的文档生效。新文件入队需要 §7 的文件查重逻辑，避免新文件挤掉旧的已经成功提取内容的文件记录。
 
 ### 9.1 判断"内容已抽取"
 
@@ -1149,12 +1179,15 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼�
 | 指定了 `P`，分块结果却像 `R` | 没有产出结构化的 `LightRAG Document`，`P` 已退化（§2.7、§3.2） | 把文件路由给 `native` / `mineru` / `docling`，而不是 `legacy` |
 | `.docx` 标题识别不准，导致 `P` 切分很差 | 该文档的 Word 大纲不可靠 | 试试 `native(smart_heading=true)`（§3.3），配合 parser CLI 迭代 |
 | 日志提示部分段落缺少 `paraId` | 由 LibreOffice / WPS / 旧版 Word 产生（§3.3） | 仅提示性。只有确实需要段落级溯源时，才用 Word 2013+ 另存一次 |
-| 文档 FAILED 且标记为重复 | 文件名查重（规范化并剥掉 hint 后）或内容 hash 查重（§7.1、§7.2） | 先删除已有文档，或给新文件改名 |
-| 上传返回 `409` | 输入目录或 doc_status 里已存在同规范名的文档（§8.5） | 用 `POST /documents/delete_document` 删除后再上传 |
-| 上传返回 `413` 或 `429` | 触发了准入限制（§8.11） | 对照该节的限制表判断是哪一条 |
-| 所有接口都返回 `503` | `recovery_required` 栅栏已升起（§8.7） | 按该节给出的恢复顺序处理 |
-| `/documents/scan` 返回 `scanning_skipped_pipeline_busy` | 流水线正忙或正在扫描、有上传在途、或有手动重试排队中（§8.2） | 等待空闲；`POST /documents/reprocess_failed` 是卡住的重试请求的一键恢复 |
-| 改了引擎或选项，输出却没变 | 引擎与 `process_options` 在入队时就冻结进 doc_status 记录。自动续跑与 `/documents/reprocess_failed` 都沿用存量值；改 `LIGHTRAG_PARSER` 或 hint 只对新上传生效（§9.3） | 删除该文档（勾选"同时删除文件"）后重新上传 |
+| 文档 FAILED 且标记为重复 | 文件名查重（规范化并剥掉 hint 后）或内容 hash 查重（§7.1、§7.2） | 先删除已有文档，或给新文件改名；重复记录（`dup-*`，或解析后就地改为 FAILED 的原记录）只能显式删除（§7.3） |
+| 上传返回 `409` | 输入目录或 doc_status 里已存在同规范名的文档（§7.2） | 用 `POST /documents/delete_document` 删除后再上传 |
+| 上传返回 `413` 或 `429` | 触发了准入限制（§8.7） | 对照该节的限制表判断是哪一条 |
+| 所有接口都返回 `503` | `recovery_required` 栅栏已升起（§8.5） | 按该节给出的恢复顺序处理 |
+| `/documents/scan` 返回 `scanning_skipped_pipeline_busy` | 流水线正忙或正在扫描、有上传在途、或有手动重试排队中（§8.1） | 等待空闲；`POST /documents/reprocess_failed` 是卡住的重试请求的一键恢复 |
+| 点了「中断」，一批文档变成 `FAILED` | 已进入本批的文档在中断时会被标记为 FAILED（§8.2） | 用 `POST /documents/scan` 或 `POST /documents/reprocess_failed` 重试；已完成的文档不受影响 |
+| 点了「中断」但流水线还在跑 | 中断是协作式的，不会打断已经发出的 LLM 调用（§8.2） | 等当前阶段结束；`GET /documents/pipeline_status` 的 `cancellation_requested` 可确认请求已收到 |
+| 重启服务后文档卡在 `PROCESSING` / `PARSING` | 中断态会自动恢复，但服务启动本身不会触发流水线（§8.2） | 调一次 `POST /documents/scan`，或上传任意文件触发 |
+| 改了引擎或选项，输出却没变 | 引擎与 `process_options` 在入队时就冻结进 doc_status 记录。自动续跑与 `/documents/reprocess_failed` 都沿用存量值；改 `LIGHTRAG_PARSER` 或 hint 只对新上传生效（§8.3、§9.3） | 删除该文档（勾选"同时删除文件"）后重新上传 |
 | 修好了外部引擎的服务配置，它却一直返回旧结果 | 命中了原始产物包缓存（§6.3） | 打开对应的 `LIGHTRAG_FORCE_REPARSE_*`（§3.7），或删除文档时勾选"同时删除文件" |
 | 扫描版 PDF 报 "extracted no usable text" | `legacy` 读不了没有文本层的 PDF（§3.2） | 改路由到开启 OCR 的 `mineru` 或 `docling` |
 | MinerU 拒绝多段页码范围 | 多段范围只有 `official` 模式支持，`local` 只接受单页或一个简单区间（§3.6） | `local` 下改用单个区间，或切换模式 |
@@ -1217,7 +1250,7 @@ per-file 个性化的典型场景：管理 UI 单独配置某个文件的 separa
 
 **不传 `file_paths` 的兼容**：核心 API `insert` / `ainsert` / `apipeline_enqueue_documents` 仍兼容未传 `file_paths` 的调用；这类文档的 `file_path` 会保存为 `unknown_source`，不会参与文件名查重，文档 ID 继续按文本内容生成。
 
-`apipeline_enqueue_documents` 自身的并发约束（last-line guard、`from_scan=True` 旁路）见 §8.2 入口行为表。
+`apipeline_enqueue_documents` 自身的并发约束见 §8.1 的状态-操作表。
 
 ### 11.5 `ainsert(split_by_character=…, split_by_character_only=…)`
 
@@ -1232,7 +1265,7 @@ per-file 个性化的典型场景：管理 UI 单独配置某个文件的 separa
 
 旧 `apipeline_enqueue_documents` 的 `reprocess_existing_non_processed=True` 行为会在 scan 时直接删除非 PROCESSED 的旧记录并重建，与 §7 / §8 的规则相冲突，已整段移除。替代路径：
 
-- 自动续跑：scan 按 §7.1 的分类规则处理同名文件（归档 / 续跑 / 删 stub 后重入队），由 §9 续跑规则在处理循环里统一接管。
+- 自动续跑：scan 按 §7.4 的规则处理同名文件（归档 / 续跑 / 删记录后重入队），由 §9 续跑规则在处理循环里统一接管。
 - 强制刷新：先调 `/documents/delete_document` 删旧文档，再上传同名新文件。
 
 ## 附录 A：从旧版升级的注意事项
@@ -1269,8 +1302,8 @@ per-file 个性化的典型场景：管理 UI 单独配置某个文件的 separa
 | MinerU | `MINERU_*` | §3.4 |
 | Docling | `DOCLING_*` | §3.5 |
 | 解析缓存 | `LIGHTRAG_FORCE_REPARSE_{NATIVE,MINERU,DOCLING}`、`{MINERU,DOCLING}_ENGINE_VERSION` | §3.7、§6.3 |
-| 目录 | `INPUT_DIR`、`WORKING_DIR`、`SCAN_SPOOL_DIR` | §6、§7.1 |
-| 并发 | `MAX_PARALLEL_*`、`QUEUE_SIZE_*` | §8.10 |
-| 准入与限制 | `MAX_UPLOAD_SIZE`、`MAX_REQUEST_BODY_BYTES`、`MAX_TEXTS_PER_REQUEST`、`MAX_PENDING_DOCUMENTS`、`PIPELINE_*`、`MAX_UNACKED_MANUAL_RETRIES`、`SCAN_ENQUEUE_BATCH_SIZE` | §8.11 |
+| 目录 | `INPUT_DIR`、`WORKING_DIR`、`SCAN_SPOOL_DIR` | §6、§7.4 |
+| 并发 | `MAX_PARALLEL_*`、`QUEUE_SIZE_*` | §8.6 |
+| 准入与限制 | `MAX_UPLOAD_SIZE`、`MAX_REQUEST_BODY_BYTES`、`MAX_TEXTS_PER_REQUEST`、`MAX_PENDING_DOCUMENTS`、`PIPELINE_*`、`MAX_UNACKED_MANUAL_RETRIES`、`SCAN_ENQUEUE_BATCH_SIZE` | §8.7 |
 | 查询期（不影响分块） | `ENABLE_CONTENT_HEADINGS` —— 组装回答上下文时为每个分块追加其标题路径；它不改变分块边界，也不改变已存储的分块文本 | [LightRAG Server](./LightRAG-API-Server-zh.md) |
 | 离线 / 分词器 | `TIKTOKEN_CACHE_DIR` | [OfflineDeployment.md](./OfflineDeployment.md) |

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -18,8 +18,8 @@ This document is organized from the perspective of **LightRAG Server** deploymen
 - [4. Multimodal Analysis (VLM)](#4-multimodal-analysis-vlm)
 - [5. Chunker Parameter Configuration (chunk_options)](#5-chunker-parameter-configuration-chunk_options)
 - [6. Storage and Directory Layout](#6-storage-and-directory-layout)
-- [7. Document Duplicate Detection Rules](#7-document-duplicate-detection-rules)
-- [8. Pipeline Concurrency and Reentry Constraints](#8-pipeline-concurrency-and-reentry-constraints)
+- [7. Same-name and Duplicate Documents](#7-same-name-and-duplicate-documents)
+- [8. Operating the Pipeline: Uploading While It Runs, Stopping, Retrying](#8-operating-the-pipeline-uploading-while-it-runs-stopping-retrying)
 - [9. Pipeline Resume Rules at Startup](#9-pipeline-resume-rules-at-startup)
 - [10. Troubleshooting](#10-troubleshooting)
 - [11. Python SDK Invocation](#11-python-sdk-invocation)
@@ -555,7 +555,7 @@ The surrounding budgets are subtracted from the total, so setting them too high 
 
 ### 4.5 Image limits and throughput
 
-`VLM_MAX_IMAGE_BYTES` (default 5 MB) and `VLM_MIN_IMAGE_PIXEL` (default 64) bound what is worth sending: the lower bound exists to skip icons and separator rules rather than pay for a VLM call on them. Analyze-stage concurrency is `MAX_PARALLEL_ANALYZE` (§8.10), which is independent of the parse and insert stages.
+`VLM_MAX_IMAGE_BYTES` (default 5 MB) and `VLM_MIN_IMAGE_PIXEL` (default 64) bound what is worth sending: the lower bound exists to skip icons and separator rules rather than pay for a VLM call on them. Analyze-stage concurrency is `MAX_PARALLEL_ANALYZE` (§8.6), which is independent of the parse and insert stages.
 
 ### 4.6 Model configuration lives elsewhere
 
@@ -571,7 +571,7 @@ MinerU has a VLM pass of its own, enabled by `MINERU_LOCAL_IMAGE_ANALYSIS`. It r
 2. Confirm the sidecar items carry `llm_analyze_result.status == "success"`.
 3. Then add `i` **together with** `VLM_PROCESS_ENABLE=true` and a vision-capable binding.
 
-Doing step 3 in two halves is what produces the failure in §4.3 step 4. And because processing options are frozen at enqueue, a document that already failed that way cannot be rescued by editing configuration and retrying: `/documents/reprocess_failed` re-runs it with the same `i`. Either make the VLM available and retry, or delete the document and upload it again without `i`.
+Doing step 3 in two halves is what produces the failure in §4.3 step 4. And because processing options are frozen at enqueue, a document that already failed that way cannot be rescued by editing configuration and retrying: `/documents/reprocess_failed` re-runs it with the same `i`. Either make the VLM available and retry, or delete the document and upload it again without `i` (§8.3).
 
 ## 5. Chunker Parameter Configuration (chunk_options)
 
@@ -843,268 +843,298 @@ Engine-specific conditions on top of that:
 
 > **"Either side empty means skip"** applies to `engine_version` and `endpoint_signature` on both external engines. If the field was empty when the manifest was written (for example `MINERU_ENGINE_VERSION` was unset at first parse), or if the current environment variable is unset, that particular check is skipped. Consequently, setting a version variable *after* a bundle already exists does not retroactively invalidate it — use the matching `LIGHTRAG_FORCE_REPARSE_*` flag for that.
 
-## 7. Document Duplicate Detection Rules
+## 7. Same-name and Duplicate Documents
 
-File upload, file-parse enqueue, and the text APIs check duplicates against two gates: "filename + content hash". Hitting either is considered a duplicate, and a `FAILED` record is written without overwriting the existing `full_docs`. `/documents/scan` directory scanning uses the same set of indexes, but in order to facilitate automatic retry of unfinished files, it has separate archive and re-process rules for duplicate filenames.
+Uploads, directory scans and the text endpoints all deduplicate. Ingesting the same content twice wastes LLM quota and creates duplicate entities in the knowledge graph, so LightRAG checks two rules — filename and content: hitting either marks the attempt a duplicate, records it as `FAILED`, and **never overwrites the existing document**. Every check completes **before** chunking, entity extraction and any graph write — but that is not the same as "before anything is stored": `native` / `mineru` / `docling` must persist a pending-parse record and then the parse result before a content hash exists at all, so that path briefly holds a record that is subsequently rolled back (see §7.1, §7.2).
 
-### 7.1 Filename (basename) Deduplication
+### 7.1 The Two Dedup Rules
 
-- The granularity of the check is basename, excluding directory path and workspace path. For example, `/data/a.pdf`, `inputs/a.pdf`, and `a.pdf` are all considered the same filename `a.pdf`.
-- Filename deduplication uses `canonical_basename` as the index: the supported-engine processing hint at the end of the filename is stripped before comparison, so `abc.docx`, `abc.[native].docx`, and `abc.[native-iet].docx` are considered the same name. Unsupported hints are not stripped; e.g., `abc.[draft].docx` is still treated by its original filename.
-- For ordinary upload, text APIs, and core enqueue APIs, as long as a file with the same name already exists in `doc_status` — whether that record is currently `PENDING`, `PARSING`, `ANALYZING`, `PROCESSING`, `FAILED`, or `PROCESSED` — the same-name file is considered a duplicate.
-- For `/documents/scan` directory scan: the canonical basename only **locates** candidate records; it is not assumed to be unique (custom-ID inserts, legacy ids and historical collisions can all share one canonical). Scan computes each physical file's canonical source key, resolves it once through `resolve_doc_source_strict`, and classifies it into exactly one of seven exits in a fixed, mutually exclusive order. Classification is **read-only**: enqueue, archive and stub deletion all happen after it, so every decision can be logged, counted and sampled before anything changes.
+**Rule one: duplicate filename.** Only the filename itself is compared (no directory, no workspace path), so `/data/a.pdf`, `inputs/a.pdf` and `a.pdf` are the same name. Any recognized `[engine-options]` hint is stripped first, so `abc.docx`, `abc.[native].docx` and `abc.[native-iet].docx` all count as the same name; an unrecognized hint is not stripped, so `abc.[draft].docx` is still a different name. If `doc_status` already holds a record under that name, the attempt is a duplicate **whatever state that record is in — `PENDING`, `PARSING`, `ANALYZING`, `PROCESSING`, `FAILED` or `PROCESSED`**.
 
-  | Exit | Condition | Action |
-  | --- | --- | --- |
-  | `CLAIMED_NEW` | no record shares the canonical source (`SourceAbsent`) | staged in the scan's disposable disk spool under the first canonical claim; later enqueued in global `st_mtime` order; `metadata.source_file` keeps the original basename including its hint |
-  | `SOURCE_CONFLICT` | several primary records share the canonical source (`SourceConflict`, historical) | not enqueued, no record deleted, and the file is **not** archived (the operator needs it in place); the job records a bounded sample of candidate doc IDs, to be repaired by doc ID before the file can be classified. Repair entry points: `GET /documents/source_conflicts` lists the conflicts and `POST /documents/source_conflicts/repair` settles one by naming the `primary_doc_id` to keep (dry-run by default; echo back the returned `candidate_count`/`fingerprint` to commit, and a changed candidate set returns 409), or offline via `python -m lightrag.tools.source_conflict_repair` |
-  | `PROCESSED` | the unique record is already `PROCESSED` | emit a warning, archive the source file to `__parsed__`, skip enqueueing |
-  | `STALE_STUB` | the unique record is `FAILED` **and** a strict point read confirms `full_docs` is absent | recognized as an extraction-error stub written by `apipeline_enqueue_error_documents` (the consistency check preserves such rows for human review): the stub is deleted and the current file is enqueued as `CLAIMED_NEW`. This is the only re-extracting exit, and it is what makes "fix the source file, scan again" take effect. If the point read is unsupported or fails, nothing is deleted and the file falls through to the non-destructive exits below |
-  | `SOURCE_IDENTITY_UNKNOWN` | the unique record has no `metadata.source_file` (custom-ID / legacy / non-scan-origin RAW rows) | keep the file, do not enqueue, record a bounded warning; a missing source file is **not** evidence of a different physical file |
-  | `RESUME_SAME_PHYSICAL_SOURCE` | physical basename == `source_file` | **resume path**: doc_status is preserved as-is, the source file remains in `INPUT/`, and the processing loop picks it up by status query (no re-extract, no overwrite of existing status) |
-  | `ALIAS_DUPLICATE` | physical basename != `source_file` | a different physical file for the same canonical source: archive the alias with a warning, and do not take the ordinary enqueue path (which would manufacture a `dup-*` FAILED row) |
+**Rule two: duplicate content.** What is compared is the **extracted text**, not the raw file bytes. Rename the file, or convert it to another format — as long as the extraction produces the same content it is still a duplicate. The value depends on the content format:
 
-  Discovery is a single unordered pass, but exact global mtime order needs O(number of files) ordering state somewhere. New candidates therefore go into a disposable SQLite spool. Its UNIQUE canonical-key index preserves first-physical-claim-wins across the whole scan before any new row reaches doc_status; its `(mtime, path, discovery sequence)` index is then read with `fetchmany(SCAN_ENQUEUE_BATCH_SIZE)`, so Python memory remains O(K). Each candidate also carries the size discovery already stat'ed, so the enqueue phase issues no second metadata read.
-
-  **Where the spool lives.** `SCAN_SPOOL_DIR`, else `WORKING_DIR/scan_spool`, narrowed in both cases to a per-workspace subdirectory. It must sit on real, writable, local disk: the point of the spool is to keep O(number of files) state out of RAM, and `/tmp` is a RAM-backed tmpfs on many Linux hosts, which silently gives that back. Set `SCAN_SPOOL_DIR` when `WORKING_DIR` is a network volume. INPUT_DIR is deliberately not used — it is frequently a network mount (the slowest possible home for the only bulk-insert phase), it is legitimately mounted read-only, and it is co-managed by sync tools that would copy or delete the spool mid-scan.
-
-  **Placement is fail-closed.** If the directory cannot be used, the scan fails with an error naming `SCAN_SPOOL_DIR` and enqueues nothing; the input files are untouched, so fixing the setting and re-scanning loses nothing. It does *not* relocate to the OS temp dir — that is not a degraded-but-correct mode, because on a tmpfs host it restores the exact memory cost the spool exists to remove and the operator would meet it as an OOM kill partway through a large scan.
-
-  **Crash residue is capped at one spool.** The spool sits on a persistent volume, where nothing reclaims what `kill -9` leaves behind, so its filename inside the per-workspace directory is fixed rather than randomized: the next scan deletes any leftover before opening its own. Residue is therefore one spool, never one per crash. The fixed name is safe because `scanning_exclusive` already admits a single scan per workspace — the same guarantee that keeps two scans from fighting over INPUT_DIR — and the per-workspace subdirectory is what keeps two workspaces sharing a `WORKING_DIR` from reusing each other's file.
-
-  Because the fixed name makes that subdirectory load-bearing, the workspace → directory mapping is injective by construction:
-
-  ```text
-  <base>/unnamed/candidates.sqlite3           # WORKSPACE unset
-  <base>/named/<workspace>/candidates.sqlite3 # every named workspace
-  ```
-
-  A bare sentinel would not be injective — workspace names are validated, not restricted, so a workspace literally called `_default` would land in the same directory as the unnamed one. Those two hold *different* per-workspace scan locks and can therefore scan concurrently, and the second one to start would delete the first one's live database.
-
-  **The cost of exact global ordering.** Nothing reaches doc_status until discovery finishes, so an interrupted scan (cancel, crash, restart) enqueues *nothing*: the source files stay in INPUT_DIR and the next scan rediscovers them. The one thing that does not come back is a `STALE_STUB` row deleted during discovery — the file is re-enqueued as new next time, but its preserved-for-review FAILED stub is gone. The spool itself is not LightRAG storage and is discarded when the scan ends.
-- For ordinary upload and core enqueue APIs, a file with the same name — even if its content has changed — must have its old document record deleted before re-upload or re-enqueue; the automatic recoveries above (`STALE_STUB` / `RESUME_SAME_PHYSICAL_SOURCE`) only apply to the directory-scan path.
-- Filesystem time is only a pre-persistence scan priority. The spool emits candidates globally oldest first; each sequential enqueue then stamps `doc_status.created_at=now()` at the actual first write. Once a file has entered doc_status, only the ordinary immutable `(created_at, id)` scheduling key matters and its filesystem mtime is discarded. An unreadable mtime sorts after every readable timestamp but does not lose the candidate; the enqueue path handles a vanished/unreadable file normally.
-- The text APIs must provide a valid `file_source`, and duplicates are checked by the basename of `file_source`; lacking a valid `file_source` returns 400 directly.
-- When the SDK path calls `insert` / `ainsert` / `apipeline_enqueue_documents` without `file_paths`, that is allowed; related behavior is detailed in §11.4. Such documents without a source have `file_path` saved as `unknown_source`.
-- Empty strings, `no-file-path`, and `unknown_source` are all considered unknown sources; they do not block new source-less text from being enqueued, nor do they deduplicate each other as same-named files.
-
-The storage backend provides basename direct lookup via `get_doc_by_file_basename`, internally comparing against the `canonical_basename` field (the input parameter is first canonicalized through `canonicalize_parser_hinted_basename`). `JsonDocStatusStorage` already implements an in-memory traversal; other backends currently fall back to the default implementation (scanning all states and comparing `canonical_basename`), to be augmented with native indexes in subsequent PRs.
-
-### 7.2 Content Hash Deduplication
-
-- Documents with different filenames but identical extracted content are also considered duplicates. The hash here is the content hash of the final text or LightRAG Document obtained by the configured extraction engine; it is not the hash of the original file bytes.
-- `full_docs` and `doc_status` write or fill in the `content_hash` field according to the content format:
-  - `parse_format=raw`: the MD5 of the text after `sanitize_text_for_encoding`.
-  - `parse_format=lightrag`: the MD5 of the `*.blocks.jsonl` file parsed out of `lightrag_document_path`. Relative paths are resolved against `INPUT_DIR`.
-  - `parse_format=pending_parse`: no hash is written yet; it is filled in by subsequent steps after parsing actually completes (to avoid mistakenly judging by empty content).
-- The `legacy` path deduplicates content hashes after locally extracting text and during enqueue; on hit, this record is written as `FAILED duplicate`, and no new `full_docs`, chunks, or graph data are generated.
-- The `native` / `mineru` / `docling` paths first enqueue with `pending_parse`; after parsing completes and `content_hash` is filled in, if another document already has the same hash, this record is stopped before entering analysis, chunking, entity extraction, and graph writing.
-- Duplicate records are marked as `filename` or `content_hash` in `metadata.duplicate_kind` for diagnosis. Content-hash duplicates also record `metadata.is_duplicate=true`, `metadata.original_doc_id`, and `metadata.original_track_id`; duplicates discovered only after parsing also have the temporarily-written `full_docs` deleted.
-- Related warnings minimize repetitive noise: when scanning discovers a same-name file already `PROCESSED`, a log and pipeline status are written; duplicates at the enqueue stage use the LightRAG layer's `Duplicate document detected (...)` log; content duplicates only discovered after parsing use `Duplicate content skipped after parsing` and write a pipeline status. Scan archiving does not emit the extra `[File Extraction]Duplicate skipped`.
-- The storage backend provides hash direct lookup via `get_doc_by_content_hash`; the naming convention is the same as `get_doc_by_file_basename`.
-
-> Within an enqueue batch (the same `apipeline_enqueue_documents` call), basename and content_hash dedup are also performed; on hit, subsequent entries are written as `FAILED` directly and marked with `existing_status=batch_duplicate`. Basename dedup only applies to valid filenames; `unknown_source`, `no-file-path`, and empty sources only participate in content-hash dedup.
->
-> **Cross-call concurrent dedup** is also guaranteed by the workspace-level serialization lock (see [§8.8 enqueue serialization lock (preventing concurrent dedup leakage)](#88-enqueue-serialization-lock-preventing-concurrent-dedup-leakage)): two concurrent enqueues of identical content with different filenames will not both leak past the `content_hash` check.
-
-## 8. Pipeline Concurrency and Reentry Constraints
-
-To prevent `scan` / `upload` / `insert` from overwriting `doc_status` / `full_docs` records of an in-flight pipeline, all write entry points coordinate via the `pipeline_status` shared dictionary. The `pipeline_status_lock` per workspace ensures that all transitions in the table below are completed atomically within the lock.
-
-### 8.1 `pipeline_status` Fields
-
-| Field | Semantics |
+| `parse_format` | The content hash comes from |
 | --- | --- |
-| `busy` | Generic pipeline-busy flag. Both the processing loop and destructive jobs (clear/delete) set it. **`busy=True` (processing loop) alone does not block enqueue** — the loop pulls a `doc_status` snapshot per batch; work arriving mid-run is picked up via the workspace ingress mailbox (in-batch feeder + batch-boundary quiescence decision). |
-| `destructive_busy` | A destructive subset of `busy`: `/documents/clear` or `/documents/delete_document` is dropping storages / removing source files. Both reservation and the enqueue last-line guard reject — a concurrent enqueue would write to storage being torn down, and accepted documents would be silently lost. The processing loop does not set this field. |
-| `scanning` | The `/documents/scan` background task is running (entire lifecycle: classification stage + processing stage). Only the `/scan` endpoint uses it to reject overlapping scans; it does **not** itself block upload/insert. |
-| `scanning_exclusive` | An exclusive subset of `scanning`: True only during scan's **classification phase** — run_scanning_process is reading doc_status to classify (already processed / resume / delete stub / archive) and cannot interleave with concurrent writers. Both reservation and the enqueue last-line guard reject. After classification, the flag is cleared immediately, and concurrent uploads are allowed once scan enters the processing phase. |
-| `pending_enqueues` | The number of upload/insert calls that have passed `_reserve_enqueue_slot` but whose bg task has not completed. Used only by the scan endpoint — to decide whether to take the exclusive lock. The bg task releases the slot in `finally`. |
+| `raw` | MD5 of the text after encoding sanitization |
+| `lightrag` | MD5 of the sidecar's `*.blocks.jsonl` file (relative paths resolve against `INPUT_DIR`) |
+| `pending_parse` | Not computed yet; filled in once parsing actually completes (so empty content cannot cause a false match) |
 
-Wake-up signals live **outside** `pipeline_status`, in the workspace **pipeline ingress mailbox** (`lightrag/kg/pipeline_ingress.py`, three channels: per-doc document messages / auto-rescan dirty flag / sticky manual retry requests). Enqueue publishes document messages under `pipeline_status_lock` after writing `doc_status`; a busy-refused processing request arms the auto-rescan flag inside the reservation's critical section; the running loop consumes these signals mid-batch (in-batch feeder) and at every batch boundary (atomic quiescence decision, which releases `busy` in the same critical section when all channels are empty). `doc_status` remains the source of truth — a dropped notification is recovered by the next run's initial strict scan.
+That also decides *when* the content check happens: `legacy` extracts text locally and can check at enqueue time; `native` / `mineru` / `docling` can only check once parsing has really finished, and at that point the attempt **stops before anything is built** — no chunking, no entity extraction, no graph writes — and the `full_docs` row written for this attempt is deleted.
 
-### 8.2 Entry Point Behavior
+Two additional rules:
 
-| Entry point | Condition | Behavior |
-| --- | --- | --- |
-| `/documents/upload` / `/documents/text` / `/documents/texts` | `scanning_exclusive=True` or `destructive_busy=True` | Throw HTTP 409; do not write file, do not call enqueue |
-| Same as above | Otherwise (including pure `busy=True`, scan-processing-phase `scanning=True` but `scanning_exclusive=False`) | Within the lock: `pending_enqueues++` reserves a slot → strict name precheck → save file → schedule bg task; the bg task releases the slot in `finally` |
-| `/documents/scan` | `busy=True` or `scanning=True` or `pending_enqueues>0` | Emit a warning and immediately return `scanning_skipped_pipeline_busy`; do not schedule a background task |
-| Same as above | All idle | Within the lock, set `scanning=True` then schedule; the task clears the flag in `finally` upon completion |
-| `/documents/clear` / `/documents/delete_document` | `busy=True` or `scanning=True` or `pending_enqueues>0` | The endpoint synchronously returns `status="busy"` and does not schedule a background task |
-| Same as above | All idle | The endpoint **synchronously** within the lock sets `busy=True` + `destructive_busy=True` (before `delete_document` returns `deletion_started`), and the bg task's finally clears both flags |
-| `apipeline_enqueue_documents` internal (last-line guard) | `scanning_exclusive=True` and `from_scan=False`, or `destructive_busy=True` | Throw `RuntimeError("Cannot enqueue while scan is classifying / clearing or deleting")` |
-| Same as above | Anything else (including pure `busy=True`, scan processing phase) | Enqueue normally; after writing `doc_status`, publish per-doc messages to the ingress mailbox (a running loop picks them up mid-batch or at the batch boundary) |
+- **The text endpoints** (`/documents/text`, `/documents/texts`) must supply a valid `file_source`, whose basename is used for the name check; without one they return 400.
+- **Sourceless documents** (SDK `insert` / `ainsert` without `file_paths`, recorded as `file_path=unknown_source`) take no part in name dedup — `unknown_source` is only a placeholder, so two sourceless documents never collide on it — but they **are still deduplicated by content**: inserting the same text again is still a duplicate. The empty string and `no-file-path` behave the same way.
 
-`from_scan=True` is a bypass for scan's own background-task enqueue: scan already holds the `scanning` flag, so it must be allowed to enqueue the files it has scanned.
+Neither documents within one enqueue batch nor two concurrently issued enqueues can both slip past the check: the later one is always recognized as a duplicate and recorded as `FAILED`.
 
-### 8.3 Why `busy` no longer blocks enqueue
+### 7.2 What You Will See
 
-In the old version, `busy=True` always rejected any new enqueue, on the reasoning that "modifying `doc_status` would interleave with the pipeline worker thread." However, in practice:
+| Symptom | What it means |
+| --- | --- |
+| Upload returns 409 `Document storage already contains '<name>' (Status: …)` | `doc_status` already holds a record under that name (any status, including `FAILED`) |
+| Upload returns 409 `Input directory already contains a file with the same canonical basename …` | No record exists, but `INPUT_DIR` still holds a file with that name |
+| An extra `FAILED` row appears with `error_msg` `File name already exists. Original doc_id: …, Status: …` | A batch enqueue or a scan hit the filename rule |
+| `FAILED` with `error_msg` `Identical content already exists under another filename. Original doc_id: …` | The content rule was hit |
+| `FAILED` with `error_msg` `N existing documents already share this file name …` | A legacy "one filename, several primary records" conflict that has to be repaired by doc id first |
 
-1. **Write order guarantees consistency**: `apipeline_enqueue_documents` always upserts `full_docs` first, then upserts `doc_status`. The consistency check at the start of the processing loop only deletes "orphan `doc_status` rows that have no corresponding `full_docs`" — a state that cannot occur with concurrent enqueue.
-2. **Batch-level snapshots**: each processing-loop batch pulls a `get_docs_by_statuses` snapshot once; newly written `PENDING` rows don't disturb the current batch — their document messages are routed straight into the running batch by the in-batch feeder, and anything left over is re-pulled at the batch boundary.
-3. **The ingress mailbox is designed for this**: enqueue publishes a per-doc notification for exactly the "new work arrives while running" case; the loop's quiescence decision consumes the signals and releases `busy` atomically, so nothing lands in a gap.
+The upload path is **fail-fast**: the first two cases return 409 outright, writing no file and leaving no trace in `doc_status`. The other three do leave a record in the document list, but **the records have different shapes** — do not go looking only for the `dup-` prefix:
 
-With this mechanism enabled in the new contract, **users can continue to upload new documents during long batch processing**, and the bg task, after writing `doc_status`, will be automatically picked up by the running loop.
+- **A duplicate caught at enqueue time** (same name, or a content hash that already exists on the `legacy` path): a new `FAILED` record with a doc id prefixed `dup-` is created, and the original document is untouched. Its `metadata` carries `duplicate_kind` (`filename` / `content_hash`), `original_doc_id` and `original_track_id`, naming the copy that was kept.
+- **A content duplicate found only after parsing** (`native` / `mineru` / `docling` have no content hash at enqueue time): **no** `dup-*` record is created. Instead this document's own `doc-*` record is flipped to `FAILED` in place with `metadata.is_duplicate=true` and `duplicate_kind=content_hash`, the `full_docs` row written for this attempt is deleted, and the source file is archived into `__parsed__`.
+- **`filename_conflict`**: several primary records already share the filename and the system **deliberately does not pick a primary for you**, so `original_doc_id` on this record does not name "the copy that was kept" — repair the conflict first, per [§7.3](#73-what-to-do-about-it).
 
-### 8.4 Why scan is still the exclusive writer
+### 7.3 What To Do About It
 
-scan not only enqueues the new files it finds, but also reads `doc_status` to decide what to do with each file (archive a `PROCESSED` one, keep a resume candidate, delete a stale stub and re-enqueue, …; the seven exits are listed in [§7.1](#71-filename-basename-deduplication)).
+- **To replace a same-named document with new content**: delete it first (`POST /documents/delete_document`, or the delete dialog in the WebUI document list), then upload. An upload never overwrites an existing record.
+- **To clear out duplicate records**: both the `dup-*` rows and an original row flipped to `FAILED` after parsing are **inert records** — they carry no content, and both `/documents/scan` and `/documents/reprocess_failed` skip them, so they neither re-run nor fail again. The only way to remove one is an explicit delete; leaving it in place does not affect retrieval.
+- **To re-run the same file with a different engine or different options**: dedup is not the obstacle, the frozen configuration is — see [§8.3](#83-retrying-after-a-failure) and [§9.3](#93-branch-b-already-extracted); this case requires delete + re-upload.
+- **`filename_conflict` (one name, several records)**: list the conflicts with `GET /documents/source_conflicts` and repair them with `POST /documents/source_conflicts/repair`, naming the `primary_doc_id` to keep (dry-run by default; submit again with the returned `candidate_count` / `fingerprint`, and a changed candidate set returns 409), or run `python -m lightrag.tools.source_conflict_repair` offline. Scan again once repaired.
 
-These "read–decide–write" combinations cannot interleave with other writers; otherwise classification decisions would be based on a stale view. So the classification stage must be exclusive (`scanning_exclusive`), and the scan endpoint rejects when any of `busy` / `scanning` / `pending_enqueues>0` / an exclusive-reset freeze (`manual_freeze_requested`) / an earlier unserved manual retry request holds — the last one keeps a scan from jumping ahead of a queued manual retry.
+### 7.4 What a Directory Scan Does Differently
 
-### 8.5 Strict name precheck (upload path)
+`/documents/scan` applies the same dedup rules, but it faces both sides at once — the files on disk and the records in storage — so it handles same-named files with extra automatic steps, precisely so that "fix the configuration, fix the source file, scan again" works directly instead of requiring a manual delete for every file:
 
-After upload passes the reservation but before saving the file, a two-pass check is required:
+| The record in storage | What the scan does |
+| --- | --- |
+| No record under that name | Enqueued as a new document; the whole batch is ordered by file modification time, oldest first |
+| Already `PROCESSED` | Not reprocessed; the source file is archived into `__parsed__` and a warning is logged |
+| `FAILED`, and content is confirmed to have never been extracted | The failure record is deleted and the file goes through as a brand-new document — this is what makes "fix the source file and scan again" work |
+| Interrupted mid-flight (`PENDING` / `PARSING` / `ANALYZING` / `PROCESSING`) | Both the record and the source file are kept as-is; the pipeline resumes them without re-extracting |
+| A different physical file under the same name / a record with unknown origin / one name with several records | Neither enqueued nor deleted, only archived or reported — these need a human decision, see [§7.3](#73-what-to-do-about-it) |
 
-1. **INPUT directory scan**: canonicalize the basename to be saved via `canonicalize_parser_hinted_basename`, traverse the INPUT directory for any existing same-canonical variant (with hint / without hint); 409 on hit.
-2. **doc_status check**: call `get_existing_doc_by_file_path_candidates` with the canonicalized basename; 409 on hit.
+Two operational notes:
 
-Both pass → save the file → schedule the bg task → bg task calls `apipeline_enqueue_documents` to write the store + calls `apipeline_process_enqueue_documents` to trigger processing.
+- **If a scan is interrupted (cancelled, crashed, restarted) nothing at all is enqueued.** Discovery and enqueue are two separate steps, the source files never leave `INPUT_DIR`, and the next scan simply rediscovers them. The one thing that does not come back is a failure record already deleted per row three above — the file re-runs as a new document, but the record kept for human review is gone.
+- **`SCAN_SPOOL_DIR` must point at real, writable local disk.** The candidate list built during a scan is stored under `SCAN_SPOOL_DIR`, falling back to `WORKING_DIR/scan_spool`, both further split per workspace. Do not point it at tmpfs (on many Linux hosts `/tmp` is RAM-backed); set it explicitly when `WORKING_DIR` itself is a network volume. If the directory is unusable the scan **fails outright and enqueues nothing**, and the error names the variable; input files are untouched, so nothing is lost by fixing the configuration and scanning again.
 
-> The old version once allowed upload to silently write a FAILED duplicate entry when a same-name record existed; the new rule is fail-fast, leaving no duplicate traces in doc_status. To replace a same-name document, call the `/documents/delete_document` API first.
+## 8. Operating the Pipeline: Uploading While It Runs, Stopping, Retrying
 
-### 8.6 Coordination of Multiple Concurrent Reservations
+This chapter answers three runtime questions: whether you can keep uploading once the pipeline is running, how to stop it, and what to do after a document fails. Concurrency tuning and request admission limits close the chapter.
 
-When two uploads arrive simultaneously (scan cannot acquire exclusivity at this time):
+### 8.1 What You Can Do While Processing Is Running
 
-1. A `_reserve_enqueue_slot` → `pending_enqueues=1`, write file, schedule bg task A, return success.
-2. B `_reserve_enqueue_slot` → `pending_enqueues=2`, write file, schedule bg task B, return success.
-3. bg task A `apipeline_enqueue_documents` → writes `doc_status` → calls `apipeline_process_enqueue_documents` → sets `busy=True` to process A's document.
-4. bg task B `apipeline_enqueue_documents` → sees `scanning=False`, writes normally; after writing, publishes B's document message to the ingress mailbox.
-5. bg task B calls `apipeline_process_enqueue_documents` → the reservation sees `busy=True`, arms the auto-rescan flag in the same critical section, and returns immediately.
-6. A's running loop routes B's document message into the current batch via the in-batch feeder — or, if the message lands at the boundary, the quiescence decision consumes the signal and re-pulls the snapshot — and picks up B's `PENDING` row.
-7. After all is complete: `busy=False`, `pending_enqueues=0`.
+| What you want to do | Processing documents | Scan classification phase | Clearing / deleting | Manual retry draining |
+| --- | :-: | :-: | :-: | :-: |
+| Upload a file / insert text | ✅ allowed | ❌ 409 | ❌ 409 | ❌ 409 |
+| `/documents/scan` | ⛔ refused | ⛔ refused | ⛔ refused | ⛔ refused |
+| Delete / clear documents | ⛔ refused | ⛔ refused | ⛔ refused | ⛔ refused |
+| Query / retrieval | ✅ not refused | ✅ not refused | ⚠️ not refused, results not guaranteed | ✅ not refused |
 
-No bg task will be falsely rejected due to busy — because enqueue no longer checks busy; the processing loop will not process the same document twice — in-batch admission dedups against the routing/inflight registries, and the auto-rescan flag is consumed exactly once per quiescence decision.
+Key points:
 
-### 8.7 The `recovery_required` Fence
+- **You can keep uploading during a long batch — no need to wait.** This is the most commonly misread part: document processing itself does **not** block uploads. Once the new document's record is written, the running pipeline picks it up on its own — possibly folded into the current batch, possibly at the batch boundary — and neither case needs anything from you.
+- **Scan, delete and clear need an idle pipeline.** A scan reads storage while deciding what to do with each file on disk ([§7.4](#74-what-a-directory-scan-does-differently)), and delete/clear tear storage down directly; neither can interleave with concurrent writes. When refused, `/documents/scan` returns HTTP 200 with `status="scanning_skipped_pipeline_busy"` and delete/clear return `status="busy"` — neither is an error, just retry once things are idle.
+- **Queries are not subject to pipeline admission, but results are not guaranteed during a clear/delete.** The query endpoints do not check pipeline state, so they are never refused with a 409 the way an upload is; but `/documents/clear` concurrently drops a dozen storages via `asyncio.gather` — text chunks, entity / relation / chunk vectors, the knowledge graph, `full_docs` and `doc_status` — while a query holds no consistent snapshot and does not wait for it to finish, so a query issued mid-clear may see empty results, partial results, or a storage error. "The request is accepted" and "the result is consistent" are different guarantees: wait for a destructive operation to finish before querying.
+- **When an upload is refused, the message identifies the cause** — three distinct 409s, one per state:
+  - `Document scan is classifying files. …` — a scan is in its classification phase.
+  - `Pipeline is clearing or deleting documents. …` — a clear or delete is running.
+  - `A retry of failed documents is draining the pipeline. …` — a manual retry is draining the pipeline ([§8.3](#83-retrying-after-a-failure)).
+- An upload returning **413 / 429** has nothing to do with pipeline busyness; those are request admission limits, see [§8.7](#87-admission-and-request-limits). For **503**, see [§8.5](#85-everything-returns-503-the-recovery_required-fence).
 
-Some failures leave the workspace in a state where continuing would be a guess. Rather than pick one, the pipeline sets a `recovery_required` fence: **every** mutation (upload / text / scan / manual retry / delete / clear) is then refused with **HTTP 503** until an operator clears it. The fence is set in three situations:
+### 8.2 Stopping a Running Pipeline
 
-1. **A worker died mid `custom_chunks` / `delete` / `clear`.** Those operations may have half-committed, so their reservation is not simply re-run. (A dead `processing` / `scan` owner is re-runnable and is reclaimed silently instead — no fence.)
-2. **A manual retry's drain cannot reach idle.** `/documents/reprocess_failed` drains the pipeline to idle before its exclusive `FAILED → PENDING` reset, and two things stop that drain: active documents that keep coming back unchanged (re-checking could only spin), and active documents the drain can never advance at all — rows holding an **unfinished custom-chunk operation**, which only `/documents/scan`'s rollback resolves. Either way the reset does not run, the retry request is left un-acknowledged (so its one attempt per document is still owed), and the fence message carries a bounded sample of the blocking document ids. `recovery_kind` distinguishes them: `manual_drain_stalled` and `manual_drain_blocked`.
-
-   (`/documents/scan` does not perform this drain — see §8.4: it is granted its reservation only while the pipeline is idle and holds `scanning_exclusive` across classification, and its reset starts no worker, so remaining `PENDING` rows are inert rather than producers.)
-3. **A reservation holder cannot be adjudicated.** Reclaiming a reservation requires proving its owning process is dead. A holder record with no process identity can never be proven either way, so its reservation is left untouched (never reclaimed on a guess) and the fence provides the way out.
-
-`GET /documents/pipeline_status` reports a sanitized projection — `recovery_required` (bool), `recovery_kind` (the coarse cause) and `recovery_message` (the same text the 503 carries, including the bounded blocker sample where the cause provides one). The raw fence record is never exposed: it sits alongside owner records carrying PIDs and reservation tokens, and a token authorizes releasing a reservation.
-
-Clear the fence with:
-
+```text
+POST /documents/cancel_pipeline      # no request body
 ```
+
+The WebUI entry point is the **Cancel** button inside the "Pipeline Status" dialog on the document management page, clickable only while the pipeline is running and no cancellation has been requested yet. The endpoint returns `{"status": "cancellation_requested" | "not_busy", "message": …}`; `not_busy` means nothing is running and there is nothing to cancel.
+
+**A 200 does not mean it has stopped.** All it does is set a cancellation-requested flag. Cancellation is **cooperative**: it takes effect between stages, at batch boundaries, and at the 0.5-second poll inside multimodal analysis — it **never interrupts an LLM call already in flight**. So expect to wait for the current step to finish; `cancellation_requested` in `GET /documents/pipeline_status` confirms the request was received.
+
+Once it stops, documents end up in one of these states:
+
+| Where the document was | State after the stop |
+| --- | --- |
+| Already finished | `PROCESSED`, kept, unaffected |
+| Already taken into the batch (parsing / analyzing / extracting, or queued) | `FAILED`, with `error_msg` like `User cancelled during parse: <filename>` |
+| Not yet taken into the batch | Stays `PENDING`, resumes on the next trigger |
+
+A few follow-ups:
+
+- **Completed work is not wasted.** The LLM cache and any multimodal items that analyzed successfully are flushed to disk, so a later retry hits the cache instead of paying again.
+- ⚠️ **Documents marked `FAILED` are not retried automatically** — you have to recover them with one of the explicit retries in [§8.3](#83-retrying-after-a-failure).
+- **Uploads keep working during a cancellation.** Newly uploaded documents are picked up by the next run, once this one has exited.
+- **When it does not apply**: a scan's classification phase does not count as "pipeline busy", so the call returns `not_busy` there, and there is currently no endpoint to cancel a scan job — just let it finish. Delete/clear jobs **can** be cancelled, per document: what was already deleted stays deleted, and the rest is reported as not deleted in the response.
+
+**Restarting or killing the server** is the other way to stop, with different consequences:
+
+- In-flight documents are left at `PARSING` / `ANALYZING` / `PROCESSING`; they are **not** written as `FAILED`.
+- Those interrupted states are **automatically reset to `PENDING` and re-run** the next time the pipeline starts, with no manual step.
+- But **starting the server does not start a run by itself**: it takes an upload, or a call to `POST /documents/scan`, to trigger one. So documents sitting at `PROCESSING` after a restart are not cause for alarm — just trigger a run.
+
+### 8.3 Retrying After a Failure
+
+There are three ways to recover a failed document, widest coverage first:
+
+| Method | What it does | When to use it |
+| --- | --- | --- |
+| `POST /documents/scan` (the WebUI "Scan/Retry" button) | First resets every recoverable `FAILED` back to `PENDING`, then scans `INPUT_DIR` for new files; it can also handle failure records whose content was never extracted (delete the record and re-run the file as a new document) | **First choice**, widest coverage |
+| `POST /documents/reprocess_failed` | Retries `FAILED` records from storage only, with no directory discovery; but a document that failed *during parsing* is **re-parsed**, which still reads the source file its record points at | When you do not want to trigger a full directory scan |
+| Delete + re-upload | Starts over completely | You need a different engine or different processing options, or neither of the above can recover it |
+
+Four rules you have to know:
+
+1. **Each retry request grants each document exactly one attempt.** Fail again and it stays `FAILED` until the next explicit retry — it never spins.
+2. **Automatic resume does not touch `FAILED`.** The run triggered by a new upload only recovers interrupted states (`PENDING` / `PARSING` / `ANALYZING` / `PROCESSING`); `FAILED` needs one of the two explicit entry points above.
+3. **Whether it re-parses depends on whether content was extracted successfully.** A document that already has content is not re-parsed: the retry restarts from the multimodal analysis stage, first purging the chunks and graph contributions written by the previous run (details in [§9.3](#93-branch-b-already-extracted)) — which is why "fix the VLM configuration / wait out the rate limit, then retry" works. A document that **failed during parsing** (only a `pending_parse` placeholder in `full_docs`) is reset to `PENDING` and re-enters the parse stage, reading the source file in `INPUT_DIR` again and calling the engine again — so retrying after fixing MinerU / Docling works, but such a retry fails again if the source file has been deleted.
+4. **A retry does not change the engine or the processing options.** `parse_engine`, `process_options` and `chunk_options` are frozen into the record at enqueue time; editing `.env` or a filename hint only affects new uploads.
+
+Which failures a retry fixes, and which need a delete + re-upload:
+
+| Failure cause | Retry in place? |
+| --- | --- |
+| Transient LLM / VLM / storage / network failure, or a rate limit | ✅ just retry |
+| Cancelled by the user (`User cancelled during …`) | ✅ just retry |
+| VLM not configured (`VLM analysis required but VLM role is not available`) | ⚠️ retry works once the VLM is configured; to drop image analysis instead (remove `i`), delete and re-upload |
+| External parser service down / wrong endpoint | ⚠️ retry after fixing the configuration; a raw-bundle cache hit avoids calling the external service again (§6.3) |
+| You want a different parser engine, chunking strategy, or `i/t/e/!` | ❌ delete and re-upload ([§9.3](#93-branch-b-already-extracted)) |
+| Bad filename hint or invalid chunk parameters (rows prefixed `[File Extraction]` that never produced content) | ❌ `reprocess_failed` skips them; fix the filename and use `/documents/scan`, or delete the record and re-upload |
+| A scanned PDF routed to `legacy`, which extracts no text | ❌ route the suffix to `mineru` / `docling` first, then delete and re-upload ([§3.2](#32-using-the-legacy-content-extractor)) |
+| A `dup-*` duplicate record | ❌ inert record; a retry will not touch it, just delete it ([§7.3](#73-what-to-do-about-it)) |
+| Deleting the document returns 409 (missing recovery anchor) | ❌ retrying unchanged is refused again; run `audit_kg_integrity(..., apply=True)` first |
+
+Two more things about `/documents/reprocess_failed`. It first freezes ingestion and drains the pipeline to idle — during which uploads return 409 and `/documents/scan` is refused — then rewrites `FAILED` back to `PENDING` with no worker running, and finally resumes normal processing; with many documents this takes a while. It can return 429 (too many unacknowledged retry requests, capped by `MAX_UNACKED_MANUAL_RETRIES`) or 503 (the fence is up, or a clear/delete is running); a drain that cannot reach idle raises the fence, see [§8.5](#85-everything-returns-503-the-recovery_required-fence).
+
+### 8.4 Deleting a Document: What the Two Checkboxes Remove
+
+Both checkboxes in the delete dialog default to unchecked; they decide whether the on-disk artifacts go away too:
+
+- **Neither checked**: only storage state is removed — chunks, vectors, graph contributions, `doc_status`, `full_docs`. The source file on disk, the archived copy and `.parsed/` sidecar under `__parsed__`, and the external engines' raw artifact bundles are **all kept**.
+- **"Also delete uploaded files"** (API parameter `delete_file=true`): additionally removes the source file in `INPUT_DIR`, the archived copy and `<base>.parsed/` sidecar under `__parsed__`, and the `<base>.mineru_raw/` / `<base>.docling_raw/` / `<base>.native_raw/` raw artifact bundles. **If you want to re-run with a different engine, or to make an external engine genuinely re-parse, you must check this**, otherwise the re-upload hits the cache and gets the old result back ([§3.7](#37-parse-cache-and-forced-re-parse), §6.3).
+- **"Also delete extracted LLM cache"**: additionally clears that document's extraction-stage LLM cache, so a re-upload really re-runs the LLM instead of hitting the cache. Check it when you want to verify the effect of a new model or new prompt.
+
+### 8.5 Everything Returns 503: the `recovery_required` Fence
+
+Some failures leave a workspace in a state where continuing would only be guesswork. The pipeline does not guess; it raises the `recovery_required` fence, after which **every** write operation (upload / text / scan / manual retry / delete / clear) returns **HTTP 503** until an operator lifts it explicitly. Three situations raise it — of which 1 and 3 depend on cross-process dead-owner detection and therefore only occur on **Linux with multi-worker Gunicorn** (single-process Uvicorn loses its coordination state with the process):
+
+1. **A worker died in the middle of `custom_chunks` / `delete` / `clear`.** These may be half-committed, so they cannot simply be re-run. (A dead `processing` / `scan` owner is re-runnable, is reclaimed silently, and raises no fence.)
+2. **A manual retry's drain cannot reach idle.** Two ways it gets stuck: the same documents keep coming back with no change in state (re-checking could only spin), and documents the drain can never advance at all — rows holding an **unfinished custom-chunk operation**, which only `/documents/scan`'s rollback can resolve. In both cases the reset does not run, the retry request stays unacknowledged (its one attempt is still owed), and the fence message carries a bounded sample of the blocking document ids. `recovery_kind` distinguishes them: `manual_drain_stalled` and `manual_drain_blocked`.
+3. **Whether an owner is alive cannot be determined.** Reclaiming an owner's hold requires proving its process is really dead; a holder record without a process identity can never prove it, so the pipeline does not reclaim on a guess and the fence provides the exit instead.
+
+`GET /documents/pipeline_status` reports `recovery_required` (boolean), `recovery_kind` (coarse reason) and `recovery_message` (the same text as the 503, with a bounded sample of blocking documents for some reasons).
+
+Lifting the fence:
+
+```text
 POST /documents/recovery/force_reset
 ```
 
-This is an **unsafe manual override** — it does not repair anything. Besides the fence it also **cancels the workspace's queued manual retry requests**, and that is required rather than incidental: a queued request makes `/documents/scan` refuse its reservation (a scan runs its own exclusive `FAILED` reset and may not jump the manual FIFO, §8.4), so clearing only the fence would leave the recovery path just as blocked. The response reports `cancelled_manual_retries`. No document is lost — failed documents stay `FAILED` and are retried by the next request or by the scan's own reset.
-
-Because both halves are required, the call is **all-or-nothing**: if the queued retries cannot be cancelled it returns **503** with the fence untouched, so a retry can complete the recovery instead of the API reporting one that did not happen.
+This is an **unsafe manual override** — it repairs nothing. Besides the fence it also **cancels the workspace's queued manual retry requests**, and that is required rather than incidental: while a request is queued `/documents/scan` refuses to run (a scan runs its own exclusive `FAILED` reset and may not jump the queue), so clearing only the fence would leave the recovery path just as blocked. The response reports `cancelled_manual_retries`. No document is lost — failed documents stay `FAILED` and are handled by the next retry request or by the scan's own reset. Because both halves are required, the call is **all-or-nothing**: if the queued requests cannot be cancelled the endpoint returns **503** and the fence stays up, so you can retry to complete the recovery rather than have the API report a recovery that did not happen.
 
 Recovery order:
 
-| Cause | Do this |
+| Reason | Action |
 |---|---|
-| `manual_drain_blocked` | `POST /documents/recovery/force_reset`, then `POST /documents/scan` — the scan rolls the unfinished operation back **and** runs the `FAILED` reset itself, so no separate retry call is needed. |
-| `manual_drain_stalled` | `POST /documents/recovery/force_reset`, then inspect the documents named in `recovery_message` — they are stuck for a reason this fence cannot name. Re-issue `POST /documents/reprocess_failed` once they are resolved. |
-| worker died mid `custom_chunks` / `delete` / `clear` | Verify the affected storages are consistent, then `POST /documents/recovery/force_reset`. |
+| `manual_drain_blocked` | `POST /documents/recovery/force_reset`, then `POST /documents/scan` — the scan rolls back the unfinished operations **and** runs the `FAILED` reset itself, so no separate retry call is needed. |
+| `manual_drain_stalled` | `POST /documents/recovery/force_reset`, then investigate the documents named in `recovery_message` — the fence cannot say why they are stuck. Re-issue `POST /documents/reprocess_failed` once they are resolved. |
+| A worker died during `custom_chunks` / `delete` / `clear` | Do not reach for `force_reset` — follow "Repairing half-committed storage" below. |
 
-Restarting the whole service also clears the fence and the queued requests, since both are runtime coordination state and neither is persisted.
+**Can a restart just fix it?** There is exactly one test — **is the blocker in memory or in storage?** A restart clears only runtime coordination state (the fence and owner records in `pipeline_status`, the queued manual retry requests in the ingress; none of it is persisted). Anything written to `doc_status` / `full_docs` / the storages survives untouched.
 
-### 8.8 enqueue Serialization Lock (Preventing Concurrent Dedup Leakage)
+| Cause | Does a restart fix it? | Why |
+| --- | :-: | --- |
+| Owner liveness undeterminable | ✅ Yes | The stuck reservation record lives in cross-process shared state, so restarting the process group removes it, and no storage was ever touched — this is the cleanest fix |
+| `manual_drain_stalled` | ⚠️ Usually | The fence and the queued requests go away with the restart; if the active rows that "keep coming back unchanged" are dead-process `PROCESSING` / `PARSING` / `ANALYZING` orphans, they are automatically reset to `PENDING` after the restart and re-run on the next trigger, so the blocker disappears. But a restart diagnoses nothing: if they stall on the same state for another reason, the next `/documents/reprocess_failed` stalls again |
+| `manual_drain_blocked` | ❌ No | The blocker is the unfinished custom-chunk journal in `doc_status.metadata`, which **is persisted** and survives the restart intact. A restart only clears the fence and the queued requests (still necessary — a queued request makes `/scan` refuse its own reservation); the actual rollback has to come from `POST /documents/scan` |
+| A worker died during `custom_chunks` / `delete` / `clear` | ❌ No | What is half-committed is the storage itself — see below |
 
-Inside `apipeline_enqueue_documents`, "read doc_status to dedupe → write `full_docs` / `doc_status`" runs serially under the workspace-level `enqueue_serialize` lock. Reason: now that concurrent enqueue is allowed during the busy/scan-processing phases, two enqueues with identical content but different filenames (typical scenario: a scan-processing-phase enqueue and an upload arriving together) would, without the lock, race as follows —
+A restart is therefore a "gentler `force_reset`": both clear the fence and the queued requests and neither repairs anything, except that a restart additionally resets interrupted documents to `PENDING` (which is exactly why a stall often heals itself), at the cost of downtime. Prefer a restart when you can take one; use `force_reset` when you cannot and have confirmed storage was never touched (causes 2 and 3).
 
-1. A reads `doc_status` to check `content_hash`: miss.
-2. B reads `doc_status` to check `content_hash`: still miss (A hasn't upserted yet).
-3. A upserts `full_docs` + `doc_status`.
-4. B upserts `full_docs` + `doc_status`.
+#### Repairing Half-committed Storage: the Two Offline Tools vs `force_reset`
 
-Result: both `PENDING` rows with the same `content_hash` enter the downstream pipeline, and the row that should have been identified as `duplicate_kind=content_hash` was **not** identified.
+The fence itself is **not persisted** (it lives in `pipeline_status`), so **restarting the service clears it along with the queued requests**. That is what decides where `force_reset` belongs:
 
-With the serialization lock, the second enqueue's dedup read is guaranteed to see the row already upserted by the first, taking the normal "no new unique document" early-return path and writing this run as a `duplicate_kind=content_hash` FAILED row. The lock only covers:
+- **Use it for causes 2 and 3.** In both, the reset never ran and storage was not touched at all — only scheduling is stuck, and stopping the service for that is not worth it.
+- **Avoid it for cause 1.** It clears a flag and repairs nothing; once cleared, every write (including concurrent uploads) resumes immediately against possibly half-committed storage. Both offline tools below already require a stopped service — and stopping it removes the fence anyway, so `force_reset` never needs to appear.
 
-- `filter_keys` (exclude existing by doc_id)
-- Filename / content hash dedup reads
-- Upsert of duplicate FAILED rows
-- `full_docs.upsert` + `doc_status.upsert`
+What each offline tool can and cannot repair:
 
-The lock does **not** cover the ingress document publish (outside the lock; only briefly takes `pipeline_status_lock`), and does **not** block the `get_docs_by_statuses` read of the processing loop (which goes through `doc_status`'s own concurrent reads — a KV-level atomic with the enqueue writes, not contending for the same lock). Lock order: `enqueue_serialize → pipeline_status_lock`; no deadlock path.
+| Tool | Source of truth and what it repairs | What it cannot repair | Cost |
+| --- | --- | --- | --- |
+| `python -m lightrag.tools.kg_integrity_repair` | Walks graph → chunk `source_id` → `text_chunks` → `full_doc_id` to rebuild missing or unusable `full_entities` / `full_relations` anchor rows; can also write empty anchor rows for a document that genuinely owns nothing | Graph↔VDB drift, `doc_status` / `full_docs` themselves, custom-chunk journals, the fence itself | Never calls the LLM or embedder — effectively free |
+| `lightrag-rebuild-vdb` | Drops and rebuilds `entities_vdb` / `relationships_vdb` from the graph and `chunks_vdb` from `text_chunks`; also clears reverse orphans (present in the vector store, absent from the graph), which incremental repair cannot do | Anchor rows, `doc_status`, the correctness of the graph itself, the fence itself | A full re-embed — real money |
 
-### 8.9 Where chunking runs
+Two ordering traps; getting them backwards turns repairable data into unrepairable data:
 
-Chunking is CPU-bound in the document supplied and — for the recursive strategy — in the separator cascade supplied with it, so it runs in a dedicated **single-worker** thread pool rather than inline on the asyncio event loop. Inline execution may block the event loop, causing latency for async operations. Everything CPU-bound between "content in hand" and "chunks written" is in that pool: the four chunking strategies, the semantic chunker's oversized-piece re-split, the multimodal chunk builder, the pre-embedding hard split, and the `surrounding` backfill.
+- **`kg_integrity_repair` must run before any further deletion.** It can only rebuild anchors from **surviving** chunk provenance; if a half-finished delete already removed the `text_chunks` rows, those contributions become irrecoverable orphans that the tool can only report and will never modify on its own. There is no reason not to run report mode (without `--apply`) first.
+- **`lightrag-rebuild-vdb` must run last.** It treats the graph and `text_chunks` as the truth: graph objects a half-finished delete should have removed will be faithfully re-embedded back into the vector store. It guarantees that vectors are **consistent** with the graph, not that the graph is **correct**. So settle the graph side first, then consider rebuilding vectors.
 
-Two consequences worth knowing:
+The full order for cause 1 is therefore:
 
-- **Concurrency is unchanged, not increased.** One worker is exactly what the event loop already imposed — while one document chunked, no other document's coroutine could run. The pool frees the loop; it does not make chunking parallel, and it does not scale with `MAX_PARALLEL_INSERT`.
-- **A custom `chunking_func` still runs on the event loop.** Its contract is "synchronous or async", so an implementation that touches the running loop when called is supported and would fail in a worker thread. Only the built-in default is dispatched to the pool; a CPU-bound custom chunker should do its own `asyncio.to_thread`.
+1. **Stop the service** (the fence disappears with it — do not reach for `force_reset`).
+2. Run `python -m lightrag.tools.kg_integrity_repair --verbose` for the report first: anchor gaps, plus the irrecoverable orphans that are already beyond saving. Run `--apply` only if there are gaps.
+3. Start the service and re-run the operation that did not finish — a whole-document purge is journaled and resumes after the phases it already completed; `clear` is simply re-run; a `custom_chunks` rollback is triggered by `POST /documents/scan`.
+4. Once things are stable, if you suspect graph↔VDB drift, stop the service again and run `lightrag-rebuild-vdb`, using its read-only consistency check first to decide whether the embedding cost is worth paying.
 
-### 8.10 Pipeline Concurrency Parameters
+Both tools must run with the service stopped and the workspace idle (concurrent writes make them read a moving target), and `lightrag-rebuild-vdb` must use the same `.env` as the server or the rebuilt vectors land in a different embedding space. See [README_KG_INTEGRITY_REPAIR.md](../lightrag/tools/README_KG_INTEGRITY_REPAIR.md) and [README_REBUILD_VDB.md](../lightrag/tools/README_REBUILD_VDB.md).
 
-The locks around `pipeline_status` solve the correctness problem of "who can write"; this section's set of parameters solves the throughput problem of "how many workers run concurrently". The pipeline is divided into 3 stages, each with an independently tunable worker pool:
+### 8.6 Pipeline Concurrency Parameters
+
+The previous sections are about the correctness question of "who may write"; this set of parameters answers the throughput question of "how many workers run at once". The pipeline has 3 stages, and each stage's worker pool is sized independently:
 
 ```
           ┌─ parse_queues["native"]  ─► [native pool  × N1] ─┐   ← legacy shares this pool
 PENDING ─►├─ parse_queues["mineru"]  ─► [mineru pool  × N2] ─┼─► q_analyze ─►[analyzer × N4] ─► q_process ─►[processor × N5]
           ├─ parse_queues["docling"] ─► [docling pool × N3] ─┤
-          └─ parse_queues[<3rd-party group>] ─► [custom pool] ┘   ← created per ParserSpec.queue_group
+          └─ parse_queues[<3rd-party>] ─► [custom pool]   ──┘   ← created dynamically per ParserSpec.queue_group
 ```
 
-Parse queues are **created dynamically from the registry's `ParserSpec.queue_group`** (one registry snapshot per batch): the built-in native/mineru/docling each own a group, legacy shares the native pool (local, no network), and a third-party engine may declare its own group with a custom worker count (see [ThirdPartyParser.md](./ThirdPartyParser.md)). At enqueue time, `resolve_stored_document_parser_engine` puts each document into the corresponding parse queue based on its `parser_engine` (from `LIGHTRAG_PARSER` defaults or the filename hint); the parse queues are **completely non-blocking** with respect to each other — mineru saturation does not slow down docling or native. After parsing, they enter `q_analyze` (multimodal analysis) uniformly, and then enter `q_process` (entity/relation extraction + ingest).
+Parse queues are **created dynamically from the registry's `ParserSpec.queue_group`** (one registry snapshot per batch): built-in native/mineru/docling each get a group, legacy shares the native pool (local, no network), and third-party engines can declare their own group and concurrency (see [ThirdPartyParser.md](./ThirdPartyParser.md)). At enqueue time each document's parser engine (from the `LIGHTRAG_PARSER` default or a filename hint) decides which parse queue it lands in; the parse queues **never block one another** — a saturated mineru queue does not slow docling or native down. After parsing, everything converges on `q_analyze` (multimodal analysis) and then `q_process` (entity/relation extraction + ingestion).
 
-| Environment variable | Default | Effect | Tuning advice |
+| Environment variable | Default | Role | Tuning advice |
 | --- | --- | --- | --- |
-| `MAX_PARALLEL_PARSE_NATIVE` | `5` | N1: number of concurrent workers for native parsing (docx / pdf / txt and other pure local processing) | Pure CPU, low memory usage; can be raised to CPU core count |
-| `MAX_PARALLEL_PARSE_MINERU` | `2` | N2: number of concurrent workers for MinerU parsing | MinerU has significant GPU/CPU usage; **the default of 2 is a modest amount of parallelism**. Lower to 1 when resources are tight; with local deployment and ample VRAM, you can set 2–3; when going through MinerU's official cloud service, you can raise it appropriately (subject to cloud quotas). |
-| `MAX_PARALLEL_PARSE_DOCLING` | `2` | N3: number of concurrent workers for Docling parsing | Docling is similarly resource-sensitive; **the default of 2 is a modest amount of parallelism**. Lower to 1 when resources are tight; with local deployment and ample CPU/GPU, you can set 2–3. |
-| `MAX_PARALLEL_ANALYZE` | `5` | N4: number of concurrent workers for multimodal analysis (VLM image / table description) | Directly consumes the VLM quota. Recommended ≤ VLM service concurrency cap. |
-| `MAX_PARALLEL_INSERT` | `3` | N5: number of concurrent documents at the entity / relation extraction + ingest stage | Recommended `MAX_ASYNC_LLM / 3`, in the range 2–10. This stage triggers multiple LLM calls per document; setting it too high will hit LLM rate limits. This value also serves as the `asyncio.Semaphore` for an additional constraint (worker count and semaphore value are the same). |
-| `QUEUE_SIZE_PARSE` | `20` | Bounded capacity of the parse-input queues (native/MinerU/Docling) | Generally no need to tune. Items here are lightweight doc_ids (the large parsed body is stripped before the analyze stage); this only bounds how many pending docs the pipeline pre-dispatches to parse workers, so tuning has little effect. |
-| `QUEUE_SIZE_ANALYZE` | `100` | Bounded capacity of the analyze queue (parse → analyze stage) | Generally no need to tune. For very large batches (thousands or more), can be raised to avoid backpressure at the enqueue side; lower it when memory is tight. |
-| `QUEUE_SIZE_INSERT` | `4` | Queue capacity between the analyze → process stage | The process stage is the slowest and most memory-hungry in the pipeline; the queue is deliberately small to provide backpressure to upstream and prevent memory bloat. |
+| `MAX_PARALLEL_PARSE_NATIVE` | `5` | N1: concurrent workers for native parsing (docx / pdf / txt, all local) | Pure CPU with a low memory footprint; scale with core count |
+| `MAX_PARALLEL_PARSE_MINERU` | `2` | N2: concurrent workers for MinerU parsing | MinerU is GPU/CPU heavy, so **2 is a moderate default**. Drop to 1 when resources are tight; 2-3 for a local deployment with enough VRAM; higher against MinerU's official cloud service (subject to its quota) |
+| `MAX_PARALLEL_PARSE_DOCLING` | `2` | N3: concurrent workers for Docling parsing | Docling is equally resource-sensitive, so **2 is a moderate default**. Drop to 1 when resources are tight; 2-3 for a local deployment with enough CPU/GPU |
+| `MAX_PARALLEL_ANALYZE` | `5` | N4: concurrent workers for multimodal analysis (VLM image / table descriptions) | Consumes VLM quota directly. Keep ≤ the VLM service's concurrency limit |
+| `MAX_PARALLEL_INSERT` | `3` | N5: concurrent documents in the entity/relation extraction + ingestion stage | `MAX_ASYNC_LLM / 3` is a good rule of thumb, in the 2~10 range. Each document triggers many LLM calls here, so too high hits LLM rate limits. The same value also backs an `asyncio.Semaphore` as a second constraint (worker count equals the semaphore value) |
+| `QUEUE_SIZE_PARSE` | `20` | Input queue length for parse (native/MinerU/Docling) | Rarely needs tuning. The queue holds only lightweight doc_ids (large document bodies are stripped before analyze), and it just bounds how many documents the pipeline pre-dispatches to parse workers |
+| `QUEUE_SIZE_ANALYZE` | `100` | Bounded capacity of the analyze queue (parse → analyze) | Rarely needs tuning. Raise it slightly for very large batches (tens of thousands) to avoid back-pressure at the enqueue side; lower it when memory is tight |
+| `QUEUE_SIZE_INSERT` | `4` | Queue capacity between the analyze and process stages | process is the slowest and most memory-hungry stage, so this queue is deliberately small, giving upstream back-pressure |
 
-**Several key points:**
+**A few key points:**
 
-1. **Parsing stage is isolated per engine**, so when mixing native/mineru/docling, you don't have to worry about a slow engine dragging another down.
-2. **mineru / docling default to 2**: both have high resource usage, so the default keeps parallelism modest. Lower to 1 when resources are tight (OOM / VRAM contention / failure retry); with multi-GPU or a dedicated parser server, you can raise them manually.
-3. **`MAX_PARALLEL_INSERT` doubles as worker pool size and semaphore cap**: the pipeline creates a `Semaphore(max_parallel_insert)`, and each process worker also takes the semaphore before extraction and ingest. So even if you manually raise the worker count, the actual concurrency cap is still bounded by this value — just tune it directly.
-4. **Queue size and backpressure**: the small default `QUEUE_SIZE_INSERT=4` is intentional — the process stage is slow and memory-hungry; when the queue fills, analyze blocks, and backpressure reaches the parse stage, preventing thousands of parsing results from piling up in memory at once.
-5. **How changes take effect**: all parameters are passed in via `.env` (or environment variables), read once at `LightRAG` construction; restart the service after changing them.
+1. **The parse stage is isolated per engine**, so mixing native/mineru/docling never lets one slow engine drag another down.
+2. **mineru / docling default to 2**: both are resource-heavy, so the default stays moderate. Drop to 1 when resources are tight (avoiding OOM / VRAM contention / failure retries); raise it by hand if you have multiple GPUs or a dedicated parsing server.
+3. **`MAX_PARALLEL_INSERT` is both pool size and semaphore ceiling**: the pipeline creates `Semaphore(max_parallel_insert)` and every process worker takes it before extracting and ingesting. So even if you raise the worker count by hand, this value still caps real concurrency — just tune it directly.
+4. **Queue size and back-pressure**: the small `QUEUE_SIZE_INSERT=4` default is deliberate — process is slow and memory-hungry, so a full queue blocks the analyze stage and back-pressures parse, instead of piling tens of thousands of parse results into memory at once.
+5. **How changes take effect**: every parameter comes from `.env` (or the environment) and is read once when the `LightRAG` instance is constructed; restart the service after changing one.
+6. **Chunking does not scale with concurrency**: chunking runs in a dedicated single-worker thread pool so it does not block the event loop, and its concurrency does not grow with `MAX_PARALLEL_INSERT` — raising that will not make chunking faster. A custom `chunking_func` still runs on the event loop (its contract allows touching the running loop), so CPU-heavy implementations should call `asyncio.to_thread` themselves.
 
 **Typical tuning scenarios:**
 
-- Large batch of PDFs + local MinerU on a single GPU: `MAX_PARALLEL_PARSE_MINERU=2`, `MAX_PARALLEL_ANALYZE=5`, `MAX_PARALLEL_INSERT=3` (defaults are fine; lower MINERU to 1 if VRAM is tight).
-- Large batch of PDFs + MinerU cloud service: `MAX_PARALLEL_PARSE_MINERU=3~5` (depending on cloud quota), others at defaults.
-- Pure docx / txt (only native): `MAX_PARALLEL_PARSE_NATIVE=10`; `MAX_PARALLEL_INSERT` derived from `MAX_ASYNC_LLM/3`.
-- Heavy LLM rate-limiting: first lower `MAX_PARALLEL_INSERT` (the process stage makes multiple LLM calls per document), then lower `MAX_PARALLEL_ANALYZE` (VLM is a separate quota).
+- Many PDFs + local MinerU on a single GPU: `MAX_PARALLEL_PARSE_MINERU=2`, `MAX_PARALLEL_ANALYZE=5`, `MAX_PARALLEL_INSERT=3` (the defaults; drop MINERU to 1 when VRAM is tight).
+- Many PDFs + MinerU's cloud service: `MAX_PARALLEL_PARSE_MINERU=3~5` (per your cloud quota), everything else default.
+- Pure docx / txt (native only): `MAX_PARALLEL_PARSE_NATIVE=10`, with `MAX_PARALLEL_INSERT` derived from `MAX_ASYNC_LLM/3`.
+- Visible LLM rate limiting: lower `MAX_PARALLEL_INSERT` first (the process stage makes many LLM calls per document), then `MAX_PARALLEL_ANALYZE` (VLM has its own quota).
 
-### 8.11 Admission and Request Limits
+### 8.7 Admission and Request Limits
 
-Before a document reaches any of the machinery above, the server can refuse it outright. These are the variables behind an upload that is rejected rather than queued:
+Before a document reaches any of the mechanisms above, the server may refuse it outright. These variables decide whether an upload is rejected or queued:
 
-| Variable | Default | Refusal |
+| Variable | Default | How it refuses |
 | --- | --- | --- |
-| `MAX_UPLOAD_SIZE` | `104857600` (100 MB) | `413` — single uploaded file too large |
-| `MAX_REQUEST_BODY_BYTES` | `1048576` (1 MiB) | `413` — raw request body too large. Applies to **every** route, layered: ordinary routes get this value, `/documents/text` and `/documents/texts` get a built-in 50 MiB **while this variable is unset**, and `/documents/upload` derives `MAX_UPLOAD_SIZE` + 1 MiB. Configuring any positive value — the 1 MiB default included — makes it govern every non-upload route. `0` disables all of them |
-| `MAX_TEXTS_PER_REQUEST` | `0` (disabled) | `413` — too many texts in one `/documents/texts` call |
-| `MAX_PENDING_DOCUMENTS` | `0` (disabled) | `429` — too many documents already PENDING / PARSING / ANALYZING / PROCESSING |
+| `MAX_UPLOAD_SIZE` | `104857600` (100 MB) | `413` — a single uploaded file is too large |
+| `MAX_REQUEST_BODY_BYTES` | `1048576` (1 MiB) | `413` — the raw request body is too large. It applies to **all** routes, in tiers: ordinary routes take this value, `/documents/text` and `/documents/texts` take a built-in 50 MiB **when the variable is unset**, and `/documents/upload` derives its limit from `MAX_UPLOAD_SIZE` + 1 MiB. Setting any positive value explicitly (including the 1 MiB default) applies it uniformly to every non-upload route. `0` disables all of them |
+| `MAX_TEXTS_PER_REQUEST` | `0` (off) | `413` — too many texts in a single `/documents/texts` call |
+| `MAX_PENDING_DOCUMENTS` | `0` (off) | `429` — too many documents already in PENDING / PARSING / ANALYZING / PROCESSING |
 
-Their full semantics, including how `MAX_UPLOAD_SIZE` interacts with a reverse proxy's own body limit, are documented in [LightRAG Server](./LightRAG-API-Server.md).
+Their full semantics (including how `MAX_UPLOAD_SIZE` relates to a reverse proxy's own body limit) are in [LightRAG Server](./LightRAG-API-Server.md).
 
-Three further knobs belong to the pipeline itself rather than to request admission:
+Three more knobs belong to the pipeline itself rather than to request admission:
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `PIPELINE_SCHEDULING_PAGE_SIZE` | `500` | keyset page size for the doc-status backlog sweep; `0` disables paging |
-| `PIPELINE_REQUIRE_STRICT_STORAGE_READS` | `false` | refuse to start when the doc-status backend cannot serve strict reads. This is what decides whether the `STALE_STUB` exit in §7.1 can act at all — without a reliable point read, nothing is deleted |
-| `MAX_UNACKED_MANUAL_RETRIES` | `64` | per-workspace ceiling on published-but-unacknowledged manual retry requests (§8.7) |
+| `PIPELINE_SCHEDULING_PAGE_SIZE` | `500` | Keyset page size for the doc_status backlog scan; `0` disables paging |
+| `PIPELINE_REQUIRE_STRICT_STORAGE_READS` | `false` | Refuse to start when the doc_status backend cannot serve strict reads. This directly decides whether the "delete the failure record and re-run the file as a new document" row in [§7.4](#74-what-a-directory-scan-does-differently) can act at all — without a reliable point read, nothing is deleted |
+| `MAX_UNACKED_MANUAL_RETRIES` | `64` | Per-workspace ceiling on published-but-unacknowledged manual retry requests ([§8.3](#83-retrying-after-a-failure)) |
 
 ## 9. Pipeline Resume Rules at Startup
 
 Each time `apipeline_process_enqueue_documents` starts up, it pulls all documents in `PARSING` / `ANALYZING` / `PROCESSING` / `PENDING` / `FAILED` to continue processing. The resume path **branches by "whether content has been extracted"**, ensuring that any document, regardless of its previous progress, has an idempotent result when resumed under the current `process_options`.
 
-The resume rule only applies to documents whose `doc_id` already exists in `doc_status`. New files joining the queue require the file dedup logic in "Concurrency and Reentry Constraints", to avoid new files squeezing out the records of files whose content has already been successfully extracted.
+The resume rule only applies to documents whose `doc_id` already exists in `doc_status`. New files joining the queue require the file dedup logic in §7, to avoid new files squeezing out the records of files whose content has already been successfully extracted.
 
 ### 9.1 Determining "Content Has Been Extracted"
 
@@ -1149,12 +1179,15 @@ Go through the full pipeline (registry-dispatched parsing `get_parser(engine).pa
 | `P` was requested but the chunks look like `R` output | No structured `LightRAG Document` was produced, so `P` degraded (§2.7, §3.2) | Route the file to `native` / `mineru` / `docling` instead of `legacy` |
 | Headings are wrong in a `.docx`, so `P` splits badly | The document's Word outline is unreliable | Try `native(smart_heading=true)` (§3.3) and iterate with the parser CLI |
 | Log notes that paragraphs lack `paraId` | Produced by LibreOffice / WPS / older Word (§3.3) | Informational. Re-save in Word 2013+ only if you need paragraph-level provenance |
-| Document is FAILED as a duplicate | Basename dedup (canonicalized, hint stripped) or content-hash dedup (§7.1, §7.2) | Delete the existing document first, or rename the new file |
-| Upload returns `409` | A document with the same canonical basename already exists in the input directory or in doc-status (§8.5) | Delete it via `POST /documents/delete_document`, then upload again |
-| Upload returns `413` or `429` | An admission limit was hit (§8.11) | See the limits table for which one |
-| Everything returns `503` | The `recovery_required` fence is up (§8.7) | Follow the recovery order documented in that section |
-| `/documents/scan` returns `scanning_skipped_pipeline_busy` | The pipeline is busy or scanning, uploads are in flight, or a manual retry is queued (§8.2) | Wait for idle; `POST /documents/reprocess_failed` is the single-call recovery for a stuck retry request |
-| Changed the engine or the options, but the output is unchanged | Both the engine and `process_options` are frozen into the doc-status record at enqueue. Automatic resume and `/documents/reprocess_failed` reuse the stored values; editing `LIGHTRAG_PARSER` or a hint affects new uploads only (§9.3) | Delete the document (with "also delete file") and upload it again |
+| Document is FAILED as a duplicate | Basename dedup (canonicalized, hint stripped) or content-hash dedup (§7.1, §7.2) | Delete the existing document first, or rename the new file; duplicate records (`dup-*`, or an original row flipped to FAILED after parsing) can only be removed explicitly (§7.3) |
+| Upload returns `409` | A document with the same canonical basename already exists in the input directory or in doc-status (§7.2) | Delete it via `POST /documents/delete_document`, then upload again |
+| Upload returns `413` or `429` | An admission limit was hit (§8.7) | See the limits table for which one |
+| Everything returns `503` | The `recovery_required` fence is up (§8.5) | Follow the recovery order documented in that section |
+| `/documents/scan` returns `scanning_skipped_pipeline_busy` | The pipeline is busy or scanning, uploads are in flight, or a manual retry is queued (§8.1) | Wait for idle; `POST /documents/reprocess_failed` is the single-call recovery for a stuck retry request |
+| Cancel was clicked and a batch of documents turned `FAILED` | Documents already taken into the batch are marked FAILED on cancellation (§8.2) | Retry with `POST /documents/scan` or `POST /documents/reprocess_failed`; finished documents are unaffected |
+| Cancel was clicked but the pipeline is still running | Cancellation is cooperative and never interrupts an LLM call already in flight (§8.2) | Wait for the current stage to end; `cancellation_requested` in `GET /documents/pipeline_status` confirms the request arrived |
+| Documents stuck at `PROCESSING` / `PARSING` after a restart | Interrupted states recover automatically, but starting the server does not itself trigger a run (§8.2) | Call `POST /documents/scan` once, or upload any file to trigger one |
+| Changed the engine or the options, but the output is unchanged | Both the engine and `process_options` are frozen into the doc-status record at enqueue. Automatic resume and `/documents/reprocess_failed` reuse the stored values; editing `LIGHTRAG_PARSER` or a hint affects new uploads only (§8.3, §9.3) | Delete the document (with "also delete file") and upload it again |
 | An external engine keeps returning stale output after fixing its service config | The raw-artifact bundle cache was hit (§6.3) | Set the matching `LIGHTRAG_FORCE_REPARSE_*` flag (§3.7), or delete the document with "also delete file" |
 | A scanned PDF fails with "extracted no usable text" | `legacy` cannot read a PDF with no text layer (§3.2) | Route it to `mineru` or `docling` with OCR enabled |
 | MinerU rejects a multi-segment page range | Multi-segment ranges require `official` mode; `local` accepts a single page or one simple range (§3.6) | Use a single range under `local`, or switch modes |
@@ -1217,7 +1250,7 @@ Typical scenarios for per-file personalization: a management UI configures separ
 
 **Compatibility for not passing `file_paths`**: the core APIs `insert` / `ainsert` / `apipeline_enqueue_documents` still support invocations without `file_paths`; the `file_path` of such documents is saved as `unknown_source`, does not participate in filename dedup, and the document ID continues to be generated from text content.
 
-For `apipeline_enqueue_documents`'s own concurrency constraints (last-line guard, `from_scan=True` bypass), see the entry-point behavior table in §8.2.
+For `apipeline_enqueue_documents`'s own concurrency constraints, see the state/action table in §8.1.
 
 ### 11.5 `ainsert(split_by_character=…, split_by_character_only=…)`
 
@@ -1232,7 +1265,7 @@ Only effective for the F strategy; other strategies' sub-dictionaries are unaffe
 
 The legacy `apipeline_enqueue_documents` behavior of `reprocess_existing_non_processed=True` would directly delete non-PROCESSED old records and rebuild them during scan, which conflicts with the rules in §7 / §8; it has been entirely removed. Replacement paths:
 
-- Automatic resume: scan handles same-named files per the classification rules in §7.1 (archive / resume / delete stub then re-enqueue), uniformly picked up by the resume rules in §9 inside the processing loop.
+- Automatic resume: scan handles same-named files per the rules in §7.4 (archive / resume / delete the record then re-enqueue), uniformly picked up by the resume rules in §9 inside the processing loop.
 - Forced refresh: first call `/documents/delete_document` to delete the old document, then upload the same-named new file.
 
 ## Appendix A. Notes on Upgrading from Legacy
@@ -1269,8 +1302,8 @@ Where to find each family of file-processing variables. This is an index, not a 
 | MinerU | `MINERU_*` | §3.4 |
 | Docling | `DOCLING_*` | §3.5 |
 | Parse cache | `LIGHTRAG_FORCE_REPARSE_{NATIVE,MINERU,DOCLING}`, `{MINERU,DOCLING}_ENGINE_VERSION` | §3.7, §6.3 |
-| Directories | `INPUT_DIR`, `WORKING_DIR`, `SCAN_SPOOL_DIR` | §6, §7.1 |
-| Concurrency | `MAX_PARALLEL_*`, `QUEUE_SIZE_*` | §8.10 |
-| Admission and limits | `MAX_UPLOAD_SIZE`, `MAX_REQUEST_BODY_BYTES`, `MAX_TEXTS_PER_REQUEST`, `MAX_PENDING_DOCUMENTS`, `PIPELINE_*`, `MAX_UNACKED_MANUAL_RETRIES`, `SCAN_ENQUEUE_BATCH_SIZE` | §8.11 |
+| Directories | `INPUT_DIR`, `WORKING_DIR`, `SCAN_SPOOL_DIR` | §6, §7.4 |
+| Concurrency | `MAX_PARALLEL_*`, `QUEUE_SIZE_*` | §8.6 |
+| Admission and limits | `MAX_UPLOAD_SIZE`, `MAX_REQUEST_BODY_BYTES`, `MAX_TEXTS_PER_REQUEST`, `MAX_PENDING_DOCUMENTS`, `PIPELINE_*`, `MAX_UNACKED_MANUAL_RETRIES`, `SCAN_ENQUEUE_BATCH_SIZE` | §8.7 |
 | Query-time (not chunking) | `ENABLE_CONTENT_HEADINGS` — appends each chunk's heading path when assembling the answer context; it does not change chunk boundaries or stored chunk text | [LightRAG Server](./LightRAG-API-Server.md) |
 | Offline / tokenizer | `TIKTOKEN_CACHE_DIR` | [OfflineDeployment.md](./OfflineDeployment.md) |


### PR DESCRIPTION
## Description

Chapters 7 and 8 of `FileProcessingPipeline` were written from an implementation standpoint — the scan spool's SQLite layout and injective directory mapping, the five `pipeline_status` fields, why `busy` no longer blocks enqueue, the multi-reservation timeline, the enqueue serialization lock's dedup-leak proof. That is design rationale, already recorded in the code and in `AGENTS.md`, and none of it answers what a reader actually arrives with:

- Can I keep uploading while the pipeline is running?
- How do I stop it once it has started?
- A document failed — when is a retry enough, and when do I have to delete and re-upload?

The third question was answered only in scattered fragments, and the first two were not answered at all. In particular **`POST /documents/cancel_pipeline` was not mentioned anywhere in the document**, so "how do I stop it" had no answer — a real gap, not just a matter of perspective.

This PR rewrites both chapters around observable behaviour and operator decisions and drops the design rationale. **Documentation only — no code, no behaviour change.**

## Related Issues

#XXXX (no tracking issue; raised directly as documentation feedback)

## Changes Made

### §7 "Document Duplicate Detection Rules" → "Same-name and Duplicate Documents"

| Subsection | Content |
| --- | --- |
| 7.1 The two dedup rules | Why dedup exists, the filename rule and the content rule; keeps the three-format `content_hash` table because it explains *when* the check can run |
| 7.2 What you will see | Symptom → meaning table, absorbing the two 409s from the old §8.5 strict-name precheck |
| 7.3 What to do about it | Replacing a same-named document, clearing inert duplicate records, when an engine change forces delete + re-upload, `filename_conflict` repair |
| 7.4 What a directory scan does differently | The seven typed exits compressed into the five outcomes a user can act on, keeping the auto-retry semantics ("fix the source file and scan again") and the `SCAN_SPOOL_DIR` requirement |

### §8 "Pipeline Concurrency and Reentry Constraints" → "Operating the Pipeline"

| Subsection | Content |
| --- | --- |
| 8.1 What you can do while processing is running | State × action matrix; leads with the most-misread fact — **uploads are not blocked by processing** — plus the three exact 409 strings |
| 8.2 Stopping a running pipeline | **New.** `POST /documents/cancel_pipeline` and the WebUI Cancel button; 200 ≠ stopped; cancellation is cooperative and never interrupts an in-flight LLM call; the state each document lands in; and the different consequences of a restart/kill |
| 8.3 Retrying after a failure | Three recovery methods compared, four rules (one attempt per request, automatic resume never touches `FAILED`, whether it re-parses, options are frozen at enqueue), and a 9-row decision table separating retry-in-place from delete + re-upload |
| 8.4 Deleting a document | **New.** What each of the two checkboxes actually removes, and why "also delete uploaded files" is mandatory before switching engines |
| 8.5 The `recovery_required` fence | Condensed, plus: whether a restart resolves each cause, and how `kg_integrity_repair` / `lightrag-rebuild-vdb` fit in (with the two ordering traps that turn repairable data into unrepairable data) |
| 8.6 / 8.7 Concurrency parameters, admission limits | Carried over unchanged (already written from a usage perspective); the old §8.9 chunking-thread-pool note folds in as one tuning bullet |

### Removed as implementation rationale

`pipeline_status` field table, entry-point behaviour table, the three "why `busy` no longer blocks enqueue" arguments, the seven-step multi-reservation timeline, the whole enqueue-serialization-lock section, and the scan spool's SQLite index / fixed filename / workspace-injective-directory derivation. Their user-visible conclusions are kept as single sentences.

### Also updated

- TOC entries and anchors, 17 cross-references across the file
- Three new §10 troubleshooting rows (documents turned FAILED after Cancel; pipeline still running after Cancel; documents stuck at `PROCESSING` after a restart)

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable) — documentation only

## Additional Notes

**Every claim was checked against the source, not written from memory.** Several rounds of review caught statements that read plausibly but did not match the implementation; those were corrected before this PR:

- `/documents/reprocess_failed` does **not** always skip parsing. A row that failed *during* parsing keeps its `pending_parse` `full_docs` record, so `_reset_failed_page` resets it and `resolve_stored_document_parser_engine` routes it back to a real engine — it re-reads the source file and calls the engine again. Only a document with successfully extracted content resumes from the analyze stage.
- Sourceless documents (`file_path=unknown_source`) are excluded from *name* dedup only; `PLACEHOLDER_DOCUMENT_SOURCES` gates source-key resolution, not the content-hash path, so identical text inserted twice is still a duplicate.
- Not every duplicate is a `dup-*` row. A content duplicate found after parsing flips the document's own `doc-*` row to `FAILED` in place and deletes its `full_docs`; and a `filename_conflict` row's `original_doc_id` does not name a surviving primary, because none has been chosen yet.
- Dedup does not complete "before anything is stored" — the external engines must persist a pending-parse record and the parse result before a content hash exists. The accurate boundary is "before chunking, extraction and any graph write".
- Queries are not *always available* during a clear. They are never refused by admission, but `/documents/clear` drops a dozen storages concurrently via `asyncio.gather` while a query holds no consistent snapshot, so results may be empty, partial, or error out.

Consistency of the two language versions is mechanically verified: both files are **1310 lines and line-for-line structurally aligned** (headings, table rows, list items and code fences at identical line numbers), all internal anchors resolve, all relative links point at existing files, and no table is ragged. Both files pass `pre-commit run --files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
