### PR TITLE
perf(kg): drop the seed-degree round trip from PGTable traversal

### DIFF
--- a/lightrag/kg/pgtable_impl.py
+++ b/lightrag/kg/pgtable_impl.py
@@ -1093,8 +1093,8 @@ class PGTableGraphStorage(BaseGraphStorage):
         the server-side edge enumeration: ranking a hub's neighbours by degree
         requires visiting that hub's edges, which is a lower bound for any
         correct top-k-by-degree. Those scans are index-driven (see the UNION
-        note below) and no longer duplicated by a second node_degrees_batch
-        round trip.
+        note below) and are the only degree work the traversal does: there is no
+        node_degrees_batch round trip left, per hop or after the loop.
 
         Within each depth level the highest-degree unvisited neighbours are
         admitted first, so when the budget cuts a level the retained nodes are
@@ -1102,8 +1102,16 @@ class PGTableGraphStorage(BaseGraphStorage):
         prior recursive CTE (which degree-sorted the full reachable set before
         truncating). Returns ``(rows, degrees)``: rows are shaped like the
         wildcard path ({"id", "properties", "depth"}) and degrees maps every
-        collected node id to its full-graph degree, so the caller reuses them for
-        the final seed-pinned ordering instead of recomputing node_degrees_batch.
+        collected node id **except the seed** to its full-graph degree, so the
+        caller reuses them for the final ordering instead of recomputing
+        node_degrees_batch. The seed is excluded because that ordering cannot
+        reach its degree: the sort key is ``(id != node_label, depth, -degree,
+        id)`` and the seed wins on *both* leading elements independently — the
+        pin term is False only for the seed, and its depth is 0 while every
+        other collected row is at depth >= 1. So the comparison short-circuits
+        before the degree element no matter which of the two is relaxed, and the
+        seed's own degree cannot change the result. Callers must therefore read
+        this mapping with ``.get(id, 0)``.
         """
         seed_row = await self._fetchrow(
             "SELECT id, properties FROM lightrag_graph_nodes "
@@ -1210,11 +1218,11 @@ class PGTableGraphStorage(BaseGraphStorage):
                 }
                 next_frontier.append(nid)
             frontier = next_frontier
-        # The seed is never a candidate (it seeds the frontier), so its degree
-        # was never gathered in the loop — fetch it once for the ordering
-        # tie-break. Isolated seeds (no neighbours) also land here.
-        if seed not in degrees:
-            degrees[seed] = (await self.node_degrees_batch([seed])).get(seed, 0)
+        # No trailing round trip for the seed's own degree: get_knowledge_graph
+        # pins the seed at position 0, so that degree can never be compared (see
+        # the Returns note above). Fetching it cost every traversal one round
+        # trip, plus an O(deg(seed)) edge enumeration inside node_degrees_batch,
+        # to produce a value no caller reads.
         return list(collected.values()), degrees
 
     async def get_knowledge_graph(
@@ -1265,6 +1273,8 @@ class PGTableGraphStorage(BaseGraphStorage):
             # which the degree-aware truncation below orders on.
             # Degrees were gathered during the BFS (see _bfs_frontier) — reused
             # below instead of a second full node_degrees_batch over the set.
+            # They cover every collected node except the seed, which the sort
+            # below pins ahead of the degree term (hence the .get default).
             node_rows, degrees = await self._bfs_frontier(
                 node_label, max_depth, node_budget
             )
@@ -1274,7 +1284,9 @@ class PGTableGraphStorage(BaseGraphStorage):
 
         # Sort before truncation so the retained set is deterministic AND faithful
         # to the BFS-level semantics of the reference backends (networkx/AGE):
-        #   1. seed pinned to position 0 (exact-label queries),
+        #   1. seed pinned to position 0 (exact-label queries) — because term 1
+        #      already separates it from every other row, the seed's own degree is
+        #      never compared, which is why _bfs_frontier does not fetch it,
         #   2. shallower BFS depth first — never drop a near node for a distant one,
         #      which keeps the truncated subgraph connected to the seed,
         #   3. higher degree first within a depth level (matches networkx),

--- a/tests/kg/pgtable_impl/test_pgtable_graph_storage.py
+++ b/tests/kg/pgtable_impl/test_pgtable_graph_storage.py
@@ -758,15 +758,27 @@ async def test_get_knowledge_graph_bfs_depth_beats_degree_on_truncation():
 
 
 @pytest.mark.asyncio
-async def test_bfs_hop_ranks_and_caps_in_sql_without_per_level_degree_roundtrip():
+async def test_bfs_hop_ranks_and_caps_in_sql_without_any_degree_roundtrip():
     """Each hop must rank + cap server-side and cost ONE query.
 
     Previously a hop fetched every neighbour (full JSONB properties included),
     then issued a second node_degrees_batch round trip over that whole
     neighbourhood, then ranked and truncated in Python. On a hub that meant
     shipping the entire neighbour set just to discard all but `node_budget` of
