### PR TITLE
fix(base): tolerate undeclared fields when rehydrating DocProcessingStatus

### DIFF
--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 import os
 from dotenv import load_dotenv
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import (
     Any,
     ClassVar,
@@ -1045,6 +1045,25 @@ class DocProcessingStatus:
                 and self.status == DocStatus.PROCESSED
             ):
                 self.status = DocStatus.PREPROCESSED
+
+    @classmethod
+    def from_stored(cls, data: dict[str, Any]) -> "DocProcessingStatus":
+        """Construct from a stored doc_status row, ignoring undeclared fields.
+
+        Producers evolve independently of this schema: RAG-Anything writes
+        ``scheme_name``/``multimodal_content``, other LightRAG versions write
+        fields an installed release does not declare yet (or no longer does).
+        ``DocProcessingStatus(**row)`` raises ``TypeError`` on any such field,
+        which makes every read path treat the row as malformed and drop it
+        from listings — the document silently disappears from the WebUI and
+        the API even though its record is intact (HKUDS/RAG-Anything#73).
+
+        Extra fields are ignored for construction only; the stored row is
+        not modified. A *missing required* field still raises ``TypeError``
+        — tolerance is strictly for extras, not for malformed rows.
+        """
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
 
 
 class CursorPosition:

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -767,8 +767,10 @@ class JsonDocStatusStorage(DocStatusStorage):
         Single source of the raw → status construction shared by
         ``get_docs_by_statuses``, ``get_docs_paginated`` and the
         ``get_full_docs_by_ids`` hydration path. Raises ``KeyError``/
-        ``TypeError`` on a malformed row; the caller decides strict (raise)
-        vs relaxed (skip).
+        ``TypeError`` on a malformed row (missing required fields); the
+        caller decides strict (raise) vs relaxed (skip). Fields the
+        dataclass does not declare are tolerated, not treated as malformed
+        — see ``DocProcessingStatus.from_stored``.
 
         Deep-copies ``row`` before use: the returned ``DocProcessingStatus``
         carries nested mutable fields (``metadata``, ``chunks_list``) that
@@ -777,17 +779,18 @@ class JsonDocStatusStorage(DocStatusStorage):
         class of bug fixed for the other read paths.
         """
         data = cls._normalize_status_row(copy.deepcopy(row))
-        return DocProcessingStatus(**data)
+        return DocProcessingStatus.from_stored(data)
 
     def _row_is_hydratable(self, doc_id: str, row: dict[str, Any]) -> bool:
         """True if ``row`` can be hydrated into a full DocProcessingStatus.
 
         Used by ``get_docs_paginated``'s validation pass to keep
         ``total_count`` consistent with what the page-hydration step can
-        actually return: a row missing a required field OR carrying an
-        unexpected one would fail ``DocProcessingStatus(**data)`` — counting
-        it as present without confirming that would let ``total_count``
-        overstate what pages can actually deliver.
+        actually return: a row missing a required field would fail
+        construction — counting it as present without confirming that
+        would let ``total_count`` overstate what pages can actually
+        deliver. (Fields the dataclass does not declare are tolerated,
+        not treated as malformed.)
 
         Attempts the SAME normalisation + construction as
         ``_doc_processing_status_from_row``, but on a shallow copy that is
@@ -797,7 +800,7 @@ class JsonDocStatusStorage(DocStatusStorage):
         ever deep-copied.
         """
         try:
-            DocProcessingStatus(**self._normalize_status_row(dict(row)))
+            DocProcessingStatus.from_stored(self._normalize_status_row(dict(row)))
             return True
         except (KeyError, TypeError) as e:
             logger.error(f"[{self.workspace}] Error processing document {doc_id}: {e}")

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -625,12 +625,13 @@ class MongoDocStatusStorage(DocStatusStorage):
         Single source of the raw -> status construction shared by
         ``get_docs_by_statuses`` and the ``get_full_docs_by_ids`` hydration
         path. Raises ``KeyError``/``TypeError`` on a malformed document
-        (``TypeError`` is what ``DocProcessingStatus(**data)`` raises on
-        missing required fields); the caller decides strict (raise) vs relaxed
-        (skip).
+        (``TypeError`` is what construction raises on missing required
+        fields); the caller decides strict (raise) vs relaxed (skip).
+        Fields the dataclass does not declare are tolerated — see
+        ``DocProcessingStatus.from_stored``.
         """
         data = self._prepare_doc_status_data(doc)
