### PR TITLE
fix(parser): enforce OOXML member and DOCX image budgets

### DIFF
--- a/env.example
+++ b/env.example
@@ -299,9 +299,13 @@ LIGHTRAG_PARSER=*:native-teP,*:legacy-R
 ### over either limit is rejected and the document is recorded FAILED.
 ### The same budget also bounds the legacy engine's .pptx and .xlsx (both are
 ### the identical OPC/ZIP bomb class), enforced before those parse locally.
-### The ratio gate applies only above DOCX_RATIO_FLOOR_BYTES (measured in
-### uncompressed bytes), because small documents legitimately compress much
-### better than large ones. Raise the three gates
+### The ratio gate is applied archive-wide and to the cumulative expansion by
+### which individual members exceed their own ratio budgets, so member
+### splitting cannot dilute it. That excess receives a fixed
+### DOCX_RATIO_FLOOR_BYTES allowance plus a 1:1 allowance for archive bytes
+### outside those members. This permits repetitive XML backed by real stored
+### media without letting padding buy another ratio-cap multiple. Raise the
+### three gates
 ### (DOCX_MAX_UNCOMPRESSED_BYTES / DOCX_MAX_COMPRESSION_RATIO / DOCX_MAX_ENTRIES)
 ### only if a legitimate document is being refused; a non-positive value
 ### disables that gate. DOCX_RATIO_FLOOR_BYTES is the opposite — it is the
@@ -311,6 +315,17 @@ LIGHTRAG_PARSER=*:native-teP,*:legacy-R
 # DOCX_MAX_COMPRESSION_RATIO=100
 # DOCX_RATIO_FLOOR_BYTES=16777216
 # DOCX_MAX_ENTRIES=10000
+
+### Native DOCX embedded-image export budgets. Images are copied from the
+### archive in 1 MiB chunks, with a 25 MiB ceiling for one image and a 64 MiB
+### cumulative ceiling for one document. An over-budget image is skipped with
+### a parse warning; document text continues. Defaults are sized against the
+### five native parse workers so attacker-controlled output remains bounded.
+### Raise these only when retaining unusually large embedded images matters
+### more than the memory/disk ceiling. A zero or negative value is NOT
+### unlimited; it falls back to the safe default.
+# NATIVE_DOCX_IMAGE_MAX_BYTES=26214400
+# NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES=67108864
 
 ### Zip-bomb budget for the result BUNDLE an external parser engine (docling,
 ### mineru) returns — a zip fetched from the configured server and extracted

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -165,11 +165,12 @@ DEFAULT_P_REFERENCES_HEADINGS = ("References", "Bibliography", "参考文献")
 # buys at most the size it declared — which is the size this budget bounds.
 #
 # The ratio gate is what actually closes the amplification: 512 MiB alone would
-# still let a ~1 MB upload expand 500x. At 100:1 an attacker must upload ~5 MB
-# to reach the hard ceiling, which puts the upload-size and rate controls back
-# in play. It applies only above DEFAULT_DOCX_RATIO_FLOOR_BYTES, because small
-# documents legitimately compress far better than large ones and a floor-less
-# ratio gate would reject them.
+# still let a ~1 MB upload expand 500x. It is enforced both archive-wide and
+# against the cumulative expansion by which individual members exceed their
+# ratio budgets, so member splitting cannot dilute it. The allowance is the
+# fixed DEFAULT_DOCX_RATIO_FLOOR_BYTES plus archive bytes outside those members
+# at 1:1: real stored media can support repetitive XML, while padding cannot buy
+# another ratio-cap multiple of expansion.
 # The same budget governs the other OPC/OOXML formats the legacy engine parses
 # locally — .pptx (python-pptx) and .xlsx (openpyxl) are the identical ZIP-bomb
 # class — so the DOCX_* knobs below bound all three, enforced in the legacy
@@ -185,6 +186,16 @@ DEFAULT_DOCX_RATIO_FLOOR_BYTES = 16 * 1024 * 1024
 # Member-count ceiling. Its "checked after the central-directory walk" scope
 # note lives once, on the lightrag/parser/docx/zip_budget.py module docstring.
 DEFAULT_DOCX_MAX_ENTRIES = 10_000
+
+# Native DOCX embedded-image export budgets. Unlike the archive-wide limits
+# above, these cap the bytes materialized into ``*.blocks.assets``: one image
+# and the sum retained for one document. Sized like the native Markdown image
+# budgets so DEFAULT_MAX_PARALLEL_PARSE_NATIVE=5 keeps attacker-controlled
+# output bounded across concurrent parses. Env: NATIVE_DOCX_IMAGE_MAX_BYTES /
+# NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES, read live for each parse. Non-positive
+# values fall back to these safe defaults rather than disabling the guard.
+DEFAULT_NATIVE_DOCX_IMAGE_MAX_BYTES = 25 * 1024 * 1024
+DEFAULT_NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES = 64 * 1024 * 1024
 
 # Zip-bomb guards for the result BUNDLE an external parser engine (docling,
 # mineru) returns — a zip fetched from an operator-configured server and

--- a/lightrag/parser/docx/drawing_image_extractor.py
+++ b/lightrag/parser/docx/drawing_image_extractor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import posixpath
 import re
 import shutil
+import tempfile
 import zipfile
 from dataclasses import dataclass, field
 from html import escape, unescape
@@ -167,8 +168,6 @@ class DrawingExtractionContext:
                 PurePosixPath(rel.part_name).name or "image"
             )
             output_file = self.export_dir_path / filename
-            partial_file = output_file.with_name(f".{output_file.name}.part")
-            partial_file.unlink(missing_ok=True)
 
             try:
                 source = zf.open(info, "r")
@@ -177,7 +176,21 @@ class DrawingExtractionContext:
                 return None
 
             try:
-                with source, partial_file.open("wb") as output:
+                # Keep the temporary file in the destination directory so the
+                # final replace stays atomic, but allocate it exclusively: a
+                # deterministic ``.<name>.part`` can be a legitimate earlier
+                # asset and must never be unlinked or overwritten here.
+                with (
+                    source,
+                    tempfile.NamedTemporaryFile(
+                        mode="wb",
+                        prefix=".lightrag-docx-image-",
+                        suffix=".part",
+                        dir=self.export_dir_path,
+                        delete=False,
+                    ) as output,
+                ):
+                    partial_file = Path(output.name)
                     while True:
                         # Ask for at most one byte beyond what remains. That
                         # makes a lying metadata size a bounded stop too, while
@@ -201,18 +214,21 @@ class DrawingExtractionContext:
 
                 partial_file.replace(output_file)
             except _EmbeddedImageReadFailed as exc:
-                partial_file.unlink(missing_ok=True)
+                if partial_file is not None:
+                    partial_file.unlink(missing_ok=True)
                 source_error = exc.__cause__ or exc
                 self._record_image_read_failure(rel.part_name, source_error)
                 return None
             except _EmbeddedImageBudgetExceeded:
-                partial_file.unlink(missing_ok=True)
+                if partial_file is not None:
+                    partial_file.unlink(missing_ok=True)
                 self._record_image_budget_skip(
                     rel.part_name, max(declared_size, written)
                 )
                 return None
             except BaseException:
-                partial_file.unlink(missing_ok=True)
+                if partial_file is not None:
+                    partial_file.unlink(missing_ok=True)
                 raise
         finally:
             zf.close()

