### PR TITLE
fix(graph): reject self-loop relations at the manual write paths

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3521,6 +3521,21 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         field=f"relationships[{index}].tgt_id",
                     )
                 )
+                # Compared after normalization, because the normalized values
+                # are the ones written as the graph edge below: two spellings
+                # that canonicalize to the same name are the same self-loop.
+                # Extraction drops self-loops (operate.py) and amerge_entities
+                # refuses to form one, so accepting them here would make this
+                # the only path that puts src == tgt into the graph.
+                if (
+                    normalized_relationship_data["src_id"]
+                    == normalized_relationship_data["tgt_id"]
+                ):
+                    raise ValueError(
+                        f"Custom KG relationships[{index}] is a self-loop on "
+                        f"'{normalized_relationship_data['src_id']}': src_id and "
+                        "tgt_id must be different entities"
+                    )
                 normalized_relationships.append(normalized_relationship_data)
 
             # Insert chunks into vector storage

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -348,16 +348,22 @@ async def _edit_entity_impl(
                     relations_to_delete.append(
                         compute_mdhash_id(target + source, prefix="rel-")
                     )
-                    if source == entity_name:
-                        await chunk_entity_relation_graph.upsert_edge(
-                            new_entity_name, target, edge_data
-                        )
-                        relations_to_update.append((new_entity_name, target, edge_data))
-                    else:  # target == entity_name
-                        await chunk_entity_relation_graph.upsert_edge(
-                            source, new_entity_name, edge_data
-                        )
-                        relations_to_update.append((source, new_entity_name, edge_data))
+                    # Rename every matching endpoint. A self-loop has the old
+                    # entity on both sides, so changing only the first match
+                    # would create (new, old), which is then removed together
+                    # with the old node below.
+                    renamed_source = (
+                        new_entity_name if source == entity_name else source
+                    )
+                    renamed_target = (
+                        new_entity_name if target == entity_name else target
+                    )
+                    await chunk_entity_relation_graph.upsert_edge(
+                        renamed_source, renamed_target, edge_data
+                    )
+                    relations_to_update.append(
+                        (renamed_source, renamed_target, edge_data)
+                    )
 
         await chunk_entity_relation_graph.delete_node(entity_name)
 

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -28,6 +28,29 @@ def _require_non_empty_description(
         )
 
 
+def _reject_self_loop_relation(
+    source_entity: Any, target_entity: Any, *, operation: str
+) -> None:
+    """Refuse a relation whose two endpoints are the same entity.
+
+    LightRAG's own extraction never emits a self-loop: ``operate.py`` drops
+    ``source == target`` in both record parsers and again in
+    ``_merge_edges_then_upsert``, and ``amerge_entities`` skips any endpoint
+    pair that would collapse into one. Manual creation is therefore the only
+    way such an edge can reach the graph, and a self-loop carries no
+    connectivity for graph retrieval — it only widens the surface where the
+    rest of the code has to reason about ``src == tgt``.
+
+    Rejected at the same layer as an empty description: before the keyed lock,
+    so a refusal writes nothing.
+    """
+    if source_entity == target_entity:
+        raise ValueError(
+            f"Cannot {operation} a self-loop relation on '{source_entity}': "
+            "source and target must be different entities"
+        )
+
+
 def _normalize_manual_entity_name(entity_name: Any) -> str:
     """Apply the extraction naming contract to a manual entity identifier."""
     if not isinstance(entity_name, str):
@@ -1211,6 +1234,9 @@ async def acreate_relation(
     _require_non_empty_description(
         relation_data.get("description"), operation="create", object_type="relation"
     )
+    # The graph edge below is written with these exact strings, so comparing
+    # them raw is precisely the condition that would produce a self-loop.
+    _reject_self_loop_relation(source_entity, target_entity, operation="create")
 
     # Use keyed lock for relation to ensure atomic graph and vector db operations
     workspace = relationships_vdb.global_config.get("workspace", "")

--- a/tests/api/routes/test_graph_entity_rename_self_loop.py
+++ b/tests/api/routes/test_graph_entity_rename_self_loop.py
@@ -1,0 +1,173 @@
+"""Regression coverage for self-loop relations during manual entity rename."""
+
+from copy import deepcopy
+
+import networkx as nx
+import pytest
+
+from lightrag import utils_graph
+from lightrag.utils import compute_mdhash_id, make_relation_chunk_key
+
+
+pytestmark = [pytest.mark.offline, pytest.mark.asyncio]
+
+
+class _NoopLock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Graph:
+    """NetworkX-backed double with real incident-edge deletion semantics."""
+
+    def __init__(self):
+        self.graph = nx.Graph()
+
+    async def has_node(self, entity_name):
+        return self.graph.has_node(entity_name)
+
+    async def get_node(self, entity_name):
+        data = self.graph.nodes.get(entity_name)
+        return deepcopy(data) if data is not None else None
+
+    async def upsert_node(self, entity_name, node_data):
+        self.graph.add_node(entity_name, **deepcopy(node_data))
+
+    async def get_node_edges(self, entity_name):
+        return list(self.graph.edges(entity_name))
+
+    async def get_edge(self, source_entity, target_entity):
+        data = self.graph.get_edge_data(source_entity, target_entity)
+        return deepcopy(data) if data is not None else None
+
+    async def upsert_edge(self, source_entity, target_entity, edge_data):
+        self.graph.add_edge(source_entity, target_entity, **deepcopy(edge_data))
+
+    async def delete_node(self, entity_name):
+        self.graph.remove_node(entity_name)
+
+    async def index_done_callback(self):
+        return None
+
+
+class _VectorStorage:
+    def __init__(self):
+        self.global_config = {"workspace": ""}
+        self.records = {}
+
+    async def upsert(self, data):
+        self.records.update(deepcopy(data))
+
+    async def delete(self, record_ids):
+        for record_id in record_ids:
+            self.records.pop(record_id, None)
+
+    async def index_done_callback(self):
+        return None
+
+
+class _ChunkTrackingStorage:
+    def __init__(self, records):
+        self.records = deepcopy(records)
+
+    async def get_by_id(self, record_id):
+        value = self.records.get(record_id)
+        return deepcopy(value) if value is not None else None
+
+    async def upsert(self, data):
+        self.records.update(deepcopy(data))
+
+    async def delete(self, record_ids):
+        for record_id in record_ids:
+            self.records.pop(record_id, None)
+
+    async def index_done_callback(self):
+        return None
+
+
+async def test_entity_rename_preserves_self_loop_across_all_storages(monkeypatch):
+    """Renaming A to B must map both endpoints of (A, A) to (B, B).
+
+    Keeping an ordinary neighbour edge in the same rename pins the existing
+    one-endpoint cascade while exercising the self-loop-specific boundary.
+    """
+    monkeypatch.setattr(
+        utils_graph,
+        "get_storage_keyed_lock",
+        lambda *args, **kwargs: _NoopLock(),
+    )
+
+    graph = _Graph()
+    await graph.upsert_node(
+        "A", {"entity_id": "A", "description": "source", "source_id": "chunk-a"}
+    )
+    await graph.upsert_node(
+        "C", {"entity_id": "C", "description": "neighbour", "source_id": "chunk-c"}
+    )
+    self_loop = {
+        "description": "A refers to itself",
+        "keywords": "self",
+        "source_id": "chunk-self",
+        "weight": 2.0,
+    }
+    neighbour = {
+        "description": "A relates to C",
+        "keywords": "neighbour",
+        "source_id": "chunk-neighbour",
+        "weight": 1.0,
+    }
+    await graph.upsert_edge("A", "A", self_loop)
+    await graph.upsert_edge("A", "C", neighbour)
+
+    entities_vdb = _VectorStorage()
+    relationships_vdb = _VectorStorage()
+    old_self_id = compute_mdhash_id("AA", prefix="rel-")
+    old_neighbour_id = compute_mdhash_id("AC", prefix="rel-")
+    relationships_vdb.records = {
+        old_self_id: {"src_id": "A", "tgt_id": "A"},
+        old_neighbour_id: {"src_id": "A", "tgt_id": "C"},
+    }
+
+    old_self_key = make_relation_chunk_key("A", "A")
+    old_neighbour_key = make_relation_chunk_key("A", "C")
+    relation_chunks = _ChunkTrackingStorage(
+        {
+            old_self_key: {"chunk_ids": ["chunk-self"], "count": 1},
+            old_neighbour_key: {"chunk_ids": ["chunk-neighbour"], "count": 1},
+        }
+    )
+
+    result = await utils_graph.aedit_entity(
+        graph,
+        entities_vdb,
+        relationships_vdb,
+        "A",
+        {"entity_name": "B"},
+        relation_chunks_storage=relation_chunks,
+    )
+
+    assert result["operation_summary"]["operation_status"] == "success"
+    assert set(graph.graph.nodes) == {"B", "C"}
+    assert {frozenset(edge) for edge in graph.graph.edges} == {
+        frozenset(("B", "B")),
+        frozenset(("B", "C")),
+    }
+    assert graph.graph.get_edge_data("B", "B") == self_loop
+    assert graph.graph.get_edge_data("B", "C") == neighbour
+
+    new_self_id = compute_mdhash_id("BB", prefix="rel-")
+    new_neighbour_id = compute_mdhash_id("BC", prefix="rel-")
+    assert set(relationships_vdb.records) == {new_self_id, new_neighbour_id}
+    assert relationships_vdb.records[new_self_id]["src_id"] == "B"
+    assert relationships_vdb.records[new_self_id]["tgt_id"] == "B"
+
+    assert set(relation_chunks.records) == {
+        make_relation_chunk_key("B", "B"),
+        make_relation_chunk_key("B", "C"),
+    }
+    assert relation_chunks.records[make_relation_chunk_key("B", "B")]["chunk_ids"] == [
+        "chunk-self"
+    ]

--- a/tests/api/routes/test_graph_self_loop_rejection.py
+++ b/tests/api/routes/test_graph_self_loop_rejection.py
@@ -1,0 +1,87 @@
+"""Manual relation creation must not put a self-loop into the graph.
+
+LightRAG's extraction pipeline never emits ``src == tgt`` (dropped in both
+record parsers and again in ``_merge_edges_then_upsert``) and
+``amerge_entities`` skips any endpoint pair that would collapse into one.
+``acreate_relation`` was the remaining path that accepted one, so these tests
+pin the guard and — crucially — pin that it refuses *before* touching storage.
+"""
+
+import pytest
+
+from lightrag import utils_graph
+
+
+pytestmark = [pytest.mark.offline, pytest.mark.asyncio]
+
+
+async def test_acreate_relation_rejects_self_loop():
+    """Passing ``None`` storages is the assertion: the guard must run before
+    the keyed lock, which dereferences ``relationships_vdb.global_config``.
+    An ``AttributeError`` here would mean the refusal came too late."""
+    with pytest.raises(ValueError, match="self-loop relation on 'A'"):
+        await utils_graph.acreate_relation(
+            chunk_entity_relation_graph=None,
+            entities_vdb=None,
+            relationships_vdb=None,
+            source_entity="A",
+            target_entity="A",
+            relation_data={"description": "A refers to itself"},
+        )
+
+
+async def test_acreate_relation_still_accepts_distinct_endpoints(monkeypatch):
+    """The guard must not disturb an ordinary two-entity relation."""
+
+    class _NoopLock:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(
+        utils_graph,
+        "get_storage_keyed_lock",
+        lambda *args, **kwargs: _NoopLock(),
+    )
+
+    upserted_edges = []
+
+    class _Graph:
+        async def has_node(self, entity_name):
+            return True
+
+        async def has_edge(self, source_entity, target_entity):
+            return False
+
+        async def get_edge(self, source_entity, target_entity):
+            return {"description": "A relates to B", "keywords": "k", "weight": 1.0}
+
+        async def upsert_edge(self, source_entity, target_entity, edge_data):
+            upserted_edges.append((source_entity, target_entity))
+
+        async def index_done_callback(self):
+            return None
+
+    class _VectorStorage:
+        def __init__(self):
+            self.global_config = {"workspace": ""}
+            self.records = {}
+
+        async def upsert(self, data):
+            self.records.update(data)
+
+        async def index_done_callback(self):
+            return None
+
+    await utils_graph.acreate_relation(
+        _Graph(),
+        _VectorStorage(),
+        _VectorStorage(),
+        "A",
+        "B",
+        {"description": "A relates to B", "keywords": "k"},
+    )
+
+    assert upserted_edges == [("A", "B")]

--- a/tests/pipeline/test_custom_kg_self_loop_rejection.py
+++ b/tests/pipeline/test_custom_kg_self_loop_rejection.py
@@ -1,0 +1,145 @@
+"""``ainsert_custom_kg`` must not put a self-loop into the graph.
+
+Companion to ``tests/api/routes/test_graph_self_loop_rejection.py``: together
+they close both manual paths that could write ``src == tgt``, which extraction
+(``operate.py``) and ``amerge_entities`` already refuse to produce.
+
+The refusal happens in the identifier-validation phase, before any chunk or
+graph object is written, so a rejected batch leaves storage untouched.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.fixture
+def single_process_shared_data():
+    """``ainsert_custom_kg`` calls ``_raise_if_recovery_required``, which reads
+    the ``pipeline_status`` namespace. Mirrors the fixture in
+    ``tests/pipeline/test_graph_keyed_locks.py``.
+    """
+    finalize_share_data()
+    initialize_share_data(1)
+    yield
+    finalize_share_data()
+
+
+def _make_rag():
+    from lightrag.lightrag import LightRAG
+
+    rag = LightRAG.__new__(LightRAG)
+    rag.workspace = ""
+    rag.tokenizer = MagicMock()
+    rag.tokenizer.encode = lambda _content: []
+    rag.chunks_vdb = _make_vdb_mock()
+    rag.text_chunks = _make_vdb_mock()
+    rag.chunk_entity_relation_graph = MagicMock()
+    rag.chunk_entity_relation_graph.upsert_node = AsyncMock(return_value=None)
+    rag.chunk_entity_relation_graph.upsert_edge = AsyncMock(return_value=None)
+    rag.entities_vdb = _make_vdb_mock()
+    rag.relationships_vdb = _make_vdb_mock()
+    rag._insert_done = AsyncMock(return_value=None)
+    return rag
+
+
+def _make_vdb_mock():
+    vdb = MagicMock()
+    vdb.global_config = {"workspace": ""}
+    vdb.upsert = AsyncMock(return_value=None)
+    vdb.index_done_callback = AsyncMock(return_value=None)
+    return vdb
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_kg_rejects_self_loop_relationship(
+    single_process_shared_data,
+):
+    rag = _make_rag()
+
+    with pytest.raises(ValueError, match=r"relationships\[0\] is a self-loop on 'A'"):
+        await rag.ainsert_custom_kg(
+            {
+                "chunks": [],
+                "entities": [],
+                "relationships": [
+                    {
+                        "src_id": "A",
+                        "tgt_id": "A",
+                        "description": "A refers to itself",
+                        "keywords": "self",
+                    }
+                ],
+            }
+        )
+
+    # Validation precedes every write, so nothing reached storage.
+    rag.chunk_entity_relation_graph.upsert_edge.assert_not_called()
+    rag.chunk_entity_relation_graph.upsert_node.assert_not_called()
+    rag.relationships_vdb.upsert.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_kg_rejects_self_loop_after_normalization(
+    single_process_shared_data,
+):
+    """Two spellings that canonicalize to the same name are the same self-loop.
+
+    The comparison must therefore run on the normalized identifiers — the ones
+    actually written as the graph edge — not on the caller's raw strings.
+    """
+    rag = _make_rag()
+
+    with pytest.raises(ValueError, match=r"relationships\[0\] is a self-loop"):
+        await rag.ainsert_custom_kg(
+            {
+                "chunks": [],
+                "entities": [],
+                "relationships": [
+                    {
+                        "src_id": '"A"',
+                        "tgt_id": "A",
+                        "description": "A refers to itself",
+                        "keywords": "self",
+                    }
+                ],
+            }
+        )
+
+    rag.chunk_entity_relation_graph.upsert_edge.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ainsert_custom_kg_reports_the_offending_index(
+    single_process_shared_data,
+):
+    """The error names which relationship failed, like the sibling validators."""
+    rag = _make_rag()
+
+    with pytest.raises(ValueError, match=r"relationships\[1\] is a self-loop on 'B'"):
+        await rag.ainsert_custom_kg(
+            {
+                "chunks": [],
+                "entities": [],
+                "relationships": [
+                    {
+                        "src_id": "A",
+                        "tgt_id": "B",
+                        "description": "A relates to B",
+                        "keywords": "k",
+                    },
+                    {
+                        "src_id": "B",
+                        "tgt_id": "B",
+                        "description": "B refers to itself",
+                        "keywords": "self",
+                    },
+                ],
+            }
+        )
+
+    rag.chunk_entity_relation_graph.upsert_edge.assert_not_called()


### PR DESCRIPTION
## Description

Stacked on #3622. That PR fixes what a self-loop does to state when its entity is renamed; this one closes the root cause — the two paths that let `src == tgt` reach the graph in the first place.

> **Stacking note:** GitHub cannot use a fork branch as a PR base, so #3622's commit (`5d134a7`, authored by @pengpengyi92) is included here rather than set as the base. **Merge #3622 first**; this PR's diff then reduces to the second commit alone. Review only `9f30b77` — the commit before it is #3622 verbatim, unmodified.

LightRAG's own extraction never emits a self-loop, and the codebase enforces that in four places:

| Location | Behavior |
|---|---|
| `operate.py:768` (delimited-record parser) | `if source == target: return None` |
| `operate.py:1006` (JSON parser) | `continue` |
| `operate.py:2698` (`_merge_edges_then_upsert`) | `if src_id == tgt_id: return None` |
| `utils_graph.py:1483` (`amerge_entities`) | skips any pair that would collapse into one |

Two manual paths had no such guard, verified by direct execution against `main`:

1. **`acreate_relation`** (`POST /graph/relation/create`) — accepted `source_entity == target_entity` and wrote both the graph edge `(A, A)` and the VDB record. Only entity existence and duplicate-edge checks ran.
2. **`ainsert_custom_kg`** — accepted a relationship with `src_id == tgt_id`; the identifier-normalization phase checked type and emptiness, but not equality.

A self-loop contributes no connectivity to graph retrieval, so it is pure surface area for the rest of the code to reason about — which is exactly what the rename bug in #3622 was.

## Related Issues

Root-cause follow-up to #3622. The two are complementary and neither subsumes the other:

- This PR stops **new** self-loops from entering.
- #3622 keeps a **pre-existing** self-loop (created before these guards) from stranding a phantom relation when its entity is renamed.

For the record, the state corruption #3622 addresses is worse than its description suggests. Renaming `A`→`B` where `A` has a self-loop, measured on `b93f7c3` (chunk-tracking keys written below as `key(x,y)`, i.e. `make_relation_chunk_key`):

| | graph | relations_vdb | relation_chunks |
|---|---|---|---|
| before | `(A,A)`, `(A,C)` | `A~A`, `A~C` | `key(A,A)`, `key(A,C)` |
| after | only `(B,C)` | **`A~B`** ← phantom, `B~C` | **`key(A,B)`** ← phantom, `key(B,C)` |

The self-loop is not merely lost: a relation record is fabricated for `A~B`, naming an entity that was just deleted and an edge that never existed in the graph. Since `global`/`hybrid` retrieval queries `relations_vdb` directly, that record is retrievable.

## Changes Made

**`lightrag/utils_graph.py`**
- New `_reject_self_loop_relation()` helper beside `_require_non_empty_description`, raising `ValueError` (already mapped to HTTP 400 by `graph_routes.py:667`).
- Called from `acreate_relation` **before** the keyed lock, so a refusal writes nothing.
- Comparison is raw, which is exact rather than lax here: `upsert_edge` is called with those same strings, so raw equality is precisely the condition that produces a self-loop edge.

**`lightrag/lightrag.py`**
- `ainsert_custom_kg` rejects `src_id == tgt_id` in the identifier-validation phase that already precedes every chunk and graph write, so a rejected batch leaves storage untouched. The error names the offending index (`relationships[1] is a self-loop on 'B'`), matching the sibling validators.
- Compared **after** normalization, not on the caller's raw strings: the normalized values are what get written as the edge, so two spellings that canonicalize to the same name are the same self-loop.

**`aedit_relation` deliberately unchanged** — it cannot alter an existing relation's endpoints, so it can't create a self-loop. Editing one that already exists stays possible.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary) — no user-facing behavior beyond the new 400
- [x] Unit tests added (if applicable)

## Additional Notes

**Tests** — `tests/api/routes/test_graph_self_loop_rejection.py` (2) and `tests/pipeline/test_custom_kg_self_loop_rejection.py` (3), placed per the `AGENTS.md` layout convention and following the existing precedent of `test_description_api_validation.py` and `test_graph_keyed_locks.py`.

Both guards are pinned as refusing *before* any write, not merely refusing:
- The `acreate_relation` test passes `None` storages — an `AttributeError` instead of the `ValueError` would mean the check landed after the lock, which dereferences `relationships_vdb.global_config`.
- The custom-KG tests assert `upsert_edge` / `upsert_node` / `relationships_vdb.upsert` were never called.

One test (`test_acreate_relation_still_accepts_distinct_endpoints`) is a control that pins no-regression on the ordinary two-entity path; it passes both with and without the guard, as intended.

**Verification**
- Red/green: the 4 guard tests fail without the change, pass with it. The control test passes both ways.
- Targeted suites (incl. #3622's own regression test, `test_description_api_validation`, `test_graph_keyed_locks`, `test_vdb_content_truncation_coverage`, `test_rebuild_vdb`): **92 passed**.
- Broad sweep (`tests/api`, `tests/pipeline`, `tests/extraction`, `tests/tools`, `tests/utils`): **1620 passed, 74 failed** vs. a **1615 passed, 74 failed** baseline on the same tree without these changes — an identical failure set, +5 being exactly the new tests. The 74 are sandbox artifacts (tiktoken encoding download blocked by the proxy, `asyncpg`/`ollama` not installable offline), not regressions.
- `ruff check` and `ruff format --check` clean on all four files.

**Behavior change worth a maintainer decision:** `ainsert_custom_kg` now raises instead of silently accepting a self-loop, so a caller currently passing one gets a `ValueError` where they previously got an inserted edge. Fail-fast matches that method's existing contract for malformed identifiers, and the message names the index so the payload is easy to fix. If you would rather it skip-and-warn like the extraction parsers do, that's a small change — say so and I'll switch it.

**Remaining inconsistency, out of scope here:** with #3622 merged, rename *preserves* a self-loop while `amerge_entities` *drops* one (verified: the drop is clean — graph, VDB, and chunk tracking all stay consistent, no phantom). Neither corrupts state, but the two policies disagree. Once these guards are in, no new self-loops arise, so this only affects graphs that already contain one. Happy to align merge with rename in a follow-up if you want a single policy.