### PR TITLE
fix(extraction): surface token-limit truncation and fail on empty truncated responses

### DIFF
--- a/env.example
+++ b/env.example
@@ -1056,6 +1056,10 @@ VLM_MIN_IMAGE_PIXEL=64
 ###     LLM_MODEL=qwen3.5:9b
 ### OLLAMA_LLM_NUM_CTX must be provided, and should at least larger than MAX_TOTAL_TOKENS + 2000
 OLLAMA_LLM_NUM_CTX=32768
+### OLLAMA_LLM_NUM_PREDICT caps the OUTPUT budget. A response cut off by it is
+### kept (and reported in doc_status.metadata.llm_truncation); one cut off
+### before emitting any content fails the document instead of indexing an empty
+### graph — raise this value, or disable thinking mode, if that happens.
 # OLLAMA_LLM_NUM_PREDICT=9000
 # OLLAMA_LLM_TEMPERATURE=0.85
 # OLLAMA_LLM_STOP='["</s>", "<|EOT|>"]'

--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -63,6 +63,22 @@ class APITimeoutError(APIConnectionError):
         super().__init__(message="Request timed out.", request=request)
 
 
+class EmptyTruncatedResponseError(RuntimeError):
+    """A token-limit-truncated LLM response that carried nothing usable.
+
+    Raised above the provider bindings, for the case none of them can see: a
+    thinking model exhausts its output budget inside the reasoning trace and
+    returns ``<think>...</think>`` with no answer after it. That payload is
+    NON-empty, so every binding's own empty-content check passes it through,
+    and it only becomes visibly empty after ``remove_think_tags``.
+
+    Same verdict as the binding-level checks (issue #3601 gap 4): nothing was
+    generated and generation was cut off, so there is nothing to salvage.
+    Failing here is what stops an empty knowledge graph from being indexed and
+    reported as success.
+    """
+
+
 class StorageNotInitializedError(RuntimeError):
     """Raised when storage operations are attempted before initialization."""
 

--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -66,16 +66,22 @@ class APITimeoutError(APIConnectionError):
 class EmptyTruncatedResponseError(RuntimeError):
     """A token-limit-truncated LLM response that carried nothing usable.
 
-    Raised above the provider bindings, for the case none of them can see: a
-    thinking model exhausts its output budget inside the reasoning trace and
-    returns ``<think>...</think>`` with no answer after it. That payload is
-    NON-empty, so every binding's own empty-content check passes it through,
-    and it only becomes visibly empty after ``remove_think_tags``.
+    Two raise surfaces share it (issue #3601 gap 4):
 
-    Same verdict as the binding-level checks (issue #3601 gap 4): nothing was
-    generated and generation was cut off, so there is nothing to salvage.
-    Failing here is what stops an empty knowledge graph from being indexed and
-    reported as success.
+    - the provider bindings (OpenAI/Gemini), when the response is empty and
+      the finish reason is the output token limit;
+    - ``use_llm_func_with_cache``, for the case no binding can see: a thinking
+      model exhausts its budget inside the reasoning trace and returns
+      ``<think>...</think>`` with no answer after it — NON-empty at the
+      binding's own check, visibly empty only after ``remove_think_tags``.
+
+    Deliberately absent from every binding's retry predicate, unlike the
+    retryable response-validity errors: hitting the token limit is a property
+    of the prompt and the configured output budget, so re-running the same
+    call re-buys the same full-budget generation just to fail identically.
+    Nothing was generated and generation was cut off — there is nothing to
+    salvage. Failing (once) is what stops an empty knowledge graph from being
+    indexed and reported as success.
     """
 
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2101,6 +2101,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     full_text=full_text,
                     file_path=file_path,
                 )
+                # Operation-scoped truncation record, fed by both KG stages
+                # below and stamped onto whichever terminal transition this
+                # operation reaches — the same durable evidence the normal
+                # pipeline writes, for the path that does not go through it.
+                truncation_tally = TokenLimitTruncationTally()
                 try:
                     # Stage 1 (barrier): persist chunks BEFORE extraction.
                     # Extraction records per-chunk LLM cache references
@@ -2154,7 +2159,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     # extraction, never call the LLM again and merge a
                     # different result into a partially applied operation.
                     chunk_results = await self._process_extract_entities(
-                        inserting_chunks, pipeline_status, pipeline_status_lock
+                        inserting_chunks,
+                        pipeline_status,
+                        pipeline_status_lock,
+                        truncation_tally=truncation_tally,
                     )
                     staging_flush = [
                         self.text_chunks,
@@ -2213,6 +2221,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                             entity_chunks_storage=self.entity_chunks,
                             relation_chunks_storage=self.relation_chunks,
                             file_path=file_path,
+                            truncation_tally=truncation_tally,
                         )
 
                     # ---- Commit: flush ALL derived stores, union the patch
@@ -2241,6 +2250,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         base_row=status_row,
                         journal=None,
                         chunks_list=final_chunks_list,
+                        metadata_extra=truncation_tally.as_metadata_extra(),
                     )
                 except BaseException as op_exc:
                     # Journal is durable: record FAILED, keep the journal and
@@ -2260,6 +2270,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                             base_row=status_row,
                             journal=failed_journal,
                             error_msg=str(op_exc)[:500],
+                            metadata_extra=truncation_tally.as_metadata_extra(),
                         )
                     except Exception as bookkeeping_error:
                         logger.error(
@@ -2424,6 +2435,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         file_path: str | None = None,
         chunks_list: list[str] | None = None,
         error_msg: str | None = None,
+        metadata_extra: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Upsert the doc_status row for a custom-chunk operation.
 
@@ -2478,6 +2490,16 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             payload["metadata"].pop(CUSTOM_CHUNK_PATCH_METADATA_KEY, None)
         else:
             payload["metadata"][CUSTOM_CHUNK_PATCH_METADATA_KEY] = journal
+
+        # Additive, unlike the pipeline's transition metadata: that path
+        # rebuilds from a carry-over whitelist, so an absent truncation key
+        # CLEARS the previous attempt's record (a full reprocess replaces the
+        # document's whole graph contribution). Here ``base_row`` is copied
+        # verbatim, and a patch ADDS to the base document rather than
+        # replacing it — so a clean patch must leave the base run's record
+        # standing, because the graph objects it describes are still there.
+        if metadata_extra:
+            payload["metadata"].update(metadata_extra)
 
         if error_msg is not None:
             payload["error_msg"] = error_msg

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2367,15 +2367,30 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                             truncation_write_ahead=_journal_truncation_write_ahead,
                         )
 
-                    # ---- Commit: flush ALL derived stores, union the patch
-                    # into the base document's anchors, then write PROCESSED
-                    # (the commit record) last with the journal cleared.
+                    # ---- Commit: flush ALL derived stores, union the
+                    # accumulated candidates into the document's anchors, then
+                    # write PROCESSED (the commit record) last with the
+                    # journal cleared.
                     await self._insert_done()
 
-                    if mode == "patch":
+                    # Patch mode AND resumed creates, not patch alone. Patch
+                    # merges pass None for the anchor storages, so this union
+                    # is their only anchor write. Create merges DO write
+                    # anchors in Phase 0 — but from the current attempt's
+                    # chunk_results only (replace semantics, correct for the
+                    # pipeline's whole-document reprocess). A resumed create
+                    # can extract a DIFFERENT sample (truncated responses are
+                    # never cached), and the PROCESSED write below clears the
+                    # journal — without this union, first-attempt-only graph
+                    # objects would be named nowhere durable and stranded
+                    # from later document purges. A first-attempt create
+                    # skips it: Phase 0 already wrote exactly these
+                    # candidates.
+                    if mode == "patch" or resume:
                         await self._union_doc_recovery_anchors(
                             doc_key, candidate_entities, candidate_relations
                         )
+                    if mode == "patch":
                         base_chunks = [
                             cid
                             for cid in ((status_row or {}).get("chunks_list") or [])

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -187,6 +187,8 @@ from lightrag.utils import (
     normalize_string_list,
     run_in_chunking_executor,
     TokenLimitTruncationTally,
+    LLM_TRUNCATION_METADATA_KEY,
+    merge_truncation_metadata,
 )
 from lightrag.types import KnowledgeGraph
 from dotenv import load_dotenv
@@ -2079,6 +2081,23 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 # BEFORE any data store is touched (discoverability before
                 # mutation). doc_status backends persist on upsert.
                 now_iso = datetime.now(timezone.utc).isoformat()
+                # Pre-operation llm_truncation snapshot (None = key absent).
+                # Captured on the FIRST attempt, while ``existing_row`` is
+                # still the untouched base document; a resume MUST reuse the
+                # journaled value instead of re-reading the row, because the
+                # failed attempt's terminal write already stamped its own
+                # tally there. This snapshot is what the terminal writes merge
+                # the operation tally INTO, and what a rollback restores.
+                if existing_journal and "prior_llm_truncation" in existing_journal:
+                    prior_truncation = existing_journal["prior_llm_truncation"]
+                elif mode == "patch":
+                    prior_truncation = ((existing_row or {}).get("metadata") or {}).get(
+                        LLM_TRUNCATION_METADATA_KEY
+                    )
+                else:
+                    # create: the document is born with this operation, so
+                    # there is nothing prior to preserve or restore.
+                    prior_truncation = None
                 journal: dict[str, Any] = {
                     "schema_version": 1,
                     "operation_id": operation_id,
@@ -2090,6 +2109,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     "relation_pairs": (existing_journal or {}).get(
                         "relation_pairs", []
                     ),
+                    "prior_llm_truncation": prior_truncation,
                     "created_at": (existing_journal or {}).get("created_at") or now_iso,
                     "updated_at": now_iso,
                 }
@@ -2106,6 +2126,26 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 # operation reaches — the same durable evidence the normal
                 # pipeline writes, for the path that does not go through it.
                 truncation_tally = TokenLimitTruncationTally()
+
+                def _terminal_truncation_kwargs() -> dict[str, Any]:
+                    """Set-or-drop arguments for a terminal status write.
+
+                    The operation tally is merged into the journal's
+                    pre-operation snapshot — never into the live row, whose
+                    value after a failed attempt is that attempt's own stamp
+                    and would double-count across resumes. Replace semantics
+                    with an explicit drop: when neither the base run nor this
+                    operation truncated, the key must come OFF the row (the
+                    live row may still carry a dead attempt's stamp).
+                    """
+                    merged = merge_truncation_metadata(
+                        journal.get("prior_llm_truncation"),
+                        truncation_tally.as_metadata(),
+                    )
+                    if merged is None:
+                        return {"metadata_drop": (LLM_TRUNCATION_METADATA_KEY,)}
+                    return {"metadata_extra": {LLM_TRUNCATION_METADATA_KEY: merged}}
+
                 try:
                     # Stage 1 (barrier): persist chunks BEFORE extraction.
                     # Extraction records per-chunk LLM cache references
@@ -2250,7 +2290,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         base_row=status_row,
                         journal=None,
                         chunks_list=final_chunks_list,
-                        metadata_extra=truncation_tally.as_metadata_extra(),
+                        **_terminal_truncation_kwargs(),
                     )
                 except BaseException as op_exc:
                     # Journal is durable: record FAILED, keep the journal and
@@ -2270,7 +2310,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                             base_row=status_row,
                             journal=failed_journal,
                             error_msg=str(op_exc)[:500],
-                            metadata_extra=truncation_tally.as_metadata_extra(),
+                            **_terminal_truncation_kwargs(),
                         )
                     except Exception as bookkeeping_error:
                         logger.error(
@@ -2436,6 +2476,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         chunks_list: list[str] | None = None,
         error_msg: str | None = None,
         metadata_extra: dict[str, Any] | None = None,
+        metadata_drop: tuple[str, ...] = (),
     ) -> dict[str, Any]:
         """Upsert the doc_status row for a custom-chunk operation.
 
@@ -2491,15 +2532,19 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         else:
             payload["metadata"][CUSTOM_CHUNK_PATCH_METADATA_KEY] = journal
 
-        # Additive, unlike the pipeline's transition metadata: that path
-        # rebuilds from a carry-over whitelist, so an absent truncation key
-        # CLEARS the previous attempt's record (a full reprocess replaces the
-        # document's whole graph contribution). Here ``base_row`` is copied
-        # verbatim, and a patch ADDS to the base document rather than
-        # replacing it — so a clean patch must leave the base run's record
-        # standing, because the graph objects it describes are still there.
+        # ``base_row``'s metadata is copied verbatim above, so keys the caller
+        # does not name are left standing — the opposite default from the
+        # pipeline's whitelist-rebuilt transition metadata, and the right one
+        # here because a patch ADDS to a base document whose earlier records
+        # still describe live graph objects. A caller that must retire a key
+        # (rollback restoring "no truncation ever happened") therefore needs
+        # ``metadata_drop``: as with doc_status_transition_metadata, passing
+        # None/empty via ``metadata_extra`` would persist that value rather
+        # than remove the key. ``metadata_drop`` wins over ``metadata_extra``.
         if metadata_extra:
             payload["metadata"].update(metadata_extra)
+        for key in metadata_drop:
+            payload["metadata"].pop(key, None)
 
         if error_msg is not None:
             payload["error_msg"] = error_msg
@@ -2818,6 +2863,23 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             for cid in ((row or {}).get("chunks_list") or [])
             if isinstance(cid, str) and cid and cid not in staged_set
         ]
+        # The FAILED row this restore copies from carries the failed attempt's
+        # llm_truncation stamp, describing extractions the purge above just
+        # removed — restoring it verbatim would leave a clean base document
+        # permanently advertising truncation from rolled-back content. The
+        # journal's pre-operation snapshot is the authority: reinstate it, or
+        # drop the key when the base never truncated. A journal written before
+        # the snapshot existed has no key and changes nothing (its attempts
+        # never stamped a tally either).
+        truncation_restore: dict[str, Any] = {}
+        if "prior_llm_truncation" in journal:
+            prior_truncation = journal["prior_llm_truncation"]
+            if prior_truncation is None:
+                truncation_restore["metadata_drop"] = (LLM_TRUNCATION_METADATA_KEY,)
+            else:
+                truncation_restore["metadata_extra"] = {
+                    LLM_TRUNCATION_METADATA_KEY: prior_truncation
+                }
         await self._upsert_custom_chunk_status(
             doc_id,
             DocStatus.PROCESSED,
@@ -2825,6 +2887,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             journal=None,
             chunks_list=cleaned_chunks,
             error_msg="",
+            **truncation_restore,
         )
 
     async def _persist_custom_chunk_recovery_warning(

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2178,6 +2178,44 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         return {"metadata_drop": (LLM_TRUNCATION_METADATA_KEY,)}
                     return {"metadata_extra": {LLM_TRUNCATION_METADATA_KEY: merged}}
 
+                truncation_persist_lock = asyncio.Lock()
+
+                async def _journal_truncation_write_ahead(
+                    pending: TokenLimitTruncationTally,
+                ) -> None:
+                    """Journal a truncation event BEFORE the mutation it warns about.
+
+                    Awaited by the merge's summary path between recording a
+                    truncated summary and upserting the object that carries
+                    it, so even a hard crash (no FAILED write) cannot leave
+                    truncated output in the graph with no journaled evidence.
+                    ``pending`` is the merge-local summary tally: its events
+                    reach the operation tally only when the merge publishes,
+                    which happens after every hook call has completed (a
+                    failing phase drains its sibling tasks first) — so the two
+                    sides of this merge are disjoint, and the later FAILED or
+                    terminal recompute overwrites this snapshot with a
+                    superset. A hook failure fails the recording entity or
+                    relation itself — fail-closed into the normal FAILED
+                    path. Fires once per truncation event (rare); serialized
+                    because sibling merges can record concurrently.
+                    """
+                    nonlocal status_row
+                    async with truncation_persist_lock:
+                        status_row = await self._upsert_custom_chunk_status(
+                            doc_key,
+                            DocStatus.PROCESSING,
+                            base_row=status_row,
+                            journal={
+                                **journal,
+                                "operation_llm_truncation": merge_truncation_metadata(
+                                    _operation_truncation_record(),
+                                    pending.as_metadata(),
+                                ),
+                                "updated_at": datetime.now(timezone.utc).isoformat(),
+                            },
+                        )
+
                 try:
                     # Stage 1 (barrier): persist chunks BEFORE extraction.
                     # Extraction records per-chunk LLM cache references
@@ -2280,13 +2318,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         "relation_pairs": [
                             list(pair) for pair in sorted(candidate_relations)
                         ],
-                        # Write-ahead for the truncation record too: any
-                        # attempt that mutates the graph has journaled its
-                        # extraction-stage truncations first. Merge-stage
-                        # summary truncations happen after this write; they
-                        # are picked up by the FAILED write below, so only a
-                        # hard crash mid-merge (no FAILED write) can lose that
-                        # attempt's summary-stage events.
+                        # Write-ahead for the truncation record too. The
+                        # invariant: any truncation event whose subject's
+                        # graph mutation has landed is already journaled —
+                        # extraction-stage events by this write (which
+                        # precedes ALL merge mutation), summary-stage events
+                        # by _journal_truncation_write_ahead (awaited before
+                        # the object carrying the truncated summary is
+                        # upserted).
                         "operation_llm_truncation": _operation_truncation_record(),
                         "updated_at": datetime.now(timezone.utc).isoformat(),
                     }
@@ -2325,6 +2364,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                             relation_chunks_storage=self.relation_chunks,
                             file_path=file_path,
                             truncation_tally=truncation_tally,
+                            truncation_write_ahead=_journal_truncation_write_ahead,
                         )
 
                     # ---- Commit: flush ALL derived stores, union the patch
@@ -2365,10 +2405,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         failed_journal = {
                             **journal,
                             "phase": "failed",
-                            # Recompute — overwrites the applying write's copy
-                            # (which already folded this attempt in) with the
-                            # same carried-plus-current merge, now including
-                            # any merge-stage summary events recorded since.
+                            # Recompute — overwrites the applying write's and
+                            # the write-ahead hook's copies (which already
+                            # folded this attempt in) with the same
+                            # carried-plus-current merge; the tally has
+                            # absorbed the merge's summary events by now, so
+                            # this is always a superset of those snapshots.
                             "operation_llm_truncation": (
                                 _operation_truncation_record()
                             ),

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -186,6 +186,7 @@ from lightrag.utils import (
     normalize_source_ids_limit_method,
     normalize_string_list,
     run_in_chunking_executor,
+    TokenLimitTruncationTally,
 )
 from lightrag.types import KnowledgeGraph
 from dotenv import load_dotenv
@@ -2999,7 +3000,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         await self._flush_storages([self.full_entities, self.full_relations])
 
     async def _process_extract_entities(
-        self, chunk: dict[str, Any], pipeline_status=None, pipeline_status_lock=None
+        self,
+        chunk: dict[str, Any],
+        pipeline_status=None,
+        pipeline_status_lock=None,
+        truncation_tally: TokenLimitTruncationTally | None = None,
     ) -> list:
         try:
             chunk_results = await extract_entities(
@@ -3009,6 +3014,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 pipeline_status_lock=pipeline_status_lock,
                 llm_response_cache=self.llm_response_cache,
                 text_chunks_storage=self.text_chunks,
+                truncation_tally=truncation_tally,
             )
             return chunk_results
         except Exception as e:

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2215,9 +2215,32 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
                     # Persist the complete candidate set in the journal BEFORE
                     # merging — the write-ahead anchor for this operation.
+                    #
+                    # UNIONED with the previous attempt's candidates (carried
+                    # into ``journal`` at the prepared write), never replaced:
+                    # truncated extraction responses are deliberately excluded
+                    # from the LLM cache, so a resume re-runs those calls and
+                    # can extract a DIFFERENT sample. A previous attempt whose
+                    # Stage 3 merge partially applied has already written ITS
+                    # candidates into the graph; dropping them here would strand
+                    # exactly those objects — the journal is this operation's
+                    # only recovery anchor and must keep naming the complete
+                    # superset across every attempt. Union is safe on the
+                    # consuming side by contract: candidates are a superset,
+                    # and purge/commit treat absent objects as no-ops.
                     candidate_entities, candidate_relations = (
                         collect_kg_merge_candidates(chunk_results or [])
                     )
+                    candidate_entities |= {
+                        name
+                        for name in (journal.get("entity_names") or [])
+                        if isinstance(name, str) and name
+                    }
+                    candidate_relations |= {
+                        (pair[0], pair[1])
+                        for pair in (journal.get("relation_pairs") or [])
+                        if isinstance(pair, (list, tuple)) and len(pair) == 2
+                    }
                     journal = {
                         **journal,
                         "phase": "applying",

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -2098,6 +2098,21 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     # create: the document is born with this operation, so
                     # there is nothing prior to preserve or restore.
                     prior_truncation = None
+                # Truncation accumulated by PREVIOUS attempts of this
+                # operation. Truncated extraction responses are never cached,
+                # so a resume re-runs those calls and can get a clean sample —
+                # but the failed attempt's partial graph mutations stay (the
+                # resume is additive, it never purges them). Without this
+                # carry, a clean resume's terminal write would merge only
+                # snapshot + its own empty tally and silently drop the record
+                # of the truncated output still living in the graph. Captured
+                # ONCE from the journal as loaded — the applying/FAILED writes
+                # below fold the current attempt into the journal copy, and
+                # recomputing from that copy would double-count (the merge
+                # sums event counts exactly).
+                carried_operation_truncation = (existing_journal or {}).get(
+                    "operation_llm_truncation"
+                )
                 journal: dict[str, Any] = {
                     "schema_version": 1,
                     "operation_id": operation_id,
@@ -2110,6 +2125,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         "relation_pairs", []
                     ),
                     "prior_llm_truncation": prior_truncation,
+                    "operation_llm_truncation": carried_operation_truncation,
                     "created_at": (existing_journal or {}).get("created_at") or now_iso,
                     "updated_at": now_iso,
                 }
@@ -2127,20 +2143,36 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 # pipeline writes, for the path that does not go through it.
                 truncation_tally = TokenLimitTruncationTally()
 
+                def _operation_truncation_record() -> dict[str, Any] | None:
+                    """Previous attempts' accumulated payload + this attempt.
+
+                    Always recomputed from ``carried_operation_truncation``
+                    (previous attempts ONLY), never from the journal copy the
+                    applying write already folded this attempt into — the
+                    merge sums event counts exactly, so folding twice would
+                    double-count.
+                    """
+                    return merge_truncation_metadata(
+                        carried_operation_truncation,
+                        truncation_tally.as_metadata(),
+                    )
+
                 def _terminal_truncation_kwargs() -> dict[str, Any]:
                     """Set-or-drop arguments for a terminal status write.
 
