### PR TITLE
fix(operate): match bidirectional relationship pairs during query truncation

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -5085,9 +5085,7 @@ async def _apply_token_truncation(
     if relations_context:
         final_relation_pairs = {
             (r["entity1"], r["entity2"]) for r in relations_context
-        } | {
-            (r["entity2"], r["entity1"]) for r in relations_context
-        }
+        } | {(r["entity2"], r["entity1"]) for r in relations_context}
         seen_edges = set()
         for relation in final_relations:
             src, tgt = relation.get("src_id"), relation.get("tgt_id")
@@ -5097,8 +5095,10 @@ async def _apply_token_truncation(
             pair = (src, tgt)
             rev_pair = (tgt, src)
             if (
-                pair in final_relation_pairs or rev_pair in final_relation_pairs
-            ) and pair not in seen_edges and rev_pair not in seen_edges:
+                (pair in final_relation_pairs or rev_pair in final_relation_pairs)
+                and pair not in seen_edges
+                and rev_pair not in seen_edges
+            ):
                 filtered_relations.append(relation)
                 filtered_relation_id_to_original[pair] = relation
                 filtered_relation_id_to_original[rev_pair] = relation

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -5008,9 +5008,11 @@ async def _apply_token_truncation(
         else:
             entity1, entity2 = relation.get("src_id"), relation.get("tgt_id")
 
-        # Store mapping from relation pair to original data
+        # Store mapping from relation pair to original data (both directions)
         relation_key = (entity1, entity2)
         relation_id_to_original[relation_key] = relation
+        if entity1 and entity2:
+            relation_id_to_original[(entity2, entity1)] = relation
 
         relations_context.append(
             {
@@ -5081,7 +5083,11 @@ async def _apply_token_truncation(
     filtered_relations = []
     filtered_relation_id_to_original = {}
     if relations_context:
-        final_relation_pairs = {(r["entity1"], r["entity2"]) for r in relations_context}
+        final_relation_pairs = {
+            (r["entity1"], r["entity2"]) for r in relations_context
+        } | {
+            (r["entity2"], r["entity1"]) for r in relations_context
+        }
         seen_edges = set()
         for relation in final_relations:
             src, tgt = relation.get("src_id"), relation.get("tgt_id")
@@ -5089,11 +5095,15 @@ async def _apply_token_truncation(
                 src, tgt = relation.get("src_tgt", (None, None))
 
             pair = (src, tgt)
-            if pair in final_relation_pairs and pair not in seen_edges:
+            rev_pair = (tgt, src)
+            if (
+                pair in final_relation_pairs or rev_pair in final_relation_pairs
+            ) and pair not in seen_edges and rev_pair not in seen_edges:
                 filtered_relations.append(relation)
                 filtered_relation_id_to_original[pair] = relation
+                filtered_relation_id_to_original[rev_pair] = relation
                 seen_edges.add(pair)
-
+                seen_edges.add(rev_pair)
     return {
         "entities_context": entities_context,
         "relations_context": relations_context,

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -6128,8 +6128,10 @@ def convert_to_user_format(
 
         # Try to get original data first
         original_relation = None
-        if relation_id_to_original and relation_key in relation_id_to_original:
-            original_relation = relation_id_to_original[relation_key]
+        if relation_id_to_original:
+            original_relation = relation_id_to_original.get(
+                relation_key
+            ) or relation_id_to_original.get((entity2, entity1))
 
         if original_relation:
             # Use original database data

--- a/tests/extraction/test_query_truncation_bidirectional_relation.py
+++ b/tests/extraction/test_query_truncation_bidirectional_relation.py
@@ -1,0 +1,82 @@
+import pytest
+from lightrag.base import QueryParam
+from lightrag.operate import _apply_token_truncation
+from lightrag.utils import Tokenizer, TokenizerInterface, convert_to_user_format
+
+
+class _DummyTokenizer(TokenizerInterface):
+    def encode(self, content: str):
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]):
+        return "".join(chr(t) for t in tokens)
+
+
+@pytest.mark.asyncio
+async def test_apply_token_truncation_bidirectional_relation_matching():
+    search_result = {
+        "final_entities": [],
+        "final_relations": [
+            {
+                "src_tgt": ("NodeA", "NodeB"),
+                "description": "Relation between NodeA and NodeB",
+                "keywords": "kw1",
+                "weight": 2.0,
+                "created_at": 1000,
+            },
+            {
+                "src_id": "NodeD",
+                "tgt_id": "NodeC",
+                "description": "Reversed edge direction relation",
+                "keywords": "kw2",
+                "weight": 3.0,
+                "created_at": 1000,
+            },
+        ],
+        "vector_chunks": [],
+        "chunk_tracking": {},
+        "query_embedding": None,
+    }
+
+    query_param = QueryParam(
+        mode="global",
+        max_relation_tokens=1000,
+        max_entity_tokens=1000,
+    )
+
+    global_config = {
+        "tokenizer": Tokenizer("dummy", _DummyTokenizer()),
+        "max_relation_tokens": 1000,
+        "max_entity_tokens": 1000,
+    }
+
+    result = await _apply_token_truncation(search_result, query_param, global_config)
+
+    filtered_relations = result["filtered_relations"]
+    relation_id_to_original = result["relation_id_to_original"]
+
+    assert len(filtered_relations) == 2, f"Expected 2 filtered relations, got {len(filtered_relations)}"
+    assert ("NodeD", "NodeC") in relation_id_to_original
+    assert ("NodeC", "NodeD") in relation_id_to_original
+
+    # Verify convert_to_user_format retrieves original DB data in both direction queries
+    user_format_reverse = convert_to_user_format(
+        entities_context=[],
+        relations_context=[
+            {
+                "entity1": "NodeC",
+                "entity2": "NodeD",
+                "description": "Truncated desc",
+                "created_at": "2026-01-01",
+                "file_path": "f.txt",
+            }
+        ],
+        chunks=[],
+        references=[],
+        query_mode="global",
+        relation_id_to_original=relation_id_to_original,
+    )
+
+    rel_out = user_format_reverse["data"]["relationships"][0]
+    assert rel_out["description"] == "Reversed edge direction relation"
+    assert rel_out["weight"] == 3.0

--- a/tests/extraction/test_query_truncation_bidirectional_relation.py
+++ b/tests/extraction/test_query_truncation_bidirectional_relation.py
@@ -55,7 +55,9 @@ async def test_apply_token_truncation_bidirectional_relation_matching():
     filtered_relations = result["filtered_relations"]
     relation_id_to_original = result["relation_id_to_original"]
 
-    assert len(filtered_relations) == 2, f"Expected 2 filtered relations, got {len(filtered_relations)}"
+    assert len(filtered_relations) == 2, (
+        f"Expected 2 filtered relations, got {len(filtered_relations)}"
+    )
     assert ("NodeD", "NodeC") in relation_id_to_original
     assert ("NodeC", "NodeD") in relation_id_to_original
 


### PR DESCRIPTION
## Summary

Query token truncation dropped undirected relationships when the stored edge direction was reversed relative to `relations_context`, which also dropped their associated text chunks from the LLM context.

## Problem

`_apply_token_truncation` built `final_relation_pairs` in one direction only and required an exact `(src, tgt)` match. For undirected query modes, retrieved edges can arrive as `(tgt, src)`. Those edges were filtered out, and `convert_to_user_format` fell back to placeholders when the reverse key was missing.

## Fix

Index and match both `(entity1, entity2)` and `(entity2, entity1)` in truncation filtering and in `convert_to_user_format` fallback lookup.

## Test plan

- [x] `pytest tests/extraction/test_query_truncation_bidirectional_relation.py`
