### PR TITLE
fix(milvus): page bulk ID queries to bound response size

### DIFF
--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -61,6 +61,14 @@ DEFAULT_MILVUS_UPSERT_MAX_PAYLOAD_BYTES = (
 DEFAULT_MILVUS_UPSERT_MAX_RECORDS_PER_BATCH = 128
 DEFAULT_MILVUS_DELETE_MAX_RECORDS_PER_BATCH = 1000
 
+# Managed Milvus gateways can enforce gRPC's 4 MiB response ceiling even when
+# self-hosted Milvus accepts much larger messages. Keep ID-query responses below
+# 2 MiB for a 2x safety margin. Vector pages account for float32 payload bytes;
+# metadata pages use the record cap because content length is not predictable.
+MILVUS_QUERY_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+MILVUS_QUERY_MAX_RECORDS_PER_BATCH = 256
+MILVUS_QUERY_ROW_OVERHEAD_BYTES = 256
+
 # Schema-migration resilience. A transient Milvus outage during the long
 # iterator-based migration must not kill worker startup: when pymilvus'
 # internal reconnect fails it closes the gRPC channel for good, so every later
@@ -2732,6 +2740,58 @@ class MilvusVectorDBStorage(BaseVectorStorage):
             )
             return None
 
+    def _resolve_query_page_size(self, *, includes_vector: bool) -> int:
+        """Resolve a bounded Milvus ID-query page size.
+
+        Vector responses are estimated from the configured float32 embedding
+        dimension. Metadata responses use only the record cap because content
+        length is unknown; that cap is a heuristic rather than a byte guarantee.
+        """
+        record_cap = max(1, MILVUS_QUERY_MAX_RECORDS_PER_BATCH)
+        if not includes_vector:
+            return record_cap
+
+        try:
+            embedding_dim = int(getattr(self.embedding_func, "embedding_dim", 0))
+        except (TypeError, ValueError):
+            return record_cap
+        if embedding_dim <= 0:
+            return record_cap
+
+        estimated_row_bytes = embedding_dim * 4 + MILVUS_QUERY_ROW_OVERHEAD_BYTES
+        byte_limited_page_size = MILVUS_QUERY_MAX_RESPONSE_BYTES // estimated_row_bytes
+        return max(1, min(record_cap, byte_limited_page_size))
+
+    async def _query_rows_by_ids(
+        self,
+        ids: list[str],
+        output_fields: list[str],
+        *,
+        includes_vector: bool,
+    ) -> list[dict[str, Any]]:
+        """Query Milvus by ID in bounded pages and return rows atomically."""
+        if not ids:
+            return []
+
+        self._ensure_collection_loaded()
+        page_size = self._resolve_query_page_size(includes_vector=includes_vector)
+        rows: list[dict[str, Any]] = []
+
+        for start in range(0, len(ids), page_size):
+            page_ids = ids[start : start + page_size]
+            id_list = '", "'.join(_escape_milvus_str(doc_id) for doc_id in page_ids)
+            filter_expr = f'id in ["{id_list}"]'
+            page_rows = self._client.query(
+                collection_name=self.final_namespace,
+                filter=filter_expr,
+                output_fields=output_fields,
+            )
+            rows.extend(page_rows or [])
+            if start + page_size < len(ids):
+                await _cooperative_yield(start // page_size + 1, every=1)
+
+        return rows
+
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         """Get multiple vector data by their IDs (read-your-writes), preserving order."""
         if not ids:
@@ -2755,31 +2815,25 @@ class MilvusVectorDBStorage(BaseVectorStorage):
         result_map: dict[str, dict[str, Any]] = {}
         if remaining:
             try:
-                # Ensure collection is loaded before querying
-                self._ensure_collection_loaded()
-
                 # Include all meta_fields (created_at is now always included) plus id
                 output_fields = list(self.meta_fields) + ["id"]
-
-                id_list = '", "'.join(_escape_milvus_str(i) for i in remaining)
-                filter_expr = f'id in ["{id_list}"]'
-
-                result = self._client.query(
-                    collection_name=self.final_namespace,
-                    filter=filter_expr,
-                    output_fields=output_fields,
+                rows = await self._query_rows_by_ids(
+                    remaining,
+                    output_fields,
+                    includes_vector=False,
                 )
 
-                if result:
-                    for row in result:
-                        if not row:
-                            continue
-                        row_id = row.get("id")
-                        if row_id is not None:
-                            result_map[str(row_id)] = row
+                for row in rows:
+                    if not row:
+                        continue
+                    row_id = row.get("id")
+                    if row_id is not None:
+                        result_map[str(row_id)] = row
             except Exception as e:
+                sample = remaining[:5]
                 logger.error(
-                    f"[{self.workspace}] Error retrieving vector data for IDs {remaining}: {e}"
+                    f"[{self.workspace}] Error retrieving vector data for "
+                    f"{len(remaining)} IDs (sample: {sample}): {e}"
                 )
                 return []
 
@@ -2852,15 +2906,10 @@ class MilvusVectorDBStorage(BaseVectorStorage):
             return result
 
         try:
-            self._ensure_collection_loaded()
-
-            id_list = '", "'.join(_escape_milvus_str(i) for i in remaining)
-            filter_expr = f'id in ["{id_list}"]'
-
-            rows = self._client.query(
-                collection_name=self.final_namespace,
-                filter=filter_expr,
-                output_fields=["id", "vector"],
+            rows = await self._query_rows_by_ids(
+                remaining,
+                ["id", "vector"],
+                includes_vector=True,
             )
 
             for item in rows or []:

--- a/tests/kg/milvus_impl/test_milvus_query_paging.py
+++ b/tests/kg/milvus_impl/test_milvus_query_paging.py
@@ -1,0 +1,181 @@
+"""Offline tests for bounded Milvus ID-query responses."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+from lightrag.kg.milvus_impl import MilvusVectorDBStorage
+
+pytestmark = pytest.mark.offline
+
+
+class MockEmbeddingFunc:
+    def __init__(self, dim: int):
+        self.embedding_dim = dim
+        self.max_token_size = 512
+        self.model_name = "mock-embed"
+
+    async def __call__(self, texts, **kwargs):
+        return np.zeros((len(texts), self.embedding_dim), dtype=np.float32)
+
+
+@pytest.fixture(autouse=True)
+def patch_namespace_lock():
+    cache: dict[tuple[str, str], asyncio.Lock] = {}
+
+    def factory(namespace, workspace=None, enable_logging=False):
+        key = (namespace, workspace or "")
+        return cache.setdefault(key, asyncio.Lock())
+
+    with patch("lightrag.kg.milvus_impl.get_namespace_lock", side_effect=factory):
+        yield
+
+
+def _make_storage(*, dim: int) -> MilvusVectorDBStorage:
+    storage = MilvusVectorDBStorage(
+        namespace="chunks",
+        workspace="test",
+        global_config={
+            "embedding_batch_num": 10,
+            "vector_db_storage_cls_kwargs": {
+                "cosine_better_than_threshold": 0.2,
+            },
+        },
+        embedding_func=MockEmbeddingFunc(dim),
+        meta_fields={"content"},
+    )
+    storage._client = MagicMock()
+    storage._client.has_collection.return_value = True
+    storage._initialized = True
+    return storage
+
+
+def _ids_from_filter(filter_expr: str) -> list[str]:
+    return json.loads(filter_expr.removeprefix("id in "))
+
+
+@pytest.mark.asyncio
+async def test_high_dimension_vector_reads_stay_below_gateway_response_limit():
+    storage = _make_storage(dim=3072)
+    requested_ids = [f"v{i}" for i in range(600)]
+
+    def query(*, filter, **kwargs):
+        page_ids = _ids_from_filter(filter)
+        if len(page_ids) > 200:
+            raise RuntimeError("RESOURCE_EXHAUSTED: received message larger than max")
+        return [
+            {"id": doc_id, "vector": [float(i)]} for i, doc_id in enumerate(page_ids)
+        ]
+
+    storage._client.query.side_effect = query
+
+    with patch(
+        "lightrag.kg.milvus_impl._cooperative_yield", new_callable=AsyncMock
+    ) as cooperative_yield:
+        result = await storage.get_vectors_by_ids(requested_ids)
+
+    assert set(result) == set(requested_ids)
+    assert storage._client.query.call_count > 1
+    assert cooperative_yield.await_count == storage._client.query.call_count - 1
+
+
+def test_query_page_size_tracks_dimension_and_record_cap():
+    small_vectors = _make_storage(dim=8)
+    large_vectors = _make_storage(dim=3072)
+
+    small_page = small_vectors._resolve_query_page_size(includes_vector=True)
+    large_page = large_vectors._resolve_query_page_size(includes_vector=True)
+
+    assert small_page == 256
+    assert large_page < small_page
+
+    with patch("lightrag.kg.milvus_impl.MILVUS_QUERY_MAX_RECORDS_PER_BATCH", 3):
+        assert small_vectors._resolve_query_page_size(includes_vector=True) == 3
+        assert small_vectors._resolve_query_page_size(includes_vector=False) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_by_ids_preserves_order_and_skips_buffered_or_deleted_ids():
+    storage = _make_storage(dim=8)
+    await storage.upsert({"buffered": {"content": "pending"}})
+    await storage.delete(["deleted"])
+
+    server_ids: list[str] = []
+
+    def query(*, filter, **kwargs):
+        page_ids = _ids_from_filter(filter)
+        server_ids.extend(page_ids)
+        return [
+            {"id": doc_id, "content": f"content:{doc_id}"}
+            for doc_id in reversed(page_ids)
+        ]
+
+    storage._client.query.side_effect = query
+    requested_ids = ["persisted-2", "buffered", "deleted", "persisted-1"]
+
+    with patch("lightrag.kg.milvus_impl.MILVUS_QUERY_MAX_RECORDS_PER_BATCH", 2):
+        result = await storage.get_by_ids(requested_ids)
+
+    assert [row and row["id"] for row in result] == [
+        "persisted-2",
+        "buffered",
+        None,
+        "persisted-1",
+    ]
+    assert result[1]["content"] == "pending"
+    assert result[2] is None
+    assert server_ids == ["persisted-2", "persisted-1"]
+    storage._client.load_collection.assert_called_once_with(storage.final_namespace)
+
+
+@pytest.mark.asyncio
+async def test_query_paging_preserves_id_filter_escaping():
+    storage = _make_storage(dim=8)
+    requested_ids = ['vec"1', "vec\\2"]
+    seen_pages: list[list[str]] = []
+
+    def query(*, filter, **kwargs):
+        page_ids = _ids_from_filter(filter)
+        seen_pages.append(page_ids)
+        return [{"id": doc_id, "vector": [1.0]} for doc_id in page_ids]
+
+    storage._client.query.side_effect = query
+
+    with patch("lightrag.kg.milvus_impl.MILVUS_QUERY_MAX_RECORDS_PER_BATCH", 1):
+        result = await storage.get_vectors_by_ids(requested_ids)
+
+    assert seen_pages == [['vec"1'], ["vec\\2"]]
+    assert set(result) == set(requested_ids)
+
+
+@pytest.mark.asyncio
+async def test_failed_page_does_not_leak_partial_server_results():
+    storage = _make_storage(dim=8)
+    await storage.upsert({"buffered": {"content": "pending"}})
+    storage._pending_vector_docs["buffered"].vector = [9.0]
+    call_count = 0
+
+    def query(*, filter, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        page_ids = _ids_from_filter(filter)
+        if call_count == 2:
+            raise RuntimeError("RESOURCE_EXHAUSTED")
+        return [{"id": doc_id, "vector": [1.0]} for doc_id in page_ids]
+
+    storage._client.query.side_effect = query
+
+    with (
+        patch("lightrag.kg.milvus_impl.MILVUS_QUERY_MAX_RECORDS_PER_BATCH", 2),
+        patch("lightrag.kg.milvus_impl.logger.error") as log_error,
+    ):
+        result = await storage.get_vectors_by_ids(
+            ["buffered", "persisted-1", "persisted-2", "persisted-3"]
+        )
+
+    assert result == {"buffered": [9.0]}
+    assert call_count == 2
+    assert "RESOURCE_EXHAUSTED" in log_error.call_args.args[0]


### PR DESCRIPTION
## Description

Milvus `get_by_ids` and `get_vectors_by_ids` currently place every requested ID in one query. For high-dimensional vectors or large ID sets, the response can exceed a managed gateway's gRPC message limit and fail with `RESOURCE_EXHAUSTED`.

This change pages bulk ID queries so each response remains bounded while preserving the existing read-your-writes behavior.

## Related Issues

No linked issue.

## Changes Made

- Add one shared helper for paged Milvus ID queries.
- Use a 256-record cap for metadata reads.
- Derive vector page size from the embedding dimension against a conservative 2 MiB response budget.
- Preserve caller ordering, buffered/deleted ID handling, ID escaping, and atomic failure behavior.
- Avoid logging an entire potentially large ID list on failure.
- Add offline regression tests for high-dimensional paging, page-size calculation, ordering, escaping, and partial-page failure.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not required; no public API change)
- [x] Unit tests added

## Test Results

```
py -m pytest tests/kg/milvus_impl -q
184 passed in 0.90s
```

The regression tests use a mocked Milvus client and do not require a live Milvus service.