-                    The operation tally is merged into the journal's
-                    pre-operation snapshot — never into the live row, whose
-                    value after a failed attempt is that attempt's own stamp
-                    and would double-count across resumes. Replace semantics
-                    with an explicit drop: when neither the base run nor this
-                    operation truncated, the key must come OFF the row (the
-                    live row may still carry a dead attempt's stamp).
+                    The operation-accumulated record (every attempt of this
+                    operation, current one included) is merged into the
+                    journal's pre-operation snapshot — never into the live
+                    row, whose value after a failed attempt is that attempt's
+                    own stamp and would double-count across resumes. Replace
+                    semantics with an explicit drop: when neither the base run
+                    nor any attempt of this operation truncated, the key must
+                    come OFF the row (the live row may still carry a dead
+                    attempt's stamp).
                     """
                     merged = merge_truncation_metadata(
                         journal.get("prior_llm_truncation"),
-                        truncation_tally.as_metadata(),
+                        _operation_truncation_record(),
                     )
                     if merged is None:
                         return {"metadata_drop": (LLM_TRUNCATION_METADATA_KEY,)}
@@ -2248,6 +2280,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         "relation_pairs": [
                             list(pair) for pair in sorted(candidate_relations)
                         ],
+                        # Write-ahead for the truncation record too: any
+                        # attempt that mutates the graph has journaled its
+                        # extraction-stage truncations first. Merge-stage
+                        # summary truncations happen after this write; they
+                        # are picked up by the FAILED write below, so only a
+                        # hard crash mid-merge (no FAILED write) can lose that
+                        # attempt's summary-stage events.
+                        "operation_llm_truncation": _operation_truncation_record(),
                         "updated_at": datetime.now(timezone.utc).isoformat(),
                     }
                     status_row = await self._upsert_custom_chunk_status(
@@ -2325,6 +2365,13 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         failed_journal = {
                             **journal,
                             "phase": "failed",
+                            # Recompute — overwrites the applying write's copy
+                            # (which already folded this attempt in) with the
+                            # same carried-plus-current merge, now including
+                            # any merge-stage summary events recorded since.
+                            "operation_llm_truncation": (
+                                _operation_truncation_record()
+                            ),
                             "updated_at": datetime.now(timezone.utc).isoformat(),
                         }
                         await self._upsert_custom_chunk_status(

--- a/lightrag/llm/bedrock.py
+++ b/lightrag/llm/bedrock.py
@@ -25,6 +25,8 @@ from typing import Any, Union
 
 from lightrag.utils import (
     TruncatedResponse,
+    empty_length_truncated_hint,
+    format_response_diagnostics,
     logger,
     wrap_embedding_func_with_attrs,
 )
@@ -444,12 +446,53 @@ async def bedrock_complete_if_cache(
                 None,
             )
 
+            stop_reason = response.get("stopReason")
+
             if not content or content.strip() == "":
-                raise BedrockError("Received empty content from Bedrock API")
+                # Already a failure before this change; what was missing is the
+                # diagnosis. Name the token limit when that is the cause, so
+                # doc_status.error_msg tells the operator which knob to turn
+                # instead of just "empty content" (issue #3601 gap 4).
+                reasoning_len = sum(
+                    len(
+                        (block["reasoningContent"].get("reasoningText") or {}).get(
+                            "text"
+                        )
+                        or ""
+                    )
+                    for block in response["output"]["message"]["content"]
+                    if isinstance(block, dict)
+                    and isinstance(block.get("reasoningContent"), dict)
+                )
+                usage = response.get("usage") or {}
+                diagnostics = format_response_diagnostics(
+                    stopReason=stop_reason,
+                    outputTokens=usage.get("outputTokens"),
+                    reasoning_content_len=reasoning_len,
+                )
+                if stop_reason == "max_tokens":
+                    hint = empty_length_truncated_hint(
+                        "consider raising BEDROCK_LLM_MAX_TOKENS or disabling "
+                        "thinking mode",
+                        reasoning_consumed_budget=bool(reasoning_len),
+                    )
+                elif reasoning_len:
+                    hint = (
+                        "model returned reasoning-only output (reasoning blocks "
+                        "are discarded on this path); consider disabling "
+                        "thinking mode for this role"
+                    )
+                else:
+                    hint = "model produced no output"
+                error_message = (
+                    f"Received empty content from Bedrock API ({diagnostics}): {hint}"
+                )
+                logger.error(error_message)
+                raise BedrockError(error_message)
 
             # Flag token-limit truncation (Converse API stopReason ==
             # "max_tokens") so the cache layer skips persisting partial output.
-            if response.get("stopReason") == "max_tokens":
+            if stop_reason == "max_tokens":
                 logger.warning(
                     "Bedrock response truncated by token limit "
                     f"(stopReason=max_tokens, content_len={len(content)}), returning partial content"

--- a/lightrag/llm/gemini.py
+++ b/lightrag/llm/gemini.py
@@ -23,6 +23,7 @@ from tenacity import (
     retry_if_exception_type,
 )
 
+from lightrag.exceptions import EmptyTruncatedResponseError
 from lightrag.utils import (
     TruncatedResponse,
     empty_length_truncated_hint,
@@ -544,8 +545,17 @@ async def gemini_complete_if_cache(
     )
     length_limited = finish_reason == types.FinishReason.MAX_TOKENS
 
-    def _empty_response_error(thought_len: int) -> InvalidResponseError:
-        """Diagnose an empty Gemini response the way the OpenAI binding does."""
+    def _empty_response_error(thought_len: int) -> Exception:
+        """Diagnose an empty Gemini response the way the OpenAI binding does.
+
+        The exception TYPE selects the retry policy: token-limit exhaustion is
+        deterministic for a given prompt and output budget, so it returns
+        ``EmptyTruncatedResponseError`` — absent from the retry predicate —
+        and fails after ONE request instead of buying two more full-budget
+        generations plus backoff. Every other empty response keeps the
+        retryable ``InvalidResponseError``: those are sampling artifacts a
+        fresh attempt can genuinely fix.
+        """
         usage_metadata = getattr(response, "usage_metadata", None)
         diagnostics = format_response_diagnostics(
             finish_reason=getattr(finish_reason, "name", finish_reason),
@@ -570,6 +580,8 @@ async def gemini_complete_if_cache(
             hint = "model produced no output"
         message = f"Received empty content from Gemini API ({diagnostics}): {hint}"
         logger.error(message)
+        if length_limited:
+            return EmptyTruncatedResponseError(message)
         return InvalidResponseError(message)
 
     if not final_text:

--- a/lightrag/llm/gemini.py
+++ b/lightrag/llm/gemini.py
@@ -25,6 +25,8 @@ from tenacity import (
 
 from lightrag.utils import (
     TruncatedResponse,
+    empty_length_truncated_hint,
+    format_response_diagnostics,
     logger,
     remove_think_tags,
     safe_unicode_decode,
@@ -536,22 +538,68 @@ async def gemini_complete_if_cache(
         # Filter out thought content, return only regular content
         final_text = regular_text or ""
 
+    candidates = getattr(response, "candidates", None)
+    finish_reason = (
+        getattr(candidates[0], "finish_reason", None) if candidates else None
+    )
+    length_limited = finish_reason == types.FinishReason.MAX_TOKENS
+
+    def _empty_response_error(thought_len: int) -> InvalidResponseError:
+        """Diagnose an empty Gemini response the way the OpenAI binding does."""
+        usage_metadata = getattr(response, "usage_metadata", None)
+        diagnostics = format_response_diagnostics(
+            finish_reason=getattr(finish_reason, "name", finish_reason),
+            candidates_token_count=getattr(
+                usage_metadata, "candidates_token_count", None
+            ),
+            thoughts_token_count=getattr(usage_metadata, "thoughts_token_count", None),
+            thought_len=thought_len,
+        )
+        if length_limited:
+            hint = empty_length_truncated_hint(
+                "consider raising GEMINI_LLM_MAX_OUTPUT_TOKENS or disabling "
+                "thinking mode",
+                reasoning_consumed_budget=bool(thought_len),
+            )
+        elif thought_len:
+            hint = (
+                "model returned reasoning-only output (thoughts are stripped "
+                "on this path); consider disabling thinking mode for this role"
+            )
+        else:
+            hint = "model produced no output"
+        message = f"Received empty content from Gemini API ({diagnostics}): {hint}"
+        logger.error(message)
+        return InvalidResponseError(message)
+
     if not final_text:
-        raise InvalidResponseError("Gemini response did not contain any text content.")
+        raise _empty_response_error(len((thought_text or "").strip()))
 
     if "\\u" in final_text:
         final_text = safe_unicode_decode(final_text.encode("utf-8"))
 
     final_text = remove_think_tags(final_text)
 
+    # A thinking model that spent its whole budget on the reasoning trace
+    # reaches here with final_text == "<think>...</think>", which the line
+    # above strips to nothing: empty AFTER sanitization is the same broken
+    # response as empty before it, and used to be returned as a successful
+    # (if truncated) empty string. Only escalated for the token-limit case,
+    # which is deterministic and actionable; a reasoning-only response that
+    # ended normally keeps its previous behavior with a warning.
+    if not final_text.strip():
+        if length_limited:
+            raise _empty_response_error(len((thought_text or "").strip()))
+        logger.warning(
+            "Gemini response contained only reasoning content "
+            f"(finish_reason={getattr(finish_reason, 'name', finish_reason)}), "
+            "returning empty content"
+        )
+
     # Flag token-limit truncation so the cache layer skips persisting partial
     # output. Must stay the last transformation of final_text: any later
     # string operation would rebuild a plain str and drop the marker.
-    candidates = getattr(response, "candidates", None)
-    finish_reason = (
-        getattr(candidates[0], "finish_reason", None) if candidates else None
-    )
-    if finish_reason == types.FinishReason.MAX_TOKENS:
+    if length_limited:
         logger.warning(
             "Gemini response truncated by token limit "
             f"(finish_reason=MAX_TOKENS, content_len={len(final_text)}), returning partial content"

--- a/lightrag/llm/gemini.py
+++ b/lightrag/llm/gemini.py
@@ -545,6 +545,21 @@ async def gemini_complete_if_cache(
     )
     length_limited = finish_reason == types.FinishReason.MAX_TOKENS
 
+    # Count usage BEFORE the empty-response validation below: the request
+    # consumed its budget whether or not the response is usable — a thinking
+    # model that burned the whole output budget on its reasoning trace is
+    # exactly the case that raises, and omitting it would under-report by a
+    # full-budget generation. The streaming path already tracks in a finally.
+    usage = getattr(response, "usage_metadata", None)
+    if token_tracker and usage:
+        token_tracker.add_usage(
+            {
+                "prompt_tokens": getattr(usage, "prompt_token_count", 0),
+                "completion_tokens": getattr(usage, "candidates_token_count", 0),
+                "total_tokens": getattr(usage, "total_token_count", 0),
+            }
+        )
+
     def _empty_response_error(thought_len: int) -> Exception:
         """Diagnose an empty Gemini response the way the OpenAI binding does.
 
@@ -617,16 +632,6 @@ async def gemini_complete_if_cache(
             f"(finish_reason=MAX_TOKENS, content_len={len(final_text)}), returning partial content"
         )
         final_text = TruncatedResponse(final_text)
-
-    usage = getattr(response, "usage_metadata", None)
-    if token_tracker and usage:
-        token_tracker.add_usage(
-            {
-                "prompt_tokens": getattr(usage, "prompt_token_count", 0),
-                "completion_tokens": getattr(usage, "candidates_token_count", 0),
-                "total_tokens": getattr(usage, "total_token_count", 0),
-            }
-        )
 
     logger.debug("Gemini response length: %s", len(final_text))
     return final_text

--- a/lightrag/llm/ollama.py
+++ b/lightrag/llm/ollama.py
@@ -28,9 +28,23 @@ import numpy as np
 from typing import Any, Optional, Union
 from lightrag.utils import (
     TruncatedResponse,
+    empty_length_truncated_hint,
+    format_response_diagnostics,
     wrap_embedding_func_with_attrs,
     logger,
 )
+
+
+class InvalidResponseError(Exception):
+    """A response that cannot be used, e.g. empty content.
+
+    Declared per binding, as in ``lightrag.llm.openai`` / ``gemini`` /
+    ``anthropic``: each provider owns its own so importing one binding never
+    drags in another's import-time setup. Deliberately absent from the retry
+    predicate below — see the raise site for why re-running is pointless here.
+    """
+
+    pass
 
 
 _OLLAMA_CLOUD_HOST = "https://ollama.com"
@@ -51,6 +65,28 @@ def _coerce_host_for_cloud_model(host: Optional[str], model: object) -> Optional
         )
         return _OLLAMA_CLOUD_HOST
     return host
+
+
+def _response_message_field(response: Any, field: str) -> Any:
+    """Read ``message.<field>`` across the ollama response shapes.
+
+    ollama<0.4 returns raw dicts, ollama>=0.4 a ChatResponse whose ``message``
+    is a SubscriptableBaseModel; both expose ``.get``, and attribute access
+    covers anything that does not. Used only for diagnostics, so an unexpected
+    shape must degrade to ``None`` rather than raise over the failure the
+    caller is in the middle of reporting.
+    """
+    try:
+        message = response["message"]
+    except Exception:
+        return None
+    getter = getattr(message, "get", None)
+    if getter is None:
+        return getattr(message, field, None)
+    try:
+        return getter(field)
+    except Exception:
+        return None
 
 
 def _normalize_ollama_response_format(kwargs: dict) -> None:
@@ -204,6 +240,38 @@ async def _ollama_model_if_cache(
             # SubscriptableBaseModel ChatResponse (ollama>=0.4); a missing key
             # returns None and keeps the previous cache-everything behavior.
             if response.get("done_reason") == "length":
+                if not model_response or not model_response.strip():
+                    # Empty AND cut off: nothing was generated at all, which is
+                    # structurally broken rather than merely short. Returning ""
+                    # here indexed an empty knowledge graph and still reported
+                    # the document PROCESSED (issue #3601 gap 4, seen with
+                    # thinking models burning the whole num_predict budget on
+                    # the reasoning trace). Raise like the OpenAI binding does,
+                    # so the document ends FAILED and stays retryable.
+                    #
+                    # Deliberately NOT added to the @retry set: unlike the
+                    # OpenAI check — which also covers non-deterministic
+                    # empty-content modes — this fires only on the token limit,
+                    # and re-running the same prompt against the same budget
+                    # would just burn three calls before failing anyway.
+                    thinking = _response_message_field(response, "thinking") or ""
+                    diagnostics = format_response_diagnostics(
+                        done_reason="length",
+                        eval_count=response.get("eval_count"),
+                        prompt_eval_count=response.get("prompt_eval_count"),
+                        thinking_len=len(thinking.strip()),
+                    )
+                    hint = empty_length_truncated_hint(
+                        "consider raising OLLAMA_LLM_NUM_PREDICT or disabling "
+                        "thinking mode",
+                        reasoning_consumed_budget=bool(thinking.strip()),
+                    )
+                    error_message = (
+                        f"Received empty content from Ollama API "
+                        f"({diagnostics}): {hint}"
+                    )
+                    logger.error(error_message)
+                    raise InvalidResponseError(error_message)
                 logger.warning(
                     "Ollama response truncated by token limit "
                     f"(done_reason=length, content_len={len(model_response)}), returning partial content"

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -28,6 +28,7 @@ from tenacity import (
 from lightrag.utils import (
     wrap_embedding_func_with_attrs,
     safe_unicode_decode,
+    empty_length_truncated_hint,
     logger,
     TruncatedResponse,
 )
@@ -767,16 +768,9 @@ async def openai_complete_if_cache(
                         f"reasoning_content_len={reasoning_len}"
                     )
                     if finish_reason == "length":
-                        hint = (
-                            "generation hit the token limit before emitting "
-                            "any content"
-                            + (
-                                " (budget consumed by reasoning)"
-                                if reasoning_len
-                                else ""
-                            )
-                            + "; consider raising max_tokens or disabling "
-                            "thinking mode"
+                        hint = empty_length_truncated_hint(
+                            "consider raising max_tokens or disabling thinking mode",
+                            reasoning_consumed_budget=bool(reasoning_len),
                         )
                     elif reasoning_len:
                         hint = (
@@ -786,17 +780,20 @@ async def openai_complete_if_cache(
                         )
                     else:
                         hint = "model produced no output"
-                    logger.error(
+                    error_message = (
                         f"Received empty content from OpenAI API "
                         f"({diagnostics}): {hint}"
                     )
+                    logger.error(error_message)
                     try:
                         await openai_async_client.close()
                     except Exception as close_error:
                         logger.warning(f"Failed to close OpenAI client: {close_error}")
-                    raise InvalidResponseError(
-                        f"Received empty content from OpenAI API ({diagnostics})"
-                    )
+                    # The hint rides along into the exception (and therefore
+                    # into doc_status.error_msg) rather than living only in the
+                    # server log: the operator reading the failed document is
+                    # the one who has to turn the knob.
+                    raise InvalidResponseError(error_message)
 
             # Apply Unicode decoding to final content if needed
             if r"\u" in final_content:

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -689,6 +689,21 @@ async def openai_complete_if_cache(
 
     else:
         try:
+            # Count usage BEFORE the validation raises below: the request
+            # consumed its budget whether or not the response is usable — a
+            # reasoning model that burned the whole output budget on its
+            # trace is exactly the case that raises, and omitting it would
+            # under-report by a full-budget generation.
+            if token_tracker and hasattr(response, "usage"):
+                token_counts = {
+                    "prompt_tokens": getattr(response.usage, "prompt_tokens", 0),
+                    "completion_tokens": getattr(
+                        response.usage, "completion_tokens", 0
+                    ),
+                    "total_tokens": getattr(response.usage, "total_tokens", 0),
+                }
+                token_tracker.add_usage(token_counts)
+
             if (
                 not response
                 or not response.choices
@@ -820,16 +835,6 @@ async def openai_complete_if_cache(
                     f"(finish_reason=length, content_len={len(final_content)}), returning partial content"
                 )
                 final_content = TruncatedResponse(final_content)
-
-            if token_tracker and hasattr(response, "usage"):
-                token_counts = {
-                    "prompt_tokens": getattr(response.usage, "prompt_tokens", 0),
-                    "completion_tokens": getattr(
-                        response.usage, "completion_tokens", 0
-                    ),
-                    "total_tokens": getattr(response.usage, "total_tokens", 0),
-                }
-                token_tracker.add_usage(token_counts)
 
             logger.debug(f"Response content len: {len(final_content)}")
             verbose_debug(f"Response: {response}")

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -34,6 +34,7 @@ from lightrag.utils import (
 )
 
 from lightrag.api import __api_version__
+from lightrag.exceptions import EmptyTruncatedResponseError
 
 import numpy as np
 import base64
@@ -793,6 +794,16 @@ async def openai_complete_if_cache(
                     # into doc_status.error_msg) rather than living only in the
                     # server log: the operator reading the failed document is
                     # the one who has to turn the knob.
+                    #
+                    # The TYPE selects the retry policy: token-limit exhaustion
+                    # is deterministic for a given prompt and output budget, so
+                    # it raises EmptyTruncatedResponseError — absent from the
+                    # retry predicate — and fails after one request instead of
+                    # buying two more full-budget generations plus backoff.
+                    # The other empty modes stay retryable: those are sampling
+                    # artifacts a fresh attempt can genuinely fix.
+                    if finish_reason == "length":
+                        raise EmptyTruncatedResponseError(error_message)
                     raise InvalidResponseError(error_message)
 
             # Apply Unicode decoding to final content if needed

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3419,9 +3419,37 @@ async def merge_nodes_and_edges(
     status_logger = PipelineStatusLogger(pipeline_status)
 
     # Merge-scoped tally: one aggregated status line for the whole merge rather
-    # than one per truncated summary, folded into the document-scoped tally at
-    # the end so the doc_status record covers extraction and merge together.
+    # than one per truncated summary, folded into the document-scoped tally so
+    # the doc_status record covers extraction and merge together.
     summary_tally = TokenLimitTruncationTally()
+    summary_truncation_published = False
+
+    def _publish_summary_truncation() -> None:
+        """Publish the merge's truncation aggregate and hand its counts upward.
+
+        Called on the success path AND from each phase's failure path: a
+        summary truncated by an entity that completed is already recorded when
+        a LATER sibling raises, and losing it there would leave the FAILED
+        document's metadata claiming extraction was the only stage that
+        truncated. Idempotent, so the two callers cannot double-publish, and
+        await-free, so it is safe to run inside a cancellation window.
+        """
+        nonlocal summary_truncation_published
+        if summary_truncation_published:
+            return
+        summary_truncation_published = True
+        if summary_tally:
+            noun = "summary" if summary_tally.affected == 1 else "summaries"
+            truncation_message = (
+                f"Warning: token-limit truncation hit {summary_tally.affected} "
+                f"description {noun} during merge "
+                f"({summary_tally.events} responses); "
+                f"merged descriptions may be incomplete"
+            )
+            logger.warning(truncation_message)
+            status_logger.log(truncation_message)
+        if truncation_tally is not None:
+            truncation_tally.absorb(summary_tally)
 
     # Collect all nodes and edges from all chunks
     all_nodes = defaultdict(list)
@@ -3583,9 +3611,13 @@ async def merge_nodes_and_edges(
     # survive failure handling — issue #3400).
     processed_entities = []
     if entity_tasks:
-        processed_entities = await wait_tasks_with_drain(
-            entity_tasks, context=f"entity merge {doc_id}"
-        )
+        try:
+            processed_entities = await wait_tasks_with_drain(
+                entity_tasks, context=f"entity merge {doc_id}"
+            )
+        except BaseException:
+            _publish_summary_truncation()
+            raise
         await asyncio.sleep(0)
 
     # ===== Phase 2: Process all relationships concurrently =====
@@ -3678,11 +3710,15 @@ async def merge_nodes_and_edges(
     all_added_entities = []
 
     if edge_tasks:
-        edge_results = await wait_tasks_with_drain(
-            edge_tasks,
-            context=f"relation merge {doc_id}",
-            task_labels=edge_task_labels,
-        )
+        try:
+            edge_results = await wait_tasks_with_drain(
+                edge_tasks,
+                context=f"relation merge {doc_id}",
+                task_labels=edge_task_labels,
+            )
+        except BaseException:
+            _publish_summary_truncation()
+            raise
         for edge_data, added_entities in edge_results:
             if edge_data is not None:
                 processed_edges.append(edge_data)
@@ -3702,17 +3738,7 @@ async def merge_nodes_and_edges(
     # exceptions — is gone: a merge whose anchors cannot be persisted no
     # longer mutates the graph at all (issue #3400).
 
-    if summary_tally:
-        noun = "summary" if summary_tally.affected == 1 else "summaries"
-        truncation_message = (
-            f"Warning: token-limit truncation hit {summary_tally.affected} "
-            f"description {noun} during merge "
-            f"({summary_tally.events} responses); merged descriptions may be incomplete"
-        )
-        logger.warning(truncation_message)
-        status_logger.log(truncation_message)
-    if truncation_tally is not None:
-        truncation_tally.absorb(summary_tally)
+    _publish_summary_truncation()
 
     log_message = f"Completed merging: {len(processed_entities)} entities, {len(all_added_entities)} extra entities, {len(processed_edges)} relations"
     logger.info(log_message)

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3792,6 +3792,16 @@ async def extract_entities(
         # Create cache keys collector for batch processing
         cache_keys_collector = []
 
+        def _report_truncation(result: str, stage: str) -> None:
+            if not is_truncated_response(result):
+                return
+            truncation_message = (
+                f"Token-limit truncation during {stage} entity extraction "
+                f"for chunk {chunk_key} in {file_path}"
+            )
+            logger.warning(truncation_message)
+            status_logger.log(truncation_message)
+
         if use_json_extraction:
             # JSON mode: use JSON prompts and pass entity_extraction flag to LLM provider
             entity_extraction_system_prompt = PROMPTS[
@@ -3838,6 +3848,8 @@ async def extract_entities(
             response_format=({"type": "json_object"} if use_json_extraction else None),
             llm_cache_identity=get_llm_cache_identity(global_config, "extract"),
         )
+
+        _report_truncation(final_result, "initial")
 
         history = pack_user_ass_to_openai_messages(
             entity_extraction_user_prompt, final_result
@@ -3906,6 +3918,8 @@ async def extract_entities(
                 ),
                 llm_cache_identity=get_llm_cache_identity(global_config, "extract"),
             )
+
+            _report_truncation(glean_result, "gleaning")
 
             # Process gleaning result with appropriate parser
             if use_json_extraction:

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -36,6 +36,7 @@ from lightrag.utils import (
     save_to_cache,
     CacheData,
     is_truncated_response,
+    TokenLimitTruncationTally,
     use_llm_func_with_cache,
     get_env_value,
     get_llm_cache_identity,
@@ -372,6 +373,7 @@ async def _handle_entity_relation_summary(
     separator: str,
     global_config: dict,
     llm_response_cache: BaseKVStorage | None = None,
+    truncation_tally: TokenLimitTruncationTally | None = None,
 ) -> tuple[str, bool]:
     """Handle entity relation description summary using map-reduce approach.
 
@@ -451,6 +453,7 @@ async def _handle_entity_relation_summary(
                     current_list,
                     global_config,
                     llm_response_cache,
+                    truncation_tally=truncation_tally,
                 )
                 return final_summary, True  # LLM was used for final summarization
 
@@ -510,6 +513,7 @@ async def _handle_entity_relation_summary(
                     chunk,
                     global_config,
                     llm_response_cache,
+                    truncation_tally=truncation_tally,
                 )
                 new_summaries.append(summary)
                 llm_was_used = True  # Mark that LLM was used in reduce phase
@@ -524,6 +528,7 @@ async def _summarize_descriptions(
     description_list: list[str],
     global_config: dict,
     llm_response_cache: BaseKVStorage | None = None,
+    truncation_tally: TokenLimitTruncationTally | None = None,
 ) -> str:
     """Helper function to summarize a list of descriptions using LLM.
 
@@ -532,6 +537,10 @@ async def _summarize_descriptions(
         descriptions: List of description strings to summarize
         global_config: Global configuration containing LLM function and settings
         llm_response_cache: Optional cache for LLM responses
+        truncation_tally: Optional accumulator for token-limit truncation. A
+            cut-off summary silently becomes the entity's/relation's persisted
+            description, so it belongs in the same operator-visible record as
+            truncated extraction.
 
     Returns:
         Summarized description string
@@ -588,6 +597,16 @@ async def _summarize_descriptions(
         cache_type="summary",
         llm_cache_identity=get_llm_cache_identity(global_config, "extract"),
     )
+
+    # Check BEFORE sanitizing: sanitize_text_for_encoding rebuilds a plain str
+    # and drops the TruncatedResponse marker that remove_think_tags preserved.
+    if is_truncated_response(summary):
+        subject = f"{description_type}:{description_name}"
+        logger.warning(
+            f"Token-limit truncation while summarizing descriptions for {subject}"
+        )
+        if truncation_tally is not None:
+            truncation_tally.record("summary", subject)
 
     # The LLM response is the only description path that bypasses
     # extraction-time sanitization; control chars / surrogates left here
@@ -798,6 +817,21 @@ def _normalize_text_extraction_record_attributes(
     return normalized
 
 
+def _truncation_cause_suffix(result: Any) -> str:
+    """Name token-limit truncation as the cause of a failed extraction parse.
+
+    An undelimited / unparseable extraction response has two very different
+    causes — a model that ignored the output contract, and a model that was cut
+    off mid-answer — and only the second is fixed by raising the output budget.
+    ``TruncatedResponse`` survives ``remove_think_tags``, so the parsers can
+    tell them apart instead of leaving the operator to correlate this warning
+    with a separate truncation line by chunk id.
+    """
+    if not is_truncated_response(result):
+        return ""
+    return " (response was truncated by the model's output token limit)"
+
+
 def _looks_like_json_extraction_result(result: str) -> bool:
     """Return True for raw or fenced JSON extraction responses."""
 
@@ -847,7 +881,10 @@ async def _process_json_extraction_result(
     # surfaced.
     parsed = tolerant_load_json_dict(result)
     if not parsed:
-        logger.warning(f"{chunk_key}: JSON extraction result is empty or unrecoverable")
+        logger.warning(
+            f"{chunk_key}: JSON extraction result is empty or unrecoverable"
+            f"{_truncation_cause_suffix(result)}"
+        )
         return dict(maybe_nodes), dict(maybe_edges)
 
     # Models quoting LaTeX in descriptions routinely under-escape backslashes
@@ -1432,6 +1469,7 @@ async def _process_extraction_result(
     if completion_delimiter not in result:
         logger.warning(
             f"{chunk_key}: Complete delimiter can not be found in extraction result"
+            f"{_truncation_cause_suffix(result)}"
         )
 
     # Split LLL output result to records by "\n"
@@ -2279,6 +2317,7 @@ async def _merge_nodes_then_upsert(
     llm_response_cache: BaseKVStorage | None = None,
     entity_chunks_storage: BaseKVStorage | None = None,
     status_logger: PipelineStatusLogger | None = None,
+    truncation_tally: TokenLimitTruncationTally | None = None,
 ):
     """Get existing nodes from knowledge graph use name,if exists, merge data, else create, then upsert."""
     if status_logger is None:
@@ -2459,6 +2498,7 @@ async def _merge_nodes_then_upsert(
             GRAPH_FIELD_SEP,
             global_config,
             llm_response_cache,
+            truncation_tally=truncation_tally,
         )
 
         # 9. Build file_path within MAX_FILE_PATHS
@@ -2624,6 +2664,7 @@ async def _merge_edges_then_upsert(
     relation_chunks_storage: BaseKVStorage | None = None,
     entity_chunks_storage: BaseKVStorage | None = None,
     status_logger: PipelineStatusLogger | None = None,
+    truncation_tally: TokenLimitTruncationTally | None = None,
 ):
     if status_logger is None:
         # Fallback for direct callers that pass pipeline_status only; a
@@ -2858,6 +2899,7 @@ async def _merge_edges_then_upsert(
             GRAPH_FIELD_SEP,
             global_config,
             llm_response_cache,
+            truncation_tally=truncation_tally,
         )
 
         # 9. Build file_path within MAX_FILE_PATHS limit
@@ -3319,6 +3361,7 @@ async def merge_nodes_and_edges(
     total_files: int = 0,
     file_path: str = "unknown_source",
     on_anchors_durable: Callable[[], Awaitable[None]] | None = None,
+    truncation_tally: TokenLimitTruncationTally | None = None,
 ) -> None:
     """Merge extracted entities/relations into the KG behind write-ahead anchors.
 
@@ -3358,6 +3401,10 @@ async def merge_nodes_and_edges(
             merge before any mutation. Not called when the anchor storages or
             ``doc_id`` are absent (patch-mode merges, which carry their own
             operation journal as the recovery proof).
+        truncation_tally: Optional document-scoped accumulator. Description
+            summaries are LLM calls too, so a too-small output budget truncates
+            them exactly like extraction; the merge folds its own count in so
+            the document's ``doc_status.metadata`` summary covers both stages.
     """
 
     # Check for cancellation at the start of merge
@@ -3370,6 +3417,11 @@ async def merge_nodes_and_edges(
     # of this document: the first history write fetches the shared list once;
     # every merge log is then a single extend on the cached handle.
     status_logger = PipelineStatusLogger(pipeline_status)
+
+    # Merge-scoped tally: one aggregated status line for the whole merge rather
+    # than one per truncated summary, folded into the document-scoped tally at
+    # the end so the doc_status record covers extraction and merge together.
+    summary_tally = TokenLimitTruncationTally()
 
     # Collect all nodes and edges from all chunks
     all_nodes = defaultdict(list)
@@ -3490,6 +3542,7 @@ async def merge_nodes_and_edges(
                         llm_response_cache,
                         entity_chunks_storage,
                         status_logger=status_logger,
+                        truncation_tally=summary_tally,
                     )
 
                     return entity_data
@@ -3580,6 +3633,7 @@ async def merge_nodes_and_edges(
                         relation_chunks_storage,
                         entity_chunks_storage,  # Add entity_chunks_storage parameter
                         status_logger=status_logger,
+                        truncation_tally=summary_tally,
                     )
 
                     if edge_data is None:
@@ -3648,6 +3702,18 @@ async def merge_nodes_and_edges(
     # exceptions — is gone: a merge whose anchors cannot be persisted no
     # longer mutates the graph at all (issue #3400).
 
+    if summary_tally:
+        noun = "summary" if summary_tally.affected == 1 else "summaries"
+        truncation_message = (
+            f"Warning: token-limit truncation hit {summary_tally.affected} "
+            f"description {noun} during merge "
+            f"({summary_tally.events} responses); merged descriptions may be incomplete"
+        )
+        logger.warning(truncation_message)
+        status_logger.log(truncation_message)
+    if truncation_tally is not None:
+        truncation_tally.absorb(summary_tally)
+
     log_message = f"Completed merging: {len(processed_entities)} entities, {len(all_added_entities)} extra entities, {len(processed_edges)} relations"
     logger.info(log_message)
     async with pipeline_status_lock:
@@ -3662,7 +3728,16 @@ async def extract_entities(
     pipeline_status_lock=None,
     llm_response_cache: BaseKVStorage | None = None,
     text_chunks_storage: BaseKVStorage | None = None,
+    truncation_tally: TokenLimitTruncationTally | None = None,
 ) -> list:
+    """Extract entities and relations from ``chunks``.
+
+    ``truncation_tally``: optional document-scoped accumulator. Extraction owns
+    a stage-scoped tally regardless (it publishes the first truncation
+    immediately and one aggregate at the end); passing this one additionally
+    hands the counts to the pipeline, which stamps them into
+    ``doc_status.metadata`` so the condition outlives the bounded status ring.
+    """
     # Check for cancellation at the start of entity extraction
     if pipeline_status is not None and pipeline_status_lock is not None:
         async with pipeline_status_lock:
@@ -3675,6 +3750,9 @@ async def extract_entities(
     # history write fetches the shared list once; every per-chunk log is then
     # a single extend on the cached handle.
     status_logger = PipelineStatusLogger(pipeline_status)
+
+    # Extraction-scoped truncation tally; see _publish_truncation_summary below.
+    stage_tally = TokenLimitTruncationTally()
 
     use_llm_func: callable = global_config["role_llm_funcs"]["extract"]
     entity_extract_max_gleaning = global_config["entity_extract_max_gleaning"]
@@ -3795,12 +3873,20 @@ async def extract_entities(
         def _report_truncation(result: str, stage: str) -> None:
             if not is_truncated_response(result):
                 return
-            truncation_message = (
+            location = f"chunk {chunk_key} in {file_path}"
+            # The server log keeps every occurrence with full identity; the
+            # bounded pipeline-status ring gets the first one plus the
+            # end-of-stage aggregate (see _publish_truncation_summary).
+            logger.warning(
                 f"Token-limit truncation during {stage} entity extraction "
-                f"for chunk {chunk_key} in {file_path}"
+                f"for {location}"
             )
-            logger.warning(truncation_message)
-            status_logger.log(truncation_message)
+            if stage_tally.record(stage, chunk_key):
+                status_logger.log(
+                    f"Warning: token-limit truncation during {stage} entity "
+                    f"extraction for {location}; further occurrences are "
+                    f"reported as one summary at the end of extraction"
+                )
 
         if use_json_extraction:
             # JSON mode: use JSON prompts and pass entity_extraction flag to LLM provider
@@ -4067,6 +4153,26 @@ async def extract_entities(
         # Return the extracted nodes and edges for centralized processing
         return maybe_nodes, maybe_edges
 
+    def _publish_truncation_summary() -> None:
+        """Publish one aggregated truncation line and hand the counts upward.
+
+        Called on both the success and the failure path, so a run that dies
+        mid-extraction still reports (and records) what it truncated before
+        dying. A no-op when nothing truncated.
+        """
+        if not stage_tally:
+            return
+        truncation_message = (
+            f"Warning: token-limit truncation hit {stage_tally.affected} of "
+            f"{total_chunks} chunks during entity extraction "
+            f"({stage_tally.stage_breakdown()}); "
+            f"extracted knowledge may be incomplete"
+        )
+        logger.warning(truncation_message)
+        status_logger.log(truncation_message)
+        if truncation_tally is not None:
+            truncation_tally.absorb(stage_tally)
+
     # Get max async tasks limit from global_config
     chunk_max_async = global_config.get("llm_model_max_async", 4)
     semaphore = asyncio.Semaphore(chunk_max_async)
@@ -4148,12 +4254,16 @@ async def extract_entities(
         if pending:
             await asyncio.wait(pending)
 
+        _publish_truncation_summary()
+
         # Add progress prefix to the exception message
         progress_prefix = f"C[{processed_chunks + 1}/{total_chunks}]"
 
         # Re-raise the original exception with a prefix
         prefixed_exception = create_prefixed_exception(first_exception, progress_prefix)
         raise prefixed_exception from first_exception
+
+    _publish_truncation_summary()
 
     # If all tasks completed successfully, chunk_results already contains the results
     # Return the chunk_results for later processing in merge_nodes_and_edges

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -374,6 +374,8 @@ async def _handle_entity_relation_summary(
     global_config: dict,
     llm_response_cache: BaseKVStorage | None = None,
     truncation_tally: TokenLimitTruncationTally | None = None,
+    truncation_write_ahead: Callable[[TokenLimitTruncationTally], Awaitable[None]]
+    | None = None,
 ) -> tuple[str, bool]:
     """Handle entity relation description summary using map-reduce approach.
 
@@ -454,6 +456,7 @@ async def _handle_entity_relation_summary(
                     global_config,
                     llm_response_cache,
                     truncation_tally=truncation_tally,
+                    truncation_write_ahead=truncation_write_ahead,
                 )
                 return final_summary, True  # LLM was used for final summarization
 
@@ -514,6 +517,7 @@ async def _handle_entity_relation_summary(
                     global_config,
                     llm_response_cache,
                     truncation_tally=truncation_tally,
+                    truncation_write_ahead=truncation_write_ahead,
                 )
                 new_summaries.append(summary)
                 llm_was_used = True  # Mark that LLM was used in reduce phase
@@ -529,6 +533,8 @@ async def _summarize_descriptions(
     global_config: dict,
     llm_response_cache: BaseKVStorage | None = None,
     truncation_tally: TokenLimitTruncationTally | None = None,
+    truncation_write_ahead: Callable[[TokenLimitTruncationTally], Awaitable[None]]
+    | None = None,
 ) -> str:
     """Helper function to summarize a list of descriptions using LLM.
 
@@ -541,6 +547,15 @@ async def _summarize_descriptions(
             cut-off summary silently becomes the entity's/relation's persisted
             description, so it belongs in the same operator-visible record as
             truncated extraction.
+        truncation_write_ahead: Optional hook awaited right after a truncation
+            is recorded, BEFORE the summary is returned to the caller that will
+            write it into the graph. Lets an additive caller (the custom-chunk
+            path, whose resume never purges a failed attempt's mutations) make
+            the record durable ahead of the mutation it warns about, so even a
+            hard crash cannot leave a truncated summary in the graph with no
+            journaled evidence. A hook failure propagates and fails this
+            entity/relation — fail-closed into the caller's normal failure
+            path.
 
     Returns:
         Summarized description string
@@ -607,6 +622,8 @@ async def _summarize_descriptions(
         )
         if truncation_tally is not None:
             truncation_tally.record("summary", subject)
+            if truncation_write_ahead is not None:
+                await truncation_write_ahead(truncation_tally)
 
     # The LLM response is the only description path that bypasses
     # extraction-time sanitization; control chars / surrogates left here
@@ -2318,6 +2335,8 @@ async def _merge_nodes_then_upsert(
     entity_chunks_storage: BaseKVStorage | None = None,
     status_logger: PipelineStatusLogger | None = None,
     truncation_tally: TokenLimitTruncationTally | None = None,
+    truncation_write_ahead: Callable[[TokenLimitTruncationTally], Awaitable[None]]
+    | None = None,
 ):
     """Get existing nodes from knowledge graph use name,if exists, merge data, else create, then upsert."""
     if status_logger is None:
@@ -2499,6 +2518,7 @@ async def _merge_nodes_then_upsert(
             global_config,
             llm_response_cache,
             truncation_tally=truncation_tally,
+            truncation_write_ahead=truncation_write_ahead,
         )
 
         # 9. Build file_path within MAX_FILE_PATHS
@@ -2665,6 +2685,8 @@ async def _merge_edges_then_upsert(
     entity_chunks_storage: BaseKVStorage | None = None,
     status_logger: PipelineStatusLogger | None = None,
     truncation_tally: TokenLimitTruncationTally | None = None,
+    truncation_write_ahead: Callable[[TokenLimitTruncationTally], Awaitable[None]]
+    | None = None,
 ):
     if status_logger is None:
         # Fallback for direct callers that pass pipeline_status only; a
@@ -2900,6 +2922,7 @@ async def _merge_edges_then_upsert(
             global_config,
             llm_response_cache,
             truncation_tally=truncation_tally,
+            truncation_write_ahead=truncation_write_ahead,
         )
 
         # 9. Build file_path within MAX_FILE_PATHS limit
@@ -3362,6 +3385,8 @@ async def merge_nodes_and_edges(
     file_path: str = "unknown_source",
     on_anchors_durable: Callable[[], Awaitable[None]] | None = None,
     truncation_tally: TokenLimitTruncationTally | None = None,
+    truncation_write_ahead: Callable[[TokenLimitTruncationTally], Awaitable[None]]
+    | None = None,
 ) -> None:
     """Merge extracted entities/relations into the KG behind write-ahead anchors.
 
@@ -3405,6 +3430,19 @@ async def merge_nodes_and_edges(
             summaries are LLM calls too, so a too-small output budget truncates
             them exactly like extraction; the merge folds its own count in so
             the document's ``doc_status.metadata`` summary covers both stages.
+        truncation_write_ahead: Optional async hook awaited right after a
+            summary truncation is recorded, before the object carrying that
+            summary is upserted. For callers whose failure recovery is
+            ADDITIVE (the custom-chunk path: a resume keeps the failed
+            attempt's graph mutations), the record must be durable before the
+            mutation it warns about — a FAILED-transition stamp alone loses
+            the event on a hard crash. The pipeline's own merges do not need
+            it: a reprocess purges the previous attempt's contributions, so
+            nothing truncated survives to warn about. Receives the tally the
+            event was recorded into (the merge-local one, folded into
+            ``truncation_tally`` only when the merge publishes — after every
+            hook call has completed, because failing phases drain their
+            sibling tasks first).
     """
 
     # Check for cancellation at the start of merge
@@ -3571,6 +3609,7 @@ async def merge_nodes_and_edges(
                         entity_chunks_storage,
                         status_logger=status_logger,
                         truncation_tally=summary_tally,
+                        truncation_write_ahead=truncation_write_ahead,
                     )
 
                     return entity_data
@@ -3666,6 +3705,7 @@ async def merge_nodes_and_edges(
                         entity_chunks_storage,  # Add entity_chunks_storage parameter
                         status_logger=status_logger,
                         truncation_tally=summary_tally,
+                        truncation_write_ahead=truncation_write_ahead,
                     )
 
                     if edge_data is None:

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -3465,12 +3465,17 @@ async def merge_nodes_and_edges(
     def _publish_summary_truncation() -> None:
         """Publish the merge's truncation aggregate and hand its counts upward.
 
-        Called on the success path AND from each phase's failure path: a
-        summary truncated by an entity that completed is already recorded when
-        a LATER sibling raises, and losing it there would leave the FAILED
-        document's metadata claiming extraction was the only stage that
-        truncated. Idempotent, so the two callers cannot double-publish, and
-        await-free, so it is safe to run inside a cancellation window.
+        Called from a ``finally`` covering both phases, so it runs on EVERY
+        merge exit — success, a failing sibling task, and a cancellation
+        landing on any await point between the phases (an inter-phase
+        ``sleep(0)`` or status-lock acquire). Wrapping only the
+        ``wait_tasks_with_drain`` calls was not enough: a cancellation at an
+        inter-phase yield skipped the absorb, and the custom-chunk failure
+        bookkeeping then recomputed the journal from the unabsorbed operation
+        tally — overwriting the summary event its write-ahead hook had
+        already persisted. Idempotent, so redundant calls cannot
+        double-publish, and await-free, so it is safe to run inside a
+        cancellation window.
         """
         nonlocal summary_truncation_published
         if summary_truncation_published:
@@ -3569,216 +3574,218 @@ async def merge_nodes_and_edges(
         if on_anchors_durable is not None:
             await on_anchors_durable()
 
-    # Get max async tasks limit from global_config for semaphore control
-    graph_max_async = global_config.get("llm_model_max_async", 4) * 2
-    semaphore = asyncio.Semaphore(graph_max_async)
+    try:
+        # Get max async tasks limit from global_config for semaphore control
+        graph_max_async = global_config.get("llm_model_max_async", 4) * 2
+        semaphore = asyncio.Semaphore(graph_max_async)
 
-    # ===== Phase 1: Process all entities concurrently =====
-    log_message = f"Phase 1: Processing {total_entities_count} entities from {doc_id} (async: {graph_max_async})"
-    logger.info(log_message)
-    async with pipeline_status_lock:
-        pipeline_status["latest_message"] = log_message
-        append_pipeline_history(pipeline_status, log_message)
+        # ===== Phase 1: Process all entities concurrently =====
+        log_message = f"Phase 1: Processing {total_entities_count} entities from {doc_id} (async: {graph_max_async})"
+        logger.info(log_message)
+        async with pipeline_status_lock:
+            pipeline_status["latest_message"] = log_message
+            append_pipeline_history(pipeline_status, log_message)
 
-    async def _locked_process_entity_name(entity_name, entities):
-        async with semaphore:
-            # Check for cancellation before processing entity
-            if pipeline_status is not None and pipeline_status_lock is not None:
-                async with pipeline_status_lock:
-                    if pipeline_status.get("cancellation_requested", False):
-                        raise PipelineCancelledException(
-                            "User cancelled during entity merge"
-                        )
+        async def _locked_process_entity_name(entity_name, entities):
+            async with semaphore:
+                # Check for cancellation before processing entity
+                if pipeline_status is not None and pipeline_status_lock is not None:
+                    async with pipeline_status_lock:
+                        if pipeline_status.get("cancellation_requested", False):
+                            raise PipelineCancelledException(
+                                "User cancelled during entity merge"
+                            )
 
-            workspace = global_config.get("workspace", "")
-            namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
-            async with get_storage_keyed_lock(
-                [entity_name], namespace=namespace, enable_logging=False
-            ):
-                try:
-                    logger.debug(f"Processing entity {entity_name}")
-                    entity_data = await _merge_nodes_then_upsert(
-                        entity_name,
-                        entities,
-                        knowledge_graph_inst,
-                        entity_vdb,
-                        global_config,
-                        pipeline_status,
-                        pipeline_status_lock,
-                        llm_response_cache,
-                        entity_chunks_storage,
-                        status_logger=status_logger,
-                        truncation_tally=summary_tally,
-                        truncation_write_ahead=truncation_write_ahead,
-                    )
-
-                    return entity_data
-
-                except Exception as e:
-                    error_msg = f"Error processing entity `{entity_name}`: {e}"
-                    logger.error(error_msg)
-
-                    # Try to update pipeline status, but don't let status update failure affect main exception
+                workspace = global_config.get("workspace", "")
+                namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
+                async with get_storage_keyed_lock(
+                    [entity_name], namespace=namespace, enable_logging=False
+                ):
                     try:
-                        if (
-                            pipeline_status is not None
-                            and pipeline_status_lock is not None
-                        ):
-                            async with pipeline_status_lock:
-                                pipeline_status["latest_message"] = error_msg
-                                append_pipeline_history(pipeline_status, error_msg)
-                    except Exception as status_error:
-                        logger.error(
-                            f"Failed to update pipeline status: {status_error}"
+                        logger.debug(f"Processing entity {entity_name}")
+                        entity_data = await _merge_nodes_then_upsert(
+                            entity_name,
+                            entities,
+                            knowledge_graph_inst,
+                            entity_vdb,
+                            global_config,
+                            pipeline_status,
+                            pipeline_status_lock,
+                            llm_response_cache,
+                            entity_chunks_storage,
+                            status_logger=status_logger,
+                            truncation_tally=summary_tally,
+                            truncation_write_ahead=truncation_write_ahead,
                         )
 
-                    # Re-raise the original exception with a prefix
-                    prefixed_exception = create_prefixed_exception(
-                        e, f"`{entity_name}`"
-                    )
-                    raise prefixed_exception from e
+                        return entity_data
 
-    # Create entity processing tasks
-    entity_tasks = []
-    for i, (entity_name, entities) in enumerate(all_nodes.items(), start=1):
-        task = asyncio.create_task(_locked_process_entity_name(entity_name, entities))
-        entity_tasks.append(task)
-        await _cooperative_yield(i, every=16)
+                    except Exception as e:
+                        error_msg = f"Error processing entity `{entity_name}`: {e}"
+                        logger.error(error_msg)
 
-    # Execute entity tasks; on any failure every sibling is cancelled and
-    # drained before the first exception propagates (no background writes
-    # survive failure handling — issue #3400).
-    processed_entities = []
-    if entity_tasks:
-        try:
+                        # Try to update pipeline status, but don't let status update failure affect main exception
+                        try:
+                            if (
+                                pipeline_status is not None
+                                and pipeline_status_lock is not None
+                            ):
+                                async with pipeline_status_lock:
+                                    pipeline_status["latest_message"] = error_msg
+                                    append_pipeline_history(pipeline_status, error_msg)
+                        except Exception as status_error:
+                            logger.error(
+                                f"Failed to update pipeline status: {status_error}"
+                            )
+
+                        # Re-raise the original exception with a prefix
+                        prefixed_exception = create_prefixed_exception(
+                            e, f"`{entity_name}`"
+                        )
+                        raise prefixed_exception from e
+
+        # Create entity processing tasks
+        entity_tasks = []
+        for i, (entity_name, entities) in enumerate(all_nodes.items(), start=1):
+            task = asyncio.create_task(
+                _locked_process_entity_name(entity_name, entities)
+            )
+            entity_tasks.append(task)
+            await _cooperative_yield(i, every=16)
+
+        # Execute entity tasks; on any failure every sibling is cancelled and
+        # drained before the first exception propagates (no background writes
+        # survive failure handling — issue #3400).
+        processed_entities = []
+        if entity_tasks:
             processed_entities = await wait_tasks_with_drain(
                 entity_tasks, context=f"entity merge {doc_id}"
             )
-        except BaseException:
-            _publish_summary_truncation()
-            raise
-        await asyncio.sleep(0)
+            await asyncio.sleep(0)
 
-    # ===== Phase 2: Process all relationships concurrently =====
-    log_message = f"Phase 2: Processing {total_relations_count} relations from {doc_id} (async: {graph_max_async})"
-    logger.info(log_message)
-    async with pipeline_status_lock:
-        pipeline_status["latest_message"] = log_message
-        append_pipeline_history(pipeline_status, log_message)
+        # ===== Phase 2: Process all relationships concurrently =====
+        log_message = f"Phase 2: Processing {total_relations_count} relations from {doc_id} (async: {graph_max_async})"
+        logger.info(log_message)
+        async with pipeline_status_lock:
+            pipeline_status["latest_message"] = log_message
+            append_pipeline_history(pipeline_status, log_message)
 
-    async def _locked_process_edges(edge_key, edges):
-        async with semaphore:
-            # Check for cancellation before processing edges
-            if pipeline_status is not None and pipeline_status_lock is not None:
-                async with pipeline_status_lock:
-                    if pipeline_status.get("cancellation_requested", False):
-                        raise PipelineCancelledException(
-                            "User cancelled during relation merge"
-                        )
+        async def _locked_process_edges(edge_key, edges):
+            async with semaphore:
+                # Check for cancellation before processing edges
+                if pipeline_status is not None and pipeline_status_lock is not None:
+                    async with pipeline_status_lock:
+                        if pipeline_status.get("cancellation_requested", False):
+                            raise PipelineCancelledException(
+                                "User cancelled during relation merge"
+                            )
 
-            workspace = global_config.get("workspace", "")
-            namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
-            sorted_edge_key = sorted([edge_key[0], edge_key[1]])
-            edge_label = _format_relation_edge_label(edge_key)
+                workspace = global_config.get("workspace", "")
+                namespace = f"{workspace}:GraphDB" if workspace else "GraphDB"
+                sorted_edge_key = sorted([edge_key[0], edge_key[1]])
+                edge_label = _format_relation_edge_label(edge_key)
 
-            async with get_storage_keyed_lock(
-                sorted_edge_key,
-                namespace=namespace,
-                enable_logging=False,
-            ):
-                try:
-                    added_entities = []  # Track entities added during edge processing
-
-                    edge_data = await _merge_edges_then_upsert(
-                        edge_key[0],
-                        edge_key[1],
-                        edges,
-                        knowledge_graph_inst,
-                        relationships_vdb,
-                        entity_vdb,
-                        global_config,
-                        pipeline_status,
-                        pipeline_status_lock,
-                        llm_response_cache,
-                        added_entities,  # Pass list to collect added entities
-                        relation_chunks_storage,
-                        entity_chunks_storage,  # Add entity_chunks_storage parameter
-                        status_logger=status_logger,
-                        truncation_tally=summary_tally,
-                        truncation_write_ahead=truncation_write_ahead,
-                    )
-
-                    if edge_data is None:
-                        return None, []
-
-                    return edge_data, added_entities
-
-                except Exception as e:
-                    error_msg = f"Error processing relation `{edge_label}`: {e}"
-                    logger.error(error_msg)
-
-                    # Try to update pipeline status, but don't let status update failure affect main exception
+                async with get_storage_keyed_lock(
+                    sorted_edge_key,
+                    namespace=namespace,
+                    enable_logging=False,
+                ):
                     try:
-                        if (
-                            pipeline_status is not None
-                            and pipeline_status_lock is not None
-                        ):
-                            async with pipeline_status_lock:
-                                pipeline_status["latest_message"] = error_msg
-                                append_pipeline_history(pipeline_status, error_msg)
-                    except Exception as status_error:
-                        logger.error(
-                            f"Failed to update pipeline status: {status_error}"
+                        added_entities = []  # Track entities added during edge processing
+
+                        edge_data = await _merge_edges_then_upsert(
+                            edge_key[0],
+                            edge_key[1],
+                            edges,
+                            knowledge_graph_inst,
+                            relationships_vdb,
+                            entity_vdb,
+                            global_config,
+                            pipeline_status,
+                            pipeline_status_lock,
+                            llm_response_cache,
+                            added_entities,  # Pass list to collect added entities
+                            relation_chunks_storage,
+                            entity_chunks_storage,  # Add entity_chunks_storage parameter
+                            status_logger=status_logger,
+                            truncation_tally=summary_tally,
+                            truncation_write_ahead=truncation_write_ahead,
                         )
 
-                    # Re-raise the original exception with a prefix
-                    prefixed_exception = create_prefixed_exception(e, f"{edge_label}")
-                    raise prefixed_exception from e
+                        if edge_data is None:
+                            return None, []
 
-    # Create relationship processing tasks
-    edge_tasks = []
-    edge_task_labels: dict[asyncio.Task, str] = {}
-    for i, (edge_key, edges) in enumerate(all_edges.items(), start=1):
-        task = asyncio.create_task(_locked_process_edges(edge_key, edges))
-        edge_tasks.append(task)
-        edge_task_labels[task] = _format_relation_edge_label(edge_key)
-        await _cooperative_yield(i, every=32)
+                        return edge_data, added_entities
 
-    # Execute relationship tasks; failures cancel + drain every sibling
-    # before propagating (see wait_tasks_with_drain).
-    processed_edges = []
-    all_added_entities = []
+                    except Exception as e:
+                        error_msg = f"Error processing relation `{edge_label}`: {e}"
+                        logger.error(error_msg)
 
-    if edge_tasks:
-        try:
+                        # Try to update pipeline status, but don't let status update failure affect main exception
+                        try:
+                            if (
+                                pipeline_status is not None
+                                and pipeline_status_lock is not None
+                            ):
+                                async with pipeline_status_lock:
+                                    pipeline_status["latest_message"] = error_msg
+                                    append_pipeline_history(pipeline_status, error_msg)
+                        except Exception as status_error:
+                            logger.error(
+                                f"Failed to update pipeline status: {status_error}"
+                            )
+
+                        # Re-raise the original exception with a prefix
+                        prefixed_exception = create_prefixed_exception(
+                            e, f"{edge_label}"
+                        )
+                        raise prefixed_exception from e
+
+        # Create relationship processing tasks
+        edge_tasks = []
+        edge_task_labels: dict[asyncio.Task, str] = {}
+        for i, (edge_key, edges) in enumerate(all_edges.items(), start=1):
+            task = asyncio.create_task(_locked_process_edges(edge_key, edges))
+            edge_tasks.append(task)
+            edge_task_labels[task] = _format_relation_edge_label(edge_key)
+            await _cooperative_yield(i, every=32)
+
+        # Execute relationship tasks; failures cancel + drain every sibling
+        # before propagating (see wait_tasks_with_drain).
+        processed_edges = []
+        all_added_entities = []
+
+        if edge_tasks:
             edge_results = await wait_tasks_with_drain(
                 edge_tasks,
                 context=f"relation merge {doc_id}",
                 task_labels=edge_task_labels,
             )
-        except BaseException:
-            _publish_summary_truncation()
-            raise
-        for edge_data, added_entities in edge_results:
-            if edge_data is not None:
-                processed_edges.append(edge_data)
-            all_added_entities.extend(added_entities)
+            for edge_data, added_entities in edge_results:
+                if edge_data is not None:
+                    processed_edges.append(edge_data)
+                all_added_entities.extend(added_entities)
 
-        logger.info(
-            "Phase 2 relation processing completed for %s: edges=%d added_entities=%d",
-            doc_id,
-            len(processed_edges),
-            len(all_added_entities),
-        )
-        await asyncio.sleep(0)
+            logger.info(
+                "Phase 2 relation processing completed for %s: edges=%d added_entities=%d",
+                doc_id,
+                len(processed_edges),
+                len(all_added_entities),
+            )
+            await asyncio.sleep(0)
 
-    # NOTE: the recovery indexes are written (and flushed) in Phase 0, BEFORE
-    # graph mutation. The historical post-merge "Phase 3" write — which
-    # derived the rows from in-memory merge results and swallowed its own
-    # exceptions — is gone: a merge whose anchors cannot be persisted no
-    # longer mutates the graph at all (issue #3400).
+        # NOTE: the recovery indexes are written (and flushed) in Phase 0, BEFORE
+        # graph mutation. The historical post-merge "Phase 3" write — which
+        # derived the rows from in-memory merge results and swallowed its own
+        # exceptions — is gone: a merge whose anchors cannot be persisted no
+        # longer mutates the graph at all (issue #3400).
 
-    _publish_summary_truncation()
+    finally:
+        # On EVERY exit — the inter-phase await points (sleep(0) yields,
+        # status-lock acquires) sit outside any narrower handler, and a
+        # cancellation landing there must still absorb the summary tally
+        # before the caller's failure bookkeeping recomputes from it.
+        _publish_summary_truncation()
 
     log_message = f"Completed merging: {len(processed_entities)} entities, {len(all_added_entities)} extra entities, {len(processed_edges)} relations"
     logger.info(log_message)

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -4229,9 +4229,12 @@ async def extract_entities(
     def _publish_truncation_summary() -> None:
         """Publish one aggregated truncation line and hand the counts upward.
 
-        Called on both the success and the failure path, so a run that dies
-        mid-extraction still reports (and records) what it truncated before
-        dying. A no-op when nothing truncated.
+        Called exactly once, from a ``finally`` covering the wait/drain on
+        the chunk tasks, so it runs on EVERY exit — success, a failing chunk,
+        and an external cancellation landing on the wait itself (which used
+        to bypass the two explicit call sites and lose already-recorded
+        truncations from the caller's document tally). Await-free, so it is
+        safe inside a cancellation unwind. A no-op when nothing truncated.
         """
         if not stage_tally:
             return
@@ -4276,67 +4279,74 @@ async def extract_entities(
         task = asyncio.create_task(_process_with_semaphore(c))
         tasks.append(task)
 
-    # Wait for tasks to complete or for the first exception to occur
-    # This allows us to cancel remaining tasks if any task fails
-    done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+    try:
+        # Wait for tasks to complete or for the first exception to occur
+        # This allows us to cancel remaining tasks if any task fails
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
 
-    # Check if any task raised an exception and ensure all exceptions are retrieved.
-    #
-    # ORDER: `done` is a SET whose iteration order derives from object identity
-    # (Task inherits object.__hash__, i.e. its memory address), so it is neither
-    # completion order nor creation order, and it is unstable across processes.
-    # Collecting results from it made `chunk_results` a different permutation on
-    # every run of the same document. That permutation reaches persisted state
-    # through merge_nodes_and_edges: `source_id` and `file_path` are built by
-    # order-preserving dedup with no sort to fall back on, and
-    # apply_source_ids_limit then truncates a DIFFERENT subset of chunks. (The
-    # description lists are sorted by (timestamp, -len) downstream, so those are
-    # only exposed on ties -- the persisted id/path fields are the unguarded
-    # ones.) Results are therefore materialised from `tasks`, a list built in
-    # `ordered_chunks` order, so chunk_results[i] always maps to ordered_chunks[i].
-    #
-    # The two passes cannot be folded into one loop over `tasks`: on the
-    # exception path `tasks` still holds pending entries, and calling
-    # .exception() on those raises InvalidStateError, which the `except Exception`
-    # below would latch as `first_exception`, masking the real failure.
-    first_exception = None
-    chunk_results = []
+        # Check if any task raised an exception and ensure all exceptions are retrieved.
+        #
+        # ORDER: `done` is a SET whose iteration order derives from object identity
+        # (Task inherits object.__hash__, i.e. its memory address), so it is neither
+        # completion order nor creation order, and it is unstable across processes.
+        # Collecting results from it made `chunk_results` a different permutation on
+        # every run of the same document. That permutation reaches persisted state
+        # through merge_nodes_and_edges: `source_id` and `file_path` are built by
+        # order-preserving dedup with no sort to fall back on, and
+        # apply_source_ids_limit then truncates a DIFFERENT subset of chunks. (The
+        # description lists are sorted by (timestamp, -len) downstream, so those are
+        # only exposed on ties -- the persisted id/path fields are the unguarded
+        # ones.) Results are therefore materialised from `tasks`, a list built in
+        # `ordered_chunks` order, so chunk_results[i] always maps to ordered_chunks[i].
+        #
+        # The two passes cannot be folded into one loop over `tasks`: on the
+        # exception path `tasks` still holds pending entries, and calling
+        # .exception() on those raises InvalidStateError, which the `except Exception`
+        # below would latch as `first_exception`, masking the real failure.
+        first_exception = None
+        chunk_results = []
 
-    for task in done:
-        try:
-            exception = task.exception()
-            if exception is not None and first_exception is None:
-                first_exception = exception
-        except Exception as e:
-            if first_exception is None:
-                first_exception = e
+        for task in done:
+            try:
+                exception = task.exception()
+                if exception is not None and first_exception is None:
+                    first_exception = exception
+            except Exception as e:
+                if first_exception is None:
+                    first_exception = e
 
-    # No exception means FIRST_EXCEPTION behaved as ALL_COMPLETED: `pending` is
-    # empty and every task in `tasks` holds a result. On the exception path we
-    # are about to unwind, so materialising results there would be wasted work.
-    if first_exception is None:
-        chunk_results = [task.result() for task in tasks]
+        # No exception means FIRST_EXCEPTION behaved as ALL_COMPLETED: `pending` is
+        # empty and every task in `tasks` holds a result. On the exception path we
+        # are about to unwind, so materialising results there would be wasted work.
+        if first_exception is None:
+            chunk_results = [task.result() for task in tasks]
 
-    # If any task failed, cancel all pending tasks and raise the first exception
-    if first_exception is not None:
-        # Cancel all pending tasks
-        for pending_task in pending:
-            pending_task.cancel()
+        # If any task failed, cancel all pending tasks and raise the first exception
+        if first_exception is not None:
+            # Cancel all pending tasks
+            for pending_task in pending:
+                pending_task.cancel()
 
-        # Wait for cancellation to complete
-        if pending:
-            await asyncio.wait(pending)
+            # Wait for cancellation to complete
+            if pending:
+                await asyncio.wait(pending)
 
+            # Add progress prefix to the exception message
+            progress_prefix = f"C[{processed_chunks + 1}/{total_chunks}]"
+
+            # Re-raise the original exception with a prefix
+            prefixed_exception = create_prefixed_exception(
+                first_exception, progress_prefix
+            )
+            raise prefixed_exception from first_exception
+    finally:
+        # On EVERY exit — mirrors merge_nodes_and_edges. The success and
+        # failure paths used to publish explicitly, but an external
+        # cancellation landing on the asyncio.wait above bypassed both,
+        # and the caller's failure bookkeeping (custom chunks) then
+        # persisted FAILED with no llm_truncation for responses that had
+        # already been recorded. Await-free, called exactly once.
         _publish_truncation_summary()
-
-        # Add progress prefix to the exception message
-        progress_prefix = f"C[{processed_chunks + 1}/{total_chunks}]"
-
-        # Re-raise the original exception with a prefix
-        prefixed_exception = create_prefixed_exception(first_exception, progress_prefix)
-        raise prefixed_exception from first_exception
-
-    _publish_truncation_summary()
 
     # If all tasks completed successfully, chunk_results already contains the results
     # Return the chunk_results for later processing in merge_nodes_and_edges

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -5273,6 +5273,16 @@ class _PipelineMixin:
                     metadata_extra={
                         "process_start_time": process_start_time,
                         "process_end_time": int(time.time()),
+                        # Same payload the merge-stage failure below writes.
+                        # None of these keys is carried over, so omitting them
+                        # here DROPPED the parse_format / parse_engine /
+                        # chunk_method / mm_chunks fields that the PROCESSING
+                        # transition had just stamped: a document that failed
+                        # during extraction ended up describing itself less
+                        # than one that failed one stage later. Always bound —
+                        # initialised empty above the try, so a failure that
+                        # precedes chunking simply contributes nothing.
+                        **extraction_meta,
                         # A run that truncated and then failed keeps the
                         # evidence: truncation is often why it failed.
                         **truncation_tally.as_metadata_extra(),

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -4540,6 +4540,27 @@ class _PipelineMixin:
             finally:
                 in_q.task_done()
 
+    @staticmethod
+    def _analyze_truncation_metadata_extra(
+        parsed_data: Any,
+    ) -> dict[str, Any] | None:
+        """``metadata_extra`` for a FAILED write on the analyze stage.
+
+        ``analyze_multimodal`` hands its truncation record over on EVERY
+        exit via ``parsed_data["llm_truncation"]``. On the raising exits
+        (fail-fast sibling failure, mid-VLM cancellation) the document goes
+        FAILED right here in the analyze worker and never reaches the
+        process stage's terminal writes — so the FAILED transition itself
+        must stamp the record, or an accepted truncated analysis whose
+        partial result is already in the sidecar leaves no durable trace.
+        """
+        payload = (
+            parsed_data.get("llm_truncation") if isinstance(parsed_data, dict) else None
+        )
+        if not payload:
+            return None
+        return {LLM_TRUNCATION_METADATA_KEY: payload}
+
     async def _analyze_worker(self, ctx: _BatchRunContext) -> None:
         """Layer 2 worker: run multimodal analysis (VLM) and feed q_process.
 
@@ -4647,6 +4668,9 @@ class _PipelineMixin:
                     stage_label="analyze",
                     pipeline_status=ctx.pipeline_status,
                     pipeline_status_lock=ctx.pipeline_status_lock,
+                    metadata_extra=self._analyze_truncation_metadata_extra(
+                        parsed_data_w
+                    ),
                 )
             except Exception as e:
                 # Mirror _parse_worker: failures here must transition the
@@ -4663,6 +4687,14 @@ class _PipelineMixin:
                         status_doc=status_doc_w,
                         file_path=getattr(status_doc_w, "file_path", "unknown_source"),
                         extra_fields={"error_msg": str(e)},
+                        # Accepted-but-truncated sibling analyses recorded
+                        # before the fail-fast raise: analyze_multimodal hands
+                        # them over on every exit, and only this transition
+                        # can make them durable — the doc never reaches the
+                        # process stage's terminal writes.
+                        metadata_extra=self._analyze_truncation_metadata_extra(
+                            parsed_data_w
+                        ),
                     )
                 except Exception as upsert_err:
                     # Mirror _parse_worker: log instead of swallowing so a
@@ -5809,6 +5841,7 @@ class _PipelineMixin:
         ctx: "_BatchRunContext",
         pipeline_status: dict,
         pipeline_status_lock,
+        metadata_extra: dict[str, Any] | None = None,
     ) -> None:
         """Mark a queued document FAILED with a 'User cancelled' message.
 
@@ -5817,7 +5850,9 @@ class _PipelineMixin:
         :meth:`_finalize_doc_failure` carries for the PROCESS stage. Also
         flushes the LLM response cache so any cache_ids written by completed
         sibling tasks (e.g. successful multimodal items inside a doc that is
-        being cancelled) survive a server restart.
+        being cancelled) survive a server restart. ``metadata_extra`` rides
+        the FAILED write — the analyze worker uses it to keep an accepted
+        truncated sibling analysis visible on the cancelled document.
         """
         status_snapshot = pipeline_status.copy()
         error_msg = (
@@ -5840,6 +5875,7 @@ class _PipelineMixin:
                 status_doc=status_doc,
                 file_path=file_path,
                 extra_fields={"error_msg": error_msg},
+                metadata_extra=metadata_extra,
             )
         except Exception as exc:
             logger.error(f"Failed to mark cancelled doc {doc_id} as FAILED: {exc}")
@@ -6405,6 +6441,13 @@ class _PipelineMixin:
                     f"d-id: {doc_id}, file: {file_path}: {enrich_err}"
                 )
 
+        # Stage-scoped truncation tally, shared by every item task on this
+        # loop (record() is await-free). A token-limit-truncated analysis
+        # that still parses is ACCEPTED — the partial description feeds KG
+        # extraction — so the condition must reach the document's durable
+        # metadata, not just the server log. Created BEFORE the try so the
+        # every-exit hand-off in its finally can always read it.
+        mm_truncation_tally = TokenLimitTruncationTally()
         try:
             lines = block_file.read_text(encoding="utf-8").splitlines()
             if not lines:
@@ -6646,15 +6689,6 @@ class _PipelineMixin:
                     "status": "skipped",
                     "message": message,
                 }
-
-            # Stage-scoped truncation tally, shared by every item task on this
-            # loop (record() is await-free). A token-limit-truncated analysis
-            # that still parses is ACCEPTED — the partial description feeds KG
-            # extraction — so the condition must reach the document's durable
-            # metadata, not just the server log. Handed to the process stage
-            # via ``parsed_data["llm_truncation"]``, which merges it with the
-            # extraction/merge tally at the terminal doc_status write.
-            mm_truncation_tally = TokenLimitTruncationTally()
 
             def _record_mm_truncation(fresh: bool, result_text: str, subject: str):
                 """Record an accepted-but-truncated fresh analysis.
@@ -7366,12 +7400,6 @@ class _PipelineMixin:
                     async with pipeline_status_lock:
                         pipeline_status["latest_message"] = truncation_message
                         append_pipeline_history(pipeline_status, truncation_message)
-                # Ride the analyze→process hand-off dict rather than doc_status:
-                # LLM_TRUNCATION_METADATA_KEY is per-attempt (not carried over),
-                # so a stamp written here would be dropped at the PROCESSING
-                # transition. The process stage merges this into its own tally
-                # at the terminal write, which is where the key becomes durable.
-                parsed_data["llm_truncation"] = mm_truncation_tally.as_metadata()
             parsed_data["multimodal_processed"] = True
             logger.info(f"[analyze_multimodal] completed for d-id: {doc_id}")
         except PipelineCancelledException:
@@ -7383,6 +7411,21 @@ class _PipelineMixin:
             raise
         except Exception as e:
             logger.warning(f"[analyze_multimodal] failed for d-id: {doc_id}: {e}")
+        finally:
+            # Analyze→process hand-off of the truncation record, on EVERY
+            # exit — not just success. Ride the hand-off dict rather than
+            # doc_status: LLM_TRUNCATION_METADATA_KEY is per-attempt (not
+            # carried over), so a stamp written here would be dropped at the
+            # PROCESSING transition. Consumers: on success and on the
+            # soft-swallowed exits the process stage merges it into its own
+            # tally at the terminal write; when this call raises (a sibling
+            # item's fail-fast failure, mid-VLM cancellation), the analyze
+            # worker stamps it onto the FAILED row. A success-only hand-off
+            # lost an accepted truncated analysis on exactly those raising
+            # exits — the item's partial result was already written to the
+            # sidecar, but the document's metadata never learned of it.
+            if mm_truncation_tally:
+                parsed_data["llm_truncation"] = mm_truncation_tally.as_metadata()
         return parsed_data
 
     def _build_mm_chunks_from_sidecars(

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -111,6 +111,7 @@ from lightrag.utils import (
     save_to_cache,
     serialize_llm_cache_identity,
     strip_control_characters,
+    TokenLimitTruncationTally,
     tolerant_load_json_dict,
 )
 from lightrag.utils_pipeline import (
@@ -4689,6 +4690,12 @@ class _PipelineMixin:
         extraction_meta: dict[str, Any] = {}
         chunk_results: list = []
         doc_process_opts = parse_process_options("")
+        # Document-scoped truncation record, fed by both KG stages (extraction
+        # + gleaning in extract_entities, description summaries in
+        # merge_nodes_and_edges). Stamped into doc_status.metadata at the
+        # terminal transition, where it survives the bounded pipeline-status
+        # ring and reaches /documents and the WebUI.
+        truncation_tally = TokenLimitTruncationTally()
 
         def get_failed_chunk_snapshot() -> tuple[list[str], int]:
             if chunks:
@@ -5242,6 +5249,7 @@ class _PipelineMixin:
                             chunks,
                             ctx.pipeline_status,
                             ctx.pipeline_status_lock,
+                            truncation_tally=truncation_tally,
                         )
                     )
                     chunk_results = await entity_relation_task
@@ -5265,6 +5273,9 @@ class _PipelineMixin:
                     metadata_extra={
                         "process_start_time": process_start_time,
                         "process_end_time": int(time.time()),
+                        # A run that truncated and then failed keeps the
+                        # evidence: truncation is often why it failed.
+                        **truncation_tally.as_metadata_extra(),
                     },
                     pipeline_status=ctx.pipeline_status,
                     pipeline_status_lock=ctx.pipeline_status_lock,
@@ -5304,6 +5315,7 @@ class _PipelineMixin:
                             on_anchors_durable=partial(
                                 self._mark_graph_mutation_started, doc_id, status_doc
                             ),
+                            truncation_tally=truncation_tally,
                         )
 
                     # If another in-flight document already triggered an abort
@@ -5347,6 +5359,11 @@ class _PipelineMixin:
                             "process_start_time": process_start_time,
                             "process_end_time": process_end_time,
                             **extraction_meta,
+                            # Empty on a clean run, which is what CLEARS a
+                            # previous attempt's summary: the key is not in the
+                            # carry-over whitelist, so absence means "this
+                            # attempt did not truncate", never "unchanged".
+                            **truncation_tally.as_metadata_extra(),
                         },
                         # A PROCESSED document has no purge in flight by
                         # definition, so retire any journal that a resume purge
@@ -5409,6 +5426,7 @@ class _PipelineMixin:
                             "process_start_time": process_start_time,
                             "process_end_time": int(time.time()),
                             **extraction_meta,
+                            **truncation_tally.as_metadata_extra(),
                         },
                         pipeline_status=ctx.pipeline_status,
                         pipeline_status_lock=ctx.pipeline_status_lock,

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -111,6 +111,8 @@ from lightrag.utils import (
     save_to_cache,
     serialize_llm_cache_identity,
     strip_control_characters,
+    LLM_TRUNCATION_METADATA_KEY,
+    merge_truncation_metadata,
     TokenLimitTruncationTally,
     tolerant_load_json_dict,
     validate_file_path_security,
@@ -4747,6 +4749,21 @@ class _PipelineMixin:
         # terminal transition, where it survives the bounded pipeline-status
         # ring and reaches /documents and the WebUI.
         truncation_tally = TokenLimitTruncationTally()
+        # Analyze-stage (multimodal VLM/EXTRACT) truncations arrive on the
+        # hand-off dict: an accepted-but-truncated analysis feeds a partial
+        # description into extraction below, so it belongs in the same
+        # document record. Merged at the terminal writes — the analyze stage
+        # cannot stamp doc_status itself, because the key is per-attempt (not
+        # carried over) and would be dropped at the PROCESSING transition.
+        analyze_truncation = parsed_data.get("llm_truncation")
+        if not isinstance(analyze_truncation, dict):
+            analyze_truncation = None
+
+        def truncation_metadata_extra() -> dict[str, Any]:
+            merged = merge_truncation_metadata(
+                analyze_truncation, truncation_tally.as_metadata()
+            )
+            return {LLM_TRUNCATION_METADATA_KEY: merged} if merged else {}
 
         def get_failed_chunk_snapshot() -> tuple[list[str], int]:
             if chunks:
@@ -5336,7 +5353,7 @@ class _PipelineMixin:
                         **extraction_meta,
                         # A run that truncated and then failed keeps the
                         # evidence: truncation is often why it failed.
-                        **truncation_tally.as_metadata_extra(),
+                        **truncation_metadata_extra(),
                     },
                     pipeline_status=ctx.pipeline_status,
                     pipeline_status_lock=ctx.pipeline_status_lock,
@@ -5424,7 +5441,7 @@ class _PipelineMixin:
                             # previous attempt's summary: the key is not in the
                             # carry-over whitelist, so absence means "this
                             # attempt did not truncate", never "unchanged".
-                            **truncation_tally.as_metadata_extra(),
+                            **truncation_metadata_extra(),
                         },
                         # A PROCESSED document has no purge in flight by
                         # definition, so retire any journal that a resume purge
@@ -5487,7 +5504,7 @@ class _PipelineMixin:
                             "process_start_time": process_start_time,
                             "process_end_time": int(time.time()),
                             **extraction_meta,
-                            **truncation_tally.as_metadata_extra(),
+                            **truncation_metadata_extra(),
                         },
                         pipeline_status=ctx.pipeline_status,
                         pipeline_status_lock=ctx.pipeline_status_lock,
@@ -6630,6 +6647,33 @@ class _PipelineMixin:
                     "message": message,
                 }
 
+            # Stage-scoped truncation tally, shared by every item task on this
+            # loop (record() is await-free). A token-limit-truncated analysis
+            # that still parses is ACCEPTED — the partial description feeds KG
+            # extraction — so the condition must reach the document's durable
+            # metadata, not just the server log. Handed to the process stage
+            # via ``parsed_data["llm_truncation"]``, which merges it with the
+            # extraction/merge tally at the terminal doc_status write.
+            mm_truncation_tally = TokenLimitTruncationTally()
+
+            def _record_mm_truncation(fresh: bool, result_text: str, subject: str):
+                """Record an accepted-but-truncated fresh analysis.
+
+                Independent of ``analysis_cache_enabled`` on purpose: with the
+                cache off, the old cache-skip branch never even inspected the
+                marker. Cache hits (``fresh=False``) cannot be truncated —
+                truncated responses are never persisted.
+                """
+                if fresh and is_truncated_response(result_text):
+                    logger.warning(
+                        f"[analyze_multimodal] {subject}: token-limit-truncated "
+                        "response accepted; analysis may be incomplete "
+                        "(never cached)"
+                    )
+                    mm_truncation_tally.record("multimodal", subject)
+                    return True
+                return False
+
             async def _analyze_drawing(
                 item_id: str, item: dict[str, Any], sidecar_dir: Path
             ) -> tuple[dict[str, Any], str | None]:
@@ -6760,38 +6804,35 @@ class _PipelineMixin:
                     lambda parsed: _validate_drawing_analysis(item_id, parsed),
                 )
                 cache_id_to_attach: str | None = None
-                if fresh and analysis_cache_enabled:
-                    if is_truncated_response(result_text):
-                        # A token-limit-truncated VLM response that still
-                        # parsed must not be persisted: the cache would replay
-                        # the partial analysis on every later run, even once a
-                        # larger token budget would have completed it.
-                        logger.warning(
-                            f"[analyze_multimodal] drawings/{item_id}: skipping "
-                            "analysis cache write for token-limit-truncated "
-                            "VLM response"
-                        )
-                    else:
-                        audit_blob = image_audit_metadata(normalized_images)
-                        original_prompt = prompt + (
-                            f"\n<vlm_images>"
-                            f"{json.dumps(audit_blob, ensure_ascii=False)}"
-                            "</vlm_images>"
-                            if audit_blob
-                            else ""
-                        )
-                        await save_to_cache(
-                            self.llm_response_cache,
-                            CacheData(
-                                args_hash=args_hash,
-                                content=str(result_text),
-                                prompt=original_prompt,
-                                mode="default",
-                                cache_type="analysis",
-                                chunk_id=None,
-                            ),
-                        )
-                        cache_id_to_attach = cache_id
+                # A token-limit-truncated VLM response that still parsed is
+                # recorded for the document's metadata and must not be
+                # persisted: the cache would replay the partial analysis on
+                # every later run, even once a larger token budget would have
+                # completed it.
+                response_truncated = _record_mm_truncation(
+                    fresh, result_text, f"drawings/{item_id}"
+                )
+                if fresh and analysis_cache_enabled and not response_truncated:
+                    audit_blob = image_audit_metadata(normalized_images)
+                    original_prompt = prompt + (
+                        f"\n<vlm_images>"
+                        f"{json.dumps(audit_blob, ensure_ascii=False)}"
+                        "</vlm_images>"
+                        if audit_blob
+                        else ""
+                    )
+                    await save_to_cache(
+                        self.llm_response_cache,
+                        CacheData(
+                            args_hash=args_hash,
+                            content=str(result_text),
+                            prompt=original_prompt,
+                            mode="default",
+                            cache_type="analysis",
+                            chunk_id=None,
+                        ),
+                    )
+                    cache_id_to_attach = cache_id
                 elif not fresh:
                     # Cache hit: the entry exists, so attaching its id is
                     # safe (and necessary for document-delete cleanup).
@@ -7054,26 +7095,24 @@ class _PipelineMixin:
                 if kind == "equation":
                     result_obj["equation"] = analysis_fields["equation"]
                 cache_id_to_attach: str | None = None
-                if fresh and analysis_cache_enabled:
-                    if is_truncated_response(result_text):
-                        logger.warning(
-                            f"[analyze_multimodal] {kind}/{item_id}: skipping "
-                            "analysis cache write for token-limit-truncated "
-                            "EXTRACT response"
-                        )
-                    else:
-                        await save_to_cache(
-                            self.llm_response_cache,
-                            CacheData(
-                                args_hash=args_hash,
-                                content=str(result_text),
-                                prompt=prompt,
-                                mode="default",
-                                cache_type="analysis",
-                                chunk_id=None,
-                            ),
-                        )
-                        cache_id_to_attach = cache_id
+                # Same contract as the drawings branch: record the accepted
+                # truncation for document metadata, never persist it.
+                response_truncated = _record_mm_truncation(
+                    fresh, result_text, f"{kind}/{item_id}"
+                )
+                if fresh and analysis_cache_enabled and not response_truncated:
+                    await save_to_cache(
+                        self.llm_response_cache,
+                        CacheData(
+                            args_hash=args_hash,
+                            content=str(result_text),
+                            prompt=prompt,
+                            mode="default",
+                            cache_type="analysis",
+                            chunk_id=None,
+                        ),
+                    )
+                    cache_id_to_attach = cache_id
                 elif not fresh:
                     # Cache hit path (handle_cache already gated by flag):
                     # safe to surface the existing cache_id for cleanup.
@@ -7315,6 +7354,24 @@ class _PipelineMixin:
                 stage_label="multimodal analyze",
                 doc_id=doc_id,
             )
+            if mm_truncation_tally:
+                truncation_message = (
+                    f"Warning: token-limit truncation hit "
+                    f"{mm_truncation_tally.affected} multimodal analyses for "
+                    f"{file_path} ({mm_truncation_tally.events} responses); "
+                    f"descriptions may be incomplete"
+                )
+                logger.warning(truncation_message)
+                if pipeline_status is not None and pipeline_status_lock is not None:
+                    async with pipeline_status_lock:
+                        pipeline_status["latest_message"] = truncation_message
+                        append_pipeline_history(pipeline_status, truncation_message)
+                # Ride the analyze→process hand-off dict rather than doc_status:
+                # LLM_TRUNCATION_METADATA_KEY is per-attempt (not carried over),
+                # so a stamp written here would be dropped at the PROCESSING
+                # transition. The process stage merges this into its own tally
+                # at the terminal write, which is where the key becomes durable.
+                parsed_data["llm_truncation"] = mm_truncation_tally.as_metadata()
             parsed_data["multimodal_processed"] = True
             logger.info(f"[analyze_multimodal] completed for d-id: {doc_id}")
         except PipelineCancelledException:

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4451,6 +4451,38 @@ def is_truncated_response(value: Any) -> bool:
     return isinstance(value, TruncatedResponse)
 
 
+def format_response_diagnostics(**fields: Any) -> str:
+    """Render provider response diagnostics as ``key=value`` pairs.
+
+    ``None`` becomes ``n/a`` so a field the provider did not report is visibly
+    absent rather than looking like a zero.
+    """
+    return ", ".join(
+        f"{key}={'n/a' if value is None else value}" for key, value in fields.items()
+    )
+
+
+def empty_length_truncated_hint(
+    budget_hint: str, *, reasoning_consumed_budget: bool = False
+) -> str:
+    """Explain an EMPTY response whose finish reason is the output token limit.
+
+    Shared by every binding so the four providers describe the same failure
+    identically. This is the structurally-broken case, not "ran a bit long":
+    generation stopped before producing a single content token, so there is
+    nothing to salvage and nothing to cache — the caller raises rather than
+    returning "" and letting the document be indexed as an empty graph
+    (issue #3601 gap 4).
+
+    ``budget_hint`` names the provider's own output-budget knob, since that is
+    the actionable part and only the binding knows it.
+    """
+    cause = "generation hit the token limit before emitting any content"
+    if reasoning_consumed_budget:
+        cause += " (budget consumed by reasoning)"
+    return f"{cause}; {budget_hint}"
+
+
 # doc_status.metadata key holding the per-document truncation summary.
 LLM_TRUNCATION_METADATA_KEY = "llm_truncation"
 

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4451,6 +4451,108 @@ def is_truncated_response(value: Any) -> bool:
     return isinstance(value, TruncatedResponse)
 
 
+# doc_status.metadata key holding the per-document truncation summary.
+LLM_TRUNCATION_METADATA_KEY = "llm_truncation"
+
+# Cap on the number of affected subjects (chunk ids / entity names) echoed into
+# that metadata entry. The doc_status row is serialized into every documents
+# listing response, so the summary must stay O(1) in document size; the exact
+# per-chunk detail lives in the server log, which is unbounded by design.
+TRUNCATION_METADATA_SAMPLE_LIMIT = 10
+
+
+class TokenLimitTruncationTally:
+    """Accumulator for token-limit truncation events over one scope.
+
+    A document whose output budget is too small does not truncate once, it
+    truncates on EVERY chunk: publishing one ``pipeline_status`` line per event
+    would push the rest of the run out of the bounded ``history_messages`` ring
+    and still leave the operator counting lines. So each producer stage keeps a
+    tally, publishes its FIRST event immediately (the condition must not stay
+    hidden until a long run ends) plus ONE aggregated line when it finishes,
+    and folds its counts into the document-scoped tally the pipeline stamps
+    into ``doc_status.metadata`` — the durable, machine-readable record that
+    outlives the status ring and reaches the API.
+
+    Not thread-safe, and does not need to be: every mutation is a plain,
+    await-free update made from tasks on a single event loop.
+    """
+
+    __slots__ = ("_events", "_stages", "_subjects")
+
+    def __init__(self) -> None:
+        self._events = 0
+        self._stages: dict[str, int] = {}
+        # Ordered set: preserves first-seen order for the metadata sample while
+        # de-duplicating a subject that truncated at more than one stage.
+        self._subjects: dict[str, None] = {}
+
+    def __bool__(self) -> bool:
+        return self._events > 0
+
+    @property
+    def events(self) -> int:
+        """Total truncated responses, counting a subject once per stage."""
+        return self._events
+
+    @property
+    def affected(self) -> int:
+        """Distinct subjects (chunk ids / entity names) with >= 1 truncation."""
+        return len(self._subjects)
+
+    def record(self, stage: str, subject: str) -> bool:
+        """Record one truncated response; True when it is this tally's first."""
+        first = self._events == 0
+        self._events += 1
+        self._stages[stage] = self._stages.get(stage, 0) + 1
+        if subject:
+            self._subjects.setdefault(subject, None)
+        return first
+
+    def absorb(self, other: "TokenLimitTruncationTally | None") -> None:
+        """Fold a stage-scoped tally into this (document-scoped) one."""
+        if not other:
+            return
+        self._events += other._events
+        for stage, count in other._stages.items():
+            self._stages[stage] = self._stages.get(stage, 0) + count
+        for subject in other._subjects:
+            self._subjects.setdefault(subject, None)
+
+    def stage_breakdown(self) -> str:
+        """Human-readable per-stage counts, e.g. ``initial: 12, gleaning: 3``."""
+        return ", ".join(f"{stage}: {count}" for stage, count in self._stages.items())
+
+    def as_metadata(self) -> dict[str, Any] | None:
+        """Summary payload for ``doc_status.metadata``; None when nothing hit."""
+        if not self._events:
+            return None
+        subjects = list(self._subjects)
+        payload: dict[str, Any] = {
+            "events": self._events,
+            "affected": len(subjects),
+            "stages": dict(self._stages),
+            "samples": subjects[:TRUNCATION_METADATA_SAMPLE_LIMIT],
+        }
+        omitted = len(subjects) - TRUNCATION_METADATA_SAMPLE_LIMIT
+        if omitted > 0:
+            payload["samples_omitted"] = omitted
+        return payload
+
+    def as_metadata_extra(self) -> dict[str, Any]:
+        """``metadata_extra`` fragment for a doc_status transition upsert.
+
+        Empty on a clean run, so the key is simply absent rather than persisting
+        a zeroed record. Because ``LLM_TRUNCATION_METADATA_KEY`` is deliberately
+        NOT in ``_DOC_STATUS_METADATA_CARRY_OVER_KEYS``, that absence also
+        CLEARS a previous attempt's summary instead of resurrecting it — a
+        re-run with a larger token budget must not keep reporting the old
+        truncation.
+        """
+        payload = self.as_metadata()
+        return {LLM_TRUNCATION_METADATA_KEY: payload} if payload else {}
+
+
 def remove_think_tags(text: str) -> str:
     """Remove <think>...</think> tags and their content from the text.
 
@@ -4604,11 +4706,11 @@ async def use_llm_func_with_cache(
             safe_user_prompt, system_prompt=safe_system_prompt, **kwargs
         )
 
-        # Capture the token-limit truncation flag before remove_think_tags
-        # rebuilds a plain str and drops the TruncatedResponse marker.
-        res_truncated = is_truncated_response(res)
-
+        # ``remove_think_tags`` re-wraps its result, so the marker survives
+        # sanitization and both this cache guard and the caller (which reports
+        # the truncation to pipeline status) read the same flag off ``res``.
         res = remove_think_tags(res)
+        res_truncated = is_truncated_response(res)
 
         # Generate timestamp for cache miss (LLM call completion time)
         current_timestamp = int(time.time())

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4641,12 +4641,13 @@ def merge_truncation_metadata(
 ) -> dict[str, Any] | None:
     """Combine two persisted ``llm_truncation`` payloads into one.
 
-    Exists for the custom-chunk patch path, which ADDS chunks to a document
-    whose earlier contributions stay in the graph: a patch that truncates must
-    not overwrite the base run's record, and a truncated base must not have
-    its record blanked by a clean patch. The pipeline never needs this — a
-    full reprocess replaces the document's whole contribution, so there
-    replace-or-clear is the correct semantics.
+    Exists for paths that ADD to a surviving record instead of replacing it:
+    the custom-chunk patch (its truncations must not overwrite the base run's
+    record, nor a truncated base be blanked by a clean patch), the same
+    operation's resumed attempts (a failed attempt's partial graph writes stay,
+    so its record must survive a clean resume), and the analyze→process
+    hand-off. The pipeline's whole-document reprocess never needs this —
+    there replace-or-clear is the correct semantics.
 
     Merging live tallies would be exact, but only the persisted payloads
     survive (the base run's tally object is long gone), and those are lossy:
@@ -4654,10 +4655,12 @@ def merge_truncation_metadata(
     subjects beyond the cap cannot be de-duplicated. ``events`` and ``stages``
     are exact sums regardless. ``affected`` is exact whenever both sample
     lists are complete (no ``samples_omitted``); otherwise it deduplicates
-    what the samples do show and over-counts a subject that truncated in both
-    runs but is visible in neither — chunk subjects cannot collide across a
-    base run and a patch (different id schemes), so in practice this only
-    brushes repeat ``summary`` subjects.
+    what the samples do show and over-counts a subject that truncated on both
+    sides but is visible in neither. Base-vs-patch merges rarely collide
+    (different chunk id schemes; only repeat ``summary`` subjects overlap),
+    but attempt-over-attempt merges re-run the SAME chunk ids, so collision is
+    the normal case there — still exact up to the sample cap, over-counted
+    past it.
     """
     if not base:
         return dict(extra) if extra else None

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -39,7 +39,7 @@ import numpy as np
 from dotenv import load_dotenv
 import json_repair
 
-from lightrag.exceptions import ChunkBlockMatchError
+from lightrag.exceptions import ChunkBlockMatchError, EmptyTruncatedResponseError
 from lightrag.constants import (
     DEFAULT_LOG_MAX_BYTES,
     DEFAULT_LOG_BACKUP_COUNT,
@@ -4658,6 +4658,44 @@ def remove_think_tags(text: str) -> str:
     return TruncatedResponse(cleaned) if was_truncated else cleaned
 
 
+def _reject_empty_truncated_response(
+    cleaned: str, *, raw_len: int, cache_type: str, chunk_id: str | None
+) -> None:
+    """Fail a truncated response that think-tag removal left with nothing.
+
+    The provider bindings each escalate their own empty + token-limit response,
+    but they cannot see this one: ``<think>reasoning</think>`` with no answer
+    after it is a NON-empty payload, so it passes every binding's check and
+    only becomes visibly empty here. This function is the shared throat that
+    every KG-building LLM call passes through, so the rule lands once for all
+    four providers.
+
+    Parse-stage callers (``cache_type="smartheading"``) already treat an empty
+    answer as an error — ``_parse_llm_json`` raises ``TitleBlockLLMError`` on
+    it — so this only replaces "answer carries no JSON object" with the actual
+    cause and its remedy.
+    """
+    if not is_truncated_response(cleaned) or cleaned.strip():
+        return
+    diagnostics = format_response_diagnostics(
+        chunk_id=chunk_id,
+        # Everything the model produced was reasoning, by construction: the
+        # payload was non-empty before think-tag removal and empty after.
+        reasoning_content_len=raw_len,
+    )
+    hint = empty_length_truncated_hint(
+        "consider raising the LLM's output token limit or disabling thinking "
+        "mode for this role",
+        reasoning_consumed_budget=True,
+    )
+    message = (
+        f"Received empty {cache_type} content after think-tag removal "
+        f"({diagnostics}): {hint}"
+    )
+    logger.error(message)
+    raise EmptyTruncatedResponseError(message)
+
+
 async def use_llm_func_with_cache(
     user_prompt: str,
     use_llm_func: callable,
@@ -4792,7 +4830,11 @@ async def use_llm_func_with_cache(
         # ``remove_think_tags`` re-wraps its result, so the marker survives
         # sanitization and both this cache guard and the caller (which reports
         # the truncation to pipeline status) read the same flag off ``res``.
+        raw_len = len(res)
         res = remove_think_tags(res)
+        _reject_empty_truncated_response(
+            res, raw_len=raw_len, cache_type=cache_type, chunk_id=chunk_id
+        )
         res_truncated = is_truncated_response(res)
 
         # Generate timestamp for cache miss (LLM call completion time)
@@ -4846,7 +4888,12 @@ async def use_llm_func_with_cache(
 
     # Generate timestamp for non-cached LLM call
     current_timestamp = int(time.time())
-    return remove_think_tags(res), current_timestamp
+    raw_len = len(res)
+    cleaned = remove_think_tags(res)
+    _reject_empty_truncated_response(
+        cleaned, raw_len=raw_len, cache_type=cache_type, chunk_id=chunk_id
+    )
+    return cleaned, current_timestamp
 
 
 def get_content_summary(content: str, max_length: int = 250) -> str:

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4636,6 +4636,63 @@ class TokenLimitTruncationTally:
         return {LLM_TRUNCATION_METADATA_KEY: payload} if payload else {}
 
 
+def merge_truncation_metadata(
+    base: dict[str, Any] | None, extra: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    """Combine two persisted ``llm_truncation`` payloads into one.
+
+    Exists for the custom-chunk patch path, which ADDS chunks to a document
+    whose earlier contributions stay in the graph: a patch that truncates must
+    not overwrite the base run's record, and a truncated base must not have
+    its record blanked by a clean patch. The pipeline never needs this — a
+    full reprocess replaces the document's whole contribution, so there
+    replace-or-clear is the correct semantics.
+
+    Merging live tallies would be exact, but only the persisted payloads
+    survive (the base run's tally object is long gone), and those are lossy:
+    ``samples`` is capped at :data:`TRUNCATION_METADATA_SAMPLE_LIMIT`, so
+    subjects beyond the cap cannot be de-duplicated. ``events`` and ``stages``
+    are exact sums regardless. ``affected`` is exact whenever both sample
+    lists are complete (no ``samples_omitted``); otherwise it deduplicates
+    what the samples do show and over-counts a subject that truncated in both
+    runs but is visible in neither — chunk subjects cannot collide across a
+    base run and a patch (different id schemes), so in practice this only
+    brushes repeat ``summary`` subjects.
+    """
+    if not base:
+        return dict(extra) if extra else None
+    if not extra:
+        return dict(base)
+
+    base_samples = [s for s in (base.get("samples") or []) if isinstance(s, str)]
+    extra_samples = [s for s in (extra.get("samples") or []) if isinstance(s, str)]
+    # Ordered union, base first — mirrors the tally's first-seen ordering.
+    union_samples = list(dict.fromkeys(base_samples + extra_samples))
+
+    both_complete = not base.get("samples_omitted") and not extra.get("samples_omitted")
+    if both_complete:
+        affected = len(union_samples)
+    else:
+        overlap = len(set(base_samples) & set(extra_samples))
+        affected = int(base.get("affected") or 0) + int(extra.get("affected") or 0)
+        affected -= overlap
+
+    stages: dict[str, int] = dict(base.get("stages") or {})
+    for stage, count in (extra.get("stages") or {}).items():
+        stages[stage] = stages.get(stage, 0) + int(count)
+
+    merged: dict[str, Any] = {
+        "events": int(base.get("events") or 0) + int(extra.get("events") or 0),
+        "affected": affected,
+        "stages": stages,
+        "samples": union_samples[:TRUNCATION_METADATA_SAMPLE_LIMIT],
+    }
+    omitted = affected - len(merged["samples"])
+    if omitted > 0:
+        merged["samples_omitted"] = omitted
+    return merged
+
+
 def remove_think_tags(text: str) -> str:
     """Remove <think>...</think> tags and their content from the text.
 

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4454,17 +4454,23 @@ def is_truncated_response(value: Any) -> bool:
 def remove_think_tags(text: str) -> str:
     """Remove <think>...</think> tags and their content from the text.
 
+    Preserves the :class:`TruncatedResponse` marker so downstream consumers
+    can still distinguish partial model output after sanitization.
+
     Handles two cases:
     1. Complete <think>...</think> blocks anywhere in the text.
     2. Orphaned </think> at the very start (e.g., from streaming that begins
        mid-think-block), removing everything before and including it.
     """
+    was_truncated = is_truncated_response(text)
+
     # First, remove orphaned </think> prefix (content before first </think>
     # when there is no preceding <think> tag)
     text = re.sub(r"^((?!<think>).)*?</think>", "", text, flags=re.DOTALL)
     # Then remove all complete <think>...</think> blocks
     text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
-    return text.strip()
+    cleaned = text.strip()
+    return TruncatedResponse(cleaned) if was_truncated else cleaned
 
 
 async def use_llm_func_with_cache(

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -47,6 +47,7 @@ from lightrag.parser.routing import (
 from lightrag.utils import (
     compute_mdhash_id,
     get_content_summary,
+    LLM_TRUNCATION_METADATA_KEY,
     logger,
     move_file_to_parsed_dir,
 )
@@ -634,6 +635,11 @@ _DOC_STATUS_METADATA_ATTEMPT_KEYS: frozenset[str] = frozenset(
         "hard_fallback_split",
         "error_type",
         "error_stage",
+        # Token-limit truncation summary for THIS attempt. Deliberately absent
+        # from the carry-over and directive whitelists: a re-run with a larger
+        # output budget must start from a clean slate, and the terminal
+        # transition rewrites the key only when the new attempt truncated too.
+        LLM_TRUNCATION_METADATA_KEY,
     }
 )
 

--- a/tests/api/routes/test_document_status_truncation_metadata.py
+++ b/tests/api/routes/test_document_status_truncation_metadata.py
@@ -1,0 +1,57 @@
+"""The truncation summary is operator-facing, not internal bookkeeping.
+
+``DocStatusResponse`` strips ``_INTERNAL_METADATA_KEYS`` from the metadata it
+returns, so anything a client needs to SEE has to stay out of that set. The
+whole point of recording token-limit truncation on the document (issue #3601)
+is that ``/documents`` and the WebUI can show why a knowledge graph came out
+short, so this guards the key against being swept in later.
+"""
+
+import importlib
+import sys
+
+import pytest
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_document_routes = importlib.import_module("lightrag.api.routers.document_routes")
+sys.argv = _original_argv
+
+from lightrag.base import DocStatus  # noqa: E402
+from lightrag.utils import LLM_TRUNCATION_METADATA_KEY  # noqa: E402
+
+pytestmark = pytest.mark.offline
+
+DocStatusResponse = _document_routes.DocStatusResponse
+
+
+def _response(metadata: dict) -> "DocStatusResponse":
+    return DocStatusResponse(
+        id="doc-1",
+        content_summary="s",
+        content_length=1,
+        status=DocStatus.PROCESSED,
+        created_at="2026-01-01T00:00:00",
+        updated_at="2026-01-01T00:00:00",
+        file_path="doc-1.txt",
+        metadata=metadata,
+    )
+
+
+def test_truncation_summary_survives_the_internal_metadata_strip():
+    response = _response(
+        {
+            LLM_TRUNCATION_METADATA_KEY: {
+                "events": 2,
+                "affected": 1,
+                "stages": {"initial": 1, "gleaning": 1},
+                "samples": ["chunk-001"],
+            },
+            # Stripped for contrast: a purge-time bookkeeping list.
+            "smartheading_llm_cache_ids": ["default:smartheading:abc"],
+        }
+    )
+
+    assert response.metadata[LLM_TRUNCATION_METADATA_KEY]["events"] == 2
+    assert response.metadata[LLM_TRUNCATION_METADATA_KEY]["samples"] == ["chunk-001"]
+    assert "smartheading_llm_cache_ids" not in response.metadata

--- a/tests/extraction/test_pipeline_log_delock.py
+++ b/tests/extraction/test_pipeline_log_delock.py
@@ -24,7 +24,7 @@ import pytest
 
 import lightrag.operate as operate
 from lightrag.operate import extract_entities
-from lightrag.utils import Tokenizer, TokenizerInterface
+from lightrag.utils import TruncatedResponse, Tokenizer, TokenizerInterface
 
 pytestmark = pytest.mark.offline
 
@@ -93,6 +93,18 @@ class _RaiseOnEnterLock:
 
     async def __aexit__(self, *exc):
         return False
+
+
+class _FakeCache:
+    def __init__(self):
+        self.global_config = {"enable_llm_cache_for_entity_extract": True}
+        self._store = {}
+
+    async def get_by_id(self, key):
+        return self._store.get(key)
+
+    async def upsert(self, entries):
+        self._store.update(entries)
 
 
 @pytest.fixture
@@ -177,3 +189,40 @@ async def test_logs_written_even_without_pipeline_status_lock(_high_token_limit)
     )
     assert any("extracted" in m for m in status["history_messages"])
     assert "extracted" in status["latest_message"]
+
+
+@pytest.mark.parametrize("cache_enabled", [False, True])
+async def test_truncated_extraction_is_published_to_pipeline_status(
+    monkeypatch, _high_token_limit, cache_enabled
+):
+    """Operators see token truncation with chunk and document identity."""
+    captured: list[tuple[str, ...]] = []
+
+    class _CaptureLogger:
+        def __init__(self, pipeline_status):
+            self.pipeline_status = pipeline_status
+
+        def log(self, *messages):
+            captured.append(messages)
+
+    monkeypatch.setattr(operate, "PipelineStatusLogger", _CaptureLogger)
+    config = _make_global_config()
+    config["role_llm_funcs"]["extract"].return_value = TruncatedResponse(
+        _EXTRACTION_RESULT
+    )
+    chunks = _make_chunks()
+    chunks["chunk-001"]["file_path"] = "reports/annual.md"
+
+    await extract_entities(
+        chunks=chunks,
+        global_config=config,
+        llm_response_cache=_FakeCache() if cache_enabled else None,
+    )
+
+    messages = [message for group in captured for message in group]
+    truncation_messages = [
+        message for message in messages if "Token-limit truncation" in message
+    ]
+    assert len(truncation_messages) == 1
+    assert "chunk-001" in truncation_messages[0]
+    assert "reports/annual.md" in truncation_messages[0]

--- a/tests/extraction/test_pipeline_log_delock.py
+++ b/tests/extraction/test_pipeline_log_delock.py
@@ -24,7 +24,7 @@ import pytest
 
 import lightrag.operate as operate
 from lightrag.operate import extract_entities
-from lightrag.utils import TruncatedResponse, Tokenizer, TokenizerInterface
+from lightrag.utils import Tokenizer, TokenizerInterface
 
 pytestmark = pytest.mark.offline
 
@@ -93,18 +93,6 @@ class _RaiseOnEnterLock:
 
     async def __aexit__(self, *exc):
         return False
-
-
-class _FakeCache:
-    def __init__(self):
-        self.global_config = {"enable_llm_cache_for_entity_extract": True}
-        self._store = {}
-
-    async def get_by_id(self, key):
-        return self._store.get(key)
-
-    async def upsert(self, entries):
-        self._store.update(entries)
 
 
 @pytest.fixture
@@ -189,40 +177,3 @@ async def test_logs_written_even_without_pipeline_status_lock(_high_token_limit)
     )
     assert any("extracted" in m for m in status["history_messages"])
     assert "extracted" in status["latest_message"]
-
-
-@pytest.mark.parametrize("cache_enabled", [False, True])
-async def test_truncated_extraction_is_published_to_pipeline_status(
-    monkeypatch, _high_token_limit, cache_enabled
-):
-    """Operators see token truncation with chunk and document identity."""
-    captured: list[tuple[str, ...]] = []
-
-    class _CaptureLogger:
-        def __init__(self, pipeline_status):
-            self.pipeline_status = pipeline_status
-
-        def log(self, *messages):
-            captured.append(messages)
-
-    monkeypatch.setattr(operate, "PipelineStatusLogger", _CaptureLogger)
-    config = _make_global_config()
-    config["role_llm_funcs"]["extract"].return_value = TruncatedResponse(
-        _EXTRACTION_RESULT
-    )
-    chunks = _make_chunks()
-    chunks["chunk-001"]["file_path"] = "reports/annual.md"
-
-    await extract_entities(
-        chunks=chunks,
-        global_config=config,
-        llm_response_cache=_FakeCache() if cache_enabled else None,
-    )
-
-    messages = [message for group in captured for message in group]
-    truncation_messages = [
-        message for message in messages if "Token-limit truncation" in message
-    ]
-    assert len(truncation_messages) == 1
-    assert "chunk-001" in truncation_messages[0]
-    assert "reports/annual.md" in truncation_messages[0]

--- a/tests/extraction/test_truncation_reporting.py
+++ b/tests/extraction/test_truncation_reporting.py
@@ -169,6 +169,61 @@ async def test_first_truncation_is_published_with_chunk_and_document_identity(
     assert tally.as_metadata()["stages"] == {"initial": 1}
 
 
+async def test_extraction_cancelled_mid_wait_still_feeds_the_document_tally(
+    _high_token_limit,
+):
+    """Codex review (PR #3607): both explicit publish call sites sat after
+    the ``asyncio.wait`` on the chunk tasks, so an external cancellation
+    landing on that wait bypassed them — a truncated response that chunk 1
+    had already recorded never reached the caller's document tally, and
+    ``ainsert_custom_chunks``'s failure bookkeeping persisted FAILED with no
+    ``llm_truncation``. The hand-off now lives in a ``finally``."""
+    import asyncio
+
+    config = _make_global_config()  # llm_model_max_async=1 serializes chunks
+    b_entered = asyncio.Event()
+    release_b = asyncio.Event()
+    calls = {"n": 0}
+
+    async def _llm(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Chunk 1: truncated but parseable — recorded, then the task
+            # completes and releases the semaphore.
+            return TruncatedResponse(_EXTRACTION_RESULT)
+        # Chunk 2 starts only after chunk 1 fully finished (semaphore of 1);
+        # park it so the parent is deterministically stuck on asyncio.wait.
+        b_entered.set()
+        await release_b.wait()
+        return _EXTRACTION_RESULT
+
+    config["role_llm_funcs"]["extract"].side_effect = _llm
+
+    tally = TokenLimitTruncationTally()
+    extract_task = asyncio.create_task(
+        extract_entities(
+            chunks=_make_chunks(2),
+            global_config=config,
+            truncation_tally=tally,
+        )
+    )
+    await b_entered.wait()
+    extract_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await extract_task
+    # Unblock the orphaned chunk-2 task so it finishes cleanly.
+    release_b.set()
+    await asyncio.sleep(0)
+
+    payload = tally.as_metadata()
+    assert payload is not None, (
+        "the cancellation on asyncio.wait discarded the truncation chunk 1 "
+        "had already recorded — the FAILED bookkeeping would persist nothing"
+    )
+    assert payload["stages"] == {"initial": 1}
+    assert payload["samples"] == ["chunk-001"]
+
+
 async def test_gleaning_truncation_is_reported_and_counted(
     _high_token_limit, status_messages
 ):

--- a/tests/extraction/test_truncation_reporting.py
+++ b/tests/extraction/test_truncation_reporting.py
@@ -447,6 +447,41 @@ class TestSummaryStage:
         lines = _truncation_lines(pipeline_status["history_messages"])
         assert len(lines) == 1, f"expected one aggregate line, got {lines}"
 
+    async def test_a_cancellation_between_phases_still_feeds_the_document_tally(
+        self, monkeypatch
+    ):
+        """Codex review (PR #3607): the summary tally used to be absorbed
+        only by the per-phase ``wait_tasks_with_drain`` wrappers and the
+        success tail. A cancellation landing on an inter-phase await point
+        (simulated here at the Phase 2 status-line write) escaped both — the
+        document tally never learned of a summary that was already truncated
+        AND merged into the graph, so the custom-chunk failure bookkeeping
+        would recompute the journal from the incomplete tally and overwrite
+        the write-ahead snapshot that did carry the event."""
+        import asyncio
+
+        pipeline_status = {"history_messages": [], "latest_message": ""}
+        document_tally = TokenLimitTruncationTally()
+
+        orig_append = operate.append_pipeline_history
+
+        def cancel_at_phase2(status, message):
+            if str(message).startswith("Phase 2"):
+                raise asyncio.CancelledError()
+            return orig_append(status, message)
+
+        monkeypatch.setattr(operate, "append_pipeline_history", cancel_at_phase2)
+
+        with pytest.raises(asyncio.CancelledError):
+            await self._run_merge(_MemGraph(), pipeline_status, document_tally)
+
+        payload = document_tally.as_metadata()
+        assert payload is not None, (
+            "the cancellation between phases discarded the truncated summary "
+            "that phase 1 had already merged into the graph"
+        )
+        assert payload["stages"] == {"summary": 1}
+
 
 class _MemGraph:
     def __init__(self):

--- a/tests/extraction/test_truncation_reporting.py
+++ b/tests/extraction/test_truncation_reporting.py
@@ -353,9 +353,10 @@ class TestSummaryStage:
 
         assert not tally
 
-    async def test_merge_publishes_one_aggregate_and_feeds_the_document_tally(self):
-        """End of the merge chain: merge_nodes_and_edges → _merge_nodes_then_upsert
-        → _handle_entity_relation_summary → _summarize_descriptions."""
+    async def _run_merge(self, graph, pipeline_status, document_tally):
+        """Drive the whole merge chain: merge_nodes_and_edges →
+        _merge_nodes_then_upsert → _handle_entity_relation_summary →
+        _summarize_descriptions, with ALICE's summary truncated."""
         import asyncio
 
         from lightrag.kg.shared_storage import initialize_share_data
@@ -388,12 +389,10 @@ class TestSummaryStage:
             }
 
         chunk_results = [({"ALICE": [_node("first", "c1"), _node("second", "c2")]}, {})]
-        pipeline_status = {"history_messages": [], "latest_message": ""}
-        document_tally = TokenLimitTruncationTally()
 
         await merge_nodes_and_edges(
             chunk_results,
-            _MemGraph(),
+            graph,
             _MemVdb(),
             _MemVdb(),
             config,
@@ -407,11 +406,46 @@ class TestSummaryStage:
             truncation_tally=document_tally,
         )
 
+    async def test_merge_publishes_one_aggregate_and_feeds_the_document_tally(self):
+        pipeline_status = {"history_messages": [], "latest_message": ""}
+        document_tally = TokenLimitTruncationTally()
+
+        await self._run_merge(_MemGraph(), pipeline_status, document_tally)
+
         lines = _truncation_lines(pipeline_status["history_messages"])
         assert len(lines) == 1, f"expected one aggregate line, got {lines}"
         assert lines[0].startswith("Warning:")
         assert "1 description summary" in lines[0]
         assert document_tally.as_metadata()["stages"] == {"summary": 1}
+
+    async def test_a_failing_merge_still_reports_what_it_truncated(self):
+        """A truncation recorded before the merge dies must not be lost.
+
+        The summary is produced (and recorded) in step 8 of the entity merge;
+        the graph write that fails comes after. The exception then leaves
+        merge_nodes_and_edges through wait_tasks_with_drain, skipping the tail
+        — so without a failure-path publish the FAILED document's metadata
+        would claim extraction was the only stage that truncated.
+        """
+
+        class _FailingGraph(_MemGraph):
+            async def upsert_node(self, name, node_data):
+                raise RuntimeError("graph write exploded")
+
+        pipeline_status = {"history_messages": [], "latest_message": ""}
+        document_tally = TokenLimitTruncationTally()
+
+        with pytest.raises(Exception, match="graph write exploded"):
+            await self._run_merge(_FailingGraph(), pipeline_status, document_tally)
+
+        payload = document_tally.as_metadata()
+        assert payload is not None, (
+            "the merge recorded a truncated summary but the failure path "
+            "never handed it to the document-scoped tally"
+        )
+        assert payload["stages"] == {"summary": 1}
+        lines = _truncation_lines(pipeline_status["history_messages"])
+        assert len(lines) == 1, f"expected one aggregate line, got {lines}"
 
 
 class _MemGraph:

--- a/tests/extraction/test_truncation_reporting.py
+++ b/tests/extraction/test_truncation_reporting.py
@@ -1,0 +1,536 @@
+"""Operator-visible reporting of token-limit truncation (issue #3601).
+
+A truncated extraction response used to be visible only as a provider-level
+WARNING carrying no document or chunk identity, so a run could index a short —
+or empty — knowledge graph and still report success. The reporting contract
+pinned here:
+
+- every truncated response is logged with chunk + file identity (server log,
+  unbounded, one line per event);
+- ``pipeline_status`` gets the FIRST event immediately (a long run must not
+  hide the condition until it ends) plus exactly ONE aggregate at the end of
+  the stage — never one line per chunk, because ``history_messages`` is a
+  bounded ring and a document whose budget is too small truncates on all of
+  them;
+- the counts reach the caller's document-scoped tally, which the pipeline
+  stamps into ``doc_status.metadata``;
+- a parse failure caused by truncation says so, instead of leaving the
+  operator to correlate two unrelated-looking warnings by chunk id.
+
+Both the initial extraction and the gleaning round are covered, with the
+extraction cache both enabled and disabled: the cache-disabled branch is the
+one that used to drop the marker entirely.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+import lightrag.operate as operate
+from lightrag.operate import extract_entities
+from lightrag.utils import (
+    Tokenizer,
+    TokenizerInterface,
+    TokenLimitTruncationTally,
+    TruncatedResponse,
+)
+
+pytestmark = pytest.mark.offline
+
+
+_EXTRACTION_RESULT = (
+    "(entity<|#|>TEST_ENTITY<|#|>CONCEPT<|#|>A test entity)<|COMPLETE|>"
+)
+
+
+class _DummyTokenizer(TokenizerInterface):
+    def encode(self, content: str):
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens):
+        return "".join(chr(t) for t in tokens)
+
+
+class _FakeCache:
+    """Extraction cache double, so both cache branches can be exercised."""
+
+    def __init__(self):
+        self.global_config = {"enable_llm_cache_for_entity_extract": True}
+        self._store = {}
+
+    async def get_by_id(self, key):
+        return self._store.get(key)
+
+    async def upsert(self, entries):
+        self._store.update(entries)
+
+
+def _make_global_config(*, gleaning: int = 0) -> dict:
+    extract_func = AsyncMock(return_value=_EXTRACTION_RESULT)
+    return {
+        "llm_model_func": extract_func,
+        "role_llm_funcs": {
+            "extract": extract_func,
+            "keyword": extract_func,
+            "query": extract_func,
+            "vlm": extract_func,
+        },
+        "entity_extract_max_gleaning": gleaning,
+        "entity_extract_max_records": 100,
+        "entity_extract_max_entities": 40,
+        "addon_params": {},
+        "tokenizer": Tokenizer("dummy", _DummyTokenizer()),
+        "llm_model_max_async": 1,
+    }
+
+
+def _make_chunks(count: int = 1, file_path: str = "reports/annual.md") -> dict:
+    content = "Test content."
+    return {
+        f"chunk-{index:03d}": {
+            "tokens": len(content),
+            "content": content,
+            "full_doc_id": "doc-001",
+            "chunk_order_index": index,
+            "file_path": file_path,
+        }
+        for index in range(1, count + 1)
+    }
+
+
+@pytest.fixture
+def _high_token_limit(monkeypatch):
+    monkeypatch.setenv("MAX_EXTRACT_INPUT_TOKENS", "999999")
+
+
+@pytest.fixture
+def _propagate_lightrag_logger(monkeypatch):
+    """``lightrag.utils.logger`` disables propagation; restore it so caplog
+    can see WARNING records emitted from inside ``lightrag.operate``."""
+    monkeypatch.setattr(logging.getLogger("lightrag"), "propagate", True)
+
+
+@pytest.fixture
+def status_messages(monkeypatch) -> list[str]:
+    """Capture what extraction publishes to ``pipeline_status``.
+
+    ``PipelineStatusLogger`` is instantiated inside ``extract_entities``, so
+    patching the class in ``operate``'s namespace is the available seam.
+    """
+    captured: list[str] = []
+
+    class _CaptureLogger:
+        def __init__(self, pipeline_status):
+            self.pipeline_status = pipeline_status
+
+        def log(self, *messages):
+            captured.extend(messages)
+
+    monkeypatch.setattr(operate, "PipelineStatusLogger", _CaptureLogger)
+    return captured
+
+
+def _truncation_lines(messages: list[str]) -> list[str]:
+    return [m for m in messages if "token-limit truncation" in m.lower()]
+
+
+@pytest.mark.parametrize("cache_enabled", [False, True])
+async def test_first_truncation_is_published_with_chunk_and_document_identity(
+    _high_token_limit, status_messages, cache_enabled
+):
+    """The condition must be visible without reading the server log.
+
+    Parametrized over the cache: with ``enable_llm_cache_for_entity_extract``
+    off, extraction takes the branch that never inspected the marker at all
+    (issue #3601 gap 3).
+    """
+    config = _make_global_config()
+    config["role_llm_funcs"]["extract"].return_value = TruncatedResponse(
+        _EXTRACTION_RESULT
+    )
+
+    tally = TokenLimitTruncationTally()
+    await extract_entities(
+        chunks=_make_chunks(),
+        global_config=config,
+        llm_response_cache=_FakeCache() if cache_enabled else None,
+        truncation_tally=tally,
+    )
+
+    first, aggregate = _truncation_lines(status_messages)
+    assert "chunk-001" in first
+    assert "reports/annual.md" in first
+    assert first.startswith("Warning:")
+    assert aggregate.startswith("Warning:")
+    assert "1 of 1 chunks" in aggregate
+    assert tally.as_metadata()["stages"] == {"initial": 1}
+
+
+async def test_gleaning_truncation_is_reported_and_counted(
+    _high_token_limit, status_messages
+):
+    """Gleaning is a second LLM call and truncates independently of the first."""
+    config = _make_global_config(gleaning=1)
+    config["role_llm_funcs"]["extract"].return_value = TruncatedResponse(
+        _EXTRACTION_RESULT
+    )
+
+    tally = TokenLimitTruncationTally()
+    await extract_entities(
+        chunks=_make_chunks(),
+        global_config=config,
+        truncation_tally=tally,
+    )
+
+    payload = tally.as_metadata()
+    assert payload["stages"] == {"initial": 1, "gleaning": 1}
+    # Two responses truncated, but only one chunk is affected.
+    assert (payload["events"], payload["affected"]) == (2, 1)
+    assert payload["samples"] == ["chunk-001"]
+
+    aggregate = _truncation_lines(status_messages)[-1]
+    assert "initial: 1, gleaning: 1" in aggregate
+
+
+async def test_status_lines_do_not_grow_with_the_number_of_truncated_chunks(
+    _high_token_limit, status_messages
+):
+    """The whole point of aggregating: a fully-truncated document must not
+    flood the bounded ``history_messages`` ring with one line per chunk."""
+    config = _make_global_config(gleaning=1)
+    config["role_llm_funcs"]["extract"].return_value = TruncatedResponse(
+        _EXTRACTION_RESULT
+    )
+
+    tally = TokenLimitTruncationTally()
+    await extract_entities(
+        chunks=_make_chunks(count=6),
+        global_config=config,
+        truncation_tally=tally,
+    )
+
+    lines = _truncation_lines(status_messages)
+    assert len(lines) == 2, f"expected first + aggregate only, got {lines}"
+    assert "6 of 6 chunks" in lines[-1]
+    # 6 chunks x (initial + gleaning) all truncated.
+    assert tally.events == 12
+    assert tally.affected == 6
+
+
+async def test_every_occurrence_still_reaches_the_server_log(
+    _high_token_limit, status_messages, caplog, _propagate_lightrag_logger
+):
+    """Aggregation trims the status ring, not the log: the per-chunk detail
+    an operator needs for diagnosis stays one line per event."""
+    config = _make_global_config()
+    config["role_llm_funcs"]["extract"].return_value = TruncatedResponse(
+        _EXTRACTION_RESULT
+    )
+
+    with caplog.at_level("WARNING", logger="lightrag"):
+        await extract_entities(chunks=_make_chunks(count=3), global_config=config)
+
+    per_chunk = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith("Token-limit truncation during initial")
+    ]
+    assert len(per_chunk) == 3
+    assert {"chunk-001", "chunk-002", "chunk-003"} == {
+        message.split("chunk ")[1].split(" ")[0] for message in per_chunk
+    }
+
+
+async def test_a_clean_run_reports_nothing(_high_token_limit, status_messages):
+    config = _make_global_config(gleaning=1)
+
+    tally = TokenLimitTruncationTally()
+    await extract_entities(
+        chunks=_make_chunks(count=3),
+        global_config=config,
+        truncation_tally=tally,
+    )
+
+    assert _truncation_lines(status_messages) == []
+    assert not tally
+    assert tally.as_metadata_extra() == {}
+
+
+async def test_truncation_is_reported_when_extraction_fails_midway(
+    _high_token_limit, status_messages
+):
+    """A run that truncates and then dies must still hand up what it saw —
+    truncation is frequently the reason the run failed."""
+    calls = {"n": 0}
+
+    async def _flaky(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return TruncatedResponse(_EXTRACTION_RESULT)
+        raise RuntimeError("provider exploded")
+
+    config = _make_global_config()
+    config["role_llm_funcs"]["extract"] = _flaky
+
+    tally = TokenLimitTruncationTally()
+    with pytest.raises(Exception, match="provider exploded"):
+        await extract_entities(
+            chunks=_make_chunks(count=2),
+            global_config=config,
+            truncation_tally=tally,
+        )
+
+    assert len(_truncation_lines(status_messages)) == 2
+    assert tally.events == 1
+
+
+async def test_extraction_reports_without_a_caller_supplied_tally(
+    _high_token_limit, status_messages
+):
+    """``truncation_tally`` is optional: direct callers (tests, custom
+    wiring) still get the status reporting."""
+    config = _make_global_config()
+    config["role_llm_funcs"]["extract"].return_value = TruncatedResponse(
+        _EXTRACTION_RESULT
+    )
+
+    await extract_entities(chunks=_make_chunks(), global_config=config)
+
+    assert len(_truncation_lines(status_messages)) == 2
+
+
+class TestSummaryStage:
+    """Description summaries are LLM calls too.
+
+    A too-small output budget cuts them off exactly like extraction, and the
+    partial text becomes the entity's/relation's persisted description with no
+    trace anywhere. They belong in the same per-document record.
+    """
+
+    @staticmethod
+    def _summary_config(summary_return) -> dict:
+        return {
+            "role_llm_funcs": {"extract": AsyncMock(return_value=summary_return)},
+            "addon_params": {},
+            "_resolved_summary_language": "English",
+            "summary_length_recommended": 100,
+            "summary_context_size": 10_000,
+            "tokenizer": Tokenizer("dummy", _DummyTokenizer()),
+        }
+
+    async def test_truncated_summary_is_recorded_against_its_subject(self):
+        """Also pins the check ORDER: ``sanitize_text_for_encoding`` rebuilds a
+        plain str, so a check placed after it would record nothing."""
+        tally = TokenLimitTruncationTally()
+
+        summary = await operate._summarize_descriptions(
+            "Entity",
+            "TEST_ENTITY",
+            ["first description", "second description"],
+            self._summary_config(TruncatedResponse("partial summ")),
+            llm_response_cache=None,
+            truncation_tally=tally,
+        )
+
+        assert summary == "partial summ"
+        assert tally.as_metadata()["stages"] == {"summary": 1}
+        assert tally.as_metadata()["samples"] == ["Entity:TEST_ENTITY"]
+
+    async def test_complete_summary_records_nothing(self):
+        tally = TokenLimitTruncationTally()
+
+        await operate._summarize_descriptions(
+            "Entity",
+            "TEST_ENTITY",
+            ["first description", "second description"],
+            self._summary_config("a complete summary"),
+            llm_response_cache=None,
+            truncation_tally=tally,
+        )
+
+        assert not tally
+
+    async def test_merge_publishes_one_aggregate_and_feeds_the_document_tally(self):
+        """End of the merge chain: merge_nodes_and_edges → _merge_nodes_then_upsert
+        → _handle_entity_relation_summary → _summarize_descriptions."""
+        import asyncio
+
+        from lightrag.kg.shared_storage import initialize_share_data
+        from lightrag.operate import merge_nodes_and_edges
+
+        initialize_share_data()
+
+        config = self._summary_config(TruncatedResponse("partial summ"))
+        config.update(
+            {
+                "summary_max_tokens": 1_000_000,
+                # 2 descriptions and a threshold of 2 forces the LLM summary.
+                "force_llm_summary_on_merge": 2,
+                "source_ids_limit_method": operate.SOURCE_IDS_LIMIT_METHOD_KEEP,
+                "max_source_ids_per_entity": 10_000,
+                "max_source_ids_per_relation": 10_000,
+                "max_file_paths": 100,
+                "file_path_more_placeholder": "...",
+            }
+        )
+
+        def _node(description: str, source: str) -> dict:
+            return {
+                "entity_name": "ALICE",
+                "entity_type": "person",
+                "description": description,
+                "source_id": source,
+                "file_path": "d.txt",
+                "timestamp": 1,
+            }
+
+        chunk_results = [({"ALICE": [_node("first", "c1"), _node("second", "c2")]}, {})]
+        pipeline_status = {"history_messages": [], "latest_message": ""}
+        document_tally = TokenLimitTruncationTally()
+
+        await merge_nodes_and_edges(
+            chunk_results,
+            _MemGraph(),
+            _MemVdb(),
+            _MemVdb(),
+            config,
+            full_entities_storage=_MemKV(),
+            full_relations_storage=_MemKV(),
+            doc_id="doc-001",
+            pipeline_status=pipeline_status,
+            pipeline_status_lock=asyncio.Lock(),
+            entity_chunks_storage=_MemKV(),
+            relation_chunks_storage=_MemKV(),
+            truncation_tally=document_tally,
+        )
+
+        lines = _truncation_lines(pipeline_status["history_messages"])
+        assert len(lines) == 1, f"expected one aggregate line, got {lines}"
+        assert lines[0].startswith("Warning:")
+        assert "1 description summary" in lines[0]
+        assert document_tally.as_metadata()["stages"] == {"summary": 1}
+
+
+class _MemGraph:
+    def __init__(self):
+        self.nodes: dict[str, dict] = {}
+        self.edges: dict = {}
+
+    async def get_node(self, name):
+        return self.nodes.get(name)
+
+    async def has_node(self, name):
+        return name in self.nodes
+
+    async def upsert_node(self, name, node_data):
+        self.nodes[name] = dict(node_data)
+
+    async def has_edge(self, src, tgt):
+        return (src, tgt) in self.edges
+
+    async def get_edge(self, src, tgt):
+        return self.edges.get((src, tgt))
+
+    async def upsert_edge(self, src, tgt, edge_data):
+        self.edges[(src, tgt)] = dict(edge_data)
+
+
+class _MemVdb:
+    async def upsert(self, data):
+        pass
+
+    async def delete(self, ids):
+        pass
+
+
+class _MemKV:
+    def __init__(self):
+        self.data: dict = {}
+
+    async def get_by_id(self, key):
+        return self.data.get(key)
+
+    async def get_by_ids(self, keys):
+        return [self.data.get(key) for key in keys]
+
+    async def upsert(self, data):
+        self.data.update(data)
+
+    async def index_done_callback(self):
+        pass
+
+
+class TestParseFailureAttribution:
+    """A failed parse must name truncation as the cause when it is the cause.
+
+    ``TruncatedResponse`` survives ``remove_think_tags``, so the parsers can
+    distinguish "the model ignored the output contract" from "the model was cut
+    off" — only the second is fixed by raising the output budget.
+    """
+
+    async def test_text_mode_undelimited_result_names_truncation(
+        self, caplog, _propagate_lightrag_logger
+    ):
+        with caplog.at_level("WARNING", logger="lightrag"):
+            await operate._process_extraction_result(
+                TruncatedResponse("(entity<|#|>A<|#|>C<|#|>d)"),
+                "chunk-001",
+                1,
+                "d.txt",
+                tuple_delimiter="<|#|>",
+                completion_delimiter="<|COMPLETE|>",
+            )
+
+        messages = [
+            record.getMessage()
+            for record in caplog.records
+            if "Complete delimiter can not be found" in record.getMessage()
+        ]
+        assert messages, "expected the undelimited-result warning"
+        assert "truncated by the model's output token limit" in messages[0]
+
+    async def test_text_mode_stays_silent_about_a_cause_it_cannot_prove(
+        self, caplog, _propagate_lightrag_logger
+    ):
+        with caplog.at_level("WARNING", logger="lightrag"):
+            await operate._process_extraction_result(
+                "(entity<|#|>A<|#|>C<|#|>d)",
+                "chunk-001",
+                1,
+                "d.txt",
+                tuple_delimiter="<|#|>",
+                completion_delimiter="<|COMPLETE|>",
+            )
+
+        messages = [
+            record.getMessage()
+            for record in caplog.records
+            if "Complete delimiter can not be found" in record.getMessage()
+        ]
+        assert messages, "expected the undelimited-result warning"
+        assert "truncated" not in messages[0]
+
+    async def test_json_mode_unparseable_result_names_truncation(
+        self, caplog, _propagate_lightrag_logger
+    ):
+        # Prose with no recoverable object at all: json_repair salvages a
+        # half-written entity list, so a cut-off *preamble* is what actually
+        # reaches the unparseable branch.
+        with caplog.at_level("WARNING", logger="lightrag"):
+            await operate._process_json_extraction_result(
+                TruncatedResponse("Sure — here is the analysis of the"),
+                "chunk-001",
+                1,
+                "d.txt",
+            )
+
+        messages = [
+            record.getMessage()
+            for record in caplog.records
+            if "empty or unrecoverable" in record.getMessage()
+        ]
+        assert messages, "expected the unparseable-result warning"
+        assert "truncated by the model's output token limit" in messages[0]

--- a/tests/llm/bedrock_impl/test_bedrock_llm.py
+++ b/tests/llm/bedrock_impl/test_bedrock_llm.py
@@ -1273,3 +1273,89 @@ async def test_bedrock_end_turn_stop_reason_is_not_marked_truncated(monkeypatch)
 
     assert result == '{"entities":[{"name":"Ali'
     assert is_truncated_response(result) is False
+
+
+class _FakeEmptyResponseClient(_FakeBedrockClient):
+    """Converse returned a well-formed envelope with no usable text.
+
+    ``stop_reason`` / ``reasoning`` shape the diagnostics the binding is
+    expected to attach.
+    """
+
+    stop_reason = "max_tokens"
+    reasoning = True
+
+    async def converse(self, **kwargs):
+        self._captured_calls.append(kwargs)
+        content = []
+        if self.reasoning:
+            content.append(
+                {"reasoningContent": {"reasoningText": {"text": "internal thought"}}}
+            )
+        content.append({"text": ""})
+        return {
+            "output": {"message": {"content": content}},
+            "stopReason": self.stop_reason,
+            "usage": {"outputTokens": 64},
+        }
+
+
+def _empty_response_session(captured_calls, *, stop_reason, reasoning):
+    client = _FakeEmptyResponseClient(captured_calls)
+    client.stop_reason = stop_reason
+    client.reasoning = reasoning
+    return SimpleNamespace(client=lambda *_args, **_kwargs: client)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_empty_max_tokens_response_names_the_token_limit(monkeypatch):
+    """Bedrock already failed on empty content; what was missing is the cause.
+
+    doc_status.error_msg has to say which knob to turn, not just report
+    "empty content" (issue #3601 gap 4).
+    """
+    monkeypatch.delenv("AWS_REGION", raising=False)
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_empty_response_session(
+            [], stop_reason="max_tokens", reasoning=True
+        ),
+    ):
+        with pytest.raises(Exception) as excinfo:
+            await bedrock_complete_if_cache.__wrapped__(
+                model="bedrock-model", prompt="Extract"
+            )
+
+    message = str(excinfo.value)
+    assert "Received empty content from Bedrock API" in message
+    assert "stopReason=max_tokens" in message
+    assert "outputTokens=64" in message
+    # Measured from the reasoning TEXT, not the repr of the block.
+    assert f"reasoning_content_len={len('internal thought')}" in message
+    assert "budget consumed by reasoning" in message
+    assert "BEDROCK_LLM_MAX_TOKENS" in message
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_bedrock_empty_response_without_token_limit_says_so(monkeypatch):
+    """A normal stop with no output is a different diagnosis, not the budget."""
+    monkeypatch.delenv("AWS_REGION", raising=False)
+
+    with patch(
+        "lightrag.llm.bedrock.aioboto3.Session",
+        return_value=_empty_response_session(
+            [], stop_reason="end_turn", reasoning=False
+        ),
+    ):
+        with pytest.raises(Exception) as excinfo:
+            await bedrock_complete_if_cache.__wrapped__(
+                model="bedrock-model", prompt="Extract"
+            )
+
+    message = str(excinfo.value)
+    assert "stopReason=end_turn" in message
+    assert "model produced no output" in message
+    assert "BEDROCK_LLM_MAX_TOKENS" not in message

--- a/tests/llm/gemini_impl/test_gemini_llm.py
+++ b/tests/llm/gemini_impl/test_gemini_llm.py
@@ -296,3 +296,86 @@ async def test_gemini_stop_finish_reason_is_not_marked_truncated(monkeypatch, re
 
     assert result == raw_json
     assert is_truncated_response(result) is False
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_gemini_thinking_only_max_tokens_response_raises(monkeypatch, request):
+    """The #3597 shape on Gemini: the whole budget went to the thought trace.
+
+    ``final_text`` is non-empty at the pre-strip check (it is
+    ``<think>...</think>``), so only a check AFTER ``remove_think_tags`` sees
+    that nothing usable came back. It used to be returned as an empty —
+    truncation-flagged — success.
+    """
+    gemini_module = _load_gemini_module(monkeypatch, request)
+
+    fake_client = _make_nonstreaming_client(
+        _make_fake_gemini_response(
+            thought_text="let me carefully consider the entities",
+            finish_reason="MAX_TOKENS",
+        )
+    )
+    monkeypatch.setattr(gemini_module, "_get_gemini_client", lambda *args: fake_client)
+
+    # Undecorated coroutine: Gemini retries InvalidResponseError, and the
+    # handler under test runs identically on every attempt.
+    with pytest.raises(gemini_module.InvalidResponseError) as excinfo:
+        await gemini_module.gemini_complete_if_cache.__wrapped__(
+            model="gemini-model",
+            prompt="Extract entities",
+            api_key="test-key",
+            enable_cot=True,
+        )
+
+    message = str(excinfo.value)
+    assert "Received empty content from Gemini API" in message
+    assert "finish_reason=MAX_TOKENS" in message
+    assert "budget consumed by reasoning" in message
+    assert "GEMINI_LLM_MAX_OUTPUT_TOKENS" in message
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_gemini_no_content_at_all_names_the_token_limit(monkeypatch, request):
+    """The pre-existing empty-response raise now says WHY it was empty."""
+    gemini_module = _load_gemini_module(monkeypatch, request)
+
+    fake_client = _make_nonstreaming_client(
+        _make_fake_gemini_response(finish_reason="MAX_TOKENS")
+    )
+    monkeypatch.setattr(gemini_module, "_get_gemini_client", lambda *args: fake_client)
+
+    with pytest.raises(gemini_module.InvalidResponseError) as excinfo:
+        await gemini_module.gemini_complete_if_cache.__wrapped__(
+            model="gemini-model",
+            prompt="Extract entities",
+            api_key="test-key",
+        )
+
+    message = str(excinfo.value)
+    assert "finish_reason=MAX_TOKENS" in message
+    assert "candidates_token_count=2" in message
+    assert "GEMINI_LLM_MAX_OUTPUT_TOKENS" in message
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_gemini_thinking_only_stop_response_is_unchanged(monkeypatch, request):
+    """Scope: only the token-limit case escalates. A reasoning-only response
+    that ended normally still returns empty content, with a warning."""
+    gemini_module = _load_gemini_module(monkeypatch, request)
+
+    fake_client = _make_nonstreaming_client(
+        _make_fake_gemini_response(thought_text="thinking", finish_reason="STOP")
+    )
+    monkeypatch.setattr(gemini_module, "_get_gemini_client", lambda *args: fake_client)
+
+    result = await gemini_module.gemini_complete_if_cache(
+        model="gemini-model",
+        prompt="Extract entities",
+        api_key="test-key",
+        enable_cot=True,
+    )
+
+    assert result == ""

--- a/tests/llm/gemini_impl/test_gemini_llm.py
+++ b/tests/llm/gemini_impl/test_gemini_llm.py
@@ -422,3 +422,45 @@ async def test_gemini_thinking_only_stop_response_is_unchanged(monkeypatch, requ
     )
 
     assert result == ""
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_gemini_counts_usage_before_the_empty_truncated_raise(
+    monkeypatch, request
+):
+    """Codex review (PR #3607): the thought-only MAX_TOKENS raise happened
+    before the token accounting, so the request that consumed its ENTIRE
+    output budget on reasoning was the one request missing from usage
+    reporting. Usage is now recorded before any validation raise, mirroring
+    the streaming path's finally."""
+    from lightrag.exceptions import EmptyTruncatedResponseError
+
+    gemini_module = _load_gemini_module(monkeypatch, request)
+
+    fake_client = _make_nonstreaming_client(
+        _make_fake_gemini_response(
+            thought_text="let me carefully consider the entities",
+            finish_reason="MAX_TOKENS",
+        )
+    )
+    monkeypatch.setattr(gemini_module, "_get_gemini_client", lambda *args: fake_client)
+
+    tracked: list[dict] = []
+    tracker = SimpleNamespace(add_usage=tracked.append)
+
+    with pytest.raises(EmptyTruncatedResponseError):
+        await gemini_module.gemini_complete_if_cache(
+            model="gemini-model",
+            prompt="Extract entities",
+            api_key="test-key",
+            enable_cot=True,
+            token_tracker=tracker,
+        )
+
+    assert tracked == [
+        {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+    ], (
+        "the exhausted request's tokens vanished from usage accounting "
+        "because the raise preceded token_tracker.add_usage"
+    )

--- a/tests/llm/gemini_impl/test_gemini_llm.py
+++ b/tests/llm/gemini_impl/test_gemini_llm.py
@@ -308,26 +308,40 @@ async def test_gemini_thinking_only_max_tokens_response_raises(monkeypatch, requ
     that nothing usable came back. It used to be returned as an empty —
     truncation-flagged — success.
     """
+    from lightrag.exceptions import EmptyTruncatedResponseError
+
     gemini_module = _load_gemini_module(monkeypatch, request)
 
-    fake_client = _make_nonstreaming_client(
-        _make_fake_gemini_response(
-            thought_text="let me carefully consider the entities",
-            finish_reason="MAX_TOKENS",
+    calls = {"n": 0}
+    fake_response = _make_fake_gemini_response(
+        thought_text="let me carefully consider the entities",
+        finish_reason="MAX_TOKENS",
+    )
+
+    async def _counting_generate_content(**kwargs):
+        calls["n"] += 1
+        return fake_response
+
+    fake_client = SimpleNamespace(
+        aio=SimpleNamespace(
+            models=SimpleNamespace(generate_content=_counting_generate_content)
         )
     )
     monkeypatch.setattr(gemini_module, "_get_gemini_client", lambda *args: fake_client)
 
-    # Undecorated coroutine: Gemini retries InvalidResponseError, and the
-    # handler under test runs identically on every attempt.
-    with pytest.raises(gemini_module.InvalidResponseError) as excinfo:
-        await gemini_module.gemini_complete_if_cache.__wrapped__(
+    # DECORATED call, deliberately: token-limit exhaustion is deterministic,
+    # so it must escape the retry predicate and fail after ONE request —
+    # retrying re-buys the same full-budget generation to fail identically
+    # (Codex review on PR #3607).
+    with pytest.raises(EmptyTruncatedResponseError) as excinfo:
+        await gemini_module.gemini_complete_if_cache(
             model="gemini-model",
             prompt="Extract entities",
             api_key="test-key",
             enable_cot=True,
         )
 
+    assert calls["n"] == 1, "a deterministic token-limit failure must not retry"
     message = str(excinfo.value)
     assert "Received empty content from Gemini API" in message
     assert "finish_reason=MAX_TOKENS" in message
@@ -346,8 +360,10 @@ async def test_gemini_no_content_at_all_names_the_token_limit(monkeypatch, reque
     )
     monkeypatch.setattr(gemini_module, "_get_gemini_client", lambda *args: fake_client)
 
-    with pytest.raises(gemini_module.InvalidResponseError) as excinfo:
-        await gemini_module.gemini_complete_if_cache.__wrapped__(
+    from lightrag.exceptions import EmptyTruncatedResponseError
+
+    with pytest.raises(EmptyTruncatedResponseError) as excinfo:
+        await gemini_module.gemini_complete_if_cache(
             model="gemini-model",
             prompt="Extract entities",
             api_key="test-key",
@@ -357,6 +373,33 @@ async def test_gemini_no_content_at_all_names_the_token_limit(monkeypatch, reque
     assert "finish_reason=MAX_TOKENS" in message
     assert "candidates_token_count=2" in message
     assert "GEMINI_LLM_MAX_OUTPUT_TOKENS" in message
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_gemini_non_length_empty_response_stays_retryable(monkeypatch, request):
+    """The split's other half: an empty response that ended normally is a
+    sampling artifact a fresh attempt can fix, so it must keep raising the
+    retryable type — NOT the fail-fast one."""
+    from lightrag.exceptions import EmptyTruncatedResponseError
+
+    gemini_module = _load_gemini_module(monkeypatch, request)
+
+    fake_client = _make_nonstreaming_client(
+        _make_fake_gemini_response(finish_reason="STOP")
+    )
+    monkeypatch.setattr(gemini_module, "_get_gemini_client", lambda *args: fake_client)
+
+    # __wrapped__ to skip the retry loop's real backoff sleeps.
+    with pytest.raises(gemini_module.InvalidResponseError) as excinfo:
+        await gemini_module.gemini_complete_if_cache.__wrapped__(
+            model="gemini-model",
+            prompt="Extract entities",
+            api_key="test-key",
+        )
+
+    assert not isinstance(excinfo.value, EmptyTruncatedResponseError)
+    assert "model produced no output" in str(excinfo.value)
 
 
 @pytest.mark.offline

--- a/tests/llm/ollama_impl/test_ollama_truncation.py
+++ b/tests/llm/ollama_impl/test_ollama_truncation.py
@@ -1,11 +1,18 @@
-"""Offline tests: token-limit-truncated Ollama responses carry the marker."""
+"""Offline tests: token-limit-truncated Ollama responses carry the marker.
 
+Partial content is returned for salvage (flagged uncacheable); content that is
+EMPTY because generation never got past the reasoning trace is a different
+animal and raises, so the document ends FAILED and retryable instead of being
+indexed as an empty knowledge graph (issue #3601 gap 4).
+"""
+
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from lightrag.llm.ollama import _ollama_model_if_cache
+from lightrag.llm.ollama import InvalidResponseError, _ollama_model_if_cache
 from lightrag.utils import is_truncated_response
 
 pytestmark = pytest.mark.offline
@@ -61,3 +68,91 @@ async def test_ollama_missing_done_reason_is_not_marked_truncated():
 
     assert result == "answer"
     assert is_truncated_response(result) is False
+
+
+@pytest.fixture
+def _propagate_lightrag_logger(monkeypatch):
+    monkeypatch.setattr(logging.getLogger("lightrag"), "propagate", True)
+
+
+@pytest.mark.parametrize("content", ["", "   \n  "])
+async def test_ollama_empty_length_truncated_response_raises(
+    caplog, _propagate_lightrag_logger, content
+):
+    """Empty AND cut off is structurally broken, not merely short.
+
+    This is the #3597 shape: a thinking model spends the whole num_predict
+    budget on its reasoning trace and emits no content. Returning "" here left
+    the document PROCESSED with an empty graph; it must fail instead.
+    """
+    fake_client = _make_fake_client(
+        {
+            "message": {"content": content},
+            "done_reason": "length",
+            "eval_count": 64,
+            "prompt_eval_count": 900,
+        }
+    )
+
+    with caplog.at_level(logging.ERROR, logger="lightrag"):
+        with patch("lightrag.llm.ollama.ollama.AsyncClient", return_value=fake_client):
+            with pytest.raises(InvalidResponseError) as excinfo:
+                await _ollama_model_if_cache(model="test-model", prompt="Extract")
+
+    message = str(excinfo.value)
+    assert "Received empty content from Ollama API" in message
+    assert "done_reason=length" in message
+    assert "eval_count=64" in message
+    # The actionable part must ride along into doc_status.error_msg, not stay
+    # behind in the server log.
+    assert "OLLAMA_LLM_NUM_PREDICT" in message
+    assert "hit the token limit" in caplog.text
+    fake_client._client.aclose.assert_awaited()
+
+
+async def test_ollama_empty_length_response_names_reasoning_as_the_consumer():
+    """``message.thinking`` present ⇒ say the budget went to reasoning."""
+    fake_client = _make_fake_client(
+        {
+            "message": {"content": "", "thinking": "let me carefully consider..."},
+            "done_reason": "length",
+            "eval_count": 64,
+        }
+    )
+
+    with patch("lightrag.llm.ollama.ollama.AsyncClient", return_value=fake_client):
+        with pytest.raises(InvalidResponseError) as excinfo:
+            await _ollama_model_if_cache(model="test-model", prompt="Extract")
+
+    message = str(excinfo.value)
+    assert "budget consumed by reasoning" in message
+    assert "thinking_len=28" in message
+
+
+async def test_ollama_empty_response_without_length_reason_is_unchanged():
+    """Scope: only the token-limit case escalates.
+
+    An empty response that ended normally is the model's answer, not a broken
+    generation, and the callers that tolerate it today keep doing so.
+    """
+    fake_client = _make_fake_client({"message": {"content": ""}, "done_reason": "stop"})
+
+    with patch("lightrag.llm.ollama.ollama.AsyncClient", return_value=fake_client):
+        result = await _ollama_model_if_cache(model="test-model", prompt="Q")
+
+    assert result == ""
+    assert is_truncated_response(result) is False
+
+
+async def test_ollama_partial_length_response_is_still_salvaged():
+    """The escalation must not swallow the salvage path: non-empty truncated
+    content is still returned (flagged), never raised."""
+    fake_client = _make_fake_client(
+        {"message": {"content": " x "}, "done_reason": "length"}
+    )
+
+    with patch("lightrag.llm.ollama.ollama.AsyncClient", return_value=fake_client):
+        result = await _ollama_model_if_cache(model="test-model", prompt="Extract")
+
+    assert result == " x "
+    assert is_truncated_response(result) is True

--- a/tests/llm/openai_impl/test_openai_length_finish_reason.py
+++ b/tests/llm/openai_impl/test_openai_length_finish_reason.py
@@ -399,4 +399,8 @@ async def test_empty_content_length_truncation_diagnostics(caplog):
     assert "reasoning_tokens=n/a" in message
     assert "reasoning_content_len=0" in message
     assert "hit the token limit" in caplog.text
+    # The hint travels with the exception too, so the document's error_msg
+    # names the knob — same contract as the Ollama/Gemini/Bedrock bindings.
+    assert "hit the token limit" in message
+    assert "consider raising max_tokens" in message
     fake_client.close.assert_awaited()

--- a/tests/llm/openai_impl/test_openai_length_finish_reason.py
+++ b/tests/llm/openai_impl/test_openai_length_finish_reason.py
@@ -373,6 +373,8 @@ async def test_empty_content_length_truncation_diagnostics(caplog):
     emitted, the response has ``finish_reason="length"`` and empty content;
     usage may lack ``completion_tokens_details`` entirely.
     """
+    from lightrag.exceptions import EmptyTruncatedResponseError
+
     completion = _make_completion("", finish_reason="length")
     fake_client = _make_fake_client(completion)
 
@@ -385,8 +387,13 @@ async def test_empty_content_length_truncation_diagnostics(caplog):
             "lightrag.llm.openai.create_openai_async_client",
             return_value=fake_client,
         ):
-            with pytest.raises(InvalidResponseError) as excinfo:
-                await openai_complete_if_cache.__wrapped__(
+            # DECORATED call, deliberately: token-limit exhaustion is
+            # deterministic for a given prompt and output budget, so it must
+            # escape the retry predicate and fail after ONE request instead of
+            # re-buying two more full-budget generations plus backoff (Codex
+            # review on PR #3607, flagged on the Gemini twin of this check).
+            with pytest.raises(EmptyTruncatedResponseError) as excinfo:
+                await openai_complete_if_cache(
                     model="test-model",
                     prompt="Describe the image",
                     response_format={"type": "json_object"},
@@ -394,6 +401,9 @@ async def test_empty_content_length_truncation_diagnostics(caplog):
     finally:
         lightrag_logger.propagate = original_propagate
 
+    assert fake_client.chat.completions.create.await_count == 1, (
+        "a deterministic token-limit failure must not retry"
+    )
     message = str(excinfo.value)
     assert "finish_reason=length" in message
     assert "reasoning_tokens=n/a" in message

--- a/tests/llm/openai_impl/test_openai_length_finish_reason.py
+++ b/tests/llm/openai_impl/test_openai_length_finish_reason.py
@@ -414,3 +414,36 @@ async def test_empty_content_length_truncation_diagnostics(caplog):
     assert "hit the token limit" in message
     assert "consider raising max_tokens" in message
     fake_client.close.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_empty_content_length_raise_still_counts_usage():
+    """Codex review (PR #3607, flagged on the Gemini twin): the empty-content
+    raise happened before token accounting, so the request that consumed its
+    ENTIRE completion budget on reasoning was the one missing from usage
+    reporting. Usage is now recorded before any validation raise."""
+    from lightrag.exceptions import EmptyTruncatedResponseError
+
+    completion = _make_completion("", finish_reason="length")
+    fake_client = _make_fake_client(completion)
+
+    tracked: list[dict] = []
+    tracker = SimpleNamespace(add_usage=tracked.append)
+
+    with patch(
+        "lightrag.llm.openai.create_openai_async_client",
+        return_value=fake_client,
+    ):
+        with pytest.raises(EmptyTruncatedResponseError):
+            await openai_complete_if_cache(
+                model="test-model",
+                prompt="Describe the image",
+                token_tracker=tracker,
+            )
+
+    assert tracked == [
+        {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+    ], (
+        "the exhausted request's tokens vanished from usage accounting "
+        "because the raise preceded token_tracker.add_usage"
+    )

--- a/tests/llm/test_remove_think_tags.py
+++ b/tests/llm/test_remove_think_tags.py
@@ -4,7 +4,11 @@ Covers the fix for issue #2895: responses truncated when retrieved chunks
 contain <think> tags.
 """
 
-from lightrag.utils import remove_think_tags
+from lightrag.utils import (
+    TruncatedResponse,
+    is_truncated_response,
+    remove_think_tags,
+)
 
 
 class TestRemoveThinkTags:
@@ -76,3 +80,12 @@ class TestRemoveThinkTags:
         """Orphaned prefix with HTML/XML-like content is fully removed."""
         text = "check <b>bold</b> reasoning</think>The answer."
         assert remove_think_tags(text) == "The answer."
+
+    def test_truncation_marker_survives_think_tag_removal(self):
+        """Sanitizing partial output must not erase its truncation metadata."""
+        text = TruncatedResponse("<think>reasoning</think>Partial answer")
+
+        result = remove_think_tags(text)
+
+        assert result == "Partial answer"
+        assert is_truncated_response(result)

--- a/tests/llm/test_utils_llm_cache.py
+++ b/tests/llm/test_utils_llm_cache.py
@@ -2,7 +2,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from lightrag.utils import TruncatedResponse, use_llm_func_with_cache
+from lightrag.utils import (
+    TruncatedResponse,
+    is_truncated_response,
+    use_llm_func_with_cache,
+)
 
 
 class _FakeKVStorage:
@@ -98,6 +102,7 @@ async def test_use_llm_func_with_cache_skips_caching_truncated_response():
 
     # Content is returned to the caller for tolerant parsing/salvage...
     assert result == '{"entities":[{"name":"Ali'
+    assert is_truncated_response(result)
     # ...but nothing was written to the cache.
     assert cache._store == {}
     llm_func.assert_awaited_once()
@@ -136,6 +141,24 @@ async def test_use_llm_func_with_cache_truncated_response_is_not_reused():
     # only the complete second result is now persisted.
     assert llm_func.await_count == 2
     assert len(cache._store) == 1
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_truncation_marker_survives_when_cache_is_disabled():
+    """Callers must observe truncation even without an extraction cache."""
+    llm_func = AsyncMock(
+        return_value=TruncatedResponse("<think>reasoning</think>Partial result")
+    )
+
+    result, _ = await use_llm_func_with_cache(
+        "extract prompt",
+        llm_func,
+        llm_response_cache=None,
+    )
+
+    assert result == "Partial result"
+    assert is_truncated_response(result)
 
 
 @pytest.mark.offline

--- a/tests/llm/test_utils_llm_cache.py
+++ b/tests/llm/test_utils_llm_cache.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from lightrag.exceptions import EmptyTruncatedResponseError
 from lightrag.utils import (
     TruncatedResponse,
     is_truncated_response,
@@ -180,3 +181,67 @@ async def test_use_llm_func_with_cache_rejects_json_schema_response_format():
         )
 
     llm_func.assert_not_awaited()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cache_enabled", [False, True])
+async def test_truncated_response_emptied_by_think_removal_is_rejected(cache_enabled):
+    """The one empty+length shape no binding can see.
+
+    A thinking model that exhausts its budget inside the reasoning trace
+    returns ``<think>...</think>`` with no answer after it. That payload is
+    NON-empty, so every binding's own empty-content check passes it through;
+    it only becomes visibly empty after think-tag removal. Returning it let
+    extraction index an empty graph and still report PROCESSED.
+    """
+    llm_func = AsyncMock(
+        return_value=TruncatedResponse("<think>let me carefully consider</think>")
+    )
+
+    with pytest.raises(EmptyTruncatedResponseError) as excinfo:
+        await use_llm_func_with_cache(
+            "extract prompt",
+            llm_func,
+            llm_response_cache=_FakeKVStorage() if cache_enabled else None,
+            chunk_id="chunk-001",
+        )
+
+    message = str(excinfo.value)
+    assert "Received empty extract content after think-tag removal" in message
+    assert "chunk_id=chunk-001" in message
+    # Everything the model produced was reasoning, by construction.
+    assert "reasoning_content_len=40" in message
+    assert "budget consumed by reasoning" in message
+    assert "output token limit" in message
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_an_untruncated_empty_response_is_still_returned():
+    """Scope: only the token-limit case escalates. A model that legitimately
+    answers with nothing (or with reasoning only, having finished normally)
+    keeps its previous behavior."""
+    llm_func = AsyncMock(return_value="<think>done thinking</think>")
+
+    result, _ = await use_llm_func_with_cache(
+        "extract prompt", llm_func, llm_response_cache=None
+    )
+
+    assert result == ""
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_a_truncated_response_with_content_after_the_think_block_survives():
+    """The rejection must not swallow the salvage path."""
+    llm_func = AsyncMock(
+        return_value=TruncatedResponse('<think>reasoning</think>{"entities":[{"name')
+    )
+
+    result, _ = await use_llm_func_with_cache(
+        "extract prompt", llm_func, llm_response_cache=None
+    )
+
+    assert result == '{"entities":[{"name'
+    assert is_truncated_response(result)

--- a/tests/pipeline/test_custom_chunk_patch.py
+++ b/tests/pipeline/test_custom_chunk_patch.py
@@ -22,12 +22,14 @@ import numpy as np
 import pytest
 
 import lightrag.lightrag as lightrag_module
+import lightrag.operate as operate_module
 from lightrag import LightRAG
 from lightrag.base import DocStatus
 from lightrag.utils import (
     EmbeddingFunc,
     LLM_TRUNCATION_METADATA_KEY,
     Tokenizer,
+    TruncatedResponse,
 )
 from lightrag.utils_pipeline import (
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
@@ -53,7 +55,7 @@ async def _dummy_llm(*args, **kwargs) -> str:
     return "ok"
 
 
-async def _build_rag(tmp_path) -> LightRAG:
+async def _build_rag(tmp_path, **overrides) -> LightRAG:
     rag = LightRAG(
         working_dir=str(tmp_path / "wd"),
         workspace=f"ccpatch-{uuid4().hex[:8]}",
@@ -63,6 +65,7 @@ async def _build_rag(tmp_path) -> LightRAG:
         ),
         tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
         max_parallel_insert=1,
+        **overrides,
     )
     await rag.initialize_storages()
     return rag
@@ -575,5 +578,82 @@ async def test_rollback_restores_the_base_documents_truncation_record(
         row = await rag.doc_status.get_by_id("doc-1")
         summary = (row.get("metadata") or {}).get(LLM_TRUNCATION_METADATA_KEY)
         assert summary == base_summary
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_summary_truncation_is_journaled_before_the_graph_write(
+    tmp_path, monkeypatch
+):
+    """Codex review (PR #3607): the custom-chunk resume never purges a failed
+    attempt's graph mutations, so a truncated summary that reaches the graph
+    must already be journaled — a FAILED-transition stamp alone loses the
+    event on a hard crash. Intercepts the graph upsert to pin the ordering:
+    by the time the object carrying the truncated summary lands, the durable
+    journal already names the summary stage."""
+    rag = await _build_rag(tmp_path, force_llm_summary_on_merge=3)
+    try:
+
+        async def fake_extract(chunks, *args, **kwargs):
+            # Three distinct descriptions force the LLM summary path.
+            return [
+                (
+                    {
+                        "ALICE": [
+                            {
+                                "entity_name": "ALICE",
+                                "entity_type": "person",
+                                "description": f"ALICE description {i}",
+                                "source_id": chunk_id,
+                                "file_path": "custom",
+                                "timestamp": i,
+                            }
+                            for i in range(3)
+                        ]
+                    },
+                    {},
+                )
+                for chunk_id in chunks
+            ]
+
+        monkeypatch.setattr(rag, "_process_extract_entities", fake_extract)
+
+        async def truncated_summary_llm(*args, **kwargs):
+            return TruncatedResponse("partial summary"), 0
+
+        monkeypatch.setattr(
+            operate_module, "use_llm_func_with_cache", truncated_summary_llm
+        )
+
+        captured: dict[str, object] = {}
+        orig_upsert_node = rag.chunk_entity_relation_graph.upsert_node
+
+        async def observing_upsert_node(node_id, node_data):
+            if node_id == "ALICE" and "journal" not in captured:
+                row = await rag.doc_status.get_by_id("doc-1")
+                captured["journal"] = (_journal(row) or {}).get(
+                    "operation_llm_truncation"
+                )
+            return await orig_upsert_node(node_id, node_data)
+
+        monkeypatch.setattr(
+            rag.chunk_entity_relation_graph, "upsert_node", observing_upsert_node
+        )
+
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        assert "journal" in captured, "precondition: the merge never upserted ALICE"
+        durable = captured["journal"]
+        assert durable is not None and "summary" in durable.get("stages", {}), (
+            "the truncated summary reached the graph before the journal knew "
+            "about it: a hard crash at that point would strand truncated "
+            "output in the graph with no durable record"
+        )
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        summary = (row.get("metadata") or {}).get(LLM_TRUNCATION_METADATA_KEY)
+        assert summary["stages"] == {"summary": 1}
     finally:
         await rag.finalize_storages()

--- a/tests/pipeline/test_custom_chunk_patch.py
+++ b/tests/pipeline/test_custom_chunk_patch.py
@@ -460,3 +460,120 @@ async def test_custom_chunk_failure_records_truncation(tmp_path, monkeypatch):
         assert summary["stages"] == {"initial": 1}
     finally:
         await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_patch_truncation_merges_with_the_base_documents_record(
+    tmp_path, monkeypatch
+):
+    """Codex review (PR #3607): a patch ADDS to the document, so its tally
+    must combine with the base run's record, not overwrite it — the base
+    run's truncated objects are still in the graph."""
+    rag = await _build_rag(tmp_path)
+    try:
+        _truncating_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+        await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        summary = (row.get("metadata") or {}).get(LLM_TRUNCATION_METADATA_KEY)
+        assert summary["events"] == 2, "the patch overwrote the base run's count"
+        assert summary["affected"] == 2
+        assert summary["stages"] == {"initial": 2}
+        assert summary["samples"] == [
+            _chunk_id("doc-1", "alice is here"),
+            _chunk_id("doc-1", "bob is there"),
+        ]
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_a_clean_patch_leaves_the_base_documents_record_standing(
+    tmp_path, monkeypatch
+):
+    rag = await _build_rag(tmp_path)
+    try:
+        _truncating_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+        base_summary = (
+            (await rag.doc_status.get_by_id("doc-1")).get("metadata") or {}
+        )[LLM_TRUNCATION_METADATA_KEY]
+
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        summary = (row.get("metadata") or {}).get(LLM_TRUNCATION_METADATA_KEY)
+        assert summary == base_summary, (
+            "a clean patch must not disturb the base run's truncation record"
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_rollback_drops_a_failed_patchs_truncation_from_a_clean_base(
+    tmp_path, monkeypatch
+):
+    """Codex review (PR #3607): the rollback restore copies the FAILED row,
+    whose metadata carries the dead attempt's tally — describing extractions
+    the rollback just purged. A clean base must come back clean."""
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        _truncating_extraction(rag, monkeypatch, then_fail=True)
+        with pytest.raises(Exception, match="extraction exploded"):
+            await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+        failed_row = await rag.doc_status.get_by_id("doc-1")
+        assert LLM_TRUNCATION_METADATA_KEY in (failed_row.get("metadata") or {}), (
+            "precondition: the FAILED row carries the attempt's stamp"
+        )
+
+        result = await rag.arollback_failed_custom_chunk_patches()
+        assert result["rolled_back_count"] == 1
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        assert LLM_TRUNCATION_METADATA_KEY not in (row.get("metadata") or {}), (
+            "rolled-back content must not leave a truncation record behind"
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_rollback_restores_the_base_documents_truncation_record(
+    tmp_path, monkeypatch
+):
+    """A truncated base rolled back from a truncating patch keeps exactly its
+    own record — neither blanked nor inflated by the dead attempt's counts."""
+    rag = await _build_rag(tmp_path)
+    try:
+        _truncating_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+        base_summary = (
+            (await rag.doc_status.get_by_id("doc-1")).get("metadata") or {}
+        )[LLM_TRUNCATION_METADATA_KEY]
+
+        _truncating_extraction(rag, monkeypatch, then_fail=True)
+        with pytest.raises(Exception, match="extraction exploded"):
+            await rag.ainsert_custom_chunks("base", ["bob is there"], doc_id="doc-1")
+        failed_summary = (
+            (await rag.doc_status.get_by_id("doc-1")).get("metadata") or {}
+        )[LLM_TRUNCATION_METADATA_KEY]
+        assert failed_summary["events"] == 2, (
+            "precondition: the FAILED row carries base + attempt merged"
+        )
+
+        result = await rag.arollback_failed_custom_chunk_patches()
+        assert result["rolled_back_count"] == 1
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        summary = (row.get("metadata") or {}).get(LLM_TRUNCATION_METADATA_KEY)
+        assert summary == base_summary
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_custom_chunk_patch.py
+++ b/tests/pipeline/test_custom_chunk_patch.py
@@ -24,7 +24,11 @@ import pytest
 import lightrag.lightrag as lightrag_module
 from lightrag import LightRAG
 from lightrag.base import DocStatus
-from lightrag.utils import EmbeddingFunc, Tokenizer
+from lightrag.utils import (
+    EmbeddingFunc,
+    LLM_TRUNCATION_METADATA_KEY,
+    Tokenizer,
+)
 from lightrag.utils_pipeline import (
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
     make_custom_chunk_id,
@@ -389,5 +393,70 @@ async def test_delete_includes_staged_patch_chunks(tmp_path, monkeypatch):
         assert (
             await rag.text_chunks.get_by_id(_chunk_id("doc-1", "alice is here")) is None
         )
+    finally:
+        await rag.finalize_storages()
+
+
+def _truncating_extraction(rag, monkeypatch, *, then_fail: bool = False):
+    """Extraction that reports a token-limit truncation into the caller's tally.
+
+    Scoped to the plumbing this covers: whether ``ainsert_custom_chunks``
+    creates an operation tally, hands it to the KG stages, and stamps it onto
+    the terminal transition. What makes extraction record is covered by
+    tests/extraction/test_truncation_reporting.py.
+    """
+
+    async def fake_extract(chunks, *args, truncation_tally=None, **kwargs):
+        assert truncation_tally is not None, (
+            "ainsert_custom_chunks must hand a truncation tally to extraction"
+        )
+        for chunk_id in chunks:
+            truncation_tally.record("initial", chunk_id)
+        if then_fail:
+            raise RuntimeError("extraction exploded")
+        return []
+
+    monkeypatch.setattr(rag, "_process_extract_entities", fake_extract)
+
+
+@pytest.mark.asyncio
+async def test_custom_chunk_commit_records_truncation(tmp_path, monkeypatch):
+    """A custom-chunk operation is a document-producing path too: its
+    truncations must reach durable metadata, not just transient status."""
+    rag = await _build_rag(tmp_path)
+    try:
+        _truncating_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        summary = (row.get("metadata") or {}).get(LLM_TRUNCATION_METADATA_KEY)
+        assert summary is not None, (
+            "the operation truncated but left no record on the document"
+        )
+        assert summary["stages"] == {"initial": 1}
+        assert summary["samples"] == [_chunk_id("doc-1", "alice is here")]
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_custom_chunk_failure_records_truncation(tmp_path, monkeypatch):
+    """Truncation is frequently why the operation failed — keep the evidence
+    on the FAILED row, alongside the retained journal."""
+    rag = await _build_rag(tmp_path)
+    try:
+        _truncating_extraction(rag, monkeypatch, then_fail=True)
+        with pytest.raises(Exception, match="extraction exploded"):
+            await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.FAILED.value
+        assert _journal(row) is not None, "the recovery journal must survive"
+        summary = (row.get("metadata") or {}).get(LLM_TRUNCATION_METADATA_KEY)
+        assert summary is not None, (
+            "the operation truncated but the failure path left no record"
+        )
+        assert summary["stages"] == {"initial": 1}
     finally:
         await rag.finalize_storages()

--- a/tests/pipeline/test_custom_chunk_rollback.py
+++ b/tests/pipeline/test_custom_chunk_rollback.py
@@ -890,3 +890,70 @@ async def test_hard_crash_after_summary_truncation_survives_resume(
         )
     finally:
         await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_between_merge_phases_keeps_the_journaled_summary_event(
+    tmp_path, monkeypatch
+):
+    """Codex review (PR #3607): a cancellation landing on an inter-phase
+    await point inside the merge used to skip the summary-tally absorb; the
+    FAILED bookkeeping then recomputed the journal from the unabsorbed
+    operation tally, OVERWRITING the write-ahead snapshot that did carry the
+    summary event — while the truncated summary itself stayed in the graph."""
+    import asyncio
+
+    rag = await _build_rag(tmp_path, force_llm_summary_on_merge=3)
+    try:
+
+        async def extract_alice(chunks, *args, truncation_tally=None, **kwargs):
+            return [
+                (
+                    {
+                        "ALICE": [
+                            {
+                                "entity_name": "ALICE",
+                                "entity_type": "person",
+                                "description": f"ALICE description {i}",
+                                "source_id": chunk_id,
+                                "file_path": "custom",
+                                "timestamp": i,
+                            }
+                            for i in range(3)
+                        ]
+                    },
+                    {},
+                )
+                for chunk_id in chunks
+            ]
+
+        monkeypatch.setattr(rag, "_process_extract_entities", extract_alice)
+
+        async def truncated_summary_llm(*args, **kwargs):
+            return TruncatedResponse("partial summary"), 0
+
+        monkeypatch.setattr(
+            operate_module, "use_llm_func_with_cache", truncated_summary_llm
+        )
+
+        orig_append = operate_module.append_pipeline_history
+
+        def cancel_at_phase2(status, message):
+            if str(message).startswith("Phase 2"):
+                raise asyncio.CancelledError()
+            return orig_append(status, message)
+
+        monkeypatch.setattr(operate_module, "append_pipeline_history", cancel_at_phase2)
+
+        with pytest.raises(asyncio.CancelledError):
+            await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        journal = _journal(await rag.doc_status.get_by_id("doc-1"))
+        record = journal["operation_llm_truncation"]
+        assert record is not None and "summary" in (record.get("stages") or {}), (
+            "the FAILED bookkeeping overwrote the write-ahead journal snapshot "
+            "with the unabsorbed tally, erasing the summary event while the "
+            "truncated summary stayed in the graph"
+        )
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_custom_chunk_rollback.py
+++ b/tests/pipeline/test_custom_chunk_rollback.py
@@ -685,6 +685,52 @@ async def test_resume_with_a_different_sample_keeps_both_attempts_candidates(
         await rag.finalize_storages()
 
 
+@pytest.mark.asyncio
+async def test_resumed_create_unions_both_attempts_into_the_durable_anchors(
+    tmp_path, monkeypatch
+):
+    """Codex review (PR #3607): the commit-time anchor union was restricted
+    to patch mode. A create merge writes Phase 0 anchors from the CURRENT
+    attempt's chunk_results only, so a resume that extracted a different
+    sample (truncated responses are never cached) overwrote the anchors with
+    attempt 2's candidates — and the PROCESSED write then cleared the
+    journal, leaving attempt 1's possibly-merged objects named nowhere
+    durable and stranded from later document purges."""
+    rag = await _build_rag(tmp_path)
+    try:
+        attempts = {"n": 0}
+
+        async def _per_attempt_extract(chunks, *args, **kwargs):
+            attempts["n"] += 1
+            name = "ALICE" if attempts["n"] == 1 else "BOB"
+            return [_entity_result(name, chunk_id) for chunk_id in chunks]
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _per_attempt_extract)
+        await _fail_one_merge(monkeypatch)
+
+        # Attempt 1: CREATE fails inside the merge, after possibly partial
+        # graph writes; the journal keeps ALICE.
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag.ainsert_custom_chunks("base", ["carol is here"], doc_id="doc-1")
+
+        # Resume: extraction genuinely re-runs and yields BOB; the create
+        # merge's Phase 0 writes anchors from THIS attempt's results.
+        await rag.ainsert_custom_chunks("base", ["carol is here"], doc_id="doc-1")
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        assert _journal(row) is None, "commit must clear the journal"
+        anchors = await rag.full_entities.get_by_id("doc-1")
+        assert "ALICE" in anchors["entity_names"], (
+            "attempt 1's candidate vanished from the durable anchors: with "
+            "the journal cleared, a later purge can no longer discover the "
+            "objects its merge may have written"
+        )
+        assert "BOB" in anchors["entity_names"]
+    finally:
+        await rag.finalize_storages()
+
+
 def _entity_result(name: str, chunk_id: str) -> tuple[dict, dict]:
     return (
         {

--- a/tests/pipeline/test_custom_chunk_rollback.py
+++ b/tests/pipeline/test_custom_chunk_rollback.py
@@ -610,3 +610,69 @@ async def test_rollback_report_samples_are_capped(tmp_path, monkeypatch):
         assert result["failed_sample"] == []
     finally:
         await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_resume_with_a_different_sample_keeps_both_attempts_candidates(
+    tmp_path, monkeypatch
+):
+    """Codex review (PR #3607): truncated extraction results are never cached,
+    so a resume re-runs the LLM and can extract a DIFFERENT sample. The first
+    attempt's merge may have partially applied its candidates to the graph;
+    the applying-phase journal write must UNION across attempts — replacing it
+    stranded attempt-1-only objects from both the journal (rollback's anchor)
+    and the commit's anchor union."""
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["carol is here"], doc_id="doc-1")
+
+        # Patch attempt 1 extracts ALICE and dies inside the merge (after the
+        # applying-phase journal write, after possibly partial graph writes).
+        calls = {"n": 0}
+
+        async def _per_attempt_extract(chunks, *args, **kwargs):
+            calls["n"] += 1
+            name = "ALICE" if calls["n"] == 1 else "BOB"
+            return [
+                (
+                    {
+                        name: [
+                            {
+                                "entity_name": name,
+                                "entity_type": "person",
+                                "description": f"{name} description",
+                                "source_id": chunk_id,
+                                "file_path": "custom",
+                                "timestamp": 1,
+                            }
+                        ]
+                    },
+                    {},
+                )
+                for chunk_id in chunks
+            ]
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _per_attempt_extract)
+        await _fail_one_merge(monkeypatch)
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag.ainsert_custom_chunks("base", ["dave is there"], doc_id="doc-1")
+
+        journal = _journal(await rag.doc_status.get_by_id("doc-1"))
+        assert journal["entity_names"] == ["ALICE"], "precondition: attempt 1 journaled"
+
+        # Resume: same input, but extraction now yields BOB (the truncated
+        # first response was never cached, so the LLM genuinely re-runs).
+        await rag.ainsert_custom_chunks("base", ["dave is there"], doc_id="doc-1")
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        anchors = await rag.full_entities.get_by_id("doc-1")
+        assert "ALICE" in anchors["entity_names"], (
+            "attempt 1's candidate vanished from the recovery anchors: a purge "
+            "can no longer discover the objects its merge may have written"
+        )
+        assert "BOB" in anchors["entity_names"]
+        assert "CAROL" in anchors["entity_names"]
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_custom_chunk_rollback.py
+++ b/tests/pipeline/test_custom_chunk_rollback.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 import lightrag.lightrag as lightrag_module
+import lightrag.operate as operate_module
 from lightrag import LightRAG
 from lightrag.base import DocStatus
 from lightrag.operate import KGRebuildReport
@@ -23,6 +24,7 @@ from lightrag.utils import (
     LLM_TRUNCATION_METADATA_KEY,
     EmbeddingFunc,
     Tokenizer,
+    TruncatedResponse,
 )
 from lightrag.utils_pipeline import (
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
@@ -49,7 +51,7 @@ async def _dummy_llm(*args, **kwargs) -> str:
     return "ok"
 
 
-async def _build_rag(tmp_path) -> LightRAG:
+async def _build_rag(tmp_path, **overrides) -> LightRAG:
     rag = LightRAG(
         working_dir=str(tmp_path / "wd"),
         workspace=f"ccroll-{uuid4().hex[:8]}",
@@ -59,6 +61,7 @@ async def _build_rag(tmp_path) -> LightRAG:
         ),
         tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
         max_parallel_insert=1,
+        **overrides,
     )
     await rag.initialize_storages()
     return rag
@@ -804,5 +807,86 @@ async def test_failed_attempts_accumulate_truncation_exactly_once_each(
         # The FAILED row's durable metadata carries the same accumulation.
         meta = (row.get("metadata") or {}).get(LLM_TRUNCATION_METADATA_KEY)
         assert meta is not None and meta["events"] == 2
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_hard_crash_after_summary_truncation_survives_resume(
+    tmp_path, monkeypatch
+):
+    """End-to-end Codex scenario (PR #3607): attempt 1 truncates at extraction
+    AND at a description summary, its graph writes land, then the process dies
+    before the FAILED bookkeeping can run. The resume extracts a different,
+    clean sample, never re-touches the truncated entity, and succeeds — the
+    PROCESSED row must still carry both stages, fed by the write-ahead
+    journal alone (no FAILED write ever happened)."""
+    rag = await _build_rag(tmp_path, force_llm_summary_on_merge=3)
+    try:
+        attempts = {"n": 0}
+
+        def _descriptions(name: str, chunk_id: str, count: int) -> list[dict]:
+            return [
+                {
+                    "entity_name": name,
+                    "entity_type": "person",
+                    "description": f"{name} description {i}",
+                    "source_id": chunk_id,
+                    "file_path": "custom",
+                    "timestamp": i,
+                }
+                for i in range(count)
+            ]
+
+        async def _per_attempt_extract(chunks, *args, truncation_tally=None, **kwargs):
+            attempts["n"] += 1
+            results = []
+            for chunk_id in chunks:
+                if attempts["n"] == 1:
+                    # Truncated extraction (uncached, so the resume genuinely
+                    # re-runs it) yielding an entity whose three descriptions
+                    # force the LLM summary path — which truncates too.
+                    truncation_tally.record("initial", chunk_id)
+                    results.append(({"ALICE": _descriptions("ALICE", chunk_id, 3)}, {}))
+                else:
+                    results.append(({"BOB": _descriptions("BOB", chunk_id, 1)}, {}))
+            return results
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _per_attempt_extract)
+
+        async def truncated_summary_llm(*args, **kwargs):
+            return TruncatedResponse("partial summary"), 0
+
+        monkeypatch.setattr(
+            operate_module, "use_llm_func_with_cache", truncated_summary_llm
+        )
+
+        # Attempt 1 fails after the merge completed its graph writes, and the
+        # "process" is gone before the FAILED bookkeeping runs: that write
+        # raises, leaving the journal exactly as the write-ahead left it.
+        await _fail_after_one_merge(monkeypatch)
+        orig_upsert_status = rag._upsert_custom_chunk_status
+
+        async def crash_on_failed_write(doc_key, status, **kwargs):
+            if status == DocStatus.FAILED:
+                raise RuntimeError("simulated hard crash")
+            return await orig_upsert_status(doc_key, status, **kwargs)
+
+        monkeypatch.setattr(rag, "_upsert_custom_chunk_status", crash_on_failed_write)
+
+        with pytest.raises(RuntimeError, match="post-merge boom"):
+            await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        # Resume: clean single-description sample, no summaries, succeeds.
+        await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        record = (row.get("metadata") or {}).get(LLM_TRUNCATION_METADATA_KEY)
+        assert record is not None, "both attempts' truncations were erased"
+        assert record["stages"] == {"initial": 1, "summary": 1}, (
+            "attempt 1's summary truncation was lost: only the FAILED write "
+            "knew about it, and a hard crash never runs the FAILED write"
+        )
     finally:
         await rag.finalize_storages()

--- a/tests/pipeline/test_custom_chunk_rollback.py
+++ b/tests/pipeline/test_custom_chunk_rollback.py
@@ -19,7 +19,11 @@ import lightrag.lightrag as lightrag_module
 from lightrag import LightRAG
 from lightrag.base import DocStatus
 from lightrag.operate import KGRebuildReport
-from lightrag.utils import EmbeddingFunc, Tokenizer
+from lightrag.utils import (
+    LLM_TRUNCATION_METADATA_KEY,
+    EmbeddingFunc,
+    Tokenizer,
+)
 from lightrag.utils_pipeline import (
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
     KG_RECOVERY_WARNINGS_METADATA_KEY,
@@ -674,5 +678,131 @@ async def test_resume_with_a_different_sample_keeps_both_attempts_candidates(
         )
         assert "BOB" in anchors["entity_names"]
         assert "CAROL" in anchors["entity_names"]
+    finally:
+        await rag.finalize_storages()
+
+
+def _entity_result(name: str, chunk_id: str) -> tuple[dict, dict]:
+    return (
+        {
+            name: [
+                {
+                    "entity_name": name,
+                    "entity_type": "person",
+                    "description": f"{name} description",
+                    "source_id": chunk_id,
+                    "file_path": "custom",
+                    "timestamp": 1,
+                }
+            ]
+        },
+        {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_clean_resume_keeps_the_failed_attempts_truncation_record(
+    tmp_path, monkeypatch
+):
+    """Codex review (PR #3607): truncated extraction responses are never
+    cached, so a resume re-runs the LLM and can come back clean — but the
+    failed attempt's partial graph mutations stay (the resume is additive,
+    it never purges them). The terminal write used to merge only the
+    pre-operation snapshot with the CURRENT attempt's tally, so a clean
+    resume erased the record of the truncated output still in the graph."""
+    rag = await _build_rag(tmp_path)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await rag.ainsert_custom_chunks("base", ["carol is here"], doc_id="doc-1")
+
+        attempts = {"n": 0}
+
+        async def _per_attempt_extract(chunks, *args, truncation_tally=None, **kwargs):
+            attempts["n"] += 1
+            results = []
+            for chunk_id in chunks:
+                if attempts["n"] == 1:
+                    # Attempt 1's response hit the token limit but was still
+                    # parseable — extraction records it and proceeds.
+                    truncation_tally.record("initial", chunk_id)
+                results.append(
+                    _entity_result("ALICE" if attempts["n"] == 1 else "BOB", chunk_id)
+                )
+            return results
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _per_attempt_extract)
+        await _fail_one_merge(monkeypatch)
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag.ainsert_custom_chunks("base", ["dave is there"], doc_id="doc-1")
+
+        # Resume: extraction genuinely re-runs (the truncated response was
+        # never cached) and this time comes back clean.
+        await rag.ainsert_custom_chunks("base", ["dave is there"], doc_id="doc-1")
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        record = (row.get("metadata") or {}).get(LLM_TRUNCATION_METADATA_KEY)
+        assert record is not None, (
+            "attempt 1 truncated and its partial output may still be in the "
+            "graph, but the clean resume erased the document's truncation "
+            "record"
+        )
+        assert record["stages"] == {"initial": 1}
+        assert record["samples"] == [_chunk_id("doc-1", "dave is there")]
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_failed_attempts_accumulate_truncation_exactly_once_each(
+    tmp_path, monkeypatch
+):
+    """The accumulated operation record is recomputed from the journal AS
+    LOADED (previous attempts only) plus the live tally. Recomputing from the
+    journal copy the applying write already folded this attempt into would sum
+    the attempt's events twice: a single failed attempt would journal 2 events
+    instead of 1."""
+    rag = await _build_rag(tmp_path)
+    try:
+
+        async def _truncating_extract(chunks, *args, truncation_tally=None, **kwargs):
+            results = []
+            for chunk_id in chunks:
+                truncation_tally.record("initial", chunk_id)
+                results.append(_entity_result("ALICE", chunk_id))
+            return results
+
+        monkeypatch.setattr(rag, "_process_extract_entities", _truncating_extract)
+
+        async def merge_boom(**kwargs):
+            raise RuntimeError("merge boom")
+
+        monkeypatch.setattr(lightrag_module, "merge_nodes_and_edges", merge_boom)
+
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        journal = _journal(await rag.doc_status.get_by_id("doc-1"))
+        record = journal["operation_llm_truncation"]
+        assert record["events"] == 1, (
+            "a single failed attempt must journal its one event exactly once — "
+            "2 means the FAILED write re-folded the applying write's copy"
+        )
+
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag.ainsert_custom_chunks("base", ["alice is here"], doc_id="doc-1")
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        record = _journal(row)["operation_llm_truncation"]
+        assert record["events"] == 2
+        assert record["stages"] == {"initial": 2}
+        # Same input, same chunk id: the subject deduplicates while the
+        # per-attempt events keep counting.
+        assert record["affected"] == 1
+        assert record["samples"] == [_chunk_id("doc-1", "alice is here")]
+
+        # The FAILED row's durable metadata carries the same accumulation.
+        meta = (row.get("metadata") or {}).get(LLM_TRUNCATION_METADATA_KEY)
+        assert meta is not None and meta["events"] == 2
     finally:
         await rag.finalize_storages()

--- a/tests/pipeline/test_doc_status_chunk_preservation.py
+++ b/tests/pipeline/test_doc_status_chunk_preservation.py
@@ -1255,7 +1255,7 @@ async def test_pipeline_cancellation_preserves_file_path_for_queued_docs(
         release_first_doc = asyncio.Event()
 
         async def _blocking_extract(
-            self, chunks, pipeline_status, pipeline_status_lock
+            self, chunks, pipeline_status, pipeline_status_lock, **kwargs
         ):
             extraction_started.set()
             await release_first_doc.wait()
@@ -1317,7 +1317,7 @@ async def test_pipeline_cancellation_repairs_placeholder_file_path_for_queued_do
         release_first_doc = asyncio.Event()
 
         async def _blocking_extract(
-            self, chunks, pipeline_status, pipeline_status_lock
+            self, chunks, pipeline_status, pipeline_status_lock, **kwargs
         ):
             extraction_started.set()
             await release_first_doc.wait()

--- a/tests/pipeline/test_doc_status_chunk_preservation.py
+++ b/tests/pipeline/test_doc_status_chunk_preservation.py
@@ -360,6 +360,64 @@ async def test_extract_failure_preserves_chunks_and_allows_delete_with_cache_cle
 
 
 @pytest.mark.asyncio
+async def test_extract_failure_keeps_the_processing_attempt_metadata(
+    tmp_path,
+):
+    """A FAILED row must describe the attempt as fully as a PROCESSED one.
+
+    ``extraction_meta`` (parse_format / parse_engine / chunk_method, plus
+    mm_chunks and friends) is stamped when the document enters PROCESSING, and
+    none of those keys is in ``_DOC_STATUS_METADATA_CARRY_OVER_KEYS`` — so the
+    FAILED transition has to re-pass them or they are dropped. The merge-stage
+    failure path always did; the extract-stage one did not, which left a
+    document that failed EARLIER describing itself LESS than one that failed
+    a stage later.
+    """
+    rag = await _build_rag(tmp_path, "extract_failure_meta", _deterministic_chunking)
+    try:
+        file_path = "extract_failure_meta.txt"
+        doc_id = compute_mdhash_id(file_path, prefix="doc-")
+        await rag.apipeline_enqueue_documents(
+            input="extract failure metadata document", file_paths=file_path
+        )
+
+        processing_metadata: dict = {}
+        original_transition = rag._upsert_doc_status_transition
+
+        async def _capture_transition(*args, status=None, **kwargs):
+            if status == DocStatus.PROCESSING:
+                processing_metadata.update(kwargs.get("metadata_extra") or {})
+            return await original_transition(*args, status=status, **kwargs)
+
+        rag._upsert_doc_status_transition = _capture_transition
+
+        async def fail_extract(
+            self, chunks, pipeline_status, pipeline_status_lock, **_
+        ):
+            raise RuntimeError("extract fail sentinel")
+
+        rag._process_extract_entities = MethodType(fail_extract, rag)
+
+        await rag.apipeline_process_enqueue_documents()
+
+        doc_status = await rag.doc_status.get_by_id(doc_id)
+        assert _status_to_text(doc_status["status"]) == "failed"
+        metadata = doc_status["metadata"]
+
+        # Everything PROCESSING recorded about how this attempt was run
+        # survives the failure, unchanged.
+        assert processing_metadata, "the PROCESSING transition wrote no metadata"
+        for key, value in processing_metadata.items():
+            assert metadata.get(key) == value, f"{key} was dropped by the FAILED write"
+        # Sanity: those are the descriptive fields, not just the timestamps.
+        assert {"parse_format", "chunk_method"} <= set(metadata)
+        # ...alongside the failure's own bookkeeping.
+        assert metadata["process_end_time"] >= metadata["process_start_time"]
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
 async def test_extract_failure_before_chunking_clears_stale_chunk_snapshot(
     tmp_path,
 ):

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -189,7 +189,7 @@ async def test_custom_chunks_use_canonical_unknown_source_before_upsert(monkeypa
     _patch_custom_chunk_saga(monkeypatch, rag)
 
     async def _process_extract_entities(
-        chunks, pipeline_status=None, pipeline_status_lock=None
+        chunks, pipeline_status=None, pipeline_status_lock=None, **kwargs
     ):
         return []
 
@@ -250,7 +250,7 @@ async def test_custom_chunks_merge_extracted_entities_into_kg(monkeypatch):
     extracted = [({"Entity": [{"entity_name": "Entity"}]}, {})]
 
     async def _process_extract_entities(
-        chunks, pipeline_status=None, pipeline_status_lock=None
+        chunks, pipeline_status=None, pipeline_status_lock=None, **kwargs
     ):
         return extracted
 
@@ -356,7 +356,7 @@ async def test_custom_chunks_persist_before_extraction(monkeypatch):
     _patch_custom_chunk_saga(monkeypatch, rag)
 
     async def _process_extract_entities(
-        chunks, pipeline_status=None, pipeline_status_lock=None
+        chunks, pipeline_status=None, pipeline_status_lock=None, **kwargs
     ):
         events.append("extract")
         # The barrier guarantees the chunk upsert completed first.
@@ -474,7 +474,7 @@ async def test_custom_chunks_rejects_when_pipeline_busy(monkeypatch):
 
     called = {"extract": False, "merge": False}
 
-    async def _process_extract_entities(chunks, ps=None, pl=None):
+    async def _process_extract_entities(chunks, ps=None, pl=None, **kwargs):
         called["extract"] = True
         return [({"E": [{"entity_name": "E"}]}, {})]
 
@@ -508,7 +508,7 @@ async def test_custom_chunks_hands_off_busy_atomically(monkeypatch):
 
     observed = {}
 
-    async def _process_extract_entities(chunks, ps=None, pl=None):
+    async def _process_extract_entities(chunks, ps=None, pl=None, **kwargs):
         observed["busy_during_extract"] = status["busy"]
         # Simulate a concurrent busy-refused process request arriving while
         # we hold busy: the reservation arms the auto-rescan flag.
@@ -554,7 +554,7 @@ async def test_custom_chunks_handoff_runs_even_when_flush_errors(monkeypatch):
     status = {"busy": False, "history_messages": []}
     rag = _custom_chunks_rag(monkeypatch, status)
 
-    async def _process_extract_entities(chunks, ps=None, pl=None):
+    async def _process_extract_entities(chunks, ps=None, pl=None, **kwargs):
         # A concurrent busy-refused process request arrived while we held busy.
         rag._test_ingress.request_auto_rescan()
         return [({"E": [{"entity_name": "E"}]}, {})]
@@ -616,7 +616,7 @@ async def test_custom_chunks_resolve_failure_fails_toward_handoff(monkeypatch):
         # The real driven run releases the handed-off slot at its own exit.
         status.update({"busy": False, "busy_owner": None})
 
-    async def _process_extract_entities(chunks, ps=None, pl=None):
+    async def _process_extract_entities(chunks, ps=None, pl=None, **kwargs):
         return [({"E": [{"entity_name": "E"}]}, {})]
 
     rag._process_extract_entities = _process_extract_entities
@@ -641,7 +641,7 @@ async def test_custom_chunks_releases_busy_without_pending(monkeypatch):
     async def _drain(_holding_busy=False, token=None):
         drained["called"] = True
 
-    async def _process_extract_entities(chunks, ps=None, pl=None):
+    async def _process_extract_entities(chunks, ps=None, pl=None, **kwargs):
         return [({"E": [{"entity_name": "E"}]}, {})]
 
     rag._process_extract_entities = _process_extract_entities
@@ -666,7 +666,7 @@ async def test_custom_chunks_busy_rejection_does_not_flush_shared_buffers(monkey
     async def _insert_done_with_cleanup():
         cleanup["called"] = True
 
-    async def _process_extract_entities(chunks, ps=None, pl=None):
+    async def _process_extract_entities(chunks, ps=None, pl=None, **kwargs):
         return []
 
     rag._insert_done_with_cleanup = _insert_done_with_cleanup
@@ -696,7 +696,7 @@ async def test_custom_chunks_clears_stale_cancellation(monkeypatch):
 
     observed = {}
 
-    async def _process_extract_entities(chunks, ps=None, pl=None):
+    async def _process_extract_entities(chunks, ps=None, pl=None, **kwargs):
         # Real extract/merge raise PipelineCancelledException when this is True;
         # it must have been cleared on acquire so this job runs.
         observed["cancel_during"] = status.get("cancellation_requested")
@@ -729,7 +729,7 @@ async def test_custom_chunks_overwrites_stale_deletion_job_name(monkeypatch):
 
     observed = {}
 
-    async def _process_extract_entities(chunks, ps=None, pl=None):
+    async def _process_extract_entities(chunks, ps=None, pl=None, **kwargs):
         # Captured while we hold busy — this is what a concurrent
         # adelete_by_doc_id would see and key its join-guard off.
         observed["job_name_during"] = status["job_name"]

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -33,8 +33,12 @@ import numpy as np
 import pytest
 
 from lightrag import LightRAG, ROLES, RoleLLMConfig
-from lightrag.exceptions import MultimodalAnalysisError
-from lightrag.utils import EmbeddingFunc, Tokenizer
+from lightrag.exceptions import MultimodalAnalysisError, PipelineCancelledException
+from lightrag.utils import (
+    EmbeddingFunc,
+    LLM_TRUNCATION_METADATA_KEY,
+    Tokenizer,
+)
 
 
 @pytest.fixture
@@ -1854,5 +1858,183 @@ async def test_clean_analysis_leaves_no_truncation_record(tmp_path):
         )
 
         assert "llm_truncation" not in analyzed
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_fail_fast_exit_still_hands_over_the_truncation_record(tmp_path):
+    """Codex review (PR #3607): sidecar groups run sequentially, so a drawing
+    whose truncated analysis was accepted (and written to the sidecar) can be
+    followed by a failing table whose fail-fast raise used to skip the
+    success-only hand-off — the recorded event never left the stage. The
+    hand-off must happen on every exit."""
+    from lightrag.utils import TruncatedResponse
+
+    async def truncated_vlm(prompt, **kwargs):
+        return TruncatedResponse(
+            json.dumps(
+                {
+                    "name": "fig-1",
+                    "type": "Chart",
+                    "description": "partial but parseable description",
+                }
+            )
+        )
+
+    rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=truncated_vlm)
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, sidecar_path = _write_sidecar_fixtures(tmp_path)
+        # A table with no ``format`` hard-fails deterministically (no LLM
+        # call), AFTER the drawings group has fully completed.
+        (sidecar_path.parent / "doc.tables.json").write_text(
+            json.dumps(
+                {
+                    "tables": {
+                        "tb-001": {
+                            "caption": "Table 1",
+                            "content": "<table><tr><td>A</td></tr></table>",
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(MultimodalAnalysisError):
+            await rag.analyze_multimodal(
+                doc_id=doc_id,
+                file_path="fixture.pdf",
+                parsed_data=parsed_data,
+                process_options="it",
+            )
+
+        summary = parsed_data.get("llm_truncation")
+        assert summary is not None, (
+            "the fail-fast exit dropped the accepted truncated analysis: its "
+            "partial result is in the sidecar but the record never left the "
+            "analyze stage"
+        )
+        assert summary["stages"] == {"multimodal": 1}
+        assert summary["samples"] == ["drawings/im-001"]
+        # The accepted partial analysis really did persist.
+        payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        assert payload["drawings"]["im-001"]["llm_analyze_result"]["status"] == (
+            "success"
+        )
+    finally:
+        await rag.finalize_storages()
+
+
+def _make_worker_ctx():
+    import asyncio
+    from lightrag.pipeline import _BatchRunContext
+    from lightrag.parser.registry import parser_specs_snapshot
+
+    return _BatchRunContext(
+        pipeline_status={
+            "latest_message": "",
+            "history_messages": [],
+            "cancellation_requested": False,
+        },
+        pipeline_status_lock=asyncio.Lock(),
+        semaphore=asyncio.Semaphore(1),
+        total_files=1,
+        parse_queues={
+            "native": asyncio.Queue(),
+            "mineru": asyncio.Queue(),
+            "docling": asyncio.Queue(),
+        },
+        parser_specs=parser_specs_snapshot(),
+        q_analyze=asyncio.Queue(),
+        q_process=asyncio.Queue(),
+    )
+
+
+async def _run_analyze_worker_once(rag, ctx, doc_id, status_doc):
+    import asyncio
+
+    worker = asyncio.create_task(rag._analyze_worker(ctx))
+    await ctx.q_analyze.put((doc_id, status_doc, {"content": "body"}))
+    await ctx.q_analyze.join()
+    worker.cancel()
+    try:
+        await worker
+    except asyncio.CancelledError:
+        pass
+
+
+def _pending_status_doc(file_path: str):
+    from lightrag.base import DocProcessingStatus, DocStatus
+
+    return DocProcessingStatus(
+        content_summary="",
+        content_length=0,
+        file_path=file_path,
+        status=DocStatus.PENDING,
+        created_at="2026-05-14T00:00:00Z",
+        updated_at="2026-05-14T00:00:00Z",
+        track_id="t",
+        content_hash="h",
+    )
+
+
+@pytest.mark.parametrize(
+    "raise_exc",
+    [
+        MultimodalAnalysisError("forced failure for test"),
+        PipelineCancelledException("cancelled mid-VLM for test"),
+    ],
+    ids=["fail-fast", "cancelled"],
+)
+@pytest.mark.asyncio
+async def test_analyze_worker_stamps_truncation_on_the_failed_row(tmp_path, raise_exc):
+    """Codex review (PR #3607): a document that fails (or is cancelled) at
+    the analyze stage never reaches the process stage's terminal writes, so
+    the analyze worker's own FAILED transition must stamp the handed-over
+    truncation record — otherwise an accepted truncated analysis whose
+    partial result is already in the sidecar leaves no durable trace."""
+    from dataclasses import asdict
+    from lightrag.base import DocStatus
+
+    async def vlm_func(prompt, **kwargs):
+        return ""
+
+    rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=vlm_func)
+    await rag.initialize_storages()
+    try:
+        doc_id = "doc-fail-trunc-1"
+        status_doc = _pending_status_doc("demo.pdf")
+        await rag.doc_status.upsert({doc_id: asdict(status_doc)})
+
+        handed_over = {
+            "events": 1,
+            "affected": 1,
+            "stages": {"multimodal": 1},
+            "samples": ["drawings/im-001"],
+        }
+
+        async def _record_then_raise(**kwargs):
+            # What analyze_multimodal's every-exit finally does: the record
+            # is on the hand-off dict by the time the exception escapes.
+            kwargs["parsed_data"]["llm_truncation"] = dict(handed_over)
+            raise raise_exc
+
+        rag.analyze_multimodal = _record_then_raise  # type: ignore[assignment]
+
+        ctx = _make_worker_ctx()
+        await _run_analyze_worker_once(rag, ctx, doc_id, status_doc)
+
+        refreshed = await rag.doc_status.get_by_id(doc_id)
+        if not isinstance(refreshed, dict):
+            refreshed = asdict(refreshed)
+        assert refreshed["status"] == DocStatus.FAILED
+        record = (refreshed.get("metadata") or {}).get(LLM_TRUNCATION_METADATA_KEY)
+        assert record == handed_over, (
+            "the analyze-stage FAILED transition dropped the truncation "
+            "record handed over by analyze_multimodal"
+        )
+        assert ctx.q_process.empty()
     finally:
         await rag.finalize_storages()

--- a/tests/pipeline/test_pipeline_analyze_multimodal.py
+++ b/tests/pipeline/test_pipeline_analyze_multimodal.py
@@ -1759,3 +1759,100 @@ async def test_truncated_vlm_response_not_cached_and_recomputed(tmp_path):
         assert len(call_log) == 2
     finally:
         await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_truncated_analysis_is_recorded_on_the_handoff_dict(tmp_path):
+    """Codex review (PR #3607): an accepted-but-truncated analysis feeds a
+    partial description into KG extraction, so it must reach the document's
+    durable metadata — not just the server log. The analyze stage records it
+    on the hand-off dict; the process stage merges it at the terminal write
+    (a doc_status stamp here would die at the PROCESSING transition, the key
+    being per-attempt rather than carried over)."""
+    from lightrag.utils import TruncatedResponse
+
+    async def truncated_vlm(prompt, **kwargs):
+        return TruncatedResponse(
+            json.dumps(
+                {
+                    "name": "fig-1",
+                    "type": "Chart",
+                    "description": "partial but parseable description",
+                }
+            )
+        )
+
+    rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=truncated_vlm)
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, _sidecar_path = _write_sidecar_fixtures(tmp_path)
+
+        analyzed = await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="i",
+        )
+
+        summary = analyzed.get("llm_truncation")
+        assert summary is not None, (
+            "an accepted truncated analysis left no record on the hand-off dict"
+        )
+        assert summary["stages"] == {"multimodal": 1}
+        assert summary["samples"] == ["drawings/im-001"]
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_truncation_is_recorded_even_with_the_analysis_cache_disabled(
+    tmp_path, monkeypatch
+):
+    """The old marker check lived inside the cache-write guard, so with
+    enable_llm_cache_for_entity_extract off it never ran at all — the same
+    gap issue #3601 point 3 describes for extraction."""
+    from lightrag.utils import TruncatedResponse
+
+    async def truncated_vlm(prompt, **kwargs):
+        return TruncatedResponse(
+            json.dumps({"name": "f", "type": "Chart", "description": "partial"})
+        )
+
+    rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=truncated_vlm)
+    rag.enable_llm_cache_for_entity_extract = False
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, _sidecar_path = _write_sidecar_fixtures(tmp_path)
+
+        analyzed = await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="i",
+        )
+
+        assert analyzed.get("llm_truncation") is not None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_clean_analysis_leaves_no_truncation_record(tmp_path):
+    async def clean_vlm(prompt, **kwargs):
+        return json.dumps({"name": "fig-1", "type": "Chart", "description": "complete"})
+
+    rag = _build_rag(tmp_path, vlm_process_enable=True, vlm_func=clean_vlm)
+    await rag.initialize_storages()
+    try:
+        doc_id, parsed_data, _sidecar_path = _write_sidecar_fixtures(tmp_path)
+
+        analyzed = await rag.analyze_multimodal(
+            doc_id=doc_id,
+            file_path="fixture.pdf",
+            parsed_data=parsed_data,
+            process_options="i",
+        )
+
+        assert "llm_truncation" not in analyzed
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_truncation_doc_status_metadata.py
+++ b/tests/pipeline/test_truncation_doc_status_metadata.py
@@ -154,3 +154,44 @@ def test_the_summary_marks_a_pending_row_as_carrying_stale_attempt_metadata():
     from lightrag.utils_pipeline import _DOC_STATUS_METADATA_ATTEMPT_KEYS
 
     assert LLM_TRUNCATION_METADATA_KEY in _DOC_STATUS_METADATA_ATTEMPT_KEYS
+
+
+async def test_analyze_stage_truncation_reaches_the_processed_row(tmp_path):
+    """Codex review (PR #3607): multimodal analysis runs BEFORE the process
+    stage creates the document tally, and the metadata key is per-attempt
+    (dropped at the PROCESSING transition), so its truncations rode only in
+    server logs. They arrive on the analyze→process hand-off dict and must be
+    merged into the terminal metadata alongside extraction's own counts."""
+
+    async def _truncating_llm(prompt, **kwargs):
+        return TruncatedResponse(_EXTRACTION_RESULT)
+
+    rag = _new_rag(tmp_path, _truncating_llm)
+    await rag.initialize_storages()
+
+    original_analyze = rag.analyze_multimodal
+
+    async def _analyze_with_truncation(*args, **kwargs):
+        parsed_data = await original_analyze(*args, **kwargs)
+        # What analyze_multimodal records when a schema-valid truncated VLM
+        # analysis is accepted (covered by its own stage tests).
+        parsed_data["llm_truncation"] = {
+            "events": 2,
+            "affected": 2,
+            "stages": {"multimodal": 2},
+            "samples": ["drawings/im-001", "table/tb-001"],
+        }
+        return parsed_data
+
+    rag.analyze_multimodal = _analyze_with_truncation
+    try:
+        status = await _ingest(rag, doc_id="doc-mm", body="Alice is an analyst.")
+    finally:
+        await rag.finalize_storages()
+
+    assert status["status"] == DocStatus.PROCESSED
+    summary = status["metadata"][LLM_TRUNCATION_METADATA_KEY]
+    # Both stages in one record: the analyze hand-off merged with extraction.
+    assert summary["stages"]["multimodal"] == 2
+    assert summary["stages"]["initial"] >= 1
+    assert "drawings/im-001" in summary["samples"]

--- a/tests/pipeline/test_truncation_doc_status_metadata.py
+++ b/tests/pipeline/test_truncation_doc_status_metadata.py
@@ -1,0 +1,156 @@
+"""Token-limit truncation must survive as a per-document record (issue #3601).
+
+``pipeline_status.history_messages`` is a bounded ring scoped to the running
+batch: by the time an operator notices a short knowledge graph, the truncation
+lines that explain it are long gone, and nothing in ``/documents`` says the
+document was built from partial model output. So the pipeline stamps the
+document-scoped tally into ``doc_status.metadata.llm_truncation``, which is
+durable and reaches the API.
+
+The write rules that make that record trustworthy — and which the tests below
+pin — are the ones that come from the metadata whitelists in
+``utils_pipeline``:
+
+- the key is written at the TERMINAL transition (PROCESSED, and both FAILED
+  stage boundaries), because that is the first point at which the attempt's
+  count is final;
+- it is NOT in ``_DOC_STATUS_METADATA_CARRY_OVER_KEYS``, so a re-run that does
+  not truncate clears it instead of resurrecting a stale summary — the whole
+  point of retrying with a larger output budget;
+- it IS in ``_DOC_STATUS_METADATA_ATTEMPT_KEYS``, so a document reset back to
+  PENDING is normalized to directives-only rather than waiting in the queue
+  advertising a previous attempt's truncation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import DocStatus
+from lightrag.utils import (
+    EmbeddingFunc,
+    LLM_TRUNCATION_METADATA_KEY,
+    Tokenizer,
+    TokenizerInterface,
+    TruncatedResponse,
+)
+from lightrag.utils_pipeline import (
+    doc_status_reset_metadata,
+    doc_status_transition_metadata,
+)
+
+pytestmark = pytest.mark.offline
+
+
+_EXTRACTION_RESULT = "(entity<|#|>ALICE<|#|>person<|#|>An analyst)<|COMPLETE|>"
+
+
+class _SimpleTokenizerImpl(TokenizerInterface):
+    def encode(self, content: str):
+        return [ord(c) for c in content]
+
+    def decode(self, tokens):
+        return "".join(chr(t) for t in tokens)
+
+
+async def _mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.full((len(texts), 32), 0.1, dtype=np.float32)
+
+
+def _new_rag(tmp_path: Path, llm_func) -> LightRAG:
+    return LightRAG(
+        working_dir=str(tmp_path),
+        workspace=f"truncation-{tmp_path.name}",
+        llm_model_func=llm_func,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=32, max_token_size=4096, func=_mock_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+    )
+
+
+async def _ingest(rag: LightRAG, *, doc_id: str, body: str) -> dict:
+    await rag.apipeline_enqueue_documents(
+        body, ids=[doc_id], file_paths=f"{doc_id}.txt", track_id=f"track-{doc_id}"
+    )
+    await rag.apipeline_process_enqueue_documents()
+    return await rag.doc_status.get_by_id(doc_id)
+
+
+async def test_a_truncated_run_records_the_summary_on_the_document(tmp_path):
+    """The document still reaches PROCESSED — that is the reported behavior
+    this issue does not change — but it now SAYS its graph is partial."""
+
+    async def _truncating_llm(prompt, **kwargs):
+        return TruncatedResponse(_EXTRACTION_RESULT)
+
+    rag = _new_rag(tmp_path, _truncating_llm)
+    await rag.initialize_storages()
+    try:
+        status = await _ingest(rag, doc_id="doc-trunc", body="Alice is an analyst.")
+    finally:
+        await rag.finalize_storages()
+
+    assert status["status"] == DocStatus.PROCESSED
+    summary = status["metadata"][LLM_TRUNCATION_METADATA_KEY]
+    assert summary["events"] >= 1
+    assert summary["affected"] == 1
+    assert "initial" in summary["stages"]
+    assert summary["samples"] == status["chunks_list"][:1]
+
+
+async def test_a_clean_run_leaves_no_truncation_record(tmp_path):
+    async def _complete_llm(prompt, **kwargs):
+        return _EXTRACTION_RESULT
+
+    rag = _new_rag(tmp_path, _complete_llm)
+    await rag.initialize_storages()
+    try:
+        status = await _ingest(rag, doc_id="doc-clean", body="Alice is an analyst.")
+    finally:
+        await rag.finalize_storages()
+
+    assert status["status"] == DocStatus.PROCESSED
+    assert LLM_TRUNCATION_METADATA_KEY not in status["metadata"]
+
+
+def test_the_summary_is_not_carried_over_to_the_next_attempt():
+    """Carry-over would resurrect a stale summary on a re-run that fixed the
+    budget: the PROCESSING transition must drop it, and only the terminal
+    transition of the NEW attempt may write it back."""
+    status_doc = {
+        "metadata": {
+            LLM_TRUNCATION_METADATA_KEY: {"events": 12, "affected": 12},
+            "process_options": "R",
+        }
+    }
+
+    carried = doc_status_transition_metadata(status_doc)
+
+    assert LLM_TRUNCATION_METADATA_KEY not in carried
+    # ...while a genuine long-lived directive still survives.
+    assert carried["process_options"] == "R"
+
+
+def test_a_reset_to_pending_drops_the_summary():
+    status_doc = {
+        "metadata": {
+            LLM_TRUNCATION_METADATA_KEY: {"events": 12, "affected": 12},
+            "process_options": "R",
+        }
+    }
+
+    reset = doc_status_reset_metadata(status_doc)
+
+    assert LLM_TRUNCATION_METADATA_KEY not in reset
+    assert reset["process_options"] == "R"
+
+
+def test_the_summary_marks_a_pending_row_as_carrying_stale_attempt_metadata():
+    from lightrag.utils_pipeline import _DOC_STATUS_METADATA_ATTEMPT_KEYS
+
+    assert LLM_TRUNCATION_METADATA_KEY in _DOC_STATUS_METADATA_ATTEMPT_KEYS

--- a/tests/utils/test_truncation_tally.py
+++ b/tests/utils/test_truncation_tally.py
@@ -127,3 +127,104 @@ def test_metadata_extra_is_keyed_for_the_doc_status_transition():
 
     assert set(extra) == {LLM_TRUNCATION_METADATA_KEY}
     assert extra[LLM_TRUNCATION_METADATA_KEY]["events"] == 1
+
+
+class TestMergeTruncationMetadata:
+    """Combining persisted payloads (custom-chunk patch semantics).
+
+    Only the persisted, sample-capped payloads survive to merge time, so
+    ``events``/``stages`` are exact sums while ``affected`` is exact only
+    when both sample lists are complete.
+    """
+
+    @staticmethod
+    def _payload(**overrides):
+        payload = {
+            "events": 1,
+            "affected": 1,
+            "stages": {"initial": 1},
+            "samples": ["chunk-001"],
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_either_side_absent_returns_a_copy_of_the_other(self):
+        from lightrag.utils import merge_truncation_metadata
+
+        base = self._payload()
+        assert merge_truncation_metadata(None, None) is None
+        assert merge_truncation_metadata(base, None) == base
+        assert merge_truncation_metadata(base, None) is not base
+        assert merge_truncation_metadata(None, base) == base
+
+    def test_complete_samples_merge_exactly(self):
+        from lightrag.utils import merge_truncation_metadata
+
+        base = self._payload(
+            events=3,
+            affected=2,
+            stages={"initial": 2, "summary": 1},
+            samples=["chunk-001", "Entity:ALICE"],
+        )
+        extra = self._payload(
+            events=2,
+            affected=2,
+            stages={"initial": 1, "summary": 1},
+            samples=["chunk-101", "Entity:ALICE"],
+        )
+
+        merged = merge_truncation_metadata(base, extra)
+
+        assert merged["events"] == 5
+        assert merged["stages"] == {"initial": 3, "summary": 2}
+        # Entity:ALICE truncated in both runs: one subject, counted once.
+        assert merged["affected"] == 3
+        assert merged["samples"] == ["chunk-001", "Entity:ALICE", "chunk-101"]
+        assert "samples_omitted" not in merged
+
+    def test_incomplete_samples_fall_back_to_summed_counts(self):
+        from lightrag.utils import (
+            TRUNCATION_METADATA_SAMPLE_LIMIT,
+            merge_truncation_metadata,
+        )
+
+        limit = TRUNCATION_METADATA_SAMPLE_LIMIT
+        base = self._payload(
+            events=limit + 5,
+            affected=limit + 5,
+            samples=[f"chunk-{i:03d}" for i in range(limit)],
+            samples_omitted=5,
+            stages={"initial": limit + 5},
+        )
+        # Overlaps one VISIBLE base sample; unseen overlap is unknowable.
+        extra = self._payload(samples=["chunk-000"])
+
+        merged = merge_truncation_metadata(base, extra)
+
+        assert merged["events"] == limit + 6
+        assert merged["affected"] == limit + 5  # sum minus the visible overlap
+        assert len(merged["samples"]) == limit
+        assert merged["samples_omitted"] == 5
+
+    def test_merged_samples_stay_capped(self):
+        from lightrag.utils import (
+            TRUNCATION_METADATA_SAMPLE_LIMIT,
+            merge_truncation_metadata,
+        )
+
+        limit = TRUNCATION_METADATA_SAMPLE_LIMIT
+        base = self._payload(
+            events=limit,
+            affected=limit,
+            samples=[f"base-{i}" for i in range(limit)],
+            stages={"initial": limit},
+        )
+        extra = self._payload(samples=["patch-0"])
+
+        merged = merge_truncation_metadata(base, extra)
+
+        assert len(merged["samples"]) == limit
+        # Base-first ordering: the patch subject is the one squeezed out.
+        assert merged["samples"] == base["samples"]
+        assert merged["affected"] == limit + 1
+        assert merged["samples_omitted"] == 1

--- a/tests/utils/test_truncation_tally.py
+++ b/tests/utils/test_truncation_tally.py
@@ -1,0 +1,129 @@
+"""``TokenLimitTruncationTally`` — the aggregation behind the truncation report.
+
+The tally exists so a document that truncates on every chunk produces ONE
+status line and ONE ``doc_status.metadata`` record instead of N of each. These
+tests pin the three properties that make that record trustworthy: events are
+counted per response while subjects are de-duplicated, the sample list is
+bounded independently of document size, and a clean run yields an EMPTY
+metadata fragment (which is what clears a previous attempt's summary, since
+the key is deliberately absent from the carry-over whitelist).
+"""
+
+import pytest
+
+from lightrag.utils import (
+    LLM_TRUNCATION_METADATA_KEY,
+    TRUNCATION_METADATA_SAMPLE_LIMIT,
+    TokenLimitTruncationTally,
+)
+
+pytestmark = pytest.mark.offline
+
+
+def test_a_clean_run_records_nothing():
+    tally = TokenLimitTruncationTally()
+
+    assert not tally
+    assert tally.events == 0
+    assert tally.affected == 0
+    assert tally.as_metadata() is None
+    # An empty fragment is load-bearing: it leaves the key out of the
+    # transition payload, which CLEARS a previous attempt's summary.
+    assert tally.as_metadata_extra() == {}
+
+
+def test_only_the_first_event_is_announced():
+    tally = TokenLimitTruncationTally()
+
+    assert tally.record("initial", "chunk-001") is True
+    assert tally.record("initial", "chunk-002") is False
+    assert tally.record("gleaning", "chunk-001") is False
+
+
+def test_events_count_responses_while_subjects_deduplicate():
+    """A chunk truncated at both stages is 2 events but 1 affected chunk."""
+    tally = TokenLimitTruncationTally()
+    tally.record("initial", "chunk-001")
+    tally.record("gleaning", "chunk-001")
+    tally.record("initial", "chunk-002")
+
+    assert tally.events == 3
+    assert tally.affected == 2
+    assert tally.as_metadata()["stages"] == {"initial": 2, "gleaning": 1}
+    assert tally.stage_breakdown() == "initial: 2, gleaning: 1"
+
+
+def test_absorb_folds_a_stage_tally_into_the_document_tally():
+    extraction = TokenLimitTruncationTally()
+    extraction.record("initial", "chunk-001")
+    extraction.record("gleaning", "chunk-001")
+    merge = TokenLimitTruncationTally()
+    merge.record("summary", "Entity:ALICE")
+
+    document = TokenLimitTruncationTally()
+    document.absorb(extraction)
+    document.absorb(merge)
+
+    assert document.events == 3
+    assert document.affected == 2
+    assert document.as_metadata()["stages"] == {
+        "initial": 1,
+        "gleaning": 1,
+        "summary": 1,
+    }
+    assert document.as_metadata()["samples"] == ["chunk-001", "Entity:ALICE"]
+
+
+def test_absorb_deduplicates_subjects_across_stages():
+    document = TokenLimitTruncationTally()
+    document.record("initial", "chunk-001")
+
+    other = TokenLimitTruncationTally()
+    other.record("summary", "chunk-001")
+    document.absorb(other)
+
+    assert document.events == 2
+    assert document.affected == 1
+
+
+def test_absorb_tolerates_an_absent_tally():
+    document = TokenLimitTruncationTally()
+    document.absorb(None)
+    document.absorb(TokenLimitTruncationTally())
+
+    assert not document
+
+
+def test_the_metadata_sample_is_bounded_by_document_size():
+    """doc_status rows are serialized into every listing response, so the
+    sample must not grow with the number of truncated chunks."""
+    tally = TokenLimitTruncationTally()
+    total = TRUNCATION_METADATA_SAMPLE_LIMIT + 7
+    for index in range(total):
+        tally.record("initial", f"chunk-{index:03d}")
+
+    payload = tally.as_metadata()
+
+    assert payload["events"] == total
+    assert payload["affected"] == total
+    assert len(payload["samples"]) == TRUNCATION_METADATA_SAMPLE_LIMIT
+    # First-seen order, so the sample points at the earliest chunks.
+    assert payload["samples"][0] == "chunk-000"
+    assert payload["samples_omitted"] == 7
+
+
+def test_no_omitted_counter_when_every_subject_fits():
+    tally = TokenLimitTruncationTally()
+    tally.record("initial", "chunk-001")
+
+    assert "samples_omitted" not in tally.as_metadata()
+
+
+def test_metadata_extra_is_keyed_for_the_doc_status_transition():
+    tally = TokenLimitTruncationTally()
+    tally.record("initial", "chunk-001")
+
+    extra = tally.as_metadata_extra()
+
+    assert set(extra) == {LLM_TRUNCATION_METADATA_KEY}
+    assert extra[LLM_TRUNCATION_METADATA_KEY]["events"] == 1


### PR DESCRIPTION
## Description

Token-limit truncation during KG building was effectively invisible to operators: a run could index a short — or completely empty — knowledge graph, and the document still reached `PROCESSED` with `/documents/track_status` reporting success. The only trace was a provider-level `WARNING` carrying no document or chunk identity.

This PR makes the condition observable, durable, and — for the one case where nothing at all was generated — fatal.

The root cause of the blindness was small: `TruncatedResponse` is a `str` subclass, but `remove_think_tags()` rebuilt it as a plain `str`, erasing the marker before `extract_entities()` could see it. With the marker preserved, the extraction stage can finally attribute what it observes.

## Related Issues

Closes #3601 (all four gaps). Related: #3597 (one concrete cause — thinking-capable Ollama models spending the whole `num_predict` budget on the reasoning trace), #3446 / #3448 (which introduced the `TruncatedResponse` marker this builds on).

## Changes Made

### 1. Preserve the truncation marker (#3601 gaps 2–3)

- `remove_think_tags()` re-wraps its result in `TruncatedResponse` when its input was truncated, so the marker survives sanitization on **both** the cache-enabled and the cache-disabled path. The latter never inspected the marker at all.
- The now-redundant pre-sanitization flag in `use_llm_func_with_cache` is gone: the cache guard and the caller read the same flag off the same value.

### 2. Report it to operators, without flooding the status ring (#3601 gap 1)

A document whose output budget is too small does not truncate once — it truncates on **every** chunk. One status line per event would evict the rest of the run from the bounded `history_messages` ring and still leave the operator counting lines. So:

| Channel | Behavior |
|---|---|
| Server log | Every occurrence, with chunk id + file path (unbounded by design) |
| `pipeline_status` | The **first** event immediately (a long run must not hide the condition until it ends) **+ one aggregate** per stage — independent of chunk count |
| `doc_status.metadata.llm_truncation` | Durable per-document summary that outlives the status ring and reaches `/documents` and the WebUI |

New `TokenLimitTruncationTally` (`lightrag/utils.py`) accumulates per stage and folds into a document-scoped tally:

```json
"llm_truncation": {
  "events": 15, "affected": 12,
  "stages": {"initial": 12, "gleaning": 2, "summary": 1, "multimodal": 1},
  "samples": ["chunk-001", "..."], "samples_omitted": 2
}
```

`samples` is capped (`TRUNCATION_METADATA_SAMPLE_LIMIT = 10`) — the doc_status row is serialized into every documents-listing response, so the summary must stay O(1) in document size.

Metadata write rules, which are the part worth reviewing closely:
- written at the **terminal** transition (PROCESSED, both FAILED stage boundaries, and the analyze-stage FAILED transition) — the first point at which the attempt's count is final;
- deliberately **not** in `_DOC_STATUS_METADATA_CARRY_OVER_KEYS`, so a re-run with a larger budget **clears** the key rather than resurrecting a stale summary;
- **is** in `_DOC_STATUS_METADATA_ATTEMPT_KEYS`, so a document reset to PENDING is normalized to directives-only.

### 3. Cover the summary stage too

Description summaries are LLM calls and truncate identically, silently persisting a cut-off description onto the entity/relation. `truncation_tally` is threaded through `merge_nodes_and_edges` → `_merge_{nodes,edges}_then_upsert` → `_handle_entity_relation_summary` → `_summarize_descriptions`, and checked **before** `sanitize_text_for_encoding` rebuilds a plain `str` and drops the marker.

### 4. Attribute parse failures to truncation

`Complete delimiter can not be found in extraction result` and `JSON extraction result is empty or unrecoverable` now append `(response was truncated by the model's output token limit)` when the marker says so — instead of leaving the operator to correlate two unrelated-looking warnings by chunk id.

### 5. Align empty-response semantics across bindings (#3601 gap 4)

The four bindings disagreed about a response that is **empty because generation was cut off before emitting a single content token**:

| Binding | Before | After |
|---|---|---|
| OpenAI | Raised, with full diagnostics + hint | Hint travels in the exception too; type is now `EmptyTruncatedResponseError` |
| **Ollama** | **Returned `""` → document PROCESSED with an empty graph** | **Raises**, with diagnostics + hint |
| Gemini | Raised, but message was `"Gemini response did not contain any text content."` — no diagnosis | Diagnostics + hint, **and a check after `remove_think_tags`**, typed `EmptyTruncatedResponseError` |
| Bedrock | Raised `"Received empty content from Bedrock API"` — no diagnosis | Diagnostics + hint |

The Gemini addition is a genuine bug fix: a thinking-only response arrives as `<think>…</think>`, which is **non-empty** at the existing pre-strip check, then gets stripped to `""` and was returned as a truncation-flagged empty success.

Shared wording lives in two helpers (`format_response_diagnostics`, `empty_length_truncated_hint`), so all four providers describe the failure identically and each only supplies its own budget knob:

```
Received empty content from Ollama API (done_reason=length, eval_count=64,
prompt_eval_count=900, thinking_len=28): generation hit the token limit before
emitting any content (budget consumed by reasoning); consider raising
OLLAMA_LLM_NUM_PREDICT or disabling thinking mode
```

The hint goes into the **exception** (and therefore `doc_status.error_msg`), because the operator reading the failed document is the one who has to turn the knob.

The bindings that **do** retry empty responses (OpenAI, Gemini) raise the new `EmptyTruncatedResponseError`, which is deliberately absent from every retry predicate; Ollama and Bedrock reach the same fail-fast outcome through their existing non-retried error types. Either way the length case costs exactly one request.

Both bindings that track token usage now **count it before** the empty-response raise: the request that burned its entire output budget on a reasoning trace is precisely the expensive one, and it used to be the one missing from usage accounting.

### 6. Keep the attempt metadata on an extract-stage failure

The extract-stage FAILED transition passed only the process timestamps while the merge-stage one re-passed `**extraction_meta`. None of those keys is carried over, so a document that failed during extraction described itself **less** than one that failed a stage later, losing `parse_format` / `parse_engine` / `chunk_method` / `mm_chunks`.

### 7. Cover the multimodal analyze stage

An accepted-but-truncated VLM analysis is *used* — the partial description feeds KG extraction — so it must be recorded too. The old marker check lived inside the cache-write guard, so with the analysis cache off it never ran at all (the same shape as gap 3).

`analyze_multimodal` now keeps a stage tally independent of the cache flag and hands its record to the process stage through the **analyze→process dict** rather than `doc_status`: the key is per-attempt (not carried over), so a stamp written there would be dropped at the PROCESSING transition. The hand-off runs in a `finally`, on **every** exit — a sibling item's fail-fast failure or a mid-VLM cancellation leaves the document FAILED at the analyze stage, never reaching the process stage's terminal writes, so `_analyze_worker` stamps the record onto its own FAILED transition.

### 8. Cover the custom-chunk path (`ainsert_custom_chunks`)

This entry point produces documents without going through the pipeline, so it needs the same durable evidence — and its recovery model is **additive** (a resume keeps the failed attempt's graph mutations instead of purging them), which makes the ordering requirements stricter than the pipeline's:

- an **operation-scoped tally** is fed by both KG stages and merged into the pre-operation snapshot at whichever terminal transition the operation reaches; rollback restores that snapshot exactly.
- the operation journal carries an **accumulated record across resumes** (`operation_llm_truncation`), so a clean resume cannot erase the evidence of truncated output the previous attempt already merged. It is always recomputed from the journal *as loaded* plus the live tally, never from the copy a previous write folded this attempt into — the payload merge sums event counts exactly, so folding twice would double-count.
- a **write-ahead hook** (`truncation_write_ahead`, mirroring the existing `on_anchors_durable`) journals a summary truncation *before* the object carrying that summary is upserted. Invariant: **any truncation event whose subject's graph mutation has landed is already journaled** — extraction events by the applying write, which precedes all merge mutation; summary events by the hook. The pipeline's own merges pass nothing here: a reprocess purges the previous attempt, so nothing truncated survives to warn about.

### 9. Publish the stage tallies on every exit

`extract_entities` and `merge_nodes_and_edges` used to hand their counts upward from explicit success/failure call sites, all of which sit *after* the `await` on their task set. An external cancellation landing on that await (or on an inter-phase yield) bypassed them, so already-recorded truncations never reached the caller's document tally — and for the custom-chunk path the failure bookkeeping then recomputed the journal from the incomplete tally, overwriting the write-ahead snapshot. Both now publish from a `finally` covering the whole wait/drain region; the helpers are idempotent and await-free, so they are safe in a cancellation unwind.

### 10. Keep the resumed custom-chunk recovery anchors complete

Truncated extraction responses are never cached, so a resumed operation genuinely re-runs the LLM and can extract a **different sample** — while the failed attempt's graph writes stay. Two places had to become unions rather than replacements, or first-attempt-only objects would be stranded from later purges (AGENTS.md's "the journal names the complete candidate superset"):

- the applying-phase journal write unions the previous attempt's `entity_names` / `relation_pairs`;
- the commit-time anchor union now also runs for **resumed creates**, whose merge writes `full_entities` / `full_relations` from the current attempt only and whose PROCESSED write clears the journal. A first-attempt create still skips it — Phase 0 wrote exactly those candidates.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (`env.example`: `OLLAMA_LLM_NUM_PREDICT` now notes the user-visible failure semantics)
- [x] Unit tests added

## Testing

New and extended coverage (~90 tests across 15 files):

| File | Covers |
|---|---|
| `tests/utils/test_truncation_tally.py` | Tally: event vs distinct-subject counting, `absorb`, bounded sample, empty-fragment-clears semantics, `merge_truncation_metadata` precision contract |
| `tests/extraction/test_truncation_reporting.py` | First-event + aggregate contract, aggregation bound (6 chunks → still 2 lines), gleaning round, cache enabled/disabled, mid-run failure, **cancellation on the task wait / between merge phases**, clean run, per-event server logging, summary stage, parse-failure attribution |
| `tests/pipeline/test_truncation_doc_status_metadata.py` | End-to-end through a real ingestion run, plus the carry-over / reset contracts |
| `tests/pipeline/test_pipeline_analyze_multimodal.py` | Analyze-stage recording (cache on **and** off), hand-off on the success and the fail-fast exits, the worker's FAILED/cancelled stamping |
| `tests/pipeline/test_custom_chunk_{patch,rollback}.py` | Operation tally on commit and failure, merge with the base document's record, rollback restore, **journal write-ahead ordering** (intercepted at the graph upsert), accumulation across resumes with no double-count, hard-crash-then-clean-resume, candidate + anchor unions for patch and resumed create |
| `tests/api/routes/test_document_status_truncation_metadata.py` | The key survives `DocStatusResponse`'s internal-metadata strip |
| `tests/pipeline/test_doc_status_chunk_preservation.py` | FAILED row keeps every key the PROCESSING transition wrote |
| `tests/llm/{ollama,gemini,bedrock,openai}_impl/` | Per binding: empty+length raise with diagnostics and hint, the reasoning-consumed-the-budget variant, non-length empty unchanged, partial-content salvage still working, usage counted before the raise |

Every regression test is a **fix-proof**: verified to fail *behaviorally* against the pre-fix code (a specific wrong value or missing record), not merely on a missing symbol.

Runs (against this branch, up to date with `main`):

- `tests/pipeline tests/extraction tests/utils`: `937 passed`
- Binding suites + LLM cache + the API route test: `88 passed`
- `ruff check` and project pre-commit hooks: clean

The failures visible locally (`test_entity_extraction_stability.py`, `test_ollama_role_kwargs.py`) reproduce unchanged on `main` in this sandbox — blocked tiktoken/model downloads, not related to this change.

## Additional Notes

Scope and deliberate non-changes, for the reviewer:

- **Only the token-limit case escalates to a failure.** An empty response that ended *normally* is the model's answer, not a broken generation, and `_ollama_model_if_cache` also serves query traffic. The token-limit case is deterministic and actionable, which is what makes raising the right call there.
- **Non-empty truncated content is still returned for salvage**, flagged uncacheable, exactly as before. The new check only intercepts responses with nothing in them.
- **Retry predicates are untouched; the deterministic case routes around them by TYPE.** Hitting the output token limit is a property of the prompt and the configured budget, so an empty+length response fails after one request in all four bindings — via `EmptyTruncatedResponseError` where the binding retries empty responses at all (OpenAI, Gemini), via the existing non-retried types elsewhere (Ollama, Bedrock). Every other empty mode keeps its binding's existing policy: those are sampling artifacts a fresh attempt can genuinely fix. Retrying the length case would re-buy the same full-budget generation to fail identically.
- **The `merge_truncation_metadata` payload merge is documented as lossy at the margins.** `events` and `stages` are exact sums; `affected` is exact whenever both sample lists are complete, and over-counts a subject visible in neither only past the 10-sample cap. Live tallies would be exact, but only the persisted payloads survive across a base run, a patch, and a resume.
- **Behavior change to flag:** with an Ollama/Gemini binding, a document whose extraction generated nothing because the budget was exhausted now ends `FAILED` and retryable, instead of `PROCESSED` with an empty graph. #3601 raised gating this behind a setting; it is implemented ungated on the grounds that "silently indexed an empty graph" is never the wanted outcome — happy to add a switch if maintainers prefer.