-    it. node_degrees_batch must now be called exactly once — for the seed's
-    ordering tie-break — no matter how many levels are walked.
+    it.
+
+    node_degrees_batch must now not be awaited at all. It previously ran once
+    more, after the loop, to fill in the seed's own degree "for the ordering
+    tie-break" — but the seed's degree cannot affect that ordering.
+    get_knowledge_graph sorts on the tuple
+
+        (r["id"] != node_label, depth, -degrees[id], id)
+
+    and the seed wins on both leading elements independently: the first is False
+    only for the seed, and the seed's depth is 0 while every other collected row
+    is at depth >= 1. The comparison therefore short-circuits before the degree
+    element. That round trip also cost an O(deg(seed)) edge enumeration inside
+    node_degrees_batch — a full hub scan for a value no caller reads.
     """
     storage = make_storage()
 
@@ -790,10 +802,10 @@ async def test_bfs_hop_ranks_and_caps_in_sql_without_per_level_degree_roundtrip(
     ):
         rows, degrees = await storage._bfs_frontier("seed", max_depth=3, node_budget=10)
 
-    # Seed only — NOT once per level.
-    degrees_batch.assert_awaited_once_with(["seed"])
-    # Degrees come from the hop query itself.
-    assert degrees == {"a": 9, "b": 4, "c": 1, "seed": 7}
+    # Never — not once per level, and not once more for the seed.
+    degrees_batch.assert_not_awaited()
+    # Degrees come from the hop query itself, and carry no seed entry.
+    assert degrees == {"a": 9, "b": 4, "c": 1}
     assert [r["id"] for r in rows] == ["seed", "a", "b", "c"]
     assert [r["depth"] for r in rows] == [0, 1, 1, 2]
 
@@ -829,15 +841,98 @@ async def test_bfs_hop_cap_never_exceeds_remaining_budget():
     with (
         patch.object(storage, "_fetchrow", new=AsyncMock(return_value=seed_row)),
         patch.object(storage, "_fetch", new=fetch),
-        patch.object(
-            storage, "node_degrees_batch", new=AsyncMock(return_value={"seed": 0})
-        ),
     ):
         await storage._bfs_frontier("seed", max_depth=5, node_budget=1)
 
     # budget 1, seed already collected -> cap 1, and the loop stops after it.
     assert fetch.await_args_list[0].args[5] == 1
     assert fetch.await_count == 1
+
+
+def _bfs_mocks(hop_rows):
+    """Build mocks for the three DB entry points _bfs_frontier can reach.
+
+    Returns (fetchrow, fetch, degrees_batch) so a test can count round trips.
+    """
+    fetchrow = AsyncMock(
+        return_value={"id": "seed", "properties": json.dumps({"entity_id": "seed"})}
+    )
+    fetch = AsyncMock(side_effect=hop_rows)
+    degrees_batch = AsyncMock(return_value={"seed": 99})
+    return fetchrow, fetch, degrees_batch
+
+
+@pytest.mark.asyncio
+async def test_bfs_costs_one_round_trip_per_hop_plus_the_seed_lookup():
+    """Total DB round trips must be max_depth + 1, not max_depth + 2.
+
+    One _fetchrow for the seed row, one _fetch per hop, and nothing else. The
+    trailing node_degrees_batch call for the seed's own degree used to make this
+    max_depth + 2 for every single traversal.
+    """
+    storage = make_storage()
+    hop_rows = [
+        [{"id": "a", "properties": json.dumps({"entity_id": "a"}), "degree": 3}],
+        [{"id": "b", "properties": json.dumps({"entity_id": "b"}), "degree": 2}],
+        [{"id": "c", "properties": json.dumps({"entity_id": "c"}), "degree": 1}],
+    ]
+    fetchrow, fetch, degrees_batch = _bfs_mocks(hop_rows)
+
+    with (
+        patch.object(storage, "_fetchrow", new=fetchrow),
+        patch.object(storage, "_fetch", new=fetch),
+        patch.object(storage, "node_degrees_batch", new=degrees_batch),
+    ):
+        await storage._bfs_frontier("seed", max_depth=3, node_budget=100)
+
+    assert fetchrow.await_count == 1
+    assert fetch.await_count == 3
+    degrees_batch.assert_not_awaited()
+    total = fetchrow.await_count + fetch.await_count + degrees_batch.await_count
+    assert total == 3 + 1, f"expected max_depth + 1 round trips, got {total}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "max_depth,hop_rows,expected_fetches",
+    [
+        # No hop ever runs: the while condition fails before the first query.
+        pytest.param(0, [], 0, id="max_depth_0"),
+        # A seed whose neighbours are all already visited (or has none) — the
+        # hop query runs but returns zero rows, so no candidate row exists.
+        pytest.param(3, [[]], 1, id="isolated_seed"),
+    ],
+)
+async def test_bfs_degenerate_seeds_issue_no_degree_round_trip(
+    max_depth, hop_rows, expected_fetches
+):
+    """Degenerate seeds must not fall back to a degree round trip either.
+
+    These are the two cases where the seed's degree cannot be carried on a hop
+    row: with max_depth=0 no hop query is issued at all, and an isolated seed's
+    hop returns no rows to attach it to. A self-loop-only seed lands in the
+    second case while having a non-zero degree (self-loops count twice), so any
+    scheme that recovers the seed degree from hop output would be wrong here.
+    Not computing it at all is well-defined in both.
+    """
+    storage = make_storage()
+    fetchrow, fetch, degrees_batch = _bfs_mocks(hop_rows)
+
+    with (
+        patch.object(storage, "_fetchrow", new=fetchrow),
+        patch.object(storage, "_fetch", new=fetch),
+        patch.object(storage, "node_degrees_batch", new=degrees_batch),
+    ):
+        rows, degrees = await storage._bfs_frontier(
+            "seed", max_depth=max_depth, node_budget=10
+        )
+
+    assert fetchrow.await_count == 1
+    assert fetch.await_count == expected_fetches
+    degrees_batch.assert_not_awaited()
+    # The seed is still returned as a row; only its degree entry is absent.
+    assert [r["id"] for r in rows] == ["seed"]
+    assert degrees == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/kg/pgtable_impl/test_pgtable_smoke.py
+++ b/tests/kg/pgtable_impl/test_pgtable_smoke.py
@@ -501,6 +501,70 @@ async def test_get_knowledge_graph_truncation_prefers_high_degree(store):
     assert kg.is_truncated is True
 
 
+@pytest.mark.asyncio
+async def test_get_knowledge_graph_seed_leads_and_survives_truncation(store):
+    """The seed leads the result and survives truncation on its own merit.
+
+    _bfs_frontier deliberately does not fetch the seed's degree, so `degrees`
+    carries no entry for it and the ordering falls back to `.get(seed, 0)`.
+    This is the adversarial shape for that: the seed has the LOWEST real degree
+    in the graph, and the budget forces a cut. If the degree term ever preceded
+    the pin/depth terms, the seed would sort last on a 0 default and be the
+    first row dropped. Only a live DB proves it, because the neighbour degrees
+    here come from the hop query's real aggregate rather than a mock.
+    """
+    for x in ("seedlow", "big", "mid"):
+        await store.upsert_node(x, _node(x))
+    await store.upsert_edge("seedlow", "big", _edge())
+    await store.upsert_edge("seedlow", "mid", _edge())
+    # seedlow degree 2; boost the neighbours well past it (extras sit at depth 2)
+    for i in range(6):
+        await store.upsert_edge("big", f"bx{i}", _edge())
+    for i in range(3):
+        await store.upsert_edge("mid", f"mx{i}", _edge())
+
+    kg = await store.get_knowledge_graph("seedlow", max_depth=1, max_nodes=2)
+
+    assert kg.nodes[0].id == "seedlow", (
+        f"seed must lead regardless of its degree: {[n.id for n in kg.nodes]}"
+    )
+    # Budget 2 = seed + the single highest-degree neighbour.
+    assert [n.id for n in kg.nodes] == ["seedlow", "big"]
+    assert kg.is_truncated is True
+
+
+@pytest.mark.asyncio
+async def test_get_knowledge_graph_self_loop_seed(store):
+    """A seed whose only edge is a self-loop still returns cleanly.
+
+    The hop query finds the seed as its own neighbour, the visited anti-join
+    removes it, and the hop yields zero rows. The seed's degree is 2 here (a
+    self-loop counts on both the src and tgt arms) yet nothing in the traversal
+    reads it — the degenerate path that any scheme recovering the seed degree
+    from hop output would get wrong.
+    """
+    await store.upsert_node("loop", _node("loop"))
+    await store.upsert_edge("loop", "loop", _edge())
+    assert await store.node_degree("loop") == 2
+
+    kg = await store.get_knowledge_graph("loop", max_depth=3, max_nodes=10)
+
+    assert [n.id for n in kg.nodes] == ["loop"]
+    assert kg.is_truncated is False
+
+
+@pytest.mark.asyncio
+async def test_get_knowledge_graph_isolated_seed(store):
+    """An isolated seed returns itself, with no degree round trip to fall back on."""
+    await store.upsert_node("lonely", _node("lonely"))
+
+    kg = await store.get_knowledge_graph("lonely", max_depth=3, max_nodes=10)
+
+    assert [n.id for n in kg.nodes] == ["lonely"]
+    assert kg.edges == []
+    assert kg.is_truncated is False
+
+
 # ---------------------------------------------------------------------------
 # Real-PG semantics the mock-based unit tests cannot exercise
 # (FK visibility inside a data-modifying CTE, concurrent JSONB merge, atomic drop)
@@ -866,7 +930,14 @@ async def test_bfs_matches_degree_ordered_reference_traversal(store):
         assert {r["id"]: r["depth"] for r in rows} == expected, (
             f"BFS depths diverged for seed={seed} depth={max_depth} budget={budget}"
         )
+        # Degrees cover every collected node except the seed, whose degree the
+        # traversal deliberately never fetches (the caller pins it ahead of the
+        # degree term — see _bfs_frontier's Returns note). Assert the exclusion
+        # explicitly so a reintroduced round trip shows up as a failure here.
+        assert seed not in degrees, f"seed degree should not be fetched: {seed}"
         for row in rows:
+            if row["id"] == seed:
+                continue
             assert degrees[row["id"]] == degree.get(row["id"], 0), (
                 f"degree diverged for {row['id']}"
             )


### PR DESCRIPTION
## What

`PGTableGraphStorage._bfs_frontier` ends every traversal with one extra query for the seed's own degree. This removes it: a traversal goes from `max_depth + 2` round trips to `max_depth + 1`.

```python
# lightrag/kg/pgtable_impl.py — removed
if seed not in degrees:
    degrees[seed] = (await self.node_degrees_batch([seed])).get(seed, 0)
```

## Why it is always paid

The branch is not conditional in practice. The seed is placed into `collected` before the loop, so it rides the visited array on every hop and the `candidates` CTE anti-joins it out. It can never be a candidate row, so `degrees` can never gain a seed entry from the loop, so `seed not in degrees` is always true.

## Why the value is never read

`degrees` has exactly one consumer — the sort in `get_knowledge_graph`:

```python
node_rows.sort(key=lambda r: (
    node_label != "*" and r["id"] != node_label,   # 1
    r.get("depth", 0),                              # 2
    -degrees.get(r["id"], 0),                       # 3
    r["id"],
))
```

The seed wins on **both** leading elements independently:

- term 1 is `False` for the seed and `True` for every other row;
- term 2 is `0` for the seed, and every other collected row is at depth `>= 1` (BFS assigns shortest-hop distance).

So the tuple comparison short-circuits before term 3 no matter which of the two is relaxed, and the seed's own degree cannot change the ordering or which rows survive truncation.

The call therefore cost every traversal one round trip, plus an `O(deg(seed))` edge enumeration inside `node_degrees_batch`, to produce a value no caller reads.

## Contract

`_bfs_frontier` is private with a single caller, so the narrowed return value stays internal — no public behaviour changes, and no reference-backend parity is affected. The docstring now states that `degrees` omits the seed and that callers must read it with `.get(id, 0)` (which the one caller already does).

## Tests

Offline (`tests/kg/pgtable_impl/test_pgtable_graph_storage.py`):

- the existing hop test asserted the call had to happen once "for the seed's ordering tie-break"; it now asserts `node_degrees_batch` is **never** awaited and that `degrees` carries no seed entry, with the reasoning above inline so the inversion is deliberate and readable;
- new: exact round-trip accounting — one `_fetchrow` for the seed row plus one `_fetch` per hop, `max_depth + 1` total;
- new: the two degenerate seeds that have no hop row able to carry a seed degree — `max_depth=0` (no hop query is issued at all) and an isolated seed (the hop returns zero rows). These are regression guards: any scheme that recovers the seed degree from hop output is wrong in both, and a self-loop-only seed lands in the second case while having a non-zero degree.

Real PostgreSQL (`tests/kg/pgtable_impl/test_pgtable_smoke.py`), because a mock that hardcodes degrees would prove nothing here:

- the adversarial ordering shape — the seed has the **lowest** real degree in the graph and the budget forces a cut; it must still lead and survive;
- a self-loop-only seed (degree 2, hop yields nothing);
- an isolated seed;
- the existing degree-parity test against the in-memory reference walk now asserts the seed's absence from `degrees` explicitly, so a reintroduced round trip fails there too.

## Verification

- `pytest tests/kg/pgtable_impl/ -m offline` — 60 passed
- `pytest tests/kg/pgtable_impl/test_pgtable_smoke.py -m pg_smoke --run-integration` on PostgreSQL 18 — 43 passed
- `LIGHTRAG_GRAPH_STORAGE=PGTableGraphStorage pytest tests/kg/test_graph_storage.py -m integration --run-integration` — 8 passed, 0 skipped
- `pre-commit run --all-files` (ruff v0.15.17 as pinned) — passed
- full `pytest tests/ -m offline` in a CI-equivalent Debian/bash-5 container — 4769 passed, 45 skipped
- full `pytest tests/ -m offline` on local Python 3.12 and 3.14 venvs — 4759 passed on each