--- a/lightrag/parser/docx/drawing_image_extractor.py
+++ b/lightrag/parser/docx/drawing_image_extractor.py
@@ -105,6 +105,9 @@ class DrawingExtractionContext:
     parse_warnings: Optional[Dict[str, object]] = None
     _exported_part_to_relpath: Dict[str, str] = field(default_factory=dict)
     _skipped_parts: set[str] = field(default_factory=set, init=False, repr=False)
+    _reported_read_failure_parts: set[str] = field(
+        default_factory=set, init=False, repr=False
+    )
     _used_filenames: Dict[str, str] = field(default_factory=dict)
     _max_image_bytes: int = field(
         default_factory=_default_image_max_bytes, init=False, repr=False
@@ -142,15 +145,15 @@ class DrawingExtractionContext:
         written = 0
         try:
             zf = zipfile.ZipFile(self.docx_path, "r")
-        except Exception:
-            self._skipped_parts.add(rel.part_name)
+        except Exception as exc:
+            self._record_image_read_failure(rel.part_name, exc)
             return None
 
         try:
             try:
                 info = zf.getinfo(zip_member)
-            except Exception:
-                self._skipped_parts.add(rel.part_name)
+            except Exception as exc:
+                self._record_image_read_failure(rel.part_name, exc)
                 return None
 
             declared_size = max(0, info.file_size)
@@ -169,8 +172,8 @@ class DrawingExtractionContext:
 
             try:
                 source = zf.open(info, "r")
-            except Exception:
-                self._skipped_parts.add(rel.part_name)
+            except Exception as exc:
+                self._record_image_read_failure(rel.part_name, exc)
                 return None
 
             try:
@@ -197,9 +200,10 @@ class DrawingExtractionContext:
                         output.write(chunk)
 
                 partial_file.replace(output_file)
-            except _EmbeddedImageReadFailed:
+            except _EmbeddedImageReadFailed as exc:
                 partial_file.unlink(missing_ok=True)
-                self._skipped_parts.add(rel.part_name)
+                source_error = exc.__cause__ or exc
+                self._record_image_read_failure(rel.part_name, source_error)
                 return None
             except _EmbeddedImageBudgetExceeded:
                 partial_file.unlink(missing_ok=True)
@@ -218,6 +222,38 @@ class DrawingExtractionContext:
         self._exported_part_to_relpath[rel.part_name] = rel_path
         self._exported_image_bytes += written
         return rel_path
+
+    def _record_image_read_failure(self, part_name: str, error: BaseException) -> None:
+        """Record a ZIP-side image read failure without hiding retryability."""
+        retryable = isinstance(error, OSError)
+        if not retryable:
+            self._skipped_parts.add(part_name)
+
+        # Reporting is deduplicated separately from the skip verdict. A
+        # transient OSError must remain retryable for a later relationship,
+        # while a persistently damaged ZIP part should not flood logs.
+        if part_name in self._reported_read_failure_parts:
+            return
+        self._reported_read_failure_parts.add(part_name)
+
+        disposition = (
+            "later references will retry"
+            if retryable
+            else "the damaged or missing part will be skipped"
+        )
+        logger.warning(
+            "[parse_native] Failed to read DOCX image %s from %s (%s); %s",
+            safe_log_value(part_name),
+            safe_log_value(str(self.docx_path)),
+            safe_log_value(f"{type(error).__name__}: {error}"),
+            disposition,
+        )
+        if self.parse_warnings is None:
+            return
+        count_key = "docx_image_read_failed_count"
+        self.parse_warnings[count_key] = (
+            int(self.parse_warnings.get(count_key, 0) or 0) + 1
+        )
 
     def _record_image_budget_skip(self, part_name: str, byte_count: int) -> None:
         self._skipped_parts.add(part_name)

--- a/lightrag/parser/docx/drawing_image_extractor.py
+++ b/lightrag/parser/docx/drawing_image_extractor.py
@@ -16,6 +16,12 @@ from pathlib import Path, PurePosixPath
 from typing import Dict, Optional, Tuple
 from urllib.parse import urlparse
 
+from lightrag.constants import (
+    DEFAULT_NATIVE_DOCX_IMAGE_MAX_BYTES,
+    DEFAULT_NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES,
+)
+from lightrag.utils import get_env_value, logger, safe_log_value
+
 try:
     from defusedxml import ElementTree as ET
 except ImportError:  # pragma: no cover
@@ -44,6 +50,35 @@ DRAWING_PATTERN = re.compile(
 DRAWING_TAG_PATTERN = re.compile(r"<drawing\b[^>]*/>")
 DRAWING_ATTR_PATTERN = re.compile(r'([a-zA-Z_][\w:.-]*)="([^"]*)"')
 
+_IMAGE_COPY_CHUNK_BYTES = 1024 * 1024
+
+
+class _EmbeddedImageBudgetExceeded(Exception):
+    """Internal control flow for a runtime image-byte budget stop."""
+
+
+class _EmbeddedImageReadFailed(Exception):
+    """Internal wrapper that distinguishes ZIP reads from output writes."""
+
+
+def _positive_env_limit(name: str, default: int) -> int:
+    """Read a live security limit; non-positive never disables the guard."""
+    value = get_env_value(name, default, int)
+    return value if value > 0 else default
+
+
+def _default_image_max_bytes() -> int:
+    return _positive_env_limit(
+        "NATIVE_DOCX_IMAGE_MAX_BYTES", DEFAULT_NATIVE_DOCX_IMAGE_MAX_BYTES
+    )
+
+
+def _default_image_max_total_bytes() -> int:
+    return _positive_env_limit(
+        "NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES",
+        DEFAULT_NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES,
+    )
+
 
 @dataclass
 class DrawingRelationship:
@@ -67,8 +102,17 @@ class DrawingExtractionContext:
     export_dir_name: Optional[str] = None
     export_dir_path: Optional[Path] = None
     relationships: Dict[str, DrawingRelationship] = field(default_factory=dict)
+    parse_warnings: Optional[Dict[str, object]] = None
     _exported_part_to_relpath: Dict[str, str] = field(default_factory=dict)
+    _skipped_parts: set[str] = field(default_factory=set, init=False, repr=False)
     _used_filenames: Dict[str, str] = field(default_factory=dict)
+    _max_image_bytes: int = field(
+        default_factory=_default_image_max_bytes, init=False, repr=False
+    )
+    _max_total_image_bytes: int = field(
+        default_factory=_default_image_max_total_bytes, init=False, repr=False
+    )
+    _exported_image_bytes: int = field(default=0, init=False, repr=False)
 
     def resolve_relationship(self, rel_id: str) -> Optional[DrawingRelationship]:
         return self.relationships.get(rel_id)
@@ -89,25 +133,117 @@ class DrawingExtractionContext:
             return None
         if rel.part_name in self._exported_part_to_relpath:
             return self._exported_part_to_relpath[rel.part_name]
-
-        zip_member = rel.part_name.lstrip("/")
-        try:
-            with zipfile.ZipFile(self.docx_path, "r") as zf:
-                blob = zf.read(zip_member)
-        except Exception:
+        if rel.part_name in self._skipped_parts:
             return None
 
-        filename = self._dedupe_filename(PurePosixPath(rel.part_name).name or "image")
-        output_file = self.export_dir_path / filename
-        output_file.write_bytes(blob)
+        zip_member = rel.part_name.lstrip("/")
+        partial_file: Optional[Path] = None
+        declared_size = 0
+        written = 0
+        try:
+            zf = zipfile.ZipFile(self.docx_path, "r")
+        except Exception:
+            self._skipped_parts.add(rel.part_name)
+            return None
+
+        try:
+            try:
+                info = zf.getinfo(zip_member)
+            except Exception:
+                self._skipped_parts.add(rel.part_name)
+                return None
+
+            declared_size = max(0, info.file_size)
+            remaining = max(0, self._max_total_image_bytes - self._exported_image_bytes)
+            effective_limit = min(self._max_image_bytes, remaining)
+            if declared_size > effective_limit:
+                self._record_image_budget_skip(rel.part_name, declared_size)
+                return None
+
+            filename = self._available_filename(
+                PurePosixPath(rel.part_name).name or "image"
+            )
+            output_file = self.export_dir_path / filename
+            partial_file = output_file.with_name(f".{output_file.name}.part")
+            partial_file.unlink(missing_ok=True)
+
+            try:
+                source = zf.open(info, "r")
+            except Exception:
+                self._skipped_parts.add(rel.part_name)
+                return None
+
+            try:
+                with source, partial_file.open("wb") as output:
+                    while True:
+                        # Ask for at most one byte beyond what remains. That
+                        # makes a lying metadata size a bounded stop too, while
+                        # never materializing the full member in memory.
+                        read_size = min(
+                            _IMAGE_COPY_CHUNK_BYTES,
+                            max(1, effective_limit - written + 1),
+                        )
+                        try:
+                            chunk = source.read(read_size)
+                        except Exception as exc:
+                            raise _EmbeddedImageReadFailed from exc
+                        if not chunk:
+                            break
+                        written += len(chunk)
+                        if written > effective_limit:
+                            raise _EmbeddedImageBudgetExceeded
+                        # Output failures are operational errors and must fail
+                        # the parse instead of masquerading as a missing image.
+                        output.write(chunk)
+
+                partial_file.replace(output_file)
+            except _EmbeddedImageReadFailed:
+                partial_file.unlink(missing_ok=True)
+                self._skipped_parts.add(rel.part_name)
+                return None
+            except _EmbeddedImageBudgetExceeded:
+                partial_file.unlink(missing_ok=True)
+                self._record_image_budget_skip(
+                    rel.part_name, max(declared_size, written)
+                )
+                return None
+            except BaseException:
+                partial_file.unlink(missing_ok=True)
+                raise
+        finally:
+            zf.close()
 
         rel_path = str(PurePosixPath(self.export_dir_name) / filename)
+        self._used_filenames[filename] = filename
         self._exported_part_to_relpath[rel.part_name] = rel_path
+        self._exported_image_bytes += written
         return rel_path
 
-    def _dedupe_filename(self, base_name: str) -> str:
+    def _record_image_budget_skip(self, part_name: str, byte_count: int) -> None:
+        self._skipped_parts.add(part_name)
+        logger.warning(
+            "[parse_native] Skipping over-budget DOCX image %s from %s "
+            "(%d declared/observed bytes; per-image limit %d; "
+            "remaining document budget %d)",
+            safe_log_value(part_name),
+            safe_log_value(str(self.docx_path)),
+            max(0, byte_count),
+            self._max_image_bytes,
+            max(0, self._max_total_image_bytes - self._exported_image_bytes),
+        )
+        if self.parse_warnings is None:
+            return
+        count_key = "docx_image_budget_skipped_count"
+        bytes_key = "docx_image_budget_skipped_bytes"
+        self.parse_warnings[count_key] = (
+            int(self.parse_warnings.get(count_key, 0) or 0) + 1
+        )
+        self.parse_warnings[bytes_key] = int(
+            self.parse_warnings.get(bytes_key, 0) or 0
+        ) + max(0, byte_count)
+
+    def _available_filename(self, base_name: str) -> str:
         if base_name not in self._used_filenames:
-            self._used_filenames[base_name] = base_name
             return base_name
 
         stem = Path(base_name).stem
@@ -116,7 +252,6 @@ class DrawingExtractionContext:
         while True:
             candidate = f"{stem}_{index}{suffix}"
             if candidate not in self._used_filenames:
-                self._used_filenames[candidate] = candidate
                 return candidate
             index += 1
 

--- a/lightrag/parser/docx/parser.py
+++ b/lightrag/parser/docx/parser.py
@@ -76,14 +76,15 @@ class NativeDocxParser(NativeParserBase):
         )
         from lightrag.parser.docx.parse_document import extract_docx_blocks
 
+        warnings: dict[str, Any] = {}
         ctx = DrawingExtractionContext(
             docx_path=source,
             blocks_output_path=parsed_dir / f"{base_name}.blocks.jsonl",
             export_dir_name=asset_dir.name,
             export_dir_path=asset_dir,
+            parse_warnings=warnings,
         )
         load_relationships(ctx)
-        warnings: dict[str, Any] = {}
         metadata: dict[str, Any] = {}
         blocks = extract_docx_blocks(
             str(source),

--- a/lightrag/parser/docx/zip_budget.py
+++ b/lightrag/parser/docx/zip_budget.py
@@ -57,12 +57,15 @@ def _limits() -> tuple[int, int, int, int]:
     Returns ``(max_uncompressed, max_ratio, ratio_floor, max_entries)``. For
     the three GATES — ``max_uncompressed``, ``max_ratio``, ``max_entries`` — a
     non-positive value disables that gate. ``ratio_floor`` is NOT a gate: it is
-    the small-file EXEMPTION threshold for the ratio gate (the ratio is only
-    checked once uncompressed size exceeds it, because small documents
-    legitimately compress far better than large ones). A non-positive
+    the small-content EXEMPTION threshold for the ratio gate. The member-ratio
+    check sums the bytes by which over-ratio members exceed their individual
+    ratio budgets. The fixed floor plus the archive bytes outside those
+    members form the allowance for that excess. This lets real stored media
+    support highly repetitive XML at one byte per byte without letting it buy
+    another ``max_ratio``-fold expansion. The archive-wide ratio likewise
+    applies only once the archive total exceeds the floor. A non-positive
     ``ratio_floor`` therefore does the OPPOSITE of "disable" — it removes the
-    exemption and makes the ratio gate apply to every non-empty archive, its
-    strictest setting.
+    fixed exemption and makes both ratio views strictest.
     """
     return (
         get_env_value(
@@ -121,17 +124,65 @@ def enforce_docx_decompression_budget(source: Path | bytes, file_path: str) -> N
             f"(limit {max_entries}, env DOCX_MAX_ENTRIES)"
         )
 
-    total = sum(info.file_size for info in infos)
+    total = 0
+    over_ratio_excess_bytes = 0
+    over_ratio_compressed_bytes = 0
+    over_ratio_members = 0
+    for info in infos:
+        member_size = info.file_size
+        total += member_size
+
+        # The total ceiling necessarily bounds every member too, but keep the
+        # member verdict explicit: it rejects as soon as one entry alone is
+        # over budget and makes the protected quantity clear in the error.
+        if max_uncompressed > 0 and member_size > max_uncompressed:
+            raise DocxDecompressionBudgetError(
+                f"Refusing {file_path}: one archive member declares "
+                f"{member_size} uncompressed bytes (per-member limit "
+                f"{max_uncompressed}, env DOCX_MAX_UNCOMPRESSED_BYTES)"
+            )
+
+        if max_ratio <= 0 or member_size <= 0:
+            continue
+
+        # Give each member its own max_ratio * compressed-size allowance.
+        # Only the expansion beyond that allowance is suspicious. This is
+        # additive across members, so splitting cannot recreate a per-member
+        # floor. A positive member with no compressed bytes has no allowance.
+        member_ratio_budget = max(0, info.compress_size) * max_ratio
+        if member_size > member_ratio_budget:
+            over_ratio_members += 1
+            over_ratio_excess_bytes += member_size - member_ratio_budget
+            over_ratio_compressed_bytes += max(0, info.compress_size)
+
     if max_uncompressed > 0 and total > max_uncompressed:
         raise DocxDecompressionBudgetError(
             f"Refusing {file_path}: declares {total} uncompressed bytes "
             f"(limit {max_uncompressed}, env DOCX_MAX_UNCOMPRESSED_BYTES)"
         )
 
-    # Ratio is measured against the whole archive, not against the summed
-    # compress_size: the gap between them (local headers, the central
-    # directory itself) is part of what the attacker had to send. ``compressed``
-    # was derived above in the same dispatch that produced ``handle``.
+    # The floor exempts a fixed amount of excess high-ratio expansion. Real
+    # archive bytes outside those members add a 1:1 allowance: this preserves
+    # mixed OOXML documents with repetitive XML plus incompressible media, but
+    # padding cannot buy max_ratio-fold expansion and member splitting remains
+    # additive. Clamp a non-positive floor to zero (strictest fixed exemption).
+    supporting_archive_bytes = max(0, compressed - over_ratio_compressed_bytes)
+    excess_allowance = max(0, ratio_floor) + supporting_archive_bytes
+    if (
+        max_ratio > 0
+        and over_ratio_members > 0
+        and over_ratio_excess_bytes > excess_allowance
+    ):
+        raise DocxDecompressionBudgetError(
+            f"Refusing {file_path}: archive contains {over_ratio_members} "
+            f"over-ratio members with {over_ratio_excess_bytes} excess "
+            f"uncompressed bytes (allowance {excess_allowance}, limit "
+            f"{max_ratio}x, env DOCX_MAX_COMPRESSION_RATIO)"
+        )
+
+    # Retain the archive-wide gate as a second view of amplification. The
+    # member gate above closes stored-padding dilution; this one includes local
+    # headers and the central directory in what the attacker had to send.
     if (
         max_ratio > 0
         and compressed > 0

--- a/tests/parser/docx/test_drawing_image_extractor.py
+++ b/tests/parser/docx/test_drawing_image_extractor.py
@@ -8,7 +8,9 @@ image references travel through ``src`` and never through ``path``.
 from __future__ import annotations
 
 import zipfile
+from errno import ENOSPC
 from pathlib import Path
+from unittest import mock
 from xml.etree import ElementTree as ET
 
 import pytest
@@ -66,6 +68,18 @@ def _external_rel(target: str, image_format: str) -> DrawingRelationship:
     )
 
 
+def _embedded_rel(rel_id: str, filename: str) -> DrawingRelationship:
+    return DrawingRelationship(
+        rel_id=rel_id,
+        target=f"media/{filename}",
+        target_mode="",
+        rel_type=IMAGE_REL_TYPE,
+        part_name=f"/word/media/{filename}",
+        content_type="image/png",
+        image_format="png",
+    )
+
+
 @pytest.mark.offline
 @pytest.mark.parametrize(
     ("target", "image_format"),
@@ -102,10 +116,21 @@ def test_vml_external_imagedata_target_lands_in_src_not_path() -> None:
 
 
 @pytest.mark.offline
-def test_embedded_blip_still_exports_to_local_path(tmp_path: Path) -> None:
+def test_embedded_blip_streams_to_local_path_in_bounded_reads(
+    tmp_path: Path, monkeypatch
+) -> None:
     docx_path = tmp_path / "doc.docx"
     with zipfile.ZipFile(docx_path, "w") as zf:
         zf.writestr("word/media/image1.png", b"PNGDATA")
+
+    read_sizes = []
+    original_read = zipfile.ZipExtFile.read
+
+    def _record_read_size(self, size=-1):
+        read_sizes.append(size)
+        return original_read(self, size)
+
+    monkeypatch.setattr(zipfile.ZipExtFile, "read", _record_read_size)
 
     export_dir = tmp_path / "doc.blocks.assets"
     export_dir.mkdir()
@@ -114,15 +139,7 @@ def test_embedded_blip_still_exports_to_local_path(tmp_path: Path) -> None:
         export_dir_name="doc.blocks.assets",
         export_dir_path=export_dir,
     )
-    ctx.relationships["rId1"] = DrawingRelationship(
-        rel_id="rId1",
-        target="media/image1.png",
-        target_mode="",
-        rel_type=IMAGE_REL_TYPE,
-        part_name="/word/media/image1.png",
-        content_type="image/png",
-        image_format="png",
-    )
+    ctx.relationships["rId1"] = _embedded_rel("rId1", "image1.png")
 
     placeholder = extract_drawing_placeholder_from_element(
         _drawing_element("embed", "rId1"), ctx
@@ -133,3 +150,302 @@ def test_embedded_blip_still_exports_to_local_path(tmp_path: Path) -> None:
     assert attrs["format"] == "png"
     assert "src" not in attrs
     assert (export_dir / "image1.png").read_bytes() == b"PNGDATA"
+    assert read_sizes
+    assert all(0 < size <= 1024 * 1024 for size in read_sizes)
+
+
+@pytest.mark.offline
+def test_single_image_budget_skips_before_read_and_records_warning(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("NATIVE_DOCX_IMAGE_MAX_BYTES", "8")
+    monkeypatch.setenv("NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES", "64")
+    docx_path = tmp_path / "doc.docx"
+    with zipfile.ZipFile(docx_path, "w") as zf:
+        zf.writestr("word/media/image.png", b"123456789")
+
+    def _explode(*args, **kwargs):  # pragma: no cover - only on regression
+        raise AssertionError("oversized image was opened")
+
+    monkeypatch.setattr(zipfile.ZipFile, "open", _explode)
+    warnings = {}
+    export_dir = tmp_path / "assets"
+    export_dir.mkdir()
+    ctx = DrawingExtractionContext(
+        docx_path=docx_path,
+        export_dir_name="assets",
+        export_dir_path=export_dir,
+        parse_warnings=warnings,
+    )
+    rel = _embedded_rel("rId1", "image.png")
+    ctx.relationships["rId1"] = rel
+
+    with mock.patch(
+        "lightrag.parser.docx.drawing_image_extractor.logger.warning"
+    ) as log_warning:
+        placeholder = extract_drawing_placeholder_from_element(
+            _drawing_element("embed", "rId1"), ctx
+        )
+        for _ in range(499):
+            assert ctx.export_embedded_image(rel) is None
+
+    attrs = parse_drawing_attributes(placeholder)
+    assert "path" not in attrs
+    assert attrs["format"] == "png"
+    assert warnings == {
+        "docx_image_budget_skipped_count": 1,
+        "docx_image_budget_skipped_bytes": 9,
+    }
+    log_warning.assert_called_once()
+    assert "Skipping over-budget DOCX image" in log_warning.call_args.args[0]
+    assert log_warning.call_args.args[1] == "/word/media/image.png"
+    assert list(export_dir.iterdir()) == []
+
+
+@pytest.mark.offline
+def test_total_image_budget_counts_successes_once_and_skips_the_rest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("NATIVE_DOCX_IMAGE_MAX_BYTES", "8")
+    monkeypatch.setenv("NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES", "10")
+    docx_path = tmp_path / "doc.docx"
+    with zipfile.ZipFile(docx_path, "w") as zf:
+        zf.writestr("word/media/first.png", b"123456")
+        zf.writestr("word/media/second.png", b"abcdef")
+
+    warnings = {}
+    export_dir = tmp_path / "assets"
+    export_dir.mkdir()
+    ctx = DrawingExtractionContext(
+        docx_path=docx_path,
+        export_dir_name="assets",
+        export_dir_path=export_dir,
+        parse_warnings=warnings,
+    )
+    first = _embedded_rel("rId1", "first.png")
+    second = _embedded_rel("rId2", "second.png")
+
+    first_path = ctx.export_embedded_image(first)
+    assert first_path == "assets/first.png"
+    assert ctx.export_embedded_image(first) == first_path
+    assert ctx.export_embedded_image(second) is None
+
+    assert (export_dir / "first.png").read_bytes() == b"123456"
+    assert not (export_dir / "second.png").exists()
+    assert warnings == {
+        "docx_image_budget_skipped_count": 1,
+        "docx_image_budget_skipped_bytes": 6,
+    }
+
+
+@pytest.mark.offline
+def test_exact_image_and_total_budget_boundary_is_allowed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("NATIVE_DOCX_IMAGE_MAX_BYTES", "8")
+    monkeypatch.setenv("NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES", "8")
+    docx_path = tmp_path / "doc.docx"
+    with zipfile.ZipFile(docx_path, "w") as zf:
+        zf.writestr("word/media/image.png", b"12345678")
+
+    export_dir = tmp_path / "assets"
+    export_dir.mkdir()
+    ctx = DrawingExtractionContext(
+        docx_path=docx_path,
+        export_dir_name="assets",
+        export_dir_path=export_dir,
+    )
+
+    assert ctx.export_embedded_image(_embedded_rel("rId1", "image.png"))
+    assert (export_dir / "image.png").read_bytes() == b"12345678"
+
+
+@pytest.mark.offline
+def test_stream_failure_removes_partial_file(tmp_path: Path, monkeypatch) -> None:
+    data = b"A" * (1024 * 1024 + 1)
+    docx_path = tmp_path / "doc.docx"
+    with zipfile.ZipFile(docx_path, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("word/media/image.png", data)
+
+    original_read = zipfile.ZipExtFile.read
+    calls = 0
+
+    def _fail_second_read(self, size=-1):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("simulated stream failure")
+        return original_read(self, size)
+
+    monkeypatch.setattr(zipfile.ZipExtFile, "read", _fail_second_read)
+    export_dir = tmp_path / "assets"
+    export_dir.mkdir()
+    ctx = DrawingExtractionContext(
+        docx_path=docx_path,
+        export_dir_name="assets",
+        export_dir_path=export_dir,
+    )
+
+    assert ctx.export_embedded_image(_embedded_rel("rId1", "image.png")) is None
+    assert calls == 2
+    assert list(export_dir.iterdir()) == []
+
+
+@pytest.mark.offline
+def test_output_write_failure_propagates_and_removes_partial_file(
+    tmp_path: Path, monkeypatch
+) -> None:
+    docx_path = tmp_path / "doc.docx"
+    with zipfile.ZipFile(docx_path, "w") as zf:
+        zf.writestr("word/media/image.png", b"PNGDATA")
+
+    export_dir = tmp_path / "assets"
+    export_dir.mkdir()
+    ctx = DrawingExtractionContext(
+        docx_path=docx_path,
+        export_dir_name="assets",
+        export_dir_path=export_dir,
+        parse_warnings={},
+    )
+    original_open = Path.open
+
+    class _FailingWriter:
+        def __init__(self, path: Path):
+            self._output = original_open(path, "wb")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self._output.close()
+
+        def write(self, data: bytes):
+            self._output.write(data[:1])
+            raise OSError(ENOSPC, "simulated full disk")
+
+    def _fail_partial_write(path: Path, mode="r", *args, **kwargs):
+        if path.name.endswith(".part") and mode == "wb":
+            return _FailingWriter(path)
+        return original_open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _fail_partial_write)
+
+    with pytest.raises(OSError) as exc:
+        ctx.export_embedded_image(_embedded_rel("rId1", "image.png"))
+
+    assert exc.value.errno == ENOSPC
+    assert list(export_dir.iterdir()) == []
+    assert ctx.parse_warnings == {}
+    assert ctx._used_filenames == {}
+    assert ctx._skipped_parts == set()
+
+
+@pytest.mark.offline
+def test_failed_source_read_does_not_reserve_filename(tmp_path: Path, monkeypatch):
+    docx_path = tmp_path / "doc.docx"
+    with zipfile.ZipFile(docx_path, "w") as zf:
+        zf.writestr("word/media/image.png", b"BROKEN")
+        zf.writestr("word/alternate/image.png", b"GOOD")
+
+    original_read = zipfile.ZipExtFile.read
+    fail_once = True
+
+    def _fail_first_read(self, size=-1):
+        nonlocal fail_once
+        if fail_once:
+            fail_once = False
+            raise OSError("simulated source failure")
+        return original_read(self, size)
+
+    monkeypatch.setattr(zipfile.ZipExtFile, "read", _fail_first_read)
+    export_dir = tmp_path / "assets"
+    export_dir.mkdir()
+    ctx = DrawingExtractionContext(
+        docx_path=docx_path,
+        export_dir_name="assets",
+        export_dir_path=export_dir,
+    )
+    failed = _embedded_rel("rId1", "image.png")
+    successful = DrawingRelationship(
+        rel_id="rId2",
+        target="alternate/image.png",
+        target_mode="",
+        rel_type=IMAGE_REL_TYPE,
+        part_name="/word/alternate/image.png",
+        content_type="image/png",
+        image_format="png",
+    )
+
+    assert ctx.export_embedded_image(failed) is None
+    assert ctx.export_embedded_image(failed) is None
+    assert ctx.export_embedded_image(successful) == "assets/image.png"
+    assert (export_dir / "image.png").read_bytes() == b"GOOD"
+    assert not (export_dir / "image_2.png").exists()
+
+
+@pytest.mark.offline
+def test_non_positive_image_env_values_restore_safe_defaults(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from lightrag.constants import (
+        DEFAULT_NATIVE_DOCX_IMAGE_MAX_BYTES,
+        DEFAULT_NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES,
+    )
+
+    monkeypatch.setenv("NATIVE_DOCX_IMAGE_MAX_BYTES", "0")
+    monkeypatch.setenv("NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES", "-1")
+    ctx = DrawingExtractionContext(docx_path=tmp_path / "doc.docx")
+
+    assert ctx._max_image_bytes == DEFAULT_NATIVE_DOCX_IMAGE_MAX_BYTES
+    assert ctx._max_total_image_bytes == DEFAULT_NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES
+
+
+@pytest.mark.offline
+def test_native_parser_threads_image_budget_warnings(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from lightrag.parser.docx.parser import NativeDocxParser
+
+    monkeypatch.setenv("NATIVE_DOCX_IMAGE_MAX_BYTES", "4")
+    monkeypatch.setenv("NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES", "8")
+    source = tmp_path / "doc.docx"
+    with zipfile.ZipFile(source, "w") as zf:
+        zf.writestr("word/media/image.png", b"12345")
+    parsed_dir = tmp_path / "parsed"
+    asset_dir = parsed_dir / "doc.blocks.assets"
+    asset_dir.mkdir(parents=True)
+
+    def _extract_blocks(
+        file_path,
+        drawing_context=None,
+        parse_warnings=None,
+        parse_metadata=None,
+        **kwargs,
+    ):
+        assert drawing_context.parse_warnings is parse_warnings
+        assert (
+            drawing_context.export_embedded_image(_embedded_rel("rId1", "image.png"))
+            is None
+        )
+        return [{"content": "body"}]
+
+    with (
+        mock.patch("lightrag.parser.docx.drawing_image_extractor.load_relationships"),
+        mock.patch(
+            "lightrag.parser.docx.parse_document.extract_docx_blocks",
+            _extract_blocks,
+        ),
+    ):
+        blocks, warnings, metadata = NativeDocxParser().extract(
+            source,
+            parsed_dir=parsed_dir,
+            asset_dir=asset_dir,
+            base_name="doc",
+        )
+
+    assert blocks == [{"content": "body"}]
+    assert warnings == {
+        "docx_image_budget_skipped_count": 1,
+        "docx_image_budget_skipped_bytes": 5,
+    }
+    assert metadata == {}

--- a/tests/parser/docx/test_drawing_image_extractor.py
+++ b/tests/parser/docx/test_drawing_image_extractor.py
@@ -7,6 +7,7 @@ image references travel through ``src`` and never through ``path``.
 
 from __future__ import annotations
 
+import tempfile
 import zipfile
 from errno import EMFILE, ENOSPC
 from pathlib import Path
@@ -261,6 +262,33 @@ def test_exact_image_and_total_budget_boundary_is_allowed(
 
 
 @pytest.mark.offline
+def test_temporary_file_cannot_delete_an_existing_dot_part_asset(
+    tmp_path: Path,
+) -> None:
+    docx_path = tmp_path / "doc.docx"
+    with zipfile.ZipFile(docx_path, "w") as zf:
+        zf.writestr("word/media/.foo.part", b"FIRST")
+        zf.writestr("word/media/foo", b"SECOND")
+
+    export_dir = tmp_path / "assets"
+    export_dir.mkdir()
+    ctx = DrawingExtractionContext(
+        docx_path=docx_path,
+        export_dir_name="assets",
+        export_dir_path=export_dir,
+    )
+
+    first = _embedded_rel("rId1", ".foo.part")
+    second = _embedded_rel("rId2", "foo")
+    assert ctx.export_embedded_image(first) == "assets/.foo.part"
+    assert ctx.export_embedded_image(second) == "assets/foo"
+
+    assert (export_dir / ".foo.part").read_bytes() == b"FIRST"
+    assert (export_dir / "foo").read_bytes() == b"SECOND"
+    assert sorted(path.name for path in export_dir.iterdir()) == [".foo.part", "foo"]
+
+
+@pytest.mark.offline
 def test_transient_stream_failure_retries_and_removes_partial_file(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -407,28 +435,27 @@ def test_output_write_failure_propagates_and_removes_partial_file(
         export_dir_path=export_dir,
         parse_warnings={},
     )
-    original_open = Path.open
+    original_named_temporary_file = tempfile.NamedTemporaryFile
 
     class _FailingWriter:
-        def __init__(self, path: Path):
-            self._output = original_open(path, "wb")
+        def __init__(self, output):
+            self._output = output
+            self.name = output.name
 
         def __enter__(self):
             return self
 
         def __exit__(self, *args):
-            self._output.close()
+            return self._output.__exit__(*args)
 
         def write(self, data: bytes):
             self._output.write(data[:1])
             raise OSError(ENOSPC, "simulated full disk")
 
-    def _fail_partial_write(path: Path, mode="r", *args, **kwargs):
-        if path.name.endswith(".part") and mode == "wb":
-            return _FailingWriter(path)
-        return original_open(path, mode, *args, **kwargs)
+    def _fail_partial_write(*args, **kwargs):
+        return _FailingWriter(original_named_temporary_file(*args, **kwargs))
 
-    monkeypatch.setattr(Path, "open", _fail_partial_write)
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", _fail_partial_write)
 
     with pytest.raises(OSError) as exc:
         ctx.export_embedded_image(_embedded_rel("rId1", "image.png"))

--- a/tests/parser/docx/test_drawing_image_extractor.py
+++ b/tests/parser/docx/test_drawing_image_extractor.py
@@ -8,7 +8,7 @@ image references travel through ``src`` and never through ``path``.
 from __future__ import annotations
 
 import zipfile
-from errno import ENOSPC
+from errno import EMFILE, ENOSPC
 from pathlib import Path
 from unittest import mock
 from xml.etree import ElementTree as ET
@@ -261,7 +261,9 @@ def test_exact_image_and_total_budget_boundary_is_allowed(
 
 
 @pytest.mark.offline
-def test_stream_failure_removes_partial_file(tmp_path: Path, monkeypatch) -> None:
+def test_transient_stream_failure_retries_and_removes_partial_file(
+    tmp_path: Path, monkeypatch
+) -> None:
     data = b"A" * (1024 * 1024 + 1)
     docx_path = tmp_path / "doc.docx"
     with zipfile.ZipFile(docx_path, "w", compression=zipfile.ZIP_STORED) as zf:
@@ -284,11 +286,109 @@ def test_stream_failure_removes_partial_file(tmp_path: Path, monkeypatch) -> Non
         docx_path=docx_path,
         export_dir_name="assets",
         export_dir_path=export_dir,
+        parse_warnings={},
     )
+    rel = _embedded_rel("rId1", "image.png")
 
-    assert ctx.export_embedded_image(_embedded_rel("rId1", "image.png")) is None
-    assert calls == 2
-    assert list(export_dir.iterdir()) == []
+    with mock.patch(
+        "lightrag.parser.docx.drawing_image_extractor.logger.warning"
+    ) as log_warning:
+        assert ctx.export_embedded_image(rel) is None
+        assert calls == 2
+        assert list(export_dir.iterdir()) == []
+
+        assert ctx.export_embedded_image(rel) == "assets/image.png"
+
+    assert (export_dir / "image.png").read_bytes() == data
+    assert rel.part_name not in ctx._skipped_parts
+    assert ctx.parse_warnings == {"docx_image_read_failed_count": 1}
+    log_warning.assert_called_once()
+    assert log_warning.call_args.args[4] == "later references will retry"
+
+
+@pytest.mark.offline
+def test_transient_zip_open_failure_retries_and_records_warning(
+    tmp_path: Path, monkeypatch
+) -> None:
+    docx_path = tmp_path / "doc.docx"
+    with zipfile.ZipFile(docx_path, "w") as zf:
+        zf.writestr("word/media/image.png", b"PNGDATA")
+
+    original_open = zipfile.ZipFile.open
+    open_calls = 0
+
+    def _fail_first_open(self, *args, **kwargs):
+        nonlocal open_calls
+        open_calls += 1
+        if open_calls == 1:
+            raise OSError(EMFILE, "simulated descriptor exhaustion")
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile.ZipFile, "open", _fail_first_open)
+    export_dir = tmp_path / "assets"
+    export_dir.mkdir()
+    ctx = DrawingExtractionContext(
+        docx_path=docx_path,
+        export_dir_name="assets",
+        export_dir_path=export_dir,
+        parse_warnings={},
+    )
+    rel = _embedded_rel("rId1", "image.png")
+
+    with mock.patch(
+        "lightrag.parser.docx.drawing_image_extractor.logger.warning"
+    ) as log_warning:
+        assert ctx.export_embedded_image(rel) is None
+        assert ctx.export_embedded_image(rel) == "assets/image.png"
+
+    assert open_calls == 2
+    assert (export_dir / "image.png").read_bytes() == b"PNGDATA"
+    assert rel.part_name not in ctx._skipped_parts
+    assert ctx.parse_warnings == {"docx_image_read_failed_count": 1}
+    log_warning.assert_called_once()
+    assert "OSError" in log_warning.call_args.args[3]
+    assert log_warning.call_args.args[4] == "later references will retry"
+
+
+@pytest.mark.offline
+def test_permanent_zip_failure_is_reported_once_and_memoized(
+    tmp_path: Path, monkeypatch
+) -> None:
+    docx_path = tmp_path / "doc.docx"
+    with zipfile.ZipFile(docx_path, "w") as zf:
+        zf.writestr("word/media/image.png", b"PNGDATA")
+
+    open_calls = 0
+
+    def _fail_open(*args, **kwargs):
+        nonlocal open_calls
+        open_calls += 1
+        raise zipfile.BadZipFile("simulated corrupt member")
+
+    monkeypatch.setattr(zipfile.ZipFile, "open", _fail_open)
+    export_dir = tmp_path / "assets"
+    export_dir.mkdir()
+    ctx = DrawingExtractionContext(
+        docx_path=docx_path,
+        export_dir_name="assets",
+        export_dir_path=export_dir,
+        parse_warnings={},
+    )
+    rel = _embedded_rel("rId1", "image.png")
+
+    with mock.patch(
+        "lightrag.parser.docx.drawing_image_extractor.logger.warning"
+    ) as log_warning:
+        assert ctx.export_embedded_image(rel) is None
+        assert ctx.export_embedded_image(rel) is None
+
+    assert open_calls == 1
+    assert rel.part_name in ctx._skipped_parts
+    assert ctx.parse_warnings == {"docx_image_read_failed_count": 1}
+    log_warning.assert_called_once()
+    assert log_warning.call_args.args[4] == (
+        "the damaged or missing part will be skipped"
+    )
 
 
 @pytest.mark.offline
@@ -377,7 +477,7 @@ def test_failed_source_read_does_not_reserve_filename(tmp_path: Path, monkeypatc
     )
 
     assert ctx.export_embedded_image(failed) is None
-    assert ctx.export_embedded_image(failed) is None
+    assert failed.part_name not in ctx._skipped_parts
     assert ctx.export_embedded_image(successful) == "assets/image.png"
     assert (export_dir / "image.png").read_bytes() == b"GOOD"
     assert not (export_dir / "image_2.png").exists()

--- a/tests/parser/docx/test_zip_budget.py
+++ b/tests/parser/docx/test_zip_budget.py
@@ -17,6 +17,7 @@ symbol.
 from __future__ import annotations
 
 import io
+import os
 import struct
 import zipfile
 from functools import lru_cache
@@ -98,6 +99,24 @@ def _benign(path: Path) -> Path:
     return _write_docx(path, body_xml="<w:p><w:r><w:t>hello world</w:t></w:r></w:p>")
 
 
+def _write_padded_high_ratio_zip(
+    path: Path,
+    *,
+    member_sizes: list[int],
+    padding_size: int,
+) -> Path:
+    """Write high-ratio members plus unrelated incompressible stored padding."""
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED, compresslevel=9) as zf:
+        for index, size in enumerate(member_sizes):
+            zf.writestr(f"payload-{index}.bin", b"\0" * size)
+        zf.writestr(
+            "padding.bin",
+            os.urandom(padding_size),
+            compress_type=zipfile.ZIP_STORED,
+        )
+    return path
+
+
 # --- fix proof -------------------------------------------------------------
 
 
@@ -165,6 +184,146 @@ def test_ratio_gate_refuses_below_the_absolute_ceiling(tmp_path, monkeypatch):
     assert total < 512 * 1024 * 1024  # under the hard cap...
     with pytest.raises(DocxDecompressionBudgetError):  # ...refused anyway
         enforce_docx_decompression_budget(src, "ratio.docx")
+
+
+def test_member_ratio_rejects_stored_padding_before_decompression(
+    tmp_path, monkeypatch
+):
+    """Unrelated stored bytes must not dilute a 1000x member below the cap."""
+    monkeypatch.setenv("DOCX_MAX_UNCOMPRESSED_BYTES", str(8 * 1024 * 1024))
+    monkeypatch.setenv("DOCX_MAX_COMPRESSION_RATIO", "100")
+    monkeypatch.setenv("DOCX_RATIO_FLOOR_BYTES", str(1024 * 1024))
+    src = _write_padded_high_ratio_zip(
+        tmp_path / "padded.docx",
+        member_sizes=[4 * 1024 * 1024],
+        padding_size=64 * 1024,
+    )
+
+    with zipfile.ZipFile(src) as zf:
+        infos = zf.infolist()
+        total = sum(info.file_size for info in infos)
+        assert total / src.stat().st_size < 100
+        assert infos[0].file_size / infos[0].compress_size > 1000
+
+    def _explode(*args, **kwargs):  # pragma: no cover - only on regression
+        raise AssertionError("member-ratio guard decompressed a member")
+
+    monkeypatch.setattr(zipfile.ZipFile, "read", _explode)
+    monkeypatch.setattr(zipfile.ZipFile, "open", _explode)
+
+    with pytest.raises(DocxDecompressionBudgetError) as exc:
+        NativeDocxParser().validate_source_blocking(src, "padded.docx")
+
+    message = str(exc.value)
+    assert "over-ratio members" in message
+    assert "payload-0.bin" not in message
+
+
+def test_real_stored_content_supports_repetitive_xml_one_for_one(tmp_path, monkeypatch):
+    """Real media may offset excess XML expansion, but only byte for byte.
+
+    The former absolute member-floor rule rejected this mixed archive even
+    though its total ratio is low. The stored bytes here model JPEG/media
+    payloads; unlike a ratio multiplier, their allowance equals their cost.
+    """
+    mib = 1024 * 1024
+    monkeypatch.setenv("DOCX_MAX_UNCOMPRESSED_BYTES", str(16 * mib))
+    monkeypatch.setenv("DOCX_MAX_COMPRESSION_RATIO", "100")
+    monkeypatch.setenv("DOCX_RATIO_FLOOR_BYTES", str(mib))
+    src = _write_padded_high_ratio_zip(
+        tmp_path / "mixed.docx",
+        member_sizes=[6 * mib],
+        padding_size=5 * mib,
+    )
+
+    with zipfile.ZipFile(src) as zf:
+        infos = zf.infolist()
+        assert infos[0].file_size / infos[0].compress_size > 100
+        assert sum(info.file_size for info in infos) / src.stat().st_size < 100
+
+    enforce_docx_decompression_budget(src, src.name)
+
+
+@pytest.mark.parametrize("suffix", ["docx", "pptx", "xlsx"])
+def test_padded_member_is_rejected_by_every_legacy_ooxml_entrypoint(
+    tmp_path, monkeypatch, suffix
+):
+    from lightrag.parser.legacy.extractors import extract_text
+
+    monkeypatch.setenv("DOCX_MAX_UNCOMPRESSED_BYTES", str(8 * 1024 * 1024))
+    monkeypatch.setenv("DOCX_MAX_COMPRESSION_RATIO", "100")
+    monkeypatch.setenv("DOCX_RATIO_FLOOR_BYTES", str(1024 * 1024))
+    payload = _write_padded_high_ratio_zip(
+        tmp_path / f"padded.{suffix}",
+        member_sizes=[4 * 1024 * 1024],
+        padding_size=64 * 1024,
+    ).read_bytes()
+
+    with pytest.raises(DocxDecompressionBudgetError):
+        extract_text(payload, suffix, file_path=f"padded.{suffix}")
+
+
+def test_ratio_floor_applies_to_cumulative_high_ratio_member_bytes(
+    tmp_path, monkeypatch
+):
+    """Splitting a bomb into individually-sub-floor members must not bypass."""
+    floor = 1024 * 1024
+    monkeypatch.setenv("DOCX_MAX_UNCOMPRESSED_BYTES", str(8 * 1024 * 1024))
+    monkeypatch.setenv("DOCX_MAX_COMPRESSION_RATIO", "100")
+    monkeypatch.setenv("DOCX_RATIO_FLOOR_BYTES", str(floor))
+    src = _write_padded_high_ratio_zip(
+        tmp_path / "split.docx",
+        member_sizes=[floor // 2, floor // 2, floor // 2],
+        padding_size=64 * 1024,
+    )
+
+    with zipfile.ZipFile(src) as zf:
+        infos = zf.infolist()
+        assert all(info.file_size <= floor for info in infos)
+        assert sum(info.file_size for info in infos) / src.stat().st_size < 100
+
+    with pytest.raises(DocxDecompressionBudgetError, match="over-ratio members"):
+        enforce_docx_decompression_budget(src, "split.docx")
+
+
+@pytest.mark.parametrize("high_ratio_bytes", [512 * 1024, 1024 * 1024])
+def test_cumulative_member_ratio_floor_keeps_small_content_exempt(
+    tmp_path, monkeypatch, high_ratio_bytes
+):
+    """The exemption includes its exact boundary and ignores stored padding."""
+    floor = 1024 * 1024
+    monkeypatch.setenv("DOCX_MAX_UNCOMPRESSED_BYTES", str(8 * 1024 * 1024))
+    monkeypatch.setenv("DOCX_MAX_COMPRESSION_RATIO", "100")
+    monkeypatch.setenv("DOCX_RATIO_FLOOR_BYTES", str(floor))
+    src = _write_padded_high_ratio_zip(
+        tmp_path / f"small-{high_ratio_bytes}.docx",
+        member_sizes=[high_ratio_bytes],
+        padding_size=64 * 1024,
+    )
+
+    enforce_docx_decompression_budget(src, src.name)
+
+
+def test_negative_ratio_floor_rejects_only_archives_with_over_ratio_members(
+    tmp_path, monkeypatch
+):
+    """A negative floor removes the exemption; it does not reject ratio-safe ZIPs."""
+    monkeypatch.setenv("DOCX_MAX_UNCOMPRESSED_BYTES", str(8 * 1024 * 1024))
+    monkeypatch.setenv("DOCX_MAX_COMPRESSION_RATIO", "100")
+    monkeypatch.setenv("DOCX_RATIO_FLOOR_BYTES", "-1")
+
+    safe = tmp_path / "stored.docx"
+    with zipfile.ZipFile(safe, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("stored.bin", b"A" * 1024)
+    enforce_docx_decompression_budget(safe, safe.name)
+
+    high_ratio = _write_padded_high_ratio_zip(
+        tmp_path / "strict.docx",
+        member_sizes=[512 * 1024],
+        padding_size=64 * 1024,
+    )
+    with pytest.raises(DocxDecompressionBudgetError, match="over-ratio members"):
+        enforce_docx_decompression_budget(high_ratio, high_ratio.name)
 
 
 def test_ratio_floor_exempts_small_documents(tmp_path, monkeypatch):


### PR DESCRIPTION
## Description

Close the residual OOXML decompression-budget bypass left after #3614. The archive-wide compression ratio could be diluted with unrelated stored padding, and individually small high-ratio members could be split below the existing exemption floor. Native DOCX image export also still materialized each embedded member in memory before writing it to disk.

This change charges each high-ratio member for the uncompressed bytes beyond its own ratio budget. The fixed floor plus archive bytes outside those members provide a 1:1 allowance, preserving legitimate repetitive XML backed by real media without letting padding buy another ratio-cap multiple of expansion. Embedded DOCX images are streamed under explicit per-image and per-document budgets. Archive-level thresholds and parser architecture remain unchanged.

## Related Issues

- GHSA-9p96-5j78-2f9x
- GHSA-2wpj-ffvv-2pq8
- Follow-up to #3614

## Changes Made

- Check each OOXML member's declared compression ratio and accumulate expansion beyond its individual ratio budget, preventing stored-padding dilution and member splitting while retaining compatibility with mixed XML/media documents.
- Preserve the existing total-size, archive-ratio, entry-count, environment override, and pre-extraction failure semantics.
- Stream native DOCX embedded images in bounded chunks through an atomic partial file instead of calling `ZipFile.read()`.
- Add live `NATIVE_DOCX_IMAGE_MAX_BYTES` (25 MiB) and `NATIVE_DOCX_IMAGE_MAX_TOTAL_BYTES` (64 MiB) limits; over-budget parts are memoized, logged once, and reported once through parse warnings while document text continues.
- Propagate destination filesystem failures such as ENOSPC/EACCES after partial-file cleanup.
- Keep ZIP-side `OSError` failures such as EMFILE retryable on later relationships; permanent missing/corrupt-part failures remain memoized. Both paths emit one sanitized log and one parse warning per affected part.
- Allocate staging files exclusively in the destination directory, preserving atomic replacement without allowing a deterministic temp path to delete or overwrite a legitimate exported asset.
- Reserve exported filenames and charge total bytes only after a successful atomic replace.
- Add fix-proof coverage for native/legacy DOCX, PPTX, XLSX, legitimate mixed content, image limits, repeated relationships, exact boundaries, transient and permanent ZIP failures, temp-name collisions, destination failures, partial-file cleanup, logging, and warning propagation.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

- Focused DOCX budget and drawing tests: 47 passed.
- Full parser suite: 1,500 passed.
- Full pipeline suite: 662 passed (2,162 combined).
- `ruff check .`: passed.
- `ruff format --check .`: 637 files already formatted.
- Full-scale regression: a 5.39 MiB archive declaring 405 MiB uncompressed at a 75.2x aggregate ratio is refused because its 1028.8x member has 378,662,400 excess bytes against a 22,020,368-byte allowance.
- No advisory state, patched-version metadata, process isolation, or parser scheduling behavior is changed in this PR.
