### PR TITLE
fix(llm): close OpenAI stream/client when GeneratorExit interrupts a mid-COT close

### DIFF
--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -516,6 +516,7 @@ async def openai_complete_if_cache(
             cot_active = False
             cot_started = False
             initial_content_seen = False
+            closing_via_generator_exit = False
 
             try:
                 iteration_started = True
@@ -611,6 +612,12 @@ async def openai_complete_if_cache(
                     logger.debug(f"Streaming token usage (from API): {token_counts}")
                 elif token_tracker:
                     logger.debug("No usage information available in streaming response")
+            except GeneratorExit:
+                # Consumer disconnect mid-COT: tell the finally block below to
+                # skip its yield, which would otherwise abort cleanup with
+                # "async generator ignored GeneratorExit".
+                closing_via_generator_exit = True
+                raise
             except Exception as e:
                 # Ensure COT is properly closed before handling exception
                 if enable_cot and cot_active:
@@ -645,8 +652,9 @@ async def openai_complete_if_cache(
                     )
                 raise
             finally:
-                # Final safety check for unclosed COT tags
-                if enable_cot and cot_active:
+                # Final safety check for unclosed COT tags, skipped while
+                # closing via GeneratorExit (see the except clause above).
+                if enable_cot and cot_active and not closing_via_generator_exit:
                     try:
                         yield "</think>"
                         cot_active = False

--- a/tests/llm/openai_impl/test_openai_stream_generatorexit_cot_cleanup.py
+++ b/tests/llm/openai_impl/test_openai_stream_generatorexit_cot_cleanup.py
@@ -1,0 +1,125 @@
+"""Regression test: closing the streaming generator mid-COT must not abort
+cleanup.
+
+``inner()`` in ``openai_complete_if_cache``'s streaming branch has a
+finally-block safety net that closes an still-open ``<think>`` tag with
+``yield "</think>"``. When the consumer disconnects while COT is open
+(``gen.aclose()``, e.g. an HTTP client going away mid reasoning-phase),
+Python throws ``GeneratorExit`` at the generator's suspension point; yielding
+again in response is illegal and makes ``aclose()`` raise "async generator
+ignored GeneratorExit", aborting the finally block before the
+``response.aclose()`` / ``openai_async_client.close()`` calls that follow it
+run. Mirrors ``tests/llm/anthropic_impl/test_anthropic_client_cleanup.py``'s
+``test_stream_closed_on_early_consumer_break``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lightrag.llm.openai import openai_complete_if_cache
+
+
+class _FakeOpenAIStream:
+    """Async-iterable fake of an OpenAI streaming response.
+
+    ``__aiter__``/``__anext__`` live on the class, matching the real
+    ``openai.AsyncStream`` shape that ``async for`` requires.
+    """
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self.aclose = AsyncMock()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+
+def _make_chunk(content=None, reasoning_content=""):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    content=content, reasoning_content=reasoning_content
+                )
+            )
+        ],
+        usage=None,
+    )
+
+
+def _make_stream_client(stream: _FakeOpenAIStream) -> SimpleNamespace:
+    return SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=AsyncMock(return_value=stream))
+        ),
+        close=AsyncMock(),
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_stream_closed_on_early_close_while_cot_open():
+    """Client disconnect mid-COT still closes the stream and the OpenAI client."""
+    stream = _FakeOpenAIStream(
+        [
+            _make_chunk(reasoning_content="Let me think"),
+            _make_chunk(reasoning_content=" about this."),
+            _make_chunk(reasoning_content=" still reasoning..."),
+        ]
+    )
+    fake_client = _make_stream_client(stream)
+
+    with patch(
+        "lightrag.llm.openai.create_openai_async_client", return_value=fake_client
+    ):
+        gen = await openai_complete_if_cache.__wrapped__(
+            model="deepseek-reasoner",
+            prompt="hello",
+            enable_cot=True,
+            stream=True,
+            api_key="test-key",
+        )
+        first = await gen.__anext__()  # opens the COT tag
+        second = await gen.__anext__()
+        await gen.aclose()  # consumer disconnects mid reasoning phase
+
+    assert first == "<think>"
+    assert second == "Let me think"
+    stream.aclose.assert_awaited()
+    fake_client.close.assert_awaited()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_stream_closed_after_full_consumption_with_cot():
+    """Draining a COT stream to completion still closes stream and client."""
+    stream = _FakeOpenAIStream(
+        [
+            _make_chunk(reasoning_content="thinking"),
+            _make_chunk(content="answer"),
+        ]
+    )
+    fake_client = _make_stream_client(stream)
+
+    with patch(
+        "lightrag.llm.openai.create_openai_async_client", return_value=fake_client
+    ):
+        gen = await openai_complete_if_cache.__wrapped__(
+            model="deepseek-reasoner",
+            prompt="hello",
+            enable_cot=True,
+            stream=True,
+            api_key="test-key",
+        )
+        chunks = [chunk async for chunk in gen]
+
+    assert chunks == ["<think>", "thinking", "</think>", "answer"]
+    stream.aclose.assert_awaited()
+    fake_client.close.assert_awaited()


### PR DESCRIPTION
## Description

`openai_complete_if_cache`'s streaming branch has a `finally`-block safety net that closes a still-open `<think>` tag with `yield "</think>"`. When the consumer disconnects while COT is open (an HTTP client going away mid reasoning-phase), `aclose()` throws `GeneratorExit` at that suspension point; yielding again is illegal there, so `aclose()` raises `RuntimeError: async generator ignored GeneratorExit` and the `finally` block is aborted before the `response.aclose()` / `openai_async_client.close()` calls that follow it run. The stream and the client leak.

## Related Issues

Fixes #3634

## Changes Made

Adds an `except GeneratorExit` clause that records the unwind reason and re-raises. The `finally` block's COT-close attempt is skipped specifically when closing via `GeneratorExit` (a yield is exactly what's disallowed there), and falls through unconditionally to the existing `response.aclose()` / `openai_async_client.close()` calls. The two other COT-close sites (after the loop ends, and inside the `except Exception` handler) are unaffected: `GeneratorExit` is a `BaseException` and never reaches the `except Exception` branch, and the post-loop close only runs on normal completion.

New regression test `tests/llm/openai_impl/test_openai_stream_generatorexit_cot_cleanup.py` drives the real `openai_complete_if_cache` through a disconnect mid-COT (only the network-facing client mocked) and asserts both the stream and the client get closed; a second test pins that a full COT stream still closes cleanly.

## Checklist

- [x] Changes tested locally
- [x] Pre-commit checks pass (`pre-commit run --all-files`)
- [x] Unit/integration tests added or updated where applicable
- [ ] Documentation updated if behavior changes
- [x] PR description explains the *why*, not just the *what*

## Additional Notes

Verified in a clean `python:3.12-slim` container, importing the real module (`lightrag.llm.openai.__file__` printed for provenance):

- The new test fails on `main` with the exact `RuntimeError: async generator ignored GeneratorExit` above, and passes on this branch, both closing the stream and the client.
- Full offline suite (`pytest tests/ -m offline`): 5213 passed, 45 skipped (pre-existing, missing spaCy models, unrelated), 0 failed on Python 3.12; the `openai_impl` subset also passes clean on 3.14.
- `coverage run --source=lightrag.llm.openai` confirms every changed line is exercised by the new test.
- `pre-commit run --files lightrag/llm/openai.py <test file>` clean.

Not verified: `GeneratorExit` arriving while the generator is suspended inside the `except Exception` handler's own COT-close `yield` (a real API error, then a disconnect before exception-path cleanup finishes) is a narrower variant of the same class of bug and is left out of scope here.
