### PR TITLE
fix(kg): return boolean values from get_all_update_flags_status

### DIFF
--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -5924,19 +5924,9 @@ def create_document_routes(
             )
 
             # Get update flags status for all namespaces
-            update_status = await get_all_update_flags_status(workspace=rag.workspace)
-
-            # Convert MutableBoolean objects to regular boolean values
-            processed_update_status = {}
-            for namespace, flags in update_status.items():
-                processed_flags = []
-                for flag in flags:
-                    # Handle both multiprocess and single process cases
-                    if hasattr(flag, "value"):
-                        processed_flags.append(bool(flag.value))
-                    else:
-                        processed_flags.append(bool(flag))
-                processed_update_status[namespace] = processed_flags
+            processed_update_status = await get_all_update_flags_status(
+                workspace=rag.workspace
+            )
 
             async with pipeline_status_lock:
                 # DictProxy.copy() is one Manager RPC; dict(proxy) may fetch

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -3632,10 +3632,7 @@ async def get_all_update_flags_status(workspace: str | None = None) -> Dict[str,
             # of ValueProxy handles, then read each .value.
             worker_statuses = []
             for flag in flags[:]:
-                if _is_multiprocess:
-                    worker_statuses.append(flag.value)
-                else:
-                    worker_statuses.append(flag)
+                worker_statuses.append(flag.value)
             result[namespace] = worker_statuses
 
     return result

--- a/tests/kg/test_get_all_update_flags_status.py
+++ b/tests/kg/test_get_all_update_flags_status.py
@@ -1,0 +1,46 @@
+"""Test get_all_update_flags_status return types in single process mode.
+
+WHY: get_all_update_flags_status maps workspace namespaces to lists of boolean update flag statuses.
+In single-process mode, returning raw MutableBoolean objects instead of Python bools breaks callers
+expecting boolean flag values (e.g. JSON serialization, status checks).
+"""
+
+import pytest
+
+from lightrag.kg.shared_storage import (
+    clear_all_update_flags,
+    finalize_share_data,
+    get_all_update_flags_status,
+    get_update_flag,
+    initialize_share_data,
+    set_all_update_flags,
+)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_get_all_update_flags_status_returns_booleans():
+    try:
+        initialize_share_data()
+        flag = await get_update_flag("test_ns", workspace="default")
+        assert flag.value is False
+
+        status_before = await get_all_update_flags_status(workspace="default")
+        assert "default:test_ns" in status_before
+        statuses = status_before["default:test_ns"]
+        assert len(statuses) == 1
+        # Must be actual Python bool, not MutableBoolean object
+        assert type(statuses[0]) is bool
+        assert statuses[0] is False
+
+        await set_all_update_flags("test_ns", workspace="default")
+        status_set = await get_all_update_flags_status(workspace="default")
+        assert type(status_set["default:test_ns"][0]) is bool
+        assert status_set["default:test_ns"][0] is True
+
+        await clear_all_update_flags("test_ns", workspace="default")
+        status_cleared = await get_all_update_flags_status(workspace="default")
+        assert type(status_cleared["default:test_ns"][0]) is bool
+        assert status_cleared["default:test_ns"][0] is False
+    finally:
+        finalize_share_data()

--- a/tests/workspace/test_workspace_isolation.py
+++ b/tests/workspace/test_workspace_isolation.py
@@ -681,19 +681,29 @@ async def test_update_flags_workspace_isolation():
     # Get status for workspace1 only
     status1 = await get_all_update_flags_status(workspace=workspace1)
 
-    # Check that workspace1's namespaces are present
-    # The keys should include workspace1's namespaces but not workspace2's
-    workspace1_keys = [k for k in status1.keys() if workspace1 in k]
-    workspace2_keys = [k for k in status1.keys() if workspace2 in k]
+    # Workspace1 query must surface exactly workspace1's namespaces, never workspace2's
+    expected_ws1_keys = {
+        f"{workspace1}:{test_namespace}",
+        f"{workspace1}:ns_a",
+        f"{workspace1}:ns_b",
+    }
+    assert set(status1.keys()) == expected_ws1_keys, (
+        f"Unexpected namespaces for workspace1: {status1.keys()}"
+    )
 
-    assert len(workspace1_keys) > 0, (
-        f"workspace1 keys should be present, got {len(workspace1_keys)}"
+    # Assert the flag values themselves, per namespace. A blanket `all(values)` over
+    # every namespace cannot express this: test_namespace was cleared for workspace1
+    # back in Test 8.2 and is legitimately False here, while ns_a/ns_b were just set.
+    assert status1[f"{workspace1}:ns_a"] == [True], (
+        f"ns_a should be set for workspace1, got {status1[f'{workspace1}:ns_a']}"
     )
-    assert len(workspace2_keys) == 0, (
-        f"workspace2 keys should not be present, got {len(workspace2_keys)}"
+    assert status1[f"{workspace1}:ns_b"] == [True], (
+        f"ns_b should be set for workspace1, got {status1[f'{workspace1}:ns_b']}"
     )
-    for key, values in status1.items():
-        assert all(values), f"All flags in {key} should be True, got {values}"
+    assert status1[f"{workspace1}:{test_namespace}"] == [False], (
+        "test_namespace was cleared for workspace1 in Test 8.2 and must stay cleared, "
+        f"got {status1[f'{workspace1}:{test_namespace}']}"
+    )
 
     # Workspace2 query should only surface workspace2 namespaces
     status2 = await get_all_update_flags_status(workspace=workspace2)
@@ -704,12 +714,17 @@ async def test_update_flags_workspace_isolation():
     assert set(status2.keys()) == expected_ws2_keys, (
         f"Unexpected namespaces for workspace2: {status2.keys()}"
     )
-    for key, values in status2.items():
-        assert all(values), f"All flags in {key} should be True, got {values}"
+    # Both were set and never cleared for workspace2 (Test 8.2 cleared workspace1 only)
+    assert status2[f"{workspace2}:{test_namespace}"] == [True], (
+        f"test_namespace should stay set for workspace2, got {status2[f'{workspace2}:{test_namespace}']}"
+    )
+    assert status2[f"{workspace2}:ns_c"] == [True], (
+        f"ns_c should be set for workspace2, got {status2[f'{workspace2}:ns_c']}"
+    )
 
     print("✅ PASSED: Update Flags - get_all_update_flags_status Filtering")
     print(
-        f"   Status correctly filtered: ws1 keys={len(workspace1_keys)}, ws2 keys={len(workspace2_keys)}"
+        f"   Status correctly filtered: ws1 keys={len(status1)}, ws2 keys={len(status2)}"
     )
 
 


### PR DESCRIPTION
## Summary

In single-process mode, `get_all_update_flags_status` returned `MutableBoolean` objects instead of Python `bool`s. That breaks JSON encoding and callers that expect plain booleans.

## Problem

The helper branched on `_is_multiprocess` and appended the raw flag object in the single-process path. The document route then had to special-case `.value` / `hasattr` conversion before responding.

## Fix

Always read `flag.value` in `get_all_update_flags_status`, and let the document route use the returned status directly.

## Test plan

- [x] `pytest tests/kg/test_get_all_update_flags_status.py`
