### PR TITLE
fix(api): fail fast for custom Ollama embedding dimensions

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -710,6 +710,22 @@ def create_optimized_embedding_function(
     except ImportError as e:
         logger.warning(f"Could not import provider function for {binding}: {e}")
 
+    if (
+        binding == "ollama"
+        and model
+        and args.embedding_dim is None
+        and provider_func is not None
+    ):
+        default_model = provider_func.model_name
+        configured_model = model.removesuffix(":latest")
+        normalized_default = default_model.removesuffix(":latest")
+        if configured_model != normalized_default:
+            raise ValueError(
+                "EMBEDDING_DIM must be set when EMBEDDING_MODEL selects a "
+                f"custom Ollama model ({model!r}); the provider default "
+                f"dimension only applies to {default_model!r}"
+            )
+
     # Step 2: Apply priority (user config > provider default)
     # For max_token_size: explicit env var > provider default > None
     final_max_token_size = args.embedding_token_limit or provider_max_token_size

--- a/tests/api/config/test_ollama_embedding_dimension.py
+++ b/tests/api/config/test_ollama_embedding_dimension.py
@@ -1,0 +1,51 @@
+"""Startup validation for custom Ollama embedding dimensions."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.offline
+
+
+def _create_embedding_function(*, model: str | None, embedding_dim: int | None):
+    with patch.object(sys, "argv", ["lightrag-server"]):
+        from lightrag.api.lightrag_server import create_optimized_embedding_function
+
+    args = SimpleNamespace(
+        embedding_dim=embedding_dim,
+        embedding_token_limit=None,
+        embedding_asymmetric=False,
+        embedding_asymmetric_configured=False,
+        embedding_query_prefix_configured=False,
+        embedding_document_prefix_configured=False,
+    )
+    return create_optimized_embedding_function(
+        config_cache=MagicMock(ollama_embedding_options=None),
+        binding="ollama",
+        model=model,
+        host="http://localhost:11434",
+        api_key=None,
+        args=args,
+    )
+
+
+def test_custom_ollama_model_requires_explicit_embedding_dimension():
+    with pytest.raises(ValueError, match=r"EMBEDDING_DIM.*nomic-embed-text"):
+        _create_embedding_function(model="nomic-embed-text", embedding_dim=None)
+
+
+def test_custom_ollama_model_accepts_explicit_embedding_dimension():
+    embedding_func = _create_embedding_function(
+        model="nomic-embed-text", embedding_dim=768
+    )
+
+    assert embedding_func.embedding_dim == 768
+
+
+@pytest.mark.parametrize("model", [None, "bge-m3", "bge-m3:latest"])
+def test_default_ollama_model_keeps_provider_dimension(model):
+    embedding_func = _create_embedding_function(model=model, embedding_dim=None)
+
+    assert embedding_func.embedding_dim == 1024


### PR DESCRIPTION
## Summary

- require an explicit `EMBEDDING_DIM` when `EMBEDDING_MODEL` selects a non-default Ollama model
- preserve the provider dimension for the default `bge-m3` model, including its `:latest` alias
- cover custom/default model behavior with offline regression tests

Closes #3596.

## Root cause

`EMBEDDING_DIM` now defaults to `None`, but the Ollama provider wrapper still correctly advertises its default `bge-m3:latest` dimension as 1024. When a different model such as `nomic-embed-text` is configured without a dimension, the factory inherits that 1024 provider default even though the model returns 768-dimensional vectors. The mismatch therefore appears only later during vector-store ingestion.

## Design boundary

This patch deliberately fails at configuration time instead of probing Ollama at startup. It adds no implicit network request and changes only the combination of Ollama + a non-default model + no explicit dimension. Default Ollama configuration and explicitly dimensioned custom models retain their current behavior.

## Validation

- `py -3 -m pytest tests/api/config/test_ollama_embedding_dimension.py tests/api/config/test_ollama_think_startup_validation.py tests/api/config/test_api_config_ollama_role_think.py -q` - 21 passed
- `py -3 -m ruff check tests/api/config/test_ollama_embedding_dimension.py` - passed
- `git diff --check` - passed
