### PR TITLE
fix(utils): correct docstring example and harden compute_incremental_chunk_ids

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -5811,18 +5811,17 @@ def compute_incremental_chunk_ids(
     """
     # Calculate changes
     chunks_to_remove = set(old_chunk_ids) - set(new_chunk_ids)
-    chunks_to_add = set(new_chunk_ids) - set(old_chunk_ids)
 
-    # Apply changes to full chunk_ids
     # Step 1: Remove chunks that are no longer needed
     updated_chunk_ids = [
         cid for cid in existing_full_chunk_ids if cid not in chunks_to_remove
     ]
+    seen = set(updated_chunk_ids)
 
-    # Step 2: Add new chunks (preserving order from new_chunk_ids)
-    # Note: 'cid not in updated_chunk_ids' check ensures deduplication
+    # Step 2: Add any chunks from new_chunk_ids not currently in updated_chunk_ids
     for cid in new_chunk_ids:
-        if cid in chunks_to_add and cid not in updated_chunk_ids:
+        if cid and cid not in seen:
+            seen.add(cid)
             updated_chunk_ids.append(cid)
 
     return updated_chunk_ids

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -5807,20 +5807,21 @@ def compute_incremental_chunk_ids(
         >>> old = ['chunk-1', 'chunk-2']
         >>> new = ['chunk-2', 'chunk-4']
         >>> compute_incremental_chunk_ids(existing, old, new)
-        ['chunk-3', 'chunk-2', 'chunk-4']
+        ['chunk-2', 'chunk-3', 'chunk-4']
     """
     # Calculate changes
     chunks_to_remove = set(old_chunk_ids) - set(new_chunk_ids)
+    chunks_to_add = set(new_chunk_ids) - set(old_chunk_ids)
 
     # Step 1: Remove chunks that are no longer needed
     updated_chunk_ids = [
-        cid for cid in existing_full_chunk_ids if cid not in chunks_to_remove
+        cid for cid in existing_full_chunk_ids if cid and cid not in chunks_to_remove
     ]
     seen = set(updated_chunk_ids)
 
-    # Step 2: Add any chunks from new_chunk_ids not currently in updated_chunk_ids
+    # Step 2: Add new chunk additions (preserving order from new_chunk_ids)
     for cid in new_chunk_ids:
-        if cid and cid not in seen:
+        if cid and cid in chunks_to_add and cid not in seen:
             seen.add(cid)
             updated_chunk_ids.append(cid)
 

--- a/tests/utils/test_compute_incremental_chunk_ids.py
+++ b/tests/utils/test_compute_incremental_chunk_ids.py
@@ -1,0 +1,17 @@
+from lightrag.utils import compute_incremental_chunk_ids
+
+
+def test_compute_incremental_chunk_ids_preserves_new_chunks_missing_from_existing():
+    # Scenario: existing_full_chunk_ids is missing chunk-1, but chunk-1 is in old_chunk_ids
+    # and remains in new_chunk_ids (re-indexing / partial storage state).
+    existing = ["chunk-3"]
+    old = ["chunk-1", "chunk-3"]
+    new = ["chunk-1", "chunk-2", "chunk-3"]
+
+    updated = compute_incremental_chunk_ids(existing, old, new)
+
+    # All chunk IDs present in `new` must be preserved in the result.
+    assert "chunk-1" in updated
+    assert "chunk-2" in updated
+    assert "chunk-3" in updated
+    assert set(updated) == {"chunk-1", "chunk-2", "chunk-3"}

--- a/tests/utils/test_compute_incremental_chunk_ids.py
+++ b/tests/utils/test_compute_incremental_chunk_ids.py
@@ -1,17 +1,26 @@
 from lightrag.utils import compute_incremental_chunk_ids
 
 
-def test_compute_incremental_chunk_ids_preserves_new_chunks_missing_from_existing():
-    # Scenario: existing_full_chunk_ids is missing chunk-1, but chunk-1 is in old_chunk_ids
-    # and remains in new_chunk_ids (re-indexing / partial storage state).
+def test_compute_incremental_chunk_ids_standard_update():
+    existing = ["chunk-1", "chunk-2", "chunk-3"]
+    old = ["chunk-1", "chunk-2"]
+    new = ["chunk-2", "chunk-4"]
+
+    updated = compute_incremental_chunk_ids(existing, old, new)
+    assert updated == ["chunk-2", "chunk-3", "chunk-4"]
+
+
+def test_compute_incremental_chunk_ids_does_not_resurrect_stale_graph_ids():
+    # Scenario: chunk-1 is in old_chunk_ids (from graph source_id) and new_chunk_ids,
+    # but was previously deleted from existing tracking storage (chunk-3 only).
+    # Incremental update must append chunk-2 (new addition) without resurrecting stale chunk-1.
     existing = ["chunk-3"]
     old = ["chunk-1", "chunk-3"]
     new = ["chunk-1", "chunk-2", "chunk-3"]
 
     updated = compute_incremental_chunk_ids(existing, old, new)
 
-    # All chunk IDs present in `new` must be preserved in the result.
-    assert "chunk-1" in updated
+    assert "chunk-1" not in updated
     assert "chunk-2" in updated
     assert "chunk-3" in updated
-    assert set(updated) == {"chunk-1", "chunk-2", "chunk-3"}
+    assert updated == ["chunk-3", "chunk-2"]


### PR DESCRIPTION
## Summary

Corrects a wrong docstring example on `compute_incremental_chunk_ids`, hardens the implementation without changing its semantics for non-empty IDs, and documents the invariant that makes its delta rule correct.

> **Note on scope.** This PR originally proposed a behavioural change — appending every `new_chunk_ids` entry so that IDs present in both `old_chunk_ids` and `new_chunk_ids` but missing from `existing_full_chunk_ids` would be restored. That approach was **reviewed and withdrawn** (see the review thread on `fb74cd1`): the chunk-tracking row is authoritative over the graph's `source_id`, so those IDs are pruned on purpose and restoring them would write stale attribution back into the authoritative store. The delta rule is unchanged; what remains is the doc fix, the hardening, and the tests/docs that pin the rule.

## Motivation

The documented example output was simply wrong. With

```python
existing = ['chunk-1', 'chunk-2', 'chunk-3']
old      = ['chunk-1', 'chunk-2']
new      = ['chunk-2', 'chunk-4']
```

the function returns `['chunk-2', 'chunk-3', 'chunk-4']`, not the documented `['chunk-3', 'chunk-2', 'chunk-4']`.

Separately, the reasoning behind "append genuine additions (`new - old`) only" lived nowhere — not in the docstring, not in the tests, only implicitly in a purge branch condition. That gap is what made the original (incorrect) change look like an obvious bug fix.

## What's changed

**`lightrag/utils.py`**

- Fix the docstring example output.
- Drop empty chunk IDs from both inputs so they can never reach storage and inflate the persisted `count`.
- Replace the `cid not in updated_chunk_ids` list scan with a `seen` set, taking deduplication from O(n²) to O(n).
- Document the **authority model**: the entity/relation chunk-tracking row is authoritative; a graph node's `source_id` is only a truncated view of it (`apply_source_ids_limit`) and may legitimately still name chunks a previous purge pruned. `_purge_kg_contributions` reads tracking first and falls back to `source_id` only when the row is absent, and its `graph_references_deleted_chunks` branch exists to repair exactly that lag. Restoring an ID that the graph names but tracking does not would make a later purge rebuild or retain KG objects sourced from chunks that no longer exist. Repairing genuinely missing attribution is the job of `audit_kg_integrity(..., apply=True)`.
- Note why the `seen` check is not redundant with `chunks_to_add`: tracking can already hold an ID that is in `new_chunk_ids` but not in `old_chunk_ids`, precisely because `source_id` is truncated.

**`tests/utils/test_compute_incremental_chunk_ids.py`** (new) — six cases:

| Test | Pins |
|---|---|
| `standard_update` | the normal delta, and the corrected docstring example |
| `does_not_resurrect_stale_graph_ids` | pruned IDs stay pruned |
| `rename_does_not_reseed_pruned_ids_when_source_id_is_unchanged` | the production path that motivates the rule — `_edit_entity_impl` reaches the helper with `old == new` because `is_renaming` alone satisfies its guard |
| `no_duplicate_when_existing_already_holds_a_new_id` | the truncation case, exercising the `seen` branch `chunks_to_add` cannot guard |
| `empty_chunk_ids_are_dropped_from_both_inputs` | the only behavioural change in this series |
| `all_chunks_removed_yields_empty_list` | full-removal boundary |

**`AGENTS.md`** — records the graph-versus-tracking precedence next to the purge recovery contract, so it is stated once for all callers instead of living only in a branch condition.

## What's broken / behavioural impact

Nothing for non-empty chunk IDs. An exhaustive differential check over all `(existing, old, new)` subset combinations of a 3-element universe shows **zero** behavioural differences against `main` when no input contains an empty string; the only divergence is that empty IDs are now dropped. Both call sites in `lightrag/utils_graph.py` already pre-filter with `if cid`, so the persisted `chunk_ids` / `count` values are unaffected in practice.

## Follow-up (not in this PR)

`utils_graph.py` decides `has_stored_data` on the truthiness of `stored_data.get("chunk_ids")`, which collapses "tracking row absent" and "tracking row present but empty" into one branch that then reseeds from the possibly-stale graph `source_id`. Tracked separately in #3609.

## Test plan

- [x] `./scripts/test.sh tests/utils` — includes the six new cases
- [x] `./scripts/test.sh tests/pipeline/test_doc_status_chunk_preservation.py tests/pipeline/test_graph_keyed_locks.py tests/tools/test_rebuild_vdb.py` — 96 passed
- [x] `ruff check lightrag/utils.py tests/utils/test_compute_incremental_chunk_ids.py`