-        return DocProcessingStatus(**data)
+        return DocProcessingStatus.from_stored(data)
 
     def __init__(self, namespace, global_config, embedding_func, workspace=None):
         super().__init__(
@@ -1071,7 +1072,7 @@ class MongoDocStatusStorage(DocStatusStorage):
 
                 data = self._prepare_doc_status_data(doc)
 
-                doc_status = DocProcessingStatus(**data)
+                doc_status = DocProcessingStatus.from_stored(data)
                 documents.append((doc_id, doc_status))
             except KeyError as e:
                 logger.error(

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -1471,10 +1471,12 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         construction shared by :meth:`get_docs_by_statuses` (via
         :meth:`_search_all_docs`) and the :meth:`get_full_docs_by_ids`
         hydration path. Raises ``KeyError``/``TypeError`` on a malformed
-        source; the caller decides strict (raise) vs relaxed (skip).
+        source (missing required fields); the caller decides strict (raise)
+        vs relaxed (skip). Fields the dataclass does not declare are
+        tolerated — see ``DocProcessingStatus.from_stored``.
         """
         data = self._prepare_doc_status_data(source)
-        return DocProcessingStatus(**data)
+        return DocProcessingStatus.from_stored(data)
 
     async def initialize(self):
         """Initialize client connection and create the doc-status index."""
@@ -2095,7 +2097,9 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             for hit in response["hits"]["hits"]:
                 try:
                     data = self._prepare_doc_status_data(hit["_source"])
-                    documents.append((hit["_id"], DocProcessingStatus(**data)))
+                    documents.append(
+                        (hit["_id"], DocProcessingStatus.from_stored(data))
+                    )
                 except (KeyError, TypeError) as e:
                     logger.error(
                         f"[{self.workspace}] Error parsing doc {hit['_id']}: {e}"

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -1057,9 +1057,11 @@ class RedisDocStatusStorage(DocStatusStorage):
 
         Single source of the decoded-JSON -> status construction shared by
         ``get_docs_by_statuses`` and the ``get_full_docs_by_ids`` hydration
-        path. Raises ``KeyError``/``TypeError`` on a malformed row (``TypeError``
-        is what ``DocProcessingStatus(**data)`` raises on missing required
+        path. Raises ``KeyError``/``TypeError`` on a malformed row
+        (``TypeError`` is what construction raises on missing required
         fields); the caller decides strict (raise) vs relaxed (skip).
+        Fields the dataclass does not declare are tolerated — see
+        ``DocProcessingStatus.from_stored``.
         """
         data = data.copy()
         data.pop("content", None)
@@ -1069,7 +1071,7 @@ class RedisDocStatusStorage(DocStatusStorage):
             data["metadata"] = {}
         if "error_msg" not in data:
             data["error_msg"] = None
-        return DocProcessingStatus(**data)
+        return DocProcessingStatus.from_stored(data)
 
     async def get_docs_by_statuses(
         self, statuses: list[DocStatus], strict: bool = False
@@ -1571,7 +1573,7 @@ class RedisDocStatusStorage(DocStatusStorage):
                                     else:
                                         sort_key = data.get(sort_field, "")
 
-                                    doc_status = DocProcessingStatus(**data)
+                                    doc_status = DocProcessingStatus.from_stored(data)
                                     all_docs.append((doc_id, doc_status, sort_key))
 
                                 except (json.JSONDecodeError, KeyError) as e:

--- a/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
+++ b/tests/kg/json_impl/test_json_doc_status_copy_on_read.py
@@ -261,15 +261,14 @@ async def test_get_docs_paginated_excludes_rows_missing_required_fields(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_get_docs_paginated_excludes_rows_with_unexpected_fields(tmp_path):
+async def test_get_docs_paginated_hydrates_rows_with_unexpected_fields(tmp_path):
     """
-    A row can carry every required field and STILL fail to hydrate — e.g. an
-    unexpected top-level key makes ``DocProcessingStatus(**data)`` raise
-    TypeError even though nothing is missing. Regression test for a bug
-    where the validation pass only checked a fixed set of required-field
-    names present, so such a row was counted in total_count but then
-    silently dropped when the page-hydration step actually tried to
-    construct it — total_count and the returned page disagreed.
+    An unexpected top-level key no longer makes a row unhydratable —
+    ``DocProcessingStatus.from_stored`` ignores undeclared fields — so the
+    row appears in BOTH total_count and the returned page. The invariant
+    this file originally pinned still holds and is what this test asserts:
+    the validation pass and the page-hydration step must agree, whatever
+    the hydration rules are, or total_count disagrees with the page.
     """
     storage = JsonDocStatusStorage(
         namespace="doc_status",
@@ -302,8 +301,10 @@ async def test_get_docs_paginated_excludes_rows_with_unexpected_fields(tmp_path)
     )
 
     docs, total = await storage.get_docs_paginated()
-    assert total == 1
-    assert [doc_id for doc_id, _ in docs] == ["doc9"]
+    assert total == 2
+    assert sorted(doc_id for doc_id, _ in docs) == ["doc10", "doc9"]
+    hydrated = dict(docs)["doc10"]
+    assert not hasattr(hydrated, "unexpected_field")
 
 
 @pytest.mark.asyncio

--- a/tests/kg/json_impl/test_json_doc_status_track_id_hydration.py
+++ b/tests/kg/json_impl/test_json_doc_status_track_id_hydration.py
@@ -7,7 +7,8 @@ does not crash queries for that track_id with an unhandled TypeError.
 track_id groups a whole upload BATCH, so the blast radius of letting one bad row
 escape is every healthy sibling document in that batch — and permanently, since
 the row stays in the store. These tests pin skip-and-log for each shape a row can
-be unusable in: missing required field, unknown field, and not a mapping at all.
+be unusable in — missing required field, and not a mapping at all — and pin that
+an unknown field does NOT make a row unusable (it is ignored at construction).
 """
 
 import logging
@@ -90,13 +91,14 @@ async def test_get_docs_by_track_id_handles_unhydratable_row_without_crashing(
     assert "invalid_doc" not in docs
 
 
-async def test_get_docs_by_track_id_skips_row_carrying_an_unknown_field(tmp_path):
-    """The realistic trigger: a version rollback.
+async def test_get_docs_by_track_id_hydrates_row_carrying_an_unknown_field(tmp_path):
+    """The realistic trigger: a version rollback, or an external producer.
 
-    A newer build persists a field the running (older) DocProcessingStatus does
-    not declare, so construction fails with ``TypeError: got an unexpected
-    keyword argument`` — no corruption required, and it hits EVERY row the newer
-    build wrote.
+    A newer build (or a producer like RAG-Anything) persists a field the
+    running DocProcessingStatus does not declare. Construction now ignores
+    undeclared fields (``DocProcessingStatus.from_stored``, matching the
+    PG backend's long-standing explicit-kwargs behavior), so the row stays
+    visible instead of silently vanishing from every listing.
     """
     storage = await _make_storage(tmp_path)
     await storage.upsert(
@@ -111,8 +113,8 @@ async def test_get_docs_by_track_id_skips_row_carrying_an_unknown_field(tmp_path
 
     docs = await storage.get_docs_by_track_id("track_123")
 
-    assert "old_doc" in docs
-    assert "written_by_newer_build" not in docs
+    assert set(docs) == {"old_doc", "written_by_newer_build"}
+    assert not hasattr(docs["written_by_newer_build"], "field_from_the_future")
 
 
 async def test_get_docs_by_track_id_logs_and_skips_a_non_mapping_row(tmp_path, caplog):

--- a/tests/kg/mongo_impl/test_mongo_doc_status_track_id_hydration.py
+++ b/tests/kg/mongo_impl/test_mongo_doc_status_track_id_hydration.py
@@ -84,8 +84,13 @@ async def test_track_id_listing_survives_a_doc_missing_required_fields():
     assert "invalid_doc" not in docs
 
 
-async def test_track_id_listing_survives_a_doc_with_an_unknown_field():
-    """Version-rollback shape: a field the running build does not declare."""
+async def test_track_id_listing_hydrates_a_doc_with_an_unknown_field():
+    """Version-rollback shape: a field the running build does not declare.
+
+    Undeclared fields are ignored at construction
+    (``DocProcessingStatus.from_stored``), so the row stays visible instead
+    of silently vanishing from the listing.
+    """
     storage = _storage(
         [
             _valid_doc("old_doc"),
@@ -95,8 +100,8 @@ async def test_track_id_listing_survives_a_doc_with_an_unknown_field():
 
     docs = await storage.get_docs_by_track_id("track_123")
 
-    assert "old_doc" in docs
-    assert "written_by_newer_build" not in docs
+    assert set(docs) == {"old_doc", "written_by_newer_build"}
+    assert not hasattr(docs["written_by_newer_build"], "field_from_the_future")
 
 
 async def test_one_bad_doc_does_not_hide_its_healthy_siblings():

--- a/tests/kg/postgres_impl/test_postgres_doc_status_track_id_hydration.py
+++ b/tests/kg/postgres_impl/test_postgres_doc_status_track_id_hydration.py
@@ -75,10 +75,12 @@ async def test_an_unknown_column_is_ignored_rather_than_fatal():
 
     ``_pg_doc_processing_status_from_row`` names every kwarg explicitly instead
     of splatting the row, so a column the running build does not declare is
-    simply not read. The version-rollback shape that breaks JSON/Redis/Mongo
-    (``TypeError: unexpected keyword argument``) therefore cannot arise here —
-    pinned so a refactor to ``DocProcessingStatus(**element)`` cannot silently
-    import that failure mode into PG.
+    simply not read. The version-rollback shape that used to break
+    JSON/Redis/Mongo (``TypeError: unexpected keyword argument``) never arose
+    here — the other backends now match via
+    ``DocProcessingStatus.from_stored``. Pinned so a refactor to
+    ``DocProcessingStatus(**element)`` cannot silently import that failure
+    mode into PG.
     """
     storage = _make_storage(
         [_row("old_doc"), _row("written_by_newer_build", field_from_the_future="value")]

--- a/tests/kg/redis_impl/test_redis_doc_status_track_id_hydration.py
+++ b/tests/kg/redis_impl/test_redis_doc_status_track_id_hydration.py
@@ -97,11 +97,12 @@ async def test_track_id_listing_survives_a_row_missing_required_fields(
     assert "invalid_doc" not in docs
 
 
-async def test_track_id_listing_survives_a_row_with_an_unknown_field(redis_doc_status):
+async def test_track_id_listing_hydrates_a_row_with_an_unknown_field(redis_doc_status):
     """Version-rollback shape: a field the running build does not declare.
 
-    ``doc-a-*`` / ``doc-b-*``: the bad row must be scanned FIRST — see
-    ``test_a_bad_row_does_not_truncate_the_rest_of_the_scan``.
+    Undeclared fields are ignored at construction
+    (``DocProcessingStatus.from_stored``), so the row stays visible instead
+    of silently vanishing from the listing.
     """
     _store_raw(
         redis_doc_status,
@@ -112,7 +113,8 @@ async def test_track_id_listing_survives_a_row_with_an_unknown_field(redis_doc_s
 
     docs = await redis_doc_status.get_docs_by_track_id("track_123")
 
-    assert set(docs) == {"doc-b-old"}
+    assert set(docs) == {"doc-a-written-by-newer-build", "doc-b-old"}
+    assert not hasattr(docs["doc-a-written-by-newer-build"], "field_from_the_future")
 
 
 async def test_a_bad_row_does_not_truncate_the_rest_of_the_scan(redis_doc_status):

--- a/tests/test_doc_processing_status_from_stored.py
+++ b/tests/test_doc_processing_status_from_stored.py
@@ -1,0 +1,91 @@
+"""Coverage for DocProcessingStatus.from_stored (tolerant rehydration).
+
+WHY: doc_status rows are written by producers that evolve independently of
+this dataclass — RAG-Anything adds scheme_name/multimodal_content
+(HKUDS/RAG-Anything#73), newer LightRAG builds add fields an older installed
+release does not declare. ``DocProcessingStatus(**row)`` raises ``TypeError``
+on any such field, and every read path treats that as a malformed row and
+drops it, so the document silently disappears from listings while its record
+is intact. ``from_stored`` ignores undeclared fields — matching the PG
+backend, whose explicit-kwargs construction always behaved this way — while
+still raising on genuinely malformed rows.
+"""
+
+import pytest
+
+from lightrag.base import DocProcessingStatus, DocStatus
+
+pytestmark = pytest.mark.offline
+
+
+def _valid_row(**extra) -> dict:
+    return {
+        "content_summary": "Summary",
+        "content_length": 100,
+        "file_path": "doc.pdf",
+        "status": DocStatus.PROCESSED,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+        **extra,
+    }
+
+
+def test_undeclared_fields_are_ignored():
+    # The RAG-Anything shape from HKUDS/RAG-Anything#73
+    row = _valid_row(
+        scheme_name="default",
+        multimodal_content=[{"type": "image"}],
+        field_from_the_future="value",
+    )
+
+    status = DocProcessingStatus.from_stored(row)
+
+    assert status.file_path == "doc.pdf"
+    assert status.status == DocStatus.PROCESSED
+    assert not hasattr(status, "scheme_name")
+    assert not hasattr(status, "field_from_the_future")
+
+
+def test_declared_fields_all_pass_through():
+    row = _valid_row(
+        track_id="track_1",
+        chunks_count=3,
+        chunks_list=["c1", "c2", "c3"],
+        error_msg=None,
+        metadata={"k": "v"},
+    )
+
+    status = DocProcessingStatus.from_stored(row)
+
+    assert status.track_id == "track_1"
+    assert status.chunks_list == ["c1", "c2", "c3"]
+    assert status.metadata == {"k": "v"}
+
+
+def test_missing_required_field_still_raises_type_error():
+    # Tolerance is strictly for extras; a malformed row must keep failing
+    # so skip-and-log callers keep skipping it.
+    row = _valid_row()
+    del row["status"]
+
+    with pytest.raises(TypeError):
+        DocProcessingStatus.from_stored(row)
+
+
+def test_post_init_status_conversion_still_applies():
+    # __post_init__ downgrades PROCESSED to PREPROCESSED when multimodal
+    # processing is pending; from_stored must not bypass it.
+    row = _valid_row(multimodal_processed=False)
+
+    status = DocProcessingStatus.from_stored(row)
+
+    assert status.status == DocStatus.PREPROCESSED
+
+
+def test_input_row_is_not_mutated():
+    row = _valid_row(field_from_the_future="value")
+    snapshot = dict(row)
+
+    DocProcessingStatus.from_stored(row)
+
+    assert row == snapshot


### PR DESCRIPTION
## Summary

`doc_status` rows are written by producers that evolve independently of the `DocProcessingStatus` schema: RAG-Anything writes `scheme_name`/`multimodal_content` (HKUDS/RAG-Anything#73, open with many affected users), a newer LightRAG build writes fields an older installed release does not declare, and a version rollback turns every row the newer build wrote into a landmine. `DocProcessingStatus(**row)` raises `TypeError` on any such field, and every read path treats that as a malformed row and skips it — **the document silently disappears from listings and the WebUI while its record sits intact in storage**.

## Changes

- Add `DocProcessingStatus.from_stored()`: constructs from a stored row, filtering to declared fields. A *missing required* field still raises `TypeError` — tolerance is strictly for extras, so skip-and-log callers keep skipping genuinely malformed rows. `__post_init__`'s PROCESSED→PREPROCESSED conversion still applies.
- Use it at every rehydration site in the JSON, Redis, Mongo and OpenSearch backends (the per-backend normalize helpers plus the paginated direct sites).
- This brings those backends in line with **PostgreSQL, which always named its kwargs explicitly** — its test suite already pins ignore-unknown-columns as the intended behavior ("pinned so a refactor to `DocProcessingStatus(**element)` cannot silently import that failure mode into PG"). This PR removes that failure mode from the other four backends instead.

## Tests

- New `tests/test_doc_processing_status_from_stored.py` (5 cases: RA-shaped extras ignored; declared fields pass through; missing required still raises; `__post_init__` conversion applies; input row not mutated).
- The four backend hydration tests that pinned unknown-field rows as *unhydratable* now pin the opposite: the row hydrates, stays listed, and the unknown field does not leak onto the object. The paginated-listing test keeps its original invariant (total_count agrees with the returned page) under the new hydration rules.
- Mutation-verified: reverting `from_stored` to strict `cls(**data)` fails 5 tests.
- Full suite: failure set identical to a pristine `main` baseline worktree in the same environment (all remaining failures pre-existing/env-dependent; 5320 passed).
- `ruff==0.6.4 check --ignore=E402` and `ruff format --diff` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
