### PR TITLE
fix(graph): validate attributes on the manual entity/relation APIs (GHSA-c922-pw4m-4wcv)

### DIFF
--- a/lightrag/api/routers/graph_routes.py
+++ b/lightrag/api/routers/graph_routes.py
@@ -291,7 +291,10 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
         Args:
             request (EntityUpdateRequest): Request containing:
                 - entity_name (str): Name of the entity to update
-                - updated_data (Dict[str, Any]): Dictionary of properties to update
+                - updated_data (Dict[str, Any]): Properties to update. Only
+                  entity_name (rename target), entity_type, description,
+                  source_id and file_path are accepted, each as a string; any
+                  other key or a non-string value is rejected with 400.
                 - allow_rename (bool): Whether to allow entity renaming (default: False)
                 - allow_merge (bool): Whether to merge into existing entity when renaming
                                      causes name conflict (default: False)
@@ -476,7 +479,11 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
         """Update a relation's properties in the knowledge graph
 
         Args:
-            request (RelationUpdateRequest): Request containing source ID, target ID and updated data
+            request (RelationUpdateRequest): Request containing source ID,
+                target ID and updated data. Only description, keywords,
+                source_id and file_path (strings) and weight (number) are
+                accepted in updated_data; any other key or a value of the wrong
+                shape is rejected with 400.
 
         Returns:
             Dict: Updated relation information

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -673,6 +673,23 @@ class BaseGraphStorage(StorageNameSpace, ABC):
         2. Only one process should updating the storage at a time before index_done_callback,
            KG-storage-log should be used to avoid data corruption
 
+        Attribute contract (applies to ``upsert_edge`` and the batch variants
+        too):
+            Every attribute name must be a plain identifier
+            (``[A-Za-z_][A-Za-z0-9_]*``) and every value must be a storable
+            scalar -- ``str`` (XML-compatible), ``int``, finite ``float``, or
+            ``bool``. Nothing else: no nested containers, and no ``None``.
+
+            This is the intersection of what the registered backends can carry,
+            and callers are responsible for it because the backends disagree on
+            what happens when it is violated. The same non-scalar is refused by
+            the Neo4j driver, stored verbatim by MongoDB and by
+            PostgreSQL's ``jsonb`` column, and fatal to GraphML serialization;
+            ``None`` deletes the property on the Cypher backends but is a hard
+            error on NetworkX. ``lightrag.utils.validate_graph_attributes``
+            is the shared enforcement point -- prefer it over re-deriving the
+            rule per backend.
+
         Args:
             node_id: The ID of the node to insert or update
             node_data: A dictionary of node properties

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -6755,6 +6755,17 @@ _XML_INCOMPATIBLE_CHAR_PATTERN = re.compile(
 # field) and a leading ``$`` is read as an update operator.
 _GRAPH_ATTRIBUTE_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
+# Integer attributes must fit in a signed 64-bit integer. Verified against the
+# installed driver rather than assumed: neo4j's packstream Packer raises
+# ``OverflowError("Integer ... out of range")`` outside ``[-2**63, 2**63)``
+# (``neo4j/_codec/packstream/v1/__init__.py``), and GraphML declares an int
+# attribute as ``attr.type="long"``, which is ``xsd:long`` -- also int64. So a
+# larger int is outside the intersection this module defines, even though
+# networkx will happily write it and PostgreSQL's arbitrary-precision ``jsonb``
+# numeric will happily store it.
+_GRAPH_ATTRIBUTE_INT_MIN = -(2**63)
+_GRAPH_ATTRIBUTE_INT_MAX = 2**63 - 1
+
 
 def graph_attribute_value_rejection(value: Any) -> str | None:
     """Explain why *value* cannot be stored as a graph node/edge attribute.
@@ -6768,7 +6779,11 @@ def graph_attribute_value_rejection(value: Any) -> str | None:
     ``GRAPH_STORAGE`` backends can carry, so the same payload behaves the same
     way on all of them:
 
-    * ``bool`` / ``int`` -- accepted everywhere.
+    * ``bool`` -- accepted everywhere.
+    * ``int`` -- must fit in int64. A larger int is written happily by networkx
+      and stored happily by PostgreSQL's arbitrary-precision ``jsonb`` numeric,
+      but the Neo4j driver refuses to pack it and GraphML mislabels it as
+      ``xsd:long``. See ``_GRAPH_ATTRIBUTE_INT_MIN``.
     * ``float`` -- must be finite. ``NaN`` / ``inf`` survive GraphML but
       ``json.dumps`` renders them as bare ``NaN`` / ``Infinity``, which is not
       valid JSON and is rejected by the ``jsonb`` column PGTableGraphStorage
@@ -6792,6 +6807,11 @@ def graph_attribute_value_rejection(value: Any) -> str | None:
     if isinstance(value, bool):
         return None
     if isinstance(value, int):
+        if not _GRAPH_ATTRIBUTE_INT_MIN <= value <= _GRAPH_ATTRIBUTE_INT_MAX:
+            return (
+                "must be a 64-bit integer "
+                f"({_GRAPH_ATTRIBUTE_INT_MIN} to {_GRAPH_ATTRIBUTE_INT_MAX})"
+            )
         return None
     if isinstance(value, float):
         if not math.isfinite(value):

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -6738,3 +6738,94 @@ def validate_workspace(workspace: str) -> str:
             "separators ('/', '\\') or be a relative path reference ('.', '..')"
         )
     return workspace
