### PR TITLE
fix(kg): return copies from NetworkXStorage get_node and get_edge

### DIFF
--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -230,7 +230,11 @@ class NetworkXStorage(BaseGraphStorage):
 
     async def get_node(self, node_id: str) -> dict[str, str] | None:
         graph = await self._get_graph()
-        return graph.nodes.get(node_id)
+        node = graph.nodes.get(node_id)
+        # Shallow-copy so callers cannot mutate the live NetworkX attr dict
+        # (same class as JsonKV/JsonDocStatus copy-on-read). get_all_nodes
+        # already copies; get_node/get_edge must match.
+        return dict(node) if node is not None else None
 
     async def node_degree(self, node_id: str) -> int:
         graph = await self._get_graph()
@@ -248,7 +252,8 @@ class NetworkXStorage(BaseGraphStorage):
         self, source_node_id: str, target_node_id: str
     ) -> dict[str, str] | None:
         graph = await self._get_graph()
-        return graph.edges.get((source_node_id, target_node_id))
+        edge = graph.edges.get((source_node_id, target_node_id))
+        return dict(edge) if edge is not None else None
 
     async def get_node_edges(self, source_node_id: str) -> list[tuple[str, str]] | None:
         graph = await self._get_graph()

--- a/tests/kg/networkx_impl/test_networkx_get_node_edge_copy_on_read.py
+++ b/tests/kg/networkx_impl/test_networkx_get_node_edge_copy_on_read.py
@@ -1,0 +1,62 @@
+import pytest
+
+from lightrag.kg.networkx_impl import NetworkXStorage
+from lightrag.kg.shared_storage import initialize_share_data
+
+
+def _storage(tmp_path, namespace: str) -> NetworkXStorage:
+    initialize_share_data()
+    return NetworkXStorage(
+        namespace=namespace,
+        workspace="ws",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_node_returns_copy_not_live_alias(tmp_path):
+    storage = _storage(tmp_path, "copy_on_read_node")
+    await storage.initialize()
+    await storage.upsert_node(
+        "A",
+        {"entity_type": "PERSON", "description": "orig", "source_id": "c1"},
+    )
+
+    node = await storage.get_node("A")
+    assert node is not None
+    node["description"] = "MUTATED"
+
+    reread = await storage.get_node("A")
+    assert reread is not None
+    assert reread["description"] == "orig"
+
+
+@pytest.mark.asyncio
+async def test_get_edge_returns_copy_not_live_alias(tmp_path):
+    storage = _storage(tmp_path, "copy_on_read_edge")
+    await storage.initialize()
+    await storage.upsert_node("A", {"entity_type": "PERSON", "description": "a"})
+    await storage.upsert_node("B", {"entity_type": "PERSON", "description": "b"})
+    await storage.upsert_edge("A", "B", {"weight": 1.0, "description": "rel-orig"})
+
+    edge = await storage.get_edge("A", "B")
+    assert edge is not None
+    edge["description"] = "REL-MUTATED"
+
+    reread = await storage.get_edge("A", "B")
+    assert reread is not None
+    assert reread["description"] == "rel-orig"
+
+
+@pytest.mark.asyncio
+async def test_get_nodes_batch_uses_copied_nodes(tmp_path):
+    storage = _storage(tmp_path, "copy_on_read_batch")
+    await storage.initialize()
+    await storage.upsert_node("A", {"entity_type": "ORG", "description": "keep-me"})
+
+    batch = await storage.get_nodes_batch(["A"])
+    batch["A"]["description"] = "batch-mutated"
+
+    reread = await storage.get_node("A")
+    assert reread["description"] == "keep-me"


### PR DESCRIPTION
## Summary

`NetworkXStorage.get_node` / `get_edge` return live NetworkX attribute dicts. Callers that mutate those dicts corrupt in-memory graph state that `index_done_callback` can persist.

## Problem

```python
node = await storage.get_node("Alice")
node["entity_type"] = "mutated"  # changes the live graph node attrs
```

`get_all_nodes` already returns copies, and JsonKV / JsonDocStatus copy-on-read already covers the same class of bug (#3556). `get_node` / `get_edge` did not.

## Fix

Return a shallow `dict(...)` copy from both read paths so external mutation cannot touch live graph attributes.

## Test plan

- [x] `pytest tests/kg/networkx_impl/test_networkx_get_node_edge_copy_on_read.py`
