### PR TITLE
fix(utils): split GRAPH_FIELD_SEP in merge_source_ids

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -1707,7 +1707,11 @@ async def _rebuild_single_entity(
             logger.error(error_msg)
             raise  # Re-raise exception
 
-    # normalized_chunk_ids = merge_source_ids([], chunk_ids)
+    # No merge_source_ids() normalization here: the rebuild caller derives
+    # chunk_ids from subtract_source_ids() over either entity_chunks_storage
+    # rows or an already-split graph `source_id` (see _purge_kg_contributions),
+    # so the ids arrive individual and non-empty. Normalizing again would only
+    # re-walk the list on the purge hot path.
     normalized_chunk_ids = chunk_ids
 
     if entity_chunks_storage is not None and normalized_chunk_ids:
@@ -1920,7 +1924,8 @@ async def _rebuild_single_relationship(
     if not current_relationship:
         return False
 
-    # normalized_chunk_ids = merge_source_ids([], chunk_ids)
+    # Same as _rebuild_single_entity: chunk_ids reach this function already
+    # split and non-empty, so no merge_source_ids() normalization is needed.
     normalized_chunk_ids = chunk_ids
 
     if relation_chunks_storage is not None and normalized_chunk_ids:

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -5740,10 +5740,11 @@ def merge_source_ids(
         for source_id in sequence:
             if not source_id:
                 continue
-            if source_id not in seen:
-                seen.add(source_id)
-                merged.append(source_id)
-
+            for sid in str(source_id).split(GRAPH_FIELD_SEP):
+                sid = sid.strip()
+                if sid and sid not in seen:
+                    seen.add(sid)
+                    merged.append(sid)
     return merged
 
 

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -5729,7 +5729,30 @@ def normalize_source_ids_limit_method(method: str | None) -> str:
 def merge_source_ids(
     existing_ids: Iterable[str] | None, new_ids: Iterable[str] | None
 ) -> list[str]:
-    """Merge two iterables of source IDs while preserving order and removing duplicates."""
+    """Merge two iterables of source IDs into one flat, ordered, deduplicated list.
+
+    Every element is split on ``GRAPH_FIELD_SEP``, stripped, and deduplicated by
+    first-seen order. The split is what makes this the normalization boundary
+    for chunk-id lists: an element that is itself a joined string
+    (``"chunk-a<SEP>chunk-b"``) would otherwise be stored as a single id, and
+    such an id matches no key in ``text_chunks``. It would then corrupt the
+    ``chunk_ids``/``count`` rows of ``entity_chunks_storage`` /
+    ``relation_chunks_storage``, miscount ``apply_source_ids_limit``'s
+    truncation (two chunks counted as one), and miss every downstream
+    ``get_by_ids`` lookup.
+
+    No in-tree producer passes a joined element today — every caller splits its
+    graph ``source_id`` first, and extraction emits one ``chunk_key`` per record
+    — so the split is a guard against a future upstream regression rather than a
+    fix for a live path. A joined element arriving here therefore means an
+    upstream bug and is logged at debug level so the silent repair does not hide
+    the root cause.
+
+    Despite the name, this also merges the sibling union fields that share the
+    same ``GRAPH_FIELD_SEP`` encoding: ``file_path`` and ``description`` in the
+    edge-dedup merges of ``mongo_impl`` / ``opensearch_impl``. Stripping applies
+    to those fragments too, so ``" foo"`` and ``"foo"`` collapse into one entry.
+    """
 
     merged: list[str] = []
     seen: set[str] = set()
@@ -5740,11 +5763,27 @@ def merge_source_ids(
         for source_id in sequence:
             if not source_id:
                 continue
-            for sid in str(source_id).split(GRAPH_FIELD_SEP):
-                sid = sid.strip()
-                if sid and sid not in seen:
+            if not isinstance(source_id, str):
+                # Coerce rather than skip: dropping the value would silently
+                # lose provenance, which is the failure mode this function
+                # exists to prevent. The warning surfaces the type bug.
+                logger.warning(
+                    f"merge_source_ids received a non-string id "
+                    f"{source_id!r} ({type(source_id).__name__}); coercing to str"
+                )
+                source_id = str(source_id)
+            if GRAPH_FIELD_SEP in source_id:
+                logger.debug(
+                    f"merge_source_ids splitting a GRAPH_FIELD_SEP-joined value "
+                    f"{source_id!r}; callers are expected to pass individual ids"
+                )
+            # split_string_by_multi_markers already strips each fragment and
+            # drops the empty ones, so a whitespace-only element yields nothing.
+            for sid in split_string_by_multi_markers(source_id, [GRAPH_FIELD_SEP]):
+                if sid not in seen:
                     seen.add(sid)
                     merged.append(sid)
+
     return merged
 
 

--- a/tests/utils/test_merge_source_ids.py
+++ b/tests/utils/test_merge_source_ids.py
@@ -1,5 +1,34 @@
+"""Regression tests for ``merge_source_ids`` normalization.
+
+``merge_source_ids`` is the single collection point for every chunk-id list that
+reaches ``entity_chunks_storage`` / ``relation_chunks_storage``, so it has to
+flatten ``GRAPH_FIELD_SEP``-joined elements instead of storing them verbatim: a
+joined id matches no key in ``text_chunks``, which would drop the chunks from
+provenance, from ``apply_source_ids_limit``'s counting, and from retrieval
+lookups.
+"""
+
+import logging
+from contextlib import contextmanager
+
 from lightrag.constants import GRAPH_FIELD_SEP
-from lightrag.utils import merge_source_ids
+from lightrag.utils import logger as lightrag_logger, merge_source_ids
+
+
+@contextmanager
+def _captured_logs(caplog, level):
+    """Capture lightrag logger records.
+
+    The lightrag logger sets ``propagate = False``, so caplog cannot see it
+    unless propagation is re-enabled for the duration of the call.
+    """
+    original_propagate = lightrag_logger.propagate
+    lightrag_logger.propagate = True
+    try:
+        with caplog.at_level(level, logger=lightrag_logger.name):
+            yield
+    finally:
+        lightrag_logger.propagate = original_propagate
 
 
 def test_merge_source_ids_splits_graph_field_sep():
@@ -12,3 +41,75 @@ def test_merge_source_ids_splits_graph_field_sep():
     # Every item in merged must be an individual chunk ID (no un-split GRAPH_FIELD_SEP strings).
     assert merged == ["chunk-1", "chunk-2", "chunk-3"]
     assert not any(GRAPH_FIELD_SEP in item for item in merged)
+
+
+def test_merge_source_ids_splits_existing_ids_too():
+    # The stored side is normalized as well: a corrupted entity_chunks_storage
+    # row must not survive a merge just because it came from storage.
+    existing = [f"chunk-1{GRAPH_FIELD_SEP}chunk-2"]
+    new = ["chunk-2", "chunk-3"]
+
+    assert merge_source_ids(existing, new) == ["chunk-1", "chunk-2", "chunk-3"]
+
+
+def test_merge_source_ids_preserves_first_seen_order_across_both_sequences():
+    existing = ["chunk-b", "chunk-a"]
+    new = ["chunk-a", "chunk-c", "chunk-b"]
+
+    assert merge_source_ids(existing, new) == ["chunk-b", "chunk-a", "chunk-c"]
+
+
+def test_merge_source_ids_strips_and_drops_blank_fragments():
+    # A whitespace-only element, and blank fragments inside a joined element,
+    # contribute nothing; surviving fragments are trimmed.
+    merged = merge_source_ids(
+        ["   "],
+        [f"  chunk-1  {GRAPH_FIELD_SEP}{GRAPH_FIELD_SEP}   {GRAPH_FIELD_SEP}chunk-2"],
+    )
+
+    assert merged == ["chunk-1", "chunk-2"]
+
+
+def test_merge_source_ids_dedups_after_stripping():
+    # Fragments differing only by surrounding whitespace collapse into one entry.
+    # This also covers the file_path/description union fields, which reuse this
+    # helper in the mongo/opensearch edge-dedup merges.
+    assert merge_source_ids(["chunk-1"], ["  chunk-1  "]) == ["chunk-1"]
+
+
+def test_merge_source_ids_handles_empty_and_none_inputs():
+    assert merge_source_ids(None, None) == []
+    assert merge_source_ids([], None) == []
+    assert merge_source_ids(None, ["chunk-1"]) == ["chunk-1"]
+    assert merge_source_ids(["chunk-1"], []) == ["chunk-1"]
+    # Falsy elements are skipped rather than emitted as empty ids.
+    assert merge_source_ids(["", "chunk-1"], [None, "chunk-2"]) == [
+        "chunk-1",
+        "chunk-2",
+    ]
+
+
+def test_merge_source_ids_coerces_non_string_ids_with_a_warning(caplog):
+    # Coercion (not skipping) keeps provenance; the warning surfaces the caller's
+    # type bug instead of letting it pass silently.
+    with _captured_logs(caplog, logging.WARNING):
+        merged = merge_source_ids([123], ["chunk-1"])
+
+    assert merged == ["123", "chunk-1"]
+    assert any("non-string id" in r.getMessage() for r in caplog.records)
+
+
+def test_merge_source_ids_logs_when_it_has_to_split(caplog):
+    # A joined element means an upstream producer skipped its own split; the
+    # repair is silent in the data but not in the log.
+    with _captured_logs(caplog, logging.DEBUG):
+        merge_source_ids([], [f"chunk-1{GRAPH_FIELD_SEP}chunk-2"])
+
+    assert any("GRAPH_FIELD_SEP-joined" in r.getMessage() for r in caplog.records)
+
+
+def test_merge_source_ids_does_not_log_for_normal_input(caplog):
+    with _captured_logs(caplog, logging.DEBUG):
+        merge_source_ids(["chunk-1"], ["chunk-2"])
+
+    assert not [r for r in caplog.records if r.name == lightrag_logger.name]

--- a/tests/utils/test_merge_source_ids.py
+++ b/tests/utils/test_merge_source_ids.py
@@ -1,0 +1,14 @@
+from lightrag.constants import GRAPH_FIELD_SEP
+from lightrag.utils import merge_source_ids
+
+
+def test_merge_source_ids_splits_graph_field_sep():
+    # Scenario: new_ids contains combined source_id strings with GRAPH_FIELD_SEP.
+    existing = ["chunk-1"]
+    new = [f"chunk-2{GRAPH_FIELD_SEP}chunk-3", "chunk-3"]
+
+    merged = merge_source_ids(existing, new)
+
+    # Every item in merged must be an individual chunk ID (no un-split GRAPH_FIELD_SEP strings).
+    assert merged == ["chunk-1", "chunk-2", "chunk-3"]
+    assert not any(GRAPH_FIELD_SEP in item for item in merged)


### PR DESCRIPTION
## Summary

`merge_source_ids` treated `GRAPH_FIELD_SEP`-joined source id strings as single ids, so downstream chunk lookups missed the real chunk keys.

## Problem

```python
merge_source_ids(["chunk-1"], [f"chunk-2{GRAPH_FIELD_SEP}chunk-3", "chunk-3"])
# before: ['chunk-1', 'chunk-2<SEP>chunk-3', 'chunk-3']
```

Joined ids never match `text_chunks_storage.get_by_ids` keys, so those chunks disappear from retrieval context.

## Fix

Split each source id on `GRAPH_FIELD_SEP`, strip whitespace, and dedup individual ids.

## Test plan

- [x] `pytest tests/utils/test_merge_source_ids.py`