+
+
+# Complement of the XML 1.0 ``Char`` production. GraphML is XML, so a string
+# holding any other code point cannot be serialized at all -- tab, newline and
+# carriage return are the only C0 controls XML admits, and descriptions
+# legitimately carry those.
+_XML_INCOMPATIBLE_CHAR_PATTERN = re.compile(
+    r"[^\u0009\u000a\u000d\u0020-\ud7ff\ue000-\ufffd\U00010000-\U0010ffff]"
+)
+
+# Graph attribute names must be plain identifiers. This is deliberately
+# narrower than "any string": MongoGraphStorage passes attribute names straight
+# into a ``$set`` document, where a dot is a *path* separator (``source_ids.0``
+# would rewrite an element of the chunk-attribution array rather than create a
+# field) and a leading ``$`` is read as an update operator.
+_GRAPH_ATTRIBUTE_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def graph_attribute_value_rejection(value: Any) -> str | None:
+    """Explain why *value* cannot be stored as a graph node/edge attribute.
+
+    Every graph backend accepts scalars; none of them accepts the same
+    non-scalar. Rather than each backend discovering that in its own way and at
+    its own time, this is the single definition of a storable attribute value,
+    applied before any storage is touched.
+
+    The rules are the intersection of what the seven registered
+    ``GRAPH_STORAGE`` backends can carry, so the same payload behaves the same
+    way on all of them:
+
+    * ``bool`` / ``int`` -- accepted everywhere.
+    * ``float`` -- must be finite. ``NaN`` / ``inf`` survive GraphML but
+      ``json.dumps`` renders them as bare ``NaN`` / ``Infinity``, which is not
+      valid JSON and is rejected by the ``jsonb`` column PGTableGraphStorage
+      writes to.
+    * ``str`` -- must be XML-compatible, because GraphML cannot encode the
+      other code points at all (see ``_XML_INCOMPATIBLE_CHAR_PATTERN``).
+    * anything else (``dict``, ``list``, ``None``, ``bytes``, ...) -- rejected.
+      ``None`` is called out because it is the one non-scalar that reads as
+      harmless: GraphML refuses it outright, while on the Cypher backends
+      ``SET n += {k: null}`` silently *deletes* the property.
+
+    Args:
+        value: Candidate attribute value.
+
+    Returns:
+        A reason fragment suitable for appending to ``"attribute 'x' "``, or
+        ``None`` when the value is storable.
+    """
+    # bool before int: bool is a subclass of int, and both are storable, but
+    # keeping the branches separate keeps the intent readable.
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return None
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return "must be a finite number"
+        return None
+    if isinstance(value, str):
+        match = _XML_INCOMPATIBLE_CHAR_PATTERN.search(value)
+        if match:
+            return (
+                "must not contain the character "
+                f"U+{ord(match.group()):04X}, which XML cannot encode"
+            )
+        return None
+    return f"must be a string, number or boolean, got {type(value).__name__}"
+
+
+def validate_graph_attributes(attributes: dict[str, Any], *, context: str) -> None:
+    """Reject a node/edge attribute mapping no graph backend could store.
+
+    Args:
+        attributes: Attribute mapping about to be written to graph storage.
+        context: Prefix identifying the object being written, used in the error
+            message (e.g. ``"entity 'Tesla'"``).
+
+    Raises:
+        ValueError: On the first unusable attribute name or value.
+    """
+    for key, value in attributes.items():
+        if not isinstance(key, str) or not _GRAPH_ATTRIBUTE_KEY_PATTERN.match(key):
+            raise ValueError(
+                f"{context}: invalid attribute name {key!r}: must start with a "
+                "letter or underscore and contain only letters, digits and "
+                "underscores"
+            )
+        rejection = graph_attribute_value_rejection(value)
+        if rejection is not None:
+            raise ValueError(f"{context}: attribute {key!r} {rejection}")

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -123,7 +123,13 @@ def _sanitize_graph_fields(
                 # the *stored* attribute is a float on the edit paths too,
                 # instead of a string that only the VDB payload converted.
                 coerced = float(value)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, OverflowError):
