### PR TITLE
fix(neo4j): omit non-existent edges in get_edges_batch and support general relationships

### DIFF
--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -880,7 +880,7 @@ class Neo4JStorage(BaseGraphStorage):
         ) as session:
             query = f"""
             UNWIND $pairs AS pair
-            MATCH (start:`{workspace_label}` {{entity_id: pair.src}})-[r:DIRECTED]-(end:`{workspace_label}` {{entity_id: pair.tgt}})
+            MATCH (start:`{workspace_label}` {{entity_id: pair.src}})-[r]-(end:`{workspace_label}` {{entity_id: pair.tgt}})
             RETURN pair.src AS src_id, pair.tgt AS tgt_id, collect(properties(r)) AS edges
             """
             result = await session.run(query, pairs=pairs)
@@ -901,14 +901,6 @@ class Neo4JStorage(BaseGraphStorage):
                         if key not in edge_props:
                             edge_props[key] = default
                     edges_dict[(src, tgt)] = edge_props
-                else:
-                    # No edge found – set default edge properties
-                    edges_dict[(src, tgt)] = {
-                        "weight": 1.0,
-                        "source_id": None,
-                        "description": None,
-                        "keywords": None,
-                    }
             await result.consume()
             return edges_dict
 

--- a/tests/kg/neo4j_impl/test_neo4j_graph_read_contract.py
+++ b/tests/kg/neo4j_impl/test_neo4j_graph_read_contract.py
@@ -116,6 +116,8 @@ async def test_get_node_edges_returns_connected_pairs():
         ("Alpha", "Beta"),
         ("Alpha", "Gamma"),
     ]
+
+
 @pytest.mark.asyncio
 async def test_get_edges_batch_omits_missing_edges():
     """get_edges_batch must omit non-existent edge pairs rather than returning dummy attributes."""

--- a/tests/kg/neo4j_impl/test_neo4j_graph_read_contract.py
+++ b/tests/kg/neo4j_impl/test_neo4j_graph_read_contract.py
@@ -116,3 +116,11 @@ async def test_get_node_edges_returns_connected_pairs():
         ("Alpha", "Beta"),
         ("Alpha", "Gamma"),
     ]
+@pytest.mark.asyncio
+async def test_get_edges_batch_omits_missing_edges():
+    """get_edges_batch must omit non-existent edge pairs rather than returning dummy attributes."""
+    storage, calls = _make_storage([{"src_id": "A", "tgt_id": "B", "edges": []}])
+    res = await storage.get_edges_batch([{"src": "A", "tgt": "B"}])
+    assert res == {}
+    query, _ = calls[0]
+    assert "-[r]-" in query


### PR DESCRIPTION
### Summary
Fix `Neo4JStorage.get_edges_batch` contract violations where querying non-existent edges returned dummy records with `None` attributes instead of omitting missing pairs, and where edge lookups were overly constrained to `:DIRECTED` relationship types.

### Problem & Motivation
In `Neo4JStorage.get_edges_batch`:
1. Querying missing edge pairs populated `edges_dict[(src, tgt)]` with dummy dictionaries `{ "weight": 1.0, "source_id": None, "description": None, "keywords": None }` instead of returning an empty dict / omitting missing pairs.
2. The Cypher query matched `-[r:DIRECTED]-`, which failed to match relationships created without explicit `:DIRECTED` label, whereas `get_edge()` matches `-[r]-`.

During RAG retrieval (`_get_edge_data`), when candidate relationships from vector search were checked against graph storage, deleted or non-existent edges returned these dummy records with `None` fields, polluting retrieved KG context and introducing `None` attributes into prompt builders.

### Changes
- Updated `Neo4JStorage.get_edges_batch` to match general relationships `-[r]-` (consistent with `get_edge()`).
- Removed dummy fallback dict insertion for missing edge pairs so `get_edges_batch` returns properties only for edges present in the graph, conforming to `BaseGraphStorage` and all other graph storage implementations (`NetworkXStorage`, `PGTableGraphStorage`, `PGGraphStorage`, etc.).
- Added unit test `test_get_edges_batch_omits_missing_edges` in `tests/kg/neo4j_impl/test_neo4j_graph_read_contract.py`.

### Verification
- `pytest tests/kg/neo4j_impl/` passed (43 passed).
- Verified `test_get_edges_batch_omits_missing_edges` fails on unpatched `main` and passes with this fix.
- Full `tests/kg/` and `tests/pipeline/` suites passed (2237 passed, 0 failures).