### PR TITLE
fix: resolve real Ollama embedding dimension instead of a single hardcoded default

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -713,11 +713,35 @@ def create_optimized_embedding_function(
     # Step 2: Apply priority (user config > provider default)
     # For max_token_size: explicit env var > provider default > None
     final_max_token_size = args.embedding_token_limit or provider_max_token_size
-    # For embedding_dim: user config (always has value) takes priority
-    # Only use provider default if user config is explicitly None (which shouldn't happen)
-    final_embedding_dim = (
-        args.embedding_dim if args.embedding_dim else provider_embedding_dim
-    )
+    # For embedding_dim: user config > known-model lookup (Ollama only) > provider default.
+    # provider_embedding_dim is a single static value per provider (1024 for Ollama,
+    # tuned for its default model bge-m3) -- correct for that one model, silently wrong
+    # for most others a user might point EMBEDDING_MODEL at instead. The Ollama API
+    # exposes no dimension metadata to check ahead of a real embed call, so for known
+    # models we resolve the real dimension from a lookup table instead of guessing;
+    # for unrecognized models we keep the provider default but warn, so a mismatch
+    # surfaces as a clear message here rather than a confusing failure mid-ingestion.
+    final_embedding_dim = args.embedding_dim
+    if not final_embedding_dim and binding == "ollama" and model:
+        from lightrag.llm.binding_options import KNOWN_OLLAMA_EMBEDDING_DIMS
+
+        base_model_name = model.split(":")[0]
+        known_dim = KNOWN_OLLAMA_EMBEDDING_DIMS.get(
+            model
+        ) or KNOWN_OLLAMA_EMBEDDING_DIMS.get(base_model_name)
+        if known_dim is not None:
+            final_embedding_dim = known_dim
+        else:
+            final_embedding_dim = provider_embedding_dim
+            logger.warning(
+                f"Ollama embedding model '{model}' has an unknown output dimension; "
+                f"defaulting to {provider_embedding_dim} (matches bge-m3, the Ollama "
+                f"binding's default model). If document insertion fails with an "
+                f"'Embedding dimension mismatch' error, set EMBEDDING_DIM explicitly "
+                f"to this model's real output size."
+            )
+    if not final_embedding_dim:
+        final_embedding_dim = provider_embedding_dim
     # Asymmetric embedding is explicit opt-in only. Provider-specific
     # validation decides whether task parameters or prefixes are required.
     asymmetric_opt_in = resolve_asymmetric_embedding_opt_in(

--- a/lightrag/llm/binding_options.py
+++ b/lightrag/llm/binding_options.py
@@ -527,6 +527,30 @@ class OllamaEmbeddingOptions(_OllamaOptionsMixin, BindingOptions):
     _binding_name: ClassVar[str] = "ollama_embedding"
 
 
+# Known output dimensions for common Ollama embedding models, keyed by model
+# name without a tag suffix (e.g. "nomic-embed-text", not
+# "nomic-embed-text:latest"). The Ollama API exposes no dimension metadata to
+# check ahead of a real embed call, and ollama_embed's
+# @wrap_embedding_func_with_attrs (lightrag/llm/ollama.py) needs a single
+# static default at import time -- 1024 is correct for bge-m3 (the binding's
+# default model) but silently wrong for most others. This lives here rather
+# than in lightrag/llm/ollama.py so resolving it doesn't require importing
+# the optional `ollama` SDK (see #3596); create_optimized_embedding_function
+# in lightrag_server.py consults it once the actual configured model name is
+# known, falling back to the bge-m3 default (with a startup warning) for
+# anything not listed here.
+KNOWN_OLLAMA_EMBEDDING_DIMS: dict[str, int] = {
+    "bge-m3": 1024,
+    "nomic-embed-text": 768,
+    "mxbai-embed-large": 1024,
+    "all-minilm": 384,
+    "snowflake-arctic-embed": 1024,
+    "snowflake-arctic-embed2": 1024,
+    "granite-embedding": 768,
+    "paraphrase-multilingual": 768,
+}
+
+
 @dataclass
 class OllamaLLMOptions(_OllamaOptionsMixin, BindingOptions):
     """Options for Ollama LLM with specialized configuration for LLM tasks."""

--- a/tests/api/config/test_api_config_ollama_embedding_dim.py
+++ b/tests/api/config/test_api_config_ollama_embedding_dim.py
@@ -1,0 +1,109 @@
+"""Ollama embedding dimension resolution (API config layer).
+
+EMBEDDING_DIM has no way to be probed ahead of a real embed call, so the
+Ollama binding used a single static default (1024, tuned for bge-m3, its
+default model) for every model. That default is silently wrong for any
+other model a user points EMBEDDING_MODEL at -- e.g. nomic-embed-text is
+actually 768-dim -- and the failure only surfaces later, mid-ingestion, as
+a confusing vector-store "dimension mismatch" error with no link back to
+the real cause. See issue #3596.
+
+KNOWN_OLLAMA_EMBEDDING_DIMS (lightrag/llm/ollama.py) resolves the real
+dimension for recognized models without requiring EMBEDDING_DIM to be set;
+unrecognized models keep the previous (bge-m3) default but now log a clear
+warning naming the actual model, instead of failing silently.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from lightrag.api.config import parse_args
+
+pytestmark = pytest.mark.offline
+
+
+def _build_embedding_func(monkeypatch, *, model: str, embedding_dim: str | None = None):
+    # lightrag.api.lightrag_server transitively imports lightrag.api.auth, whose
+    # module-level `AuthHandler()` singleton reads sys.argv (via global_args) on
+    # first import. Patch argv before that first import is triggered (below),
+    # not just before parse_args() -- otherwise pytest's own argv reaches
+    # argparse and the collection-time import fails outright.
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    from lightrag.api.lightrag_server import create_embedding_function_from_args
+
+    monkeypatch.setenv("EMBEDDING_BINDING", "ollama")
+    monkeypatch.setenv("EMBEDDING_MODEL", model)
+    if embedding_dim is None:
+        monkeypatch.delenv("EMBEDDING_DIM", raising=False)
+    else:
+        monkeypatch.setenv("EMBEDDING_DIM", embedding_dim)
+    args = parse_args()
+    return create_embedding_function_from_args(args)
+
+
+def test_known_model_resolves_its_real_dimension_not_the_bge_m3_default(monkeypatch):
+    """The exact regression from #3596: nomic-embed-text is 768-dim, not 1024."""
+    embedding_func = _build_embedding_func(monkeypatch, model="nomic-embed-text")
+
+    assert embedding_func.embedding_dim == 768
+
+
+def test_a_tag_suffix_on_a_known_model_still_resolves(monkeypatch):
+    """Model names commonly carry a tag (":latest", ":v1.5", ...); matching
+    must not require the user to omit it."""
+    embedding_func = _build_embedding_func(monkeypatch, model="nomic-embed-text:latest")
+
+    assert embedding_func.embedding_dim == 768
+
+
+def test_default_model_is_unaffected(monkeypatch):
+    """bge-m3 (the binding's own default model) keeps working exactly as
+    before -- this table only adds coverage, it doesn't change existing
+    correct behavior."""
+    embedding_func = _build_embedding_func(monkeypatch, model="bge-m3")
+
+    assert embedding_func.embedding_dim == 1024
+
+
+def test_unknown_model_falls_back_to_1024_with_a_clear_warning(monkeypatch):
+    """Models this table doesn't recognize keep the historical behavior
+    (no regression for anyone currently relying on the 1024 default by
+    coincidence) but must no longer fail silently -- the warning is the
+    difference between this and the original bug.
+
+    Spies directly on logger.warning rather than using caplog: the
+    "lightrag" logger's propagate=False plus its own handler being attached
+    on first import (which this test necessarily triggers, since
+    lightrag.api.lightrag_server can only be imported after sys.argv is
+    patched -- see _build_embedding_func) left caplog's handler seeing no
+    records no matter how the import/attach ordering was arranged. A direct
+    spy has no such ordering dependency.
+    """
+    warning_calls: list[str] = []
+    from lightrag.utils import logger
+
+    monkeypatch.setattr(
+        logger, "warning", lambda msg, *a, **kw: warning_calls.append(msg)
+    )
+
+    embedding_func = _build_embedding_func(
+        monkeypatch, model="some-future-embedding-model"
+    )
+
+    assert embedding_func.embedding_dim == 1024
+    assert any("some-future-embedding-model" in msg for msg in warning_calls)
+    assert any("EMBEDDING_DIM" in msg for msg in warning_calls)
+
+
+def test_explicit_embedding_dim_still_wins_over_the_lookup_table(monkeypatch):
+    """User-set EMBEDDING_DIM is an explicit override and must take priority
+    over table-driven resolution, e.g. for a fine-tuned or quantized variant
+    of a known model that changed its output size."""
+    embedding_func = _build_embedding_func(
+        monkeypatch, model="nomic-embed-text", embedding_dim="512"
+    )
+
+    assert embedding_func.embedding_dim == 512


### PR DESCRIPTION
## Description

The Ollama embedding binding used a single static `embedding_dim` (1024, tuned for `bge-m3`, the binding's default model) for every model. That default is silently wrong for any other model a user points `EMBEDDING_MODEL` at — e.g. `nomic-embed-text` is actually 768-dim — and the mismatch only surfaces later, mid-ingestion, as a confusing vector-store "dimension mismatch" error with no link back to the real cause.

This PR resolves the real dimension for known Ollama embedding models instead of guessing, and turns the failure mode for unrecognized models from silent into a clear warning.

## Related Issues

Fixes #3596

## Changes Made

- Added `KNOWN_OLLAMA_EMBEDDING_DIMS` (`lightrag/llm/binding_options.py`) — a lookup table of real output dimensions for common Ollama embedding models, keyed by model name with the tag suffix stripped (e.g. `nomic-embed-text`, not `nomic-embed-text:latest`). Placed here rather than in `lightrag/llm/ollama.py` so resolving it doesn't require importing the optional `ollama` SDK.
- Updated `create_optimized_embedding_function()` (`lightrag/api/lightrag_server.py`) to consult this table when `EMBEDDING_DIM` isn't set explicitly and the binding is `ollama`. Priority order: explicit `EMBEDDING_DIM` > known-model lookup > previous `bge-m3`-shaped provider default.
- Unrecognized models keep the previous default (no behavior change for anyone currently relying on it) but now log a clear warning naming the actual model and pointing at `EMBEDDING_DIM`, instead of failing silently until a confusing error appears mid-ingestion.
- Added `tests/api/config/test_api_config_ollama_embedding_dim.py` (5 tests): known-model resolution (the exact `nomic-embed-text` regression), tag-suffix handling, the default model is unaffected, unknown models fall back with a warning, and explicit `EMBEDDING_DIM` still wins over the lookup table.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary) — n/a, no user-facing docs describe this default
- [x] Unit tests added (if applicable)

## Additional Notes

Verified against the full offline test suite (`python -m pytest tests -m offline`): 4682 passed, 0 regressions. The only failures in that run (17, in `tests/setup/`) are pre-existing and environmental — macOS ships Bash 3.2 by default, and `scripts/setup/setup.sh` requires Bash 4+; confirmed unrelated to this change (none of the failing test files reference `embedding_dim` or `ollama`).

`pre-commit run --all-files` passes clean.