+                # OverflowError is what `float()` raises for an int too large to
+                # convert. The int64 bound in `graph_attribute_value_rejection`
+                # already refuses those above, so this is belt-and-braces for a
+                # future caller passing some other type whose `__float__`
+                # overflows -- without it the endpoint returns 500 for what is a
+                # validation failure.
                 raise ValueError(
                     f"{object_type.capitalize()} field '{key}' must be a number, "
                     f"got {value!r}"

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -122,12 +122,25 @@ def _sanitize_graph_fields(
                 # always run the value through `float()`; normalizing here means
                 # the *stored* attribute is a float on the edit paths too,
                 # instead of a string that only the VDB payload converted.
-                sanitized[key] = float(value)
+                coerced = float(value)
             except (TypeError, ValueError):
                 raise ValueError(
                     f"{object_type.capitalize()} field '{key}' must be a number, "
                     f"got {value!r}"
                 ) from None
+            # Re-check the *coerced* value. The check above ran on what the
+            # caller sent, and for a numeric string that is a perfectly storable
+            # `str` -- it is this conversion that can produce the non-scalar the
+            # contract forbids ("nan" -> NaN, "1e999" -> inf). Skipping it would
+            # accept the request and then fail in storage: PGTableGraphStorage's
+            # jsonb column rejects the bare `NaN` json.dumps emits, so a 400
+            # would arrive as a 500, while permissive backends keep the value.
+            rejection = graph_attribute_value_rejection(coerced)
+            if rejection is not None:
+                raise ValueError(
+                    f"{object_type.capitalize()} field '{key}' {rejection}"
+                )
+            sanitized[key] = coerced
         elif not isinstance(value, str):
             raise ValueError(
                 f"{object_type.capitalize()} field '{key}' must be a string, got "

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -11,12 +11,132 @@ from .operate import _truncate_vdb_content
 from .utils import (
     VectorStorageConsistencyError,
     compute_mdhash_id,
+    graph_attribute_value_rejection,
     logger,
     make_relation_vdb_ids,
     normalize_entity_name,
     safe_vdb_operation_with_exception,
 )
 from .base import StorageNameSpace
+
+# Field specs for the manual entity/relation mutation APIs. The value is the
+# expected shape: "text" for a string attribute, "number" for a numeric one.
+#
+# These are an allowlist, not documentation. `updated_data` used to be merged
+# into the stored object wholesale (`{**node_data, **updated_data}`), so any key
+# a caller invented was written with whatever value it carried -- including
+# values no graph backend can store. See `_sanitize_graph_fields`.
+_TEXT_FIELD = "text"
+_NUMBER_FIELD = "number"
+
+# `entity_name` is the rename target, which `aedit_entity` resolves and writes
+# back into `updated_data` before the merge; it is a legal edit field but not a
+# legal *create* field (create takes the name as its own argument).
+_EDITABLE_ENTITY_FIELDS: dict[str, str] = {
+    "entity_name": _TEXT_FIELD,
+    "entity_type": _TEXT_FIELD,
+    "description": _TEXT_FIELD,
+    "source_id": _TEXT_FIELD,
+    "file_path": _TEXT_FIELD,
+}
+_ENTITY_DATA_FIELDS: dict[str, str] = {
+    key: kind for key, kind in _EDITABLE_ENTITY_FIELDS.items() if key != "entity_name"
+}
+_RELATION_DATA_FIELDS: dict[str, str] = {
+    "description": _TEXT_FIELD,
+    "keywords": _TEXT_FIELD,
+    "source_id": _TEXT_FIELD,
+    "file_path": _TEXT_FIELD,
+    "weight": _NUMBER_FIELD,
+}
+
+
+def _sanitize_graph_fields(
+    data: dict[str, Any],
+    *,
+    allowed_fields: dict[str, str],
+    object_type: str,
+    reject_unknown: bool,
+) -> dict[str, Any]:
+    """Return *data* reduced to well-typed, storable graph attributes.
+
+    Two call shapes, because the two families of caller differ in what they do
+    with a key they do not recognise:
+
+    * ``reject_unknown=True`` (the edit/merge paths) -- these merge the caller's
+      mapping into the stored object, so an unrecognised key *is written*. It
+      has to be refused, and refused loudly: silently dropping it on an edit
+      endpoint would report success for a change that never happened.
+    * ``reject_unknown=False`` (the create paths) -- these already copy a fixed
+      set of named fields out of the mapping, so an unrecognised key is
+      structurally incapable of reaching storage. Only the values of the
+      recognised keys need checking, and refusing extra keys here would break
+      payloads that work today for no security gain.
+
+    Per-field types matter as much as the allowlist. A value can be a perfectly
+    storable scalar and still be wrong: ``{"source_id": 123}`` serializes fine
+    (GraphML long, JSON number), reaches disk, survives a restart, and then
+    breaks every later reader that splits ``source_id`` on ``GRAPH_FIELD_SEP``
+    -- a durable failure, unlike the transient one a non-scalar causes.
+
+    Args:
+        data: Caller-supplied attribute mapping.
+        allowed_fields: Field name to expected shape (``_TEXT_FIELD`` /
+            ``_NUMBER_FIELD``).
+        object_type: ``"entity"`` or ``"relation"``, for error messages.
+        reject_unknown: Whether an unrecognised key is an error (see above).
+
+    Returns:
+        A new mapping holding only recognised fields, with numeric fields
+        coerced to ``float``.
+
+    Raises:
+        ValueError: On an unknown field (when ``reject_unknown``), a field whose
+            value has the wrong shape, or a value no graph backend can store.
+    """
+    sanitized: dict[str, Any] = {}
+    for key, value in data.items():
+        kind = allowed_fields.get(key)
+        if kind is None:
+            if reject_unknown:
+                raise ValueError(
+                    f"Unknown {object_type} field '{key}'. Allowed fields: "
+                    f"{', '.join(sorted(allowed_fields))}"
+                )
+            continue
+
+        rejection = graph_attribute_value_rejection(value)
+        if rejection is not None:
+            raise ValueError(f"{object_type.capitalize()} field '{key}' {rejection}")
+
+        if kind == _NUMBER_FIELD:
+            # bool is an int subclass, and `float(True)` would quietly become
+            # 1.0 -- a boolean weight is a caller mistake, not a number.
+            if isinstance(value, bool):
+                raise ValueError(
+                    f"{object_type.capitalize()} field '{key}' must be a number, "
+                    "got bool"
+                )
+            try:
+                # A numeric string is accepted because the create paths have
+                # always run the value through `float()`; normalizing here means
+                # the *stored* attribute is a float on the edit paths too,
+                # instead of a string that only the VDB payload converted.
+                sanitized[key] = float(value)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"{object_type.capitalize()} field '{key}' must be a number, "
+                    f"got {value!r}"
+                ) from None
+        elif not isinstance(value, str):
+            raise ValueError(
+                f"{object_type.capitalize()} field '{key}' must be a string, got "
+                f"{type(value).__name__}"
+            )
+        else:
+            sanitized[key] = value
+
+    return sanitized
 
 
 def _require_non_empty_description(
@@ -590,7 +710,11 @@ async def aedit_entity(
         entities_vdb: Vector database storage for entities
         relationships_vdb: Vector database storage for relationships
         entity_name: Name of the entity to edit
-        updated_data: Dictionary containing updated attributes, e.g. {"description": "new description", "entity_type": "new type"}
+        updated_data: Attributes to update. Allowed fields: ``entity_name``
+            (rename target), ``entity_type``, ``description``,
+            ``source_id``, ``file_path`` -- all strings. Any other key,
+            or a value that is not a storable string, is rejected with
+            ``ValueError``.
         allow_rename: Whether to allow entity renaming, defaults to True
         allow_merge: Whether to merge into an existing entity when renaming to an existing name, defaults to False
         entity_chunks_storage: Optional KV storage for tracking chunks that reference this entity
@@ -625,14 +749,27 @@ async def aedit_entity(
             - "failed": Merge operation failed
             - "not_attempted": No merge was attempted (normal update/rename)
     """
+    # Order matters: the empty-description check runs first so a `None`
+    # description keeps reporting itself as empty (which is what it means to a
+    # caller) rather than as a type error. Both refuse before any storage is
+    # touched, so the ordering is about the message, not about safety.
     if "description" in updated_data:
         _require_non_empty_description(
             updated_data.get("description"), operation="edit", object_type="entity"
         )
 
+    # Reduce to allowed, well-typed fields before anything else: this runs
+    # outside the storage lock and before the first graph read, so a rejected
+    # payload has touched nothing at all.
+    updated_data = _sanitize_graph_fields(
+        updated_data,
+        allowed_fields=_EDITABLE_ENTITY_FIELDS,
+        object_type="entity",
+        reject_unknown=True,
+    )
+
     requested_entity_name = entity_name
     normalized_entity_name = _normalize_manual_entity_name(requested_entity_name)
-    updated_data = dict(updated_data)
 
     has_new_entity_name = "entity_name" in updated_data
     requested_new_entity_name = updated_data.get("entity_name")
@@ -856,16 +993,27 @@ async def aedit_relation(
         relationships_vdb: Vector database storage for relationships
         source_entity: Name of the source entity
         target_entity: Name of the target entity
-        updated_data: Dictionary containing updated attributes, e.g. {"description": "new description", "keywords": "new keywords"}
+        updated_data: Attributes to update. Allowed fields:
+            ``description``, ``keywords``, ``source_id``, ``file_path``
+            (strings) and ``weight`` (number). Any other key, or a value
+            of the wrong shape, is rejected with ``ValueError``.
         relation_chunks_storage: Optional KV storage for tracking chunks that reference this relation
 
     Returns:
         Dictionary containing updated relation information
     """
+    # See `aedit_entity` for the ordering rationale.
     if "description" in updated_data:
         _require_non_empty_description(
             updated_data.get("description"), operation="edit", object_type="relation"
         )
+
+    updated_data = _sanitize_graph_fields(
+        updated_data,
+        allowed_fields=_RELATION_DATA_FIELDS,
+        object_type="relation",
+        reject_unknown=True,
+    )
 
     # Normalize entity order for undirected graph (ensures consistent key generation)
     if source_entity > target_entity:
@@ -1063,6 +1211,17 @@ async def acreate_entity(
         entity_data.get("description"), operation="create", object_type="entity"
     )
 
+    # The named-field copy below stops an unknown *key* from reaching storage,
+    # but not an unstorable *value* on a known one: a non-scalar `entity_type`
+    # reaches `upsert_node` unexamined. Type-check the recognised fields (extra
+    # keys stay ignored, as they always were -- see `_sanitize_graph_fields`).
+    entity_data = _sanitize_graph_fields(
+        entity_data,
+        allowed_fields=_ENTITY_DATA_FIELDS,
+        object_type="entity",
+        reject_unknown=False,
+    )
+
     requested_entity_name = entity_name
     entity_name = _normalize_manual_entity_name(requested_entity_name)
     if not entity_name:
@@ -1204,6 +1363,15 @@ async def acreate_relation(
     """
     _require_non_empty_description(
         relation_data.get("description"), operation="create", object_type="relation"
+    )
+
+    # Same reasoning as `acreate_entity`: values of the recognised fields are
+    # type-checked, unrecognised keys stay ignored.
+    relation_data = _sanitize_graph_fields(
+        relation_data,
+        allowed_fields=_RELATION_DATA_FIELDS,
+        object_type="relation",
+        reject_unknown=False,
     )
 
     # Use keyed lock for relation to ensure atomic graph and vector db operations
@@ -1880,6 +2048,18 @@ async def amerge_entities(
     """
     if not source_entities:
         raise ValueError("At least one source entity is required for merge")
+
+    # `_merge_entities_impl` copies these keys onto the merged node verbatim
+    # (`merged_entity_data[key] = value`), which is the same wholesale merge the
+    # edit paths do. Not reachable from the HTTP route today -- the merge
+    # endpoint does not pass it -- but it is part of the public Python API.
+    if target_entity_data:
+        target_entity_data = _sanitize_graph_fields(
+            target_entity_data,
+            allowed_fields=_ENTITY_DATA_FIELDS,
+            object_type="entity",
+            reject_unknown=True,
+        )
 
     requested_source_entities = list(source_entities)
     normalized_source_entities = [

--- a/tests/api/routes/test_graph_attribute_validation.py
+++ b/tests/api/routes/test_graph_attribute_validation.py
@@ -1,0 +1,408 @@
+"""Attribute validation for the manual entity/relation mutation APIs.
+
+Regression tests for GHSA-c922-pw4m-4wcv. `updated_data` used to be merged into
+the stored object wholesale (`{**node_data, **updated_data}`), so a caller with
+one API key could write an attribute no graph backend can store. On the default
+NetworkX backend that mutation lands in the in-memory `nx.Graph` *before*
+serialization, and there is no rollback -- so every later whole-graph flush by
+any caller re-hits the same failure and the instance stops persisting entirely.
+
+`Test*WritePathStaysHealthy` are the fix proofs. Each one runs a hostile payload
+through a **real** `NetworkXStorage` and then asserts that an ordinary,
+unrelated write still succeeds. On the pre-fix code the rejection does not
+happen, the ordinary write raises `TypeError: GraphML does not support ...`, and
+the test fails behaviourally. Nothing here imports a symbol added by the fix, so
+the module still collects against the pre-fix tree -- otherwise the whole file
+would error out on import and prove nothing. The shared validator's own unit
+tests live in tests/utils/test_graph_attribute_validator.py.
+
+`TestAllowedFieldsAndTypes` pins the rules, including the two a
+plausible-looking fix gets wrong (`None` and control characters are *not*
+storable scalars) and the one that over-rejects (a multi-line description is
+perfectly legal and must keep working).
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from lightrag import utils_graph
+from lightrag.kg.networkx_impl import NetworkXStorage
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+
+pytestmark = pytest.mark.offline
+
+NESTED = {"any": ["object"]}
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+class _NoopLock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _patch_graph_lock(monkeypatch):
+    monkeypatch.setattr(
+        utils_graph, "get_storage_keyed_lock", lambda *a, **k: _NoopLock()
+    )
+
+
+class _KVStorage:
+    def __init__(self):
+        self.records: dict = {}
+
+    async def get_by_id(self, key):
+        return self.records.get(key)
+
+    async def upsert(self, data):
+        self.records.update(deepcopy(data))
+
+    async def delete(self, ids):
+        for key in ids:
+            self.records.pop(key, None)
+
+    async def index_done_callback(self):
+        return None
+
+
+class _VectorStorage(_KVStorage):
+    def __init__(self, global_config):
+        super().__init__()
+        self.global_config = global_config
+
+
+class _Fixture:
+    """A real NetworkXStorage plus in-memory VDB/KV doubles.
+
+    The graph storage is deliberately the real thing: the defect this file
+    guards is that a bad attribute reaches `nx.Graph` and breaks *serialization*
+    for every subsequent writer, which a fake graph cannot express.
+    """
+
+    def __init__(self, tmp_path):
+        self.global_config = {
+            "working_dir": str(tmp_path),
+            "workspace": "",
+            "embedding_batch_num": 10,
+            "max_total_tokens": 30000,
+        }
+        self.graph = NetworkXStorage(
+            namespace="chunk_entity_relation",
+            workspace="",
+            global_config=self.global_config,
+            embedding_func=None,
+        )
+        self.entities_vdb = _VectorStorage(self.global_config)
+        self.relationships_vdb = _VectorStorage(self.global_config)
+        self.entity_chunks = _KVStorage()
+        self.relation_chunks = _KVStorage()
+
+    async def start(self):
+        await self.graph.initialize()
+        return self
+
+    async def create_entity(self, name, **overrides):
+        data = {"description": "d", "entity_type": "t", "source_id": "chunk-1"}
+        data.update(overrides)
+        return await utils_graph.acreate_entity(
+            self.graph,
+            self.entities_vdb,
+            self.relationships_vdb,
+            name,
+            data,
+            entity_chunks_storage=self.entity_chunks,
+            relation_chunks_storage=self.relation_chunks,
+        )
+
+    async def edit_entity(self, name, updated_data):
+        return await utils_graph.aedit_entity(
+            self.graph,
+            self.entities_vdb,
+            self.relationships_vdb,
+            name,
+            updated_data,
+            entity_chunks_storage=self.entity_chunks,
+            relation_chunks_storage=self.relation_chunks,
+        )
+
+    async def create_relation(self, source, target, **overrides):
+        data = {
+            "description": "d",
+            "keywords": "k",
+            "source_id": "chunk-1",
+            "weight": 1.0,
+        }
+        data.update(overrides)
+        return await utils_graph.acreate_relation(
+            self.graph,
+            self.entities_vdb,
+            self.relationships_vdb,
+            source,
+            target,
+            data,
+            relation_chunks_storage=self.relation_chunks,
+        )
+
+    async def edit_relation(self, source, target, updated_data):
+        return await utils_graph.aedit_relation(
+            self.graph,
+            self.entities_vdb,
+            self.relationships_vdb,
+            source,
+            target,
+            updated_data,
+            relation_chunks_storage=self.relation_chunks,
+        )
+
+    def graphml_text(self):
+        with open(self.graph._graphml_xml_file, encoding="utf-8") as handle:
+            return handle.read()
+
+
+@pytest.fixture
+async def rag(tmp_path):
+    return await _Fixture(tmp_path).start()
+
+
+# ---------------------------------------------------------------------------
+# Fix proofs: a rejected payload must leave the write path usable.
+# ---------------------------------------------------------------------------
+
+
+class TestEntityEditWritePathStaysHealthy:
+    @pytest.mark.asyncio
+    async def test_unknown_key_with_non_scalar_value_is_refused(self, rag):
+        await rag.create_entity("VICTIM")
+
+        with pytest.raises(ValueError, match="Unknown entity field 'poc_nested'"):
+            await rag.edit_entity("VICTIM", {"poc_nested": NESTED})
+
+        # The whole point: nothing landed in the in-memory graph, so an
+        # unrelated write still reaches disk. Pre-fix this raised TypeError.
+        assert "poc_nested" not in await rag.graph.get_node("VICTIM")
+        await rag.create_entity("AFTER")
+        assert "AFTER" in rag.graphml_text()
+
+    @pytest.mark.asyncio
+    async def test_null_on_an_allowed_field_is_refused(self, rag):
+        """`None` is the bypass an "allowlist + any scalar" fix leaves open.
+
+        GraphML rejects `NoneType` exactly like it rejects `dict`, so allowing
+        it reproduces the original outage through an accepted field name.
+        """
+        await rag.create_entity("VICTIM")
+
+        with pytest.raises(ValueError, match="'file_path' must be a string"):
+            await rag.edit_entity("VICTIM", {"file_path": None})
+
+        await rag.create_entity("AFTER")
+        assert "AFTER" in rag.graphml_text()
+
+    @pytest.mark.asyncio
+    async def test_control_character_on_an_allowed_field_is_refused(self, rag):
+        """The second bypass: a `str` XML cannot encode is still not storable."""
+        await rag.create_entity("VICTIM")
+
+        with pytest.raises(ValueError, match=r"must not contain the character U\+000B"):
+            await rag.edit_entity("VICTIM", {"file_path": "a\x0bb"})
+
+        await rag.create_entity("AFTER")
+        assert "AFTER" in rag.graphml_text()
+
+    @pytest.mark.asyncio
+    async def test_wrong_scalar_type_on_source_id_is_refused(self, rag):
+        """The durable variant: an `int` here is storable but poisonous.
+
+        It serializes fine, reaches disk and survives a restart -- and then
+        every reader that splits `source_id` on GRAPH_FIELD_SEP raises
+        `AttributeError`, including the ingestion merge. So a scalar check alone
+        is not enough; the field's own type has to be enforced.
+        """
+        await rag.create_entity("VICTIM")
+
+        with pytest.raises(ValueError, match="'source_id' must be a string, got int"):
+            await rag.edit_entity("VICTIM", {"source_id": 123})
+
+        assert (await rag.graph.get_node("VICTIM"))["source_id"] == "chunk-1"
+        # Still editable afterwards -- pre-fix this raised AttributeError
+        # forever, restart included.
+        await rag.edit_entity("VICTIM", {"description": "an ordinary update"})
+        assert (await rag.graph.get_node("VICTIM"))["description"] == (
+            "an ordinary update"
+        )
+
+
+class TestRelationEditWritePathStaysHealthy:
+    @pytest.mark.asyncio
+    async def test_unknown_key_with_non_scalar_value_is_refused(self, rag):
+        await rag.create_entity("REL_A")
+        await rag.create_entity("REL_B")
+        await rag.create_relation("REL_A", "REL_B")
+
+        with pytest.raises(ValueError, match="Unknown relation field 'poc_nested'"):
+            await rag.edit_relation("REL_A", "REL_B", {"poc_nested": NESTED})
+
+        assert "poc_nested" not in await rag.graph.get_edge("REL_A", "REL_B")
+        await rag.create_entity("AFTER")
+        assert "AFTER" in rag.graphml_text()
+
+
+class TestEntityCreateWritePathStaysHealthy:
+    @pytest.mark.asyncio
+    async def test_non_scalar_on_a_known_field_is_refused(self, rag):
+        """The create path was reported as unaffected. It is not.
+
+        Copying six named fields stops an unknown *key*, but a non-scalar value
+        on a known one (`entity_type` here) reached `upsert_node` unexamined and
+        produced the identical instance-wide outage. Only `description` was
+        incidentally safe, because building the VDB content concatenates it.
+        """
+        await rag.create_entity("CTRL")
+
+        with pytest.raises(ValueError, match="'entity_type' must be a string"):
+            await rag.create_entity("ATTACK", entity_type=NESTED)
+
+        assert not await rag.graph.has_node("ATTACK")
+        await rag.create_entity("AFTER")
+        assert "AFTER" in rag.graphml_text()
+
+    @pytest.mark.asyncio
+    async def test_unknown_key_is_still_ignored_not_rejected(self, rag):
+        """Create keeps dropping unknown keys.
+
+        It never wrote them (the named-field copy is a structural allowlist), so
+        turning them into a 400 would break working payloads for no gain. Only
+        the merging paths need reject-unknown.
+        """
+        await rag.create_entity("CREATE_EXTRA", poc_nested=NESTED)
+
+        node = await rag.graph.get_node("CREATE_EXTRA")
+        assert "poc_nested" not in node
+        assert "CREATE_EXTRA" in rag.graphml_text()
+
+
+# ---------------------------------------------------------------------------
+# The rules themselves.
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedFieldsAndTypes:
+    @pytest.mark.asyncio
+    async def test_multiline_description_is_accepted(self, rag):
+        """Guard against over-rejection: tab/newline/CR are valid XML."""
+        await rag.create_entity("VICTIM")
+        text = "first line\nsecond\tline\rthird"
+
+        await rag.edit_entity("VICTIM", {"description": text})
+
+        assert (await rag.graph.get_node("VICTIM"))["description"] == text
+        assert "VICTIM" in rag.graphml_text()
+
+    @pytest.mark.asyncio
+    async def test_rename_field_is_still_allowed(self, rag):
+        """`entity_name` is the rename target and must stay editable."""
+        await rag.create_entity("OLD_NAME")
+
+        await rag.edit_entity("OLD_NAME", {"entity_name": "NEW_NAME"})
+
+        assert await rag.graph.has_node("NEW_NAME")
+        assert not await rag.graph.has_node("OLD_NAME")
+
+    @pytest.mark.asyncio
+    async def test_entity_id_is_not_an_editable_field(self, rag):
+        """It was silently ignored before (overwritten by the rename target).
+
+        A 400 naming the allowed fields is the discoverable behaviour; silently
+        accepting a rename request that does nothing is not.
+        """
+        await rag.create_entity("VICTIM")
+
+        with pytest.raises(ValueError, match="Unknown entity field 'entity_id'"):
+            await rag.edit_entity("VICTIM", {"entity_id": "SOMETHING_ELSE"})
+
+    @pytest.mark.asyncio
+    async def test_error_message_lists_the_allowed_fields(self, rag):
+        await rag.create_entity("VICTIM")
+
+        with pytest.raises(ValueError) as excinfo:
+            await rag.edit_entity("VICTIM", {"nope": "x"})
+
+        message = str(excinfo.value)
+        for field in ("entity_name", "entity_type", "description", "source_id"):
+            assert field in message
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "weight, expected",
+        [(2, 2.0), (2.5, 2.5), ("2.5", 2.5)],
+    )
+    async def test_relation_weight_is_normalized_to_float(self, rag, weight, expected):
+        """A numeric string is accepted, and stored as a number.
+
+        The create path has always run `weight` through `float()`, so accepting
+        a numeric string keeps existing callers working; normalizing here means
+        the stored attribute is a float on the edit path too, instead of a
+        string that only the VDB payload converted.
+        """
+        await rag.create_entity("REL_A")
+        await rag.create_entity("REL_B")
+        await rag.create_relation("REL_A", "REL_B")
+
+        await rag.edit_relation("REL_A", "REL_B", {"weight": weight})
+
+        stored = (await rag.graph.get_edge("REL_A", "REL_B"))["weight"]
+        assert isinstance(stored, float)
+        assert stored == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("weight", [True, "abc", NESTED, None])
+    async def test_relation_weight_rejects_non_numbers(self, rag, weight):
+        await rag.create_entity("REL_A")
+        await rag.create_entity("REL_B")
+        await rag.create_relation("REL_A", "REL_B")
+
+        with pytest.raises(ValueError, match="'weight'"):
+            await rag.edit_relation("REL_A", "REL_B", {"weight": weight})
+
+        await rag.create_entity("AFTER")
+        assert "AFTER" in rag.graphml_text()
+
+    @pytest.mark.asyncio
+    async def test_merge_target_entity_data_is_validated(self, rag):
+        """The third copy of the same wholesale merge, in `_merge_entities_impl`.
+
+        Not reachable from the HTTP route (it does not pass the argument), but
+        part of the public Python API, so the report's two-site patch would have
+        left it open.
+        """
+        await rag.create_entity("SOURCE")
+        await rag.create_entity("TARGET")
+
+        with pytest.raises(ValueError, match="Unknown entity field 'poc_nested'"):
+            await utils_graph.amerge_entities(
+                rag.graph,
+                rag.entities_vdb,
+                rag.relationships_vdb,
+                ["SOURCE"],
+                "TARGET",
+                target_entity_data={"poc_nested": NESTED},
+                entity_chunks_storage=rag.entity_chunks,
+                relation_chunks_storage=rag.relation_chunks,
+            )
+
+        assert await rag.graph.has_node("SOURCE")
+        await rag.create_entity("AFTER")
+        assert "AFTER" in rag.graphml_text()

--- a/tests/api/routes/test_graph_attribute_validation.py
+++ b/tests/api/routes/test_graph_attribute_validation.py
@@ -394,6 +394,27 @@ class TestAllowedFieldsAndTypes:
         assert "AFTER" in rag.graphml_text()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("weight", [10**400, 2**63, -(10**400)])
+    async def test_relation_weight_rejects_oversized_integers(self, rag, weight):
+        """A huge JSON integer must be a 400, not an uncaught OverflowError.
+
+        `json.loads` yields a Python int of unbounded size, and `float()` raises
+        `OverflowError` past ~1e308 -- which is neither `TypeError` nor
+        `ValueError`, so it escaped the coercion handler and reached the route as
+        a 500. The int64 bound refuses it before the conversion is attempted.
+        """
+        await rag.create_entity("REL_A")
+        await rag.create_entity("REL_B")
+        await rag.create_relation("REL_A", "REL_B")
+
+        with pytest.raises(ValueError, match="must be a 64-bit integer"):
+            await rag.edit_relation("REL_A", "REL_B", {"weight": weight})
+
+        assert (await rag.graph.get_edge("REL_A", "REL_B"))["weight"] == 1.0
+        await rag.create_entity("AFTER")
+        assert "AFTER" in rag.graphml_text()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("weight", [True, "abc", NESTED, None])
     async def test_relation_weight_rejects_non_numbers(self, rag, weight):
         await rag.create_entity("REL_A")

--- a/tests/api/routes/test_graph_attribute_validation.py
+++ b/tests/api/routes/test_graph_attribute_validation.py
@@ -368,6 +368,32 @@ class TestAllowedFieldsAndTypes:
         assert stored == expected
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "weight", ["nan", "NaN", "inf", "Infinity", "1e999", "-1e999"]
+    )
+    async def test_relation_weight_rejects_strings_that_coerce_to_non_finite(
+        self, rag, weight
+    ):
+        """The value check has to run on the *coerced* number, not the input.
+
+        A numeric string is a perfectly storable `str`, so validating only what
+        the caller sent lets the `float()` conversion manufacture the non-scalar
+        the contract forbids. That would be accepted here and rejected later in
+        storage -- PGTableGraphStorage's jsonb column refuses the bare `NaN`
+        `json.dumps` emits -- turning an intended 400 into a 500.
+        """
+        await rag.create_entity("REL_A")
+        await rag.create_entity("REL_B")
+        await rag.create_relation("REL_A", "REL_B")
+
+        with pytest.raises(ValueError, match="'weight' must be a finite number"):
+            await rag.edit_relation("REL_A", "REL_B", {"weight": weight})
+
+        assert (await rag.graph.get_edge("REL_A", "REL_B"))["weight"] == 1.0
+        await rag.create_entity("AFTER")
+        assert "AFTER" in rag.graphml_text()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("weight", [True, "abc", NESTED, None])
     async def test_relation_weight_rejects_non_numbers(self, rag, weight):
         await rag.create_entity("REL_A")

--- a/tests/utils/test_graph_attribute_validator.py
+++ b/tests/utils/test_graph_attribute_validator.py
@@ -61,6 +61,26 @@ class TestUnstorableValues:
             validate_graph_attributes({"attr": value}, context="entity 'X'")
 
     @pytest.mark.parametrize(
+        "value",
+        [2**63, -(2**63) - 1, 10**400, -(10**400)],
+    )
+    def test_integers_outside_int64_are_rejected(self, value):
+        """networkx writes them and jsonb stores them; Neo4j cannot pack them.
+
+        Verified against the installed driver: neo4j's packstream Packer raises
+        ``OverflowError`` outside ``[-2**63, 2**63)``. GraphML also mislabels
+        such a value, declaring ``attr.type="long"`` (``xsd:long`` is int64). So
+        it is outside the intersection this validator defines even though two of
+        the three backends accept it.
+        """
+        with pytest.raises(ValueError, match="must be a 64-bit integer"):
+            validate_graph_attributes({"created_at": value}, context="entity 'X'")
+
+    @pytest.mark.parametrize("value", [2**63 - 1, -(2**63), 0, 1786431045])
+    def test_integers_inside_int64_are_accepted(self, value):
+        validate_graph_attributes({"created_at": value}, context="entity 'X'")
+
+    @pytest.mark.parametrize(
         "value", [float("nan"), float("inf"), float("-inf"), float("1e999")]
     )
     def test_non_finite_floats_are_rejected(self, value):

--- a/tests/utils/test_graph_attribute_validator.py
+++ b/tests/utils/test_graph_attribute_validator.py
@@ -60,7 +60,9 @@ class TestUnstorableValues:
         with pytest.raises(ValueError, match=expected):
             validate_graph_attributes({"attr": value}, context="entity 'X'")
 
-    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    @pytest.mark.parametrize(
+        "value", [float("nan"), float("inf"), float("-inf"), float("1e999")]
+    )
     def test_non_finite_floats_are_rejected(self, value):
         """They survive GraphML but ``json.dumps`` emits bare ``NaN``/``Infinity``.
 

--- a/tests/utils/test_graph_attribute_validator.py
+++ b/tests/utils/test_graph_attribute_validator.py
@@ -1,0 +1,133 @@
+"""`validate_graph_attributes` -- the shared definition of a storable attribute.
+
+The rules are the *intersection* of what the registered GRAPH_STORAGE backends
+can carry, not what any one of them happens to tolerate. That matters because
+the backends disagree loudly on a violation: the same non-scalar is refused by
+the Neo4j driver, stored verbatim by MongoDB and by PostgreSQL's ``jsonb``
+column, and fatal to GraphML serialization. Anything that is legal here must be
+legal everywhere, and the two easy-to-miss cases are pinned below: ``None``
+(deletes the property on the Cypher backends, hard error on NetworkX) and a
+string holding a code point XML cannot encode.
+
+The behavioural regression tests for the vulnerability this validator closes
+(GHSA-c922-pw4m-4wcv) are in tests/api/routes/test_graph_attribute_validation.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.utils import validate_graph_attributes
+
+pytestmark = pytest.mark.offline
+
+
+class TestStorableValues:
+    @pytest.mark.parametrize("value", ["text", "", 1, 0, -3, 2.5, True, False])
+    def test_scalars_are_accepted(self, value):
+        validate_graph_attributes({"attr": value}, context="entity 'X'")
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Tab, newline and carriage return are the only C0 controls XML
+            # admits -- and descriptions legitimately carry all three.
+            "first line\nsecond line",
+            "col\tcol",
+            "line\r\nline",
+            "中文描述",
+            "emoji \U0001f600",
+            "DEL \x7f and NEL \x85 are valid XML 1.0 characters",
+        ],
+    )
+    def test_xml_compatible_strings_are_accepted(self, text):
+        validate_graph_attributes({"description": text}, context="entity 'X'")
+
+
+class TestUnstorableValues:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (None, "got NoneType"),
+            ({"a": 1}, "got dict"),
+            (["a"], "got list"),
+            (("a",), "got tuple"),
+            (b"bytes", "got bytes"),
+            (set(), "got set"),
+        ],
+    )
+    def test_non_scalars_are_rejected(self, value, expected):
+        with pytest.raises(ValueError, match=expected):
+            validate_graph_attributes({"attr": value}, context="entity 'X'")
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_floats_are_rejected(self, value):
+        """They survive GraphML but ``json.dumps`` emits bare ``NaN``/``Infinity``.
+
+        That is not valid JSON, so the ``jsonb`` column PGTableGraphStorage
+        writes to rejects it -- the value is storable on one backend and not on
+        another, which is exactly what this validator exists to prevent.
+        """
+        with pytest.raises(ValueError, match="must be a finite number"):
+            validate_graph_attributes({"weight": value}, context="relation 'A~B'")
+
+    @pytest.mark.parametrize(
+        "char, code",
+        [
+            ("\x00", r"U\+0000"),
+            ("\x0b", r"U\+000B"),
+            ("\x1f", r"U\+001F"),
+            ("￾", r"U\+FFFE"),
+            ("\ud800", r"U\+D800"),
+        ],
+    )
+    def test_xml_incompatible_strings_are_rejected(self, char, code):
+        with pytest.raises(ValueError, match=code):
+            validate_graph_attributes(
+                {"description": f"a{char}b"}, context="entity 'X'"
+            )
+
+    def test_the_first_offender_is_reported(self):
+        with pytest.raises(ValueError, match="attribute 'bad'"):
+            validate_graph_attributes({"good": "ok", "bad": None}, context="entity 'X'")
+
+
+class TestAttributeNames:
+    @pytest.mark.parametrize("key", ["entity_id", "_private", "created_at", "a9", "A"])
+    def test_identifiers_are_accepted(self, key):
+        validate_graph_attributes({key: "x"}, context="entity 'X'")
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            # In a MongoDB ``$set`` a dot is a *path* separator, so this would
+            # rewrite an element of the chunk-attribution array rather than
+            # create a field named "source_ids.0".
+            "source_ids.0",
+            "a.b",
+            # A leading ``$`` is read as an update operator.
+            "$set",
+            "$where",
+            "has space",
+            "9leading_digit",
+            "dash-ed",
+            "",
+        ],
+    )
+    def test_unsafe_names_are_rejected(self, key):
+        with pytest.raises(ValueError, match="invalid attribute name"):
+            validate_graph_attributes({key: "x"}, context="entity 'X'")
+
+    @pytest.mark.parametrize("key", [1, None, ("a",)])
+    def test_non_string_names_are_rejected(self, key):
+        with pytest.raises(ValueError, match="invalid attribute name"):
+            validate_graph_attributes({key: "x"}, context="entity 'X'")
+
+
+def test_context_appears_in_the_message():
+    with pytest.raises(ValueError, match="entity 'Tesla'"):
+        validate_graph_attributes({"attr": None}, context="entity 'Tesla'")
+
+
+def test_empty_mapping_is_accepted():
+    validate_graph_attributes({}, context="entity 'X'")


### PR DESCRIPTION
## Summary

Closes the unvalidated graph-attribute write reported as GHSA-c922-pw4m-4wcv, and the four further instances of the same defect that the report does not cover.

`aedit_entity` / `aedit_relation` merged the caller's mapping into the stored object wholesale (`{**node_data, **updated_data}`) with no key allowlist and no check on the value, so any caller that can reach `POST /graph/entity/edit` could write an attribute no graph backend is able to store.

## Motivation

On the default NetworkX backend this is not one failed request. `upsert_node` mutates the in-memory `nx.Graph` before serialization and nothing rolls it back, so the unstorable value stays on the node for the life of the process; `write_nx_graph` serializes the *whole* graph, so every later flush by any caller re-hits the same failure. Entity writes and document ingestion fail from then on while reads and `/health` keep returning 200.

Verified against a real `NetworkXStorage` at the storage level (no server, no LLM). Four things came out of that which change the shape of the fix:

1. **Non-scalars are not the only unstorable values.** `None` is refused by GraphML exactly like `dict`, and a string holding a code point XML cannot encode fails identically. An allowlist that admits "any scalar, plus `None`" leaves the original outage fully reachable through an accepted field name — `{"file_path": null}` and a `file_path` carrying `U+000B` both reproduce it.
2. **A storable scalar of the wrong type is worse, not better.** `{"source_id": 123}` serializes fine (GraphML long, JSON number), reaches disk and **survives a restart**, after which every reader that splits `source_id` on `GRAPH_FIELD_SEP` raises `AttributeError` — including the ingestion merge in `operate.py`. So fields are validated against their own type, not against "is a scalar".
3. **The create path is affected too.** Copying six named fields stops an unknown *key*, but a non-scalar value on a known one reached `upsert_node` unexamined: `POST /graph/entity/create` with `{"entity_data": {"entity_type": {"any": ["object"]}}}` produces the identical instance-wide outage. Only `description` was incidentally safe, because building the VDB content concatenates it.
4. **There is a third copy of the merge.** `_merge_entities_impl` applies `target_entity_data` the same way. Not reachable from the HTTP route (the merge endpoint does not pass it), but part of the public Python API.

The other backends are not exempt, they just fail differently — and mostly worse, because they *persist*: PGTableGraph (`jsonb`) and MongoGraph store a nested object verbatim and return 200; OpenSearchGraph stores it and adds a field to the index mapping; Neo4j/Memgraph refuse it per-request; on the Cypher backends `null` silently *deletes* the property instead of erroring. One request, four outcomes — which is why the rule belongs at the backend-independent entry layer.

## What's changed

**Entry layer** (`lightrag/utils_graph.py`) — `_sanitize_graph_fields` at the five public entry points (`aedit_entity`, `aedit_relation`, `acreate_entity`, `acreate_relation`, `amerge_entities`), before any lock is taken and before the first graph read, so a rejected payload has touched nothing. `ValueError` already maps to 400 on both routes, so no route change was needed.

Allowed fields:

| API | Fields |
|---|---|
| entity edit | `entity_name` (rename target), `entity_type`, `description`, `source_id`, `file_path` — strings |
| entity create / merge override | the same, minus `entity_name` |
| relation edit / create | `description`, `keywords`, `source_id`, `file_path` (strings), `weight` (number) |

The two families of caller differ deliberately in how they treat an unrecognised key:

- **edit / merge — reject (400).** These merge, so an unknown key *is written*. Silently dropping it on an edit endpoint would report success for a change that never happened. The error names the allowed fields.
- **create — keep ignoring it.** These already copy a fixed set of named fields, so an unknown key is structurally incapable of reaching storage. They only gain the type check, which avoids new 400s for payloads that work today.

`weight` accepts a numeric string (the create path has always run it through `float()`) and is normalized to `float`, so the *stored* attribute is a number on the edit path too, instead of a string that only the VDB payload converted.

**Contract layer** (`lightrag/utils.py`, `lightrag/base.py`) — `validate_graph_attributes` states the rule as the intersection of what the seven registered `GRAPH_STORAGE` backends can carry: identifier-shaped names, and values that are `str` (XML-compatible), `int` (int64), finite `float` or `bool`. `BaseGraphStorage.upsert_node` documents it as the caller's contract and points at the shared helper rather than inviting each backend to re-derive it.

The string rule is the XML 1.0 `Char` production, matched against GraphML's actual acceptance: tab, newline and carriage return stay legal, because descriptions carry all three.

> The *name* half of that rule is narrowed in the follow-up (#3624) from "identifier-shaped" to the actual interpretation hazard (no `.`, no leading `$`), after review pointed out that the wider rule would strand entities holding an unusual-but-harmless legacy attribute name. Nothing in this PR calls it — the entry layer works from the explicit field allowlist above — so the narrowing changes no behaviour here.

## What's deliberately not here

Enforcing the contract *inside* the backends: NetworkX validate-before-mutate (its "mutate, then serialize the whole graph, no rollback" shape is what turns one bad value into an instance-wide outage) and MongoDB attribute-name rejection (attribute names go straight into a `$set`, where a dot is a path separator and `source_ids.0` would rewrite an element of the chunk-attribution array). Those are backend-specific defects, not a change to the abstract contract, and they are a follow-up PR stacked on this one (#3624). The other four backends need no change — the driver or the DB already refuses, and the entry layer now covers the rest.

Also not here: length caps on attribute values. `MAX_REQUEST_BODY_BYTES` (1 MiB by default) bounds a single request; cumulative growth across many requests is a separate concern.

## Testing

```
./scripts/test.sh tests/api/routes tests/utils tests/kg/networkx_impl tests/extraction
767 passed, 4 skipped
```

New: 51 offline tests.

- `tests/api/routes/test_graph_attribute_validation.py` — behavioural fix proofs. Each drives a **real** `NetworkXStorage` and asserts an ordinary unrelated write still reaches disk after a hostile payload is refused. On the pre-fix tree these fail because that write raises `TypeError: GraphML does not support ...` — not because a symbol is missing; the module deliberately imports nothing added by this PR so it stays collectable there. Covers all four attack shapes above plus the merge path, and pins that a multi-line description is still accepted (guarding against over-rejection).
- `tests/utils/test_graph_attribute_validator.py` — the shared validator's own rules.

### Revised after review

Two P2 findings from Codex, both valid, both fixed:

- **Coerced `weight` was not revalidated** (f1839293). The value check ran on what the caller sent, and a numeric string is a perfectly storable `str` — it is the `float()` afterwards that manufactures the forbidden value, so `{"weight": "nan"}` was accepted. `json.dumps` emits a bare `NaN`, which PGTable's `jsonb` column rejects, so an intended 400 would have arrived as a 500.
- **Oversized integers returned 500** (94391b29). `{"weight": 10**400}` — `json.loads` yields an unbounded Python int, and `float()` raises `OverflowError`, which is neither `TypeError` nor `ValueError`. Beyond catching it, the gap behind it is fixed: integers are now bounded to **int64**, because that *is* the intersection the contract claims. Verified against the installed neo4j driver (`packstream/v1/__init__.py:117-121` raises `OverflowError` outside `[-2**63, 2**63)`), and GraphML declares int attributes `attr.type="long"` = `xsd:long` = int64. Only PostgreSQL's arbitrary-precision `jsonb numeric` was genuinely fine with a larger value.

These bounds are a **caller** contract only. A later review round showed that enforcing them inside a storage backend strands data — GraphML round-trips `NaN` and out-of-int64 integers, so a workspace can already hold one — so #3624 splits the value rule and has NetworkX enforce only what XML cannot encode. Nothing changes here: caller input still has to meet the full contract.

One existing test moved behaviour: `test_aedit_entity_rejects_empty_description` sends `{"description": None}`. The empty-description check now runs *before* sanitization so `None` keeps reporting itself as an empty description rather than as a type error — both refuse before storage is touched, so the ordering is about the message only. There is a comment at each call site to stop it being "tidied" back.

Note for reviewers reproducing the pre-fix failures: running the whole fix-proof file in one process on the pre-fix tree segfaulted for me while pytest was formatting the failures (macOS / CPython 3.12, lxml + spacy loaded). Individually each test fails cleanly, and a standalone script that fails the same GraphML write 400 times in one process does not crash — so this looks like a local harness artifact on a code path that no longer exists after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
