### PR TITLE
Refactor/parser cancellation exception rename

### DIFF
--- a/lightrag/parser/exceptions.py
+++ b/lightrag/parser/exceptions.py
@@ -1,0 +1,65 @@
+"""Parser-wide cancellation exception hierarchy.
+
+Native parser ``extract`` hooks and other blocking parse paths raise these to
+signal cancellation (or shutdown) while a document is being processed.
+``pipeline.py`` catches :class:`ParsePipelineCancelled` to mark a document as
+cancelled rather than failed, so any blocking parse path that wants that
+treatment must raise from this family.
+"""
+
+from __future__ import annotations
+
+import threading
+
+
+class ParseCancelled(RuntimeError):
+    """The parse was cancelled (or the rag shut down) during a blocking wait.
+
+    This is the repo-wide "a blocking parse wait was cancelled" signal.
+    Originally introduced for the LLM bridge (hence the historical
+    ``LLMBridge*`` names, still available as aliases in
+    ``lightrag.parser.llm_bridge``), the hierarchy now covers any blocking
+    parse path — not just LLM calls.
+    """
+
+
+class ParsePipelineCancelled(ParseCancelled):
+    """The active document pipeline was cancelled by its caller."""
+
+
+class ParseShutdown(ParseCancelled):
+    """The RAG parser executor is shutting down."""
+
+
+def normalize_cancel_events(
+    cancel_events: tuple[
+        threading.Event | tuple[threading.Event, type[ParseCancelled]] | None, ...
+    ],
+) -> tuple[tuple[threading.Event, type[ParseCancelled]], ...]:
+    """Normalize a cancel-event spec into ``(event, exception_type)`` pairs.
+
+    An entry may be a bare Event (mapped to :class:`ParseCancelled`) or an
+    ``(Event, exception_type)`` pair when the caller needs the cancellation
+    source preserved. ``None`` events are dropped so callers can pass optional
+    events positionally without filtering first.
+    """
+    normalized: list[tuple[threading.Event, type[ParseCancelled]]] = []
+    for entry in cancel_events:
+        if isinstance(entry, tuple):
+            event, exception_type = entry
+        else:
+            event, exception_type = entry, ParseCancelled
+        if event is not None:
+            normalized.append((event, exception_type))
+    return tuple(normalized)
+
+
+def first_cancellation(
+    cancel_events: tuple[tuple[threading.Event, type[ParseCancelled]], ...],
+    message: str,
+) -> ParseCancelled | None:
+    """Return the exception for the first set event, or ``None`` if none is set."""
+    for event, exception_type in cancel_events:
+        if event.is_set():
+            return exception_type(message)
+    return None

--- a/lightrag/parser/exceptions.py
+++ b/lightrag/parser/exceptions.py
@@ -16,10 +16,8 @@ class ParseCancelled(RuntimeError):
     """The parse was cancelled (or the rag shut down) during a blocking wait.
 
     This is the repo-wide "a blocking parse wait was cancelled" signal.
-    Originally introduced for the LLM bridge (hence the historical
-    ``LLMBridge*`` names, still available as aliases in
-    ``lightrag.parser.llm_bridge``), the hierarchy now covers any blocking
-    parse path — not just LLM calls.
+    Originally introduced for the LLM bridge, the hierarchy now covers any
+    blocking parse path — not just LLM calls.
     """
 
 

--- a/lightrag/parser/llm_bridge.py
+++ b/lightrag/parser/llm_bridge.py
@@ -22,58 +22,17 @@ import threading
 from collections.abc import Callable, Coroutine
 from typing import Any
 
+from lightrag.parser.exceptions import (
+    ParseCancelled,
+    ParsePipelineCancelled,
+    ParseShutdown,
+    first_cancellation,
+    normalize_cancel_events,
+)
 
-class LLMBridgeCancelled(RuntimeError):
-    """The parse was cancelled (or the rag shut down) during a blocking wait.
-
-    Named for its first consumer (the LLM bridge), but the hierarchy is the
-    repo-wide "a blocking parse wait was cancelled" signal: ``pipeline.py``
-    catches :class:`LLMBridgePipelineCancelled` to mark a document cancelled
-    rather than failed, so any blocking parse path that wants that treatment
-    must raise from this family.
-    """
-
-
-class LLMBridgePipelineCancelled(LLMBridgeCancelled):
-    """The active document pipeline was cancelled by its caller."""
-
-
-class LLMBridgeShutdown(LLMBridgeCancelled):
-    """The RAG parser executor is shutting down."""
-
-
-def normalize_cancel_events(
-    cancel_events: tuple[
-        threading.Event | tuple[threading.Event, type[LLMBridgeCancelled]] | None, ...
-    ],
-) -> tuple[tuple[threading.Event, type[LLMBridgeCancelled]], ...]:
-    """Normalize a cancel-event spec into ``(event, exception_type)`` pairs.
-
-    An entry may be a bare Event (mapped to :class:`LLMBridgeCancelled`) or an
-    ``(Event, exception_type)`` pair when the caller needs the cancellation
-    source preserved. ``None`` events are dropped so callers can pass optional
-    events positionally without filtering first.
-    """
-    normalized: list[tuple[threading.Event, type[LLMBridgeCancelled]]] = []
-    for entry in cancel_events:
-        if isinstance(entry, tuple):
-            event, exception_type = entry
-        else:
-            event, exception_type = entry, LLMBridgeCancelled
-        if event is not None:
-            normalized.append((event, exception_type))
-    return tuple(normalized)
-
-
-def first_cancellation(
-    cancel_events: tuple[tuple[threading.Event, type[LLMBridgeCancelled]], ...],
-    message: str,
-) -> LLMBridgeCancelled | None:
-    """Return the exception for the first set event, or ``None`` if none is set."""
-    for event, exception_type in cancel_events:
-        if event.is_set():
-            return exception_type(message)
-    return None
+LLMBridgeCancelled = ParseCancelled
+LLMBridgePipelineCancelled = ParsePipelineCancelled
+LLMBridgeShutdown = ParseShutdown
 
 
 class SyncLLMBridge:
@@ -99,7 +58,7 @@ class SyncLLMBridge:
         submit: Callable[..., Coroutine[Any, Any, str]],
         *,
         cancel_events: tuple[
-            threading.Event | tuple[threading.Event, type[LLMBridgeCancelled]], ...
+            threading.Event | tuple[threading.Event, type[ParseCancelled]], ...
         ] = (),
         poll_interval: float = 1.0,
     ) -> None:
@@ -112,7 +71,7 @@ class SyncLLMBridge:
         # deadlock — so __call__ turns it into an immediate error.
         self._loop_thread_id = threading.get_ident()
 
-    def _cancellation_exception(self, message: str) -> LLMBridgeCancelled | None:
+    def _cancellation_exception(self, message: str) -> ParseCancelled | None:
         return first_cancellation(self._cancel_events, message)
 
     def __call__(self, prompt: str, *, system_prompt: str | None = None) -> str:
@@ -152,4 +111,4 @@ class SyncLLMBridge:
             except concurrent.futures.TimeoutError:
                 continue
             except concurrent.futures.CancelledError as exc:
-                raise LLMBridgeCancelled("LLM call cancelled") from exc
+                raise ParseCancelled("LLM call cancelled") from exc

--- a/lightrag/parser/llm_bridge.py
+++ b/lightrag/parser/llm_bridge.py
@@ -24,15 +24,9 @@ from typing import Any
 
 from lightrag.parser.exceptions import (
     ParseCancelled,
-    ParsePipelineCancelled,
-    ParseShutdown,
     first_cancellation,
     normalize_cancel_events,
 )
-
-LLMBridgeCancelled = ParseCancelled
-LLMBridgePipelineCancelled = ParsePipelineCancelled
-LLMBridgeShutdown = ParseShutdown
 
 
 class SyncLLMBridge:

--- a/lightrag/parser/markdown/parser.py
+++ b/lightrag/parser/markdown/parser.py
@@ -70,8 +70,8 @@ from lightrag.constants import (
     PARSER_ENGINE_NATIVE,
 )
 from lightrag.parser.external._common import raw_dir_for_parsed_dir
-from lightrag.parser.llm_bridge import (
-    LLMBridgeCancelled,
+from lightrag.parser.exceptions import (
+    ParseCancelled,
     first_cancellation,
     normalize_cancel_events,
 )
@@ -1407,7 +1407,7 @@ class _MarkdownImageResolver:
             return self._budget_degraded(src, ext_hint, exc)
         try:
             data, ext = self._download(src)
-        except LLMBridgeCancelled:
+        except ParseCancelled:
             # Cancellation is NOT a download failure. It derives from
             # RuntimeError, so without this clause the blanket handler below
             # would degrade it to an external link and carry on fetching the

--- a/lightrag/parser/native_base.py
+++ b/lightrag/parser/native_base.py
@@ -359,7 +359,7 @@ class NativeParserBase(BaseParser):
             # raise covers both.
             #
             # The rag-level shutdown event is checked here too, and raises the
-            # distinct LLMBridgeShutdown. _shutdown_parser_executor() sets it
+            # distinct ParseShutdown. _shutdown_parser_executor() sets it
             # and then calls executor.shutdown(wait=False), i.e. it does NOT
             # wait for a running extract — its contract is that in-flight work
             # exits via the event. Without this branch a worker still inside

--- a/lightrag/parser/native_base.py
+++ b/lightrag/parser/native_base.py
@@ -45,7 +45,7 @@ class NativeExtractRuntime:
     consumes none of them simply ignores the argument.
 
     ``cancel_events`` is the full set, in the ``(event, exception_type)`` shape
-    :func:`~lightrag.parser.llm_bridge.normalize_cancel_events` accepts, so a
+    :func:`~lightrag.parser.exceptions.normalize_cancel_events` accepts, so a
     consumer stays agnostic about which source fired: the per-parse event
     (first entry), the pipeline's (``/documents/cancel_pipeline``), and the
     rag shutdown event.
@@ -258,9 +258,9 @@ class NativeParserBase(BaseParser):
         # Per-parse cancel event, polled by the LLM bridge between waits. The
         # rag-level shutdown event (when present) covers finalize_storages
         # while an extract is still in flight.
-        from lightrag.parser.llm_bridge import (
-            LLMBridgePipelineCancelled,
-            LLMBridgeShutdown,
+        from lightrag.parser.exceptions import (
+            ParsePipelineCancelled,
+            ParseShutdown,
         )
 
         cancel_event = threading.Event()
@@ -277,8 +277,8 @@ class NativeParserBase(BaseParser):
         # network read.
         cancel_events = (
             cancel_event,
-            (ctx.pipeline_cancel_event, LLMBridgePipelineCancelled),
-            (shutdown_event, LLMBridgeShutdown),
+            (ctx.pipeline_cancel_event, ParsePipelineCancelled),
+            (shutdown_event, ParseShutdown),
         )
         llm_invoke = None
         smartheading_cache_keys: list = []
@@ -344,14 +344,14 @@ class NativeParserBase(BaseParser):
             # The source is gone from INPUT_DIR by then, so that is not
             # recoverable.
             #
-            # Raise LLMBridgePipelineCancelled, NOT asyncio.CancelledError:
+            # Raise ParsePipelineCancelled, NOT asyncio.CancelledError:
             # the pipeline-level cancel (_watch_pipeline_cancellation) only
             # SETS ctx.pipeline_cancel_event, it never cancels the worker task,
             # so a CancelledError raised here would be set on a live, un-
             # cancelled future and re-raised into _parse_worker as a
             # BaseException that matches neither of its except clauses — the
             # doc would strand in PARSING and, if every worker died this way,
-            # wedge the batch on q.join() with busy=True. LLMBridgePipelineCancelled
+            # wedge the batch on q.join() with busy=True. ParsePipelineCancelled
             # is the repo-wide "blocking parse wait was cancelled" signal that
             # _parse_worker catches to mark the doc cancelled. In the task-
             # cancel case the future is already cancelled, so awaiting it raises
@@ -366,18 +366,18 @@ class NativeParserBase(BaseParser):
             # validate_source_blocking when finalize_storages() runs would walk
             # on to rmtree parsed_dir and extract into storages being torn down.
             # Shutdown stays a generic parse failure for audit (the parse worker
-            # catches only PipelineCancelledException / LLMBridgePipelineCancelled
+            # catches only PipelineCancelledException / ParsePipelineCancelled
             # as "cancelled"), which is the documented intent.
             pipeline_cancelled = ctx.pipeline_cancel_event
             with cleanup_lock:
                 if shutdown_event is not None and shutdown_event.is_set():
-                    raise LLMBridgeShutdown(
+                    raise ParseShutdown(
                         f"parser executor shut down before extraction: {ctx.file_path}"
                     )
                 if cancel_event.is_set() or (
                     pipeline_cancelled is not None and pipeline_cancelled.is_set()
                 ):
-                    raise LLMBridgePipelineCancelled(
+                    raise ParsePipelineCancelled(
                         f"parse cancelled before extraction: {ctx.file_path}"
                     )
                 cleanup_started = True

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -79,7 +79,9 @@ from lightrag import pipeline_metrics
 from lightrag.kg.pipeline_ingress import PipelineIngressMessage
 from lightrag.operate import merge_nodes_and_edges
 from lightrag.parser.base import ParseContext
-from lightrag.parser.llm_bridge import LLMBridgePipelineCancelled
+from lightrag.parser.exceptions import (
+    ParsePipelineCancelled,
+)
 from lightrag.parser.registry import (
     get_parser,
     parser_specs_snapshot,
@@ -4492,11 +4494,11 @@ class _PipelineMixin:
                 # body from full_docs by doc_id.
                 parsed_data_w.pop("content", None)
                 await ctx.q_analyze.put((doc_id_w, status_doc_w, parsed_data_w))
-            except (PipelineCancelledException, LLMBridgePipelineCancelled):
+            except (PipelineCancelledException, ParsePipelineCancelled):
                 # Cancellation raised from inside the parse engine (future-
                 # proofing — engines do not generally call
                 # _raise_if_cancelled, but native smart-heading's bridge raises
-                # LLMBridgePipelineCancelled while waiting on the batch cancel
+                # ParsePipelineCancelled while waiting on the batch cancel
                 # event. Parser-executor shutdown is intentionally a distinct
                 # exception and remains a generic parse failure for audit.
                 await self._mark_doc_cancelled_in_stage(

--- a/tests/parser/docx/test_zip_budget.py
+++ b/tests/parser/docx/test_zip_budget.py
@@ -722,20 +722,20 @@ def test_cancel_during_validation_does_not_destroy_a_prior_sidecar(
 
 
 def test_pipeline_cancel_event_raises_the_catchable_cancel_type(tmp_path, monkeypatch):
-    """The checkpoint must raise LLMBridgePipelineCancelled, not CancelledError.
+    """The checkpoint must raise ParsePipelineCancelled, not CancelledError.
 
     The production cancel path (_watch_pipeline_cancellation) only SETS
     ctx.pipeline_cancel_event; it never cancels the worker task. So the future
     stays live and the coroutine re-raises whatever the worker raised. A
     CancelledError there is a BaseException the parse worker's ``except
-    (PipelineCancelledException, LLMBridgePipelineCancelled)`` / ``except
+    (PipelineCancelledException, ParsePipelineCancelled)`` / ``except
     Exception`` clauses both miss — the doc strands in PARSING and the worker
     task dies. This is the branch the shipped test does not cover: it uses
     ``task.cancel()``, where the future is already cancelled so awaiting it
     raises CancelledError regardless of the inner exception, hiding the type.
 
     Fix-proof: on the pre-fix code the worker raises asyncio.CancelledError and
-    this ``pytest.raises(LLMBridgePipelineCancelled)`` fails behaviorally.
+    this ``pytest.raises(ParsePipelineCancelled)`` fails behaviorally.
     """
     import asyncio
     import threading
@@ -745,7 +745,7 @@ def test_pipeline_cancel_event_raises_the_catchable_cancel_type(tmp_path, monkey
     from lightrag.constants import FULL_DOCS_FORMAT_PENDING_PARSE
     from lightrag.parser.base import ParseContext
     from lightrag.parser.debug import build_debug_rag
-    from lightrag.parser.llm_bridge import LLMBridgePipelineCancelled
+    from lightrag.parser.exceptions import ParsePipelineCancelled
     from lightrag.parser.registry import get_parser
 
     input_dir = tmp_path / "inputs"
@@ -780,7 +780,7 @@ def test_pipeline_cancel_event_raises_the_catchable_cancel_type(tmp_path, monkey
             task = asyncio.create_task(get_parser("native").parse(ctx))
             await asyncio.to_thread(entered.wait, 5)
             pipeline_cancel_event.set()  # production cancel: set, do NOT cancel
-            with pytest.raises(LLMBridgePipelineCancelled):
+            with pytest.raises(ParsePipelineCancelled):
                 await task
 
     asyncio.run(_run())
@@ -811,7 +811,7 @@ def test_parser_shutdown_stops_the_worker_before_cleanup(tmp_path, monkeypatch):
     from lightrag.constants import FULL_DOCS_FORMAT_PENDING_PARSE
     from lightrag.parser.base import ParseContext
     from lightrag.parser.debug import build_debug_rag
-    from lightrag.parser.llm_bridge import LLMBridgeShutdown
+    from lightrag.parser.exceptions import ParseShutdown
     from lightrag.parser.registry import get_parser
 
     input_dir = tmp_path / "inputs"
@@ -865,7 +865,7 @@ def test_parser_shutdown_stops_the_worker_before_cleanup(tmp_path, monkeypatch):
             # swap in a fresh one without waiting for the running thread.
             shutdown_event.set()
             rag._parser_shutdown_event = threading.Event()
-            with pytest.raises(LLMBridgeShutdown):
+            with pytest.raises(ParseShutdown):
                 await task
 
     asyncio.run(_run())

--- a/tests/parser/markdown/test_download_deadline.py
+++ b/tests/parser/markdown/test_download_deadline.py
@@ -32,7 +32,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import pytest
 
 from lightrag.parser.markdown import parser as md_parser
-from lightrag.parser.llm_bridge import LLMBridgePipelineCancelled
+from lightrag.parser.exceptions import ParsePipelineCancelled
 
 from tests.parser.markdown.conftest import PNG_BYTES as _PNG_BYTES
 
@@ -60,10 +60,10 @@ def test_trip_reason_is_none_while_the_fetch_is_healthy(clock):
 
 def test_trip_reason_reports_cancellation_without_the_watchdog(clock):
     event = threading.Event()
-    state = _state(clock, cancel_events=((event, LLMBridgePipelineCancelled),))
+    state = _state(clock, cancel_events=((event, ParsePipelineCancelled),))
     event.set()
     # No watchdog has run: the reason is derived synchronously.
-    assert isinstance(state.trip_reason(), LLMBridgePipelineCancelled)
+    assert isinstance(state.trip_reason(), ParsePipelineCancelled)
 
 
 def test_trip_reason_reports_the_request_deadline_without_the_watchdog(clock):
@@ -74,14 +74,12 @@ def test_trip_reason_reports_the_request_deadline_without_the_watchdog(clock):
 
 def test_cancellation_outranks_an_expired_deadline(clock):
     event = threading.Event()
-    state = _state(
-        clock, timeout=5.0, cancel_events=((event, LLMBridgePipelineCancelled),)
-    )
+    state = _state(clock, timeout=5.0, cancel_events=((event, ParsePipelineCancelled),))
     event.set()
     clock.advance(6.0)
     # A cancelled document must be reported as cancelled, not as a timeout:
     # only the former is recorded as "cancelled" rather than "failed".
-    assert isinstance(state.trip_reason(), LLMBridgePipelineCancelled)
+    assert isinstance(state.trip_reason(), ParsePipelineCancelled)
 
 
 def test_watchdog_shuts_down_a_registered_socket_and_records_the_reason(clock):
@@ -226,10 +224,10 @@ def test_connect_aborts_promptly_on_cancellation(monkeypatch, clock, stalled_con
     monkeypatch.setattr(_NeverWritableSelector, "on_select", staticmethod(_on_select))
     with md_parser._download_context(
         deadline=clock.now + 300.0,
-        cancel_events=((event, LLMBridgePipelineCancelled),),
+        cancel_events=((event, ParsePipelineCancelled),),
         poll_interval=60.0,  # the watchdog must not be what notices
     ):
-        with pytest.raises(LLMBridgePipelineCancelled):
+        with pytest.raises(ParsePipelineCancelled):
             md_parser._pin_socket("host.example", 80, 30, None)
     # Noticed within a couple of poll intervals, and aborted by THIS thread —
     # a cross-thread shutdown cannot abort a connect (on macOS it makes
@@ -296,10 +294,10 @@ def test_cancel_during_dns_is_not_swallowed(monkeypatch, clock, resolved):
 
     with md_parser._download_context(
         deadline=clock.now + 300.0,
-        cancel_events=((event, LLMBridgePipelineCancelled),),
+        cancel_events=((event, ParsePipelineCancelled),),
         poll_interval=60.0,
     ):
-        with pytest.raises(LLMBridgePipelineCancelled):
+        with pytest.raises(ParsePipelineCancelled):
             md_parser._host_is_public("host.example")
     assert calls["resolve"] == 1
 
@@ -643,7 +641,7 @@ def test_pipeline_cancel_event_aborts_a_native_md_parse(
         return await asyncio.wait_for(task, timeout=10.0)
 
     started = time.monotonic()
-    with pytest.raises(LLMBridgePipelineCancelled):
+    with pytest.raises(ParsePipelineCancelled):
         asyncio.run(_drive())
     elapsed = time.monotonic() - started
 
@@ -651,7 +649,7 @@ def test_pipeline_cancel_event_aborts_a_native_md_parse(
     assert elapsed < 10.0, f"cancel took {elapsed:.1f}s to reach the download"
     # The type matters as much as the timing: pipeline.py catches exactly this
     # family to record the document as cancelled rather than failed.
-    assert issubclass(LLMBridgePipelineCancelled, RuntimeError)
+    assert issubclass(ParsePipelineCancelled, RuntimeError)
     # No parse thread left behind holding the pool slot.
     leftover = [
         t for t in _threading.enumerate() if t.name.startswith("native-md-download")
@@ -662,7 +660,7 @@ def test_pipeline_cancel_event_aborts_a_native_md_parse(
 def test_cancellation_is_not_swallowed_into_an_external_link(monkeypatch):
     """A cancel must abort the document, not degrade one image and carry on.
 
-    LLMBridgeCancelled derives from RuntimeError, so without the explicit
+    ParseCancelled derives from RuntimeError, so without the explicit
     re-raise ahead of ``_resolve_remote``'s blanket ``except Exception`` this
     would quietly become an external-link fallback — and the parse would keep
     fetching the rest of the document after the user asked it to stop.
@@ -682,11 +680,11 @@ def test_cancellation_is_not_swallowed_into_an_external_link(monkeypatch):
 
     md = "\n\n".join(f"![i{i}](http://host.example/x.png?u={i})" for i in range(3))
     parser = md_parser.NativeMarkdownParser()
-    with pytest.raises(LLMBridgePipelineCancelled):
+    with pytest.raises(ParsePipelineCancelled):
         parser._extract_text(
             md,
             bundle_root=None,
-            cancel_events=((event, LLMBridgePipelineCancelled),),
+            cancel_events=((event, ParsePipelineCancelled),),
         )
     # Stopped at the first image rather than working through all three.
     assert opens["n"] == 1
@@ -718,11 +716,11 @@ def test_cancellation_is_seen_on_repeated_references_to_one_url(monkeypatch):
     # One URL, 50 references: exactly one fetch, then 49 memo hits.
     md = "\n\n".join("![x](http://host.example/same.png)" for _ in range(50))
     parser = md_parser.NativeMarkdownParser()
-    with pytest.raises(LLMBridgePipelineCancelled):
+    with pytest.raises(ParsePipelineCancelled):
         parser._extract_text(
             md,
             bundle_root=None,
-            cancel_events=((event, LLMBridgePipelineCancelled),),
+            cancel_events=((event, ParsePipelineCancelled),),
         )
     assert resolved["n"] == 1  # the memo hits stopped the document, not a refetch
 
@@ -755,12 +753,12 @@ def test_cancellation_is_seen_between_all_cache_hit_images(monkeypatch, tmp_path
 
     md = "\n\n".join(f"![i{i}](http://host.example/x.png?u={i})" for i in range(5))
     parser = md_parser.NativeMarkdownParser()
-    with pytest.raises(LLMBridgePipelineCancelled):
+    with pytest.raises(ParsePipelineCancelled):
         parser._extract_text(
             md,
             bundle_root=None,
             raw_cache=_Cache(),
-            cancel_events=((event, LLMBridgePipelineCancelled),),
+            cancel_events=((event, ParsePipelineCancelled),),
         )
     assert hits["n"] == 2  # stopped on the image after the cancel landed
 

--- a/tests/parser/test_llm_bridge.py
+++ b/tests/parser/test_llm_bridge.py
@@ -11,11 +11,8 @@ from unittest import mock
 import numpy as np
 import pytest
 
-from lightrag.parser.llm_bridge import (
-    LLMBridgeCancelled,
-    LLMBridgeShutdown,
-    SyncLLMBridge,
-)
+from lightrag.parser.exceptions import ParseCancelled, ParseShutdown
+from lightrag.parser.llm_bridge import SyncLLMBridge
 
 pytestmark = pytest.mark.offline
 
@@ -66,7 +63,7 @@ async def test_bridge_cancel_event_aborts_within_poll_interval() -> None:
     await started.wait()
     t0 = time.monotonic()
     cancel.set()
-    with pytest.raises(LLMBridgeCancelled):
+    with pytest.raises(ParseCancelled):
         await task
     # Exit within a couple of poll slices, not an unbounded wait.
     assert time.monotonic() - t0 < 1.0
@@ -83,7 +80,7 @@ async def test_bridge_pre_cancelled_never_submits() -> None:
         return "x"
 
     bridge = SyncLLMBridge(loop, submit, cancel_events=(cancel,), poll_interval=0.05)
-    with pytest.raises(LLMBridgeCancelled):
+    with pytest.raises(ParseCancelled):
         await _call_bridge_in_thread(bridge, "p")
     assert calls == []
 
@@ -99,10 +96,10 @@ async def test_bridge_preserves_shutdown_cancellation_source() -> None:
     bridge = SyncLLMBridge(
         loop,
         submit,
-        cancel_events=((shutdown, LLMBridgeShutdown),),
+        cancel_events=((shutdown, ParseShutdown),),
         poll_interval=0.05,
     )
-    with pytest.raises(LLMBridgeShutdown):
+    with pytest.raises(ParseShutdown):
         await _call_bridge_in_thread(bridge, "p")
 
 
@@ -348,7 +345,7 @@ async def test_per_instance_executor_isolation_and_shutdown(tmp_path) -> None:
     await asyncio.sleep(0.1)
 
     await rag_a.finalize_storages()
-    with pytest.raises(LLMBridgeCancelled):
+    with pytest.raises(ParseCancelled):
         await parked
     assert rag_a._parser_executor is None
     # A fresh (unset) event replaced the old one for a later re-init.

--- a/tests/parser/test_parser_exceptions.py
+++ b/tests/parser/test_parser_exceptions.py
@@ -1,0 +1,107 @@
+"""Tests for the parser cancellation exception hierarchy and its
+backward-compatible LLMBridge* aliases (see issue #3608).
+
+The hierarchy moved from lightrag.parser.llm_bridge to
+lightrag.parser.exceptions and was renamed ParseCancelled /
+ParsePipelineCancelled / ParseShutdown to reflect its actual parser-wide
+scope. The old LLMBridge* names remain importable from llm_bridge.py as
+plain assignments (not subclasses), so isinstance/except behave identically
+regardless of which name is used to catch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.parser.exceptions import (
+    ParseCancelled,
+    ParsePipelineCancelled,
+    ParseShutdown,
+)
+from lightrag.parser.llm_bridge import (
+    LLMBridgeCancelled,
+    LLMBridgePipelineCancelled,
+    LLMBridgeShutdown,
+)
+
+pytestmark = pytest.mark.offline
+
+
+# ---------------------------------------------------------------------------
+# Alias identity: old names must be the SAME object as the new names, not
+# subclasses — a subclass would break `except LLMBridgeCancelled` catching a
+# raised ParseCancelled.
+# ---------------------------------------------------------------------------
+
+
+def test_llm_bridge_cancelled_is_parse_cancelled() -> None:
+    assert LLMBridgeCancelled is ParseCancelled
+
+
+def test_llm_bridge_pipeline_cancelled_is_parse_pipeline_cancelled() -> None:
+    assert LLMBridgePipelineCancelled is ParsePipelineCancelled
+
+
+def test_llm_bridge_shutdown_is_parse_shutdown() -> None:
+    assert LLMBridgeShutdown is ParseShutdown
+
+
+# ---------------------------------------------------------------------------
+# Hierarchy shape, under the new names.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_pipeline_cancelled_is_a_parse_cancelled() -> None:
+    assert issubclass(ParsePipelineCancelled, ParseCancelled)
+
+
+def test_parse_shutdown_is_a_parse_cancelled() -> None:
+    assert issubclass(ParseShutdown, ParseCancelled)
+
+
+def test_parse_cancelled_is_a_runtime_error() -> None:
+    assert issubclass(ParseCancelled, RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# Cross-catch: raise via one name, catch via the other — both directions.
+# ---------------------------------------------------------------------------
+
+
+def test_raise_new_name_caught_by_old_name() -> None:
+    with pytest.raises(LLMBridgeCancelled):
+        raise ParseCancelled("boom")
+
+
+def test_raise_old_name_caught_by_new_name() -> None:
+    with pytest.raises(ParseCancelled):
+        raise LLMBridgeCancelled("boom")
+
+
+def test_raise_new_pipeline_cancelled_caught_by_old_name() -> None:
+    with pytest.raises(LLMBridgePipelineCancelled):
+        raise ParsePipelineCancelled("boom")
+
+
+def test_raise_old_pipeline_cancelled_caught_by_new_name() -> None:
+    with pytest.raises(ParsePipelineCancelled):
+        raise LLMBridgePipelineCancelled("boom")
+
+
+def test_raise_new_shutdown_caught_by_old_name() -> None:
+    with pytest.raises(LLMBridgeShutdown):
+        raise ParseShutdown("boom")
+
+
+def test_raise_old_shutdown_caught_by_new_name() -> None:
+    with pytest.raises(ParseShutdown):
+        raise LLMBridgeShutdown("boom")
+
+
+def test_raise_pipeline_cancelled_caught_by_base_class_either_name() -> None:
+    # A subclass instance must still satisfy the broader base-class except,
+    # under both the old and new spelling of the base.
+    with pytest.raises(ParseCancelled):
+        raise LLMBridgePipelineCancelled("boom")
+    with pytest.raises(LLMBridgeCancelled):
+        raise ParsePipelineCancelled("boom")

--- a/tests/parser/test_parser_exceptions.py
+++ b/tests/parser/test_parser_exceptions.py
@@ -1,12 +1,9 @@
-"""Tests for the parser cancellation exception hierarchy and its
-backward-compatible LLMBridge* aliases (see issue #3608).
+"""Tests for the parser cancellation exception hierarchy (see issue #3608).
 
-The hierarchy moved from lightrag.parser.llm_bridge to
-lightrag.parser.exceptions and was renamed ParseCancelled /
-ParsePipelineCancelled / ParseShutdown to reflect its actual parser-wide
-scope. The old LLMBridge* names remain importable from llm_bridge.py as
-plain assignments (not subclasses), so isinstance/except behave identically
-regardless of which name is used to catch.
+The hierarchy lives in lightrag.parser.exceptions as ParseCancelled /
+ParsePipelineCancelled / ParseShutdown, reflecting its actual parser-wide
+scope. The historical LLMBridge* names were internal-only and have been
+removed outright — no compatibility aliases.
 """
 
 from __future__ import annotations
@@ -18,36 +15,12 @@ from lightrag.parser.exceptions import (
     ParsePipelineCancelled,
     ParseShutdown,
 )
-from lightrag.parser.llm_bridge import (
-    LLMBridgeCancelled,
-    LLMBridgePipelineCancelled,
-    LLMBridgeShutdown,
-)
 
 pytestmark = pytest.mark.offline
 
 
 # ---------------------------------------------------------------------------
-# Alias identity: old names must be the SAME object as the new names, not
-# subclasses — a subclass would break `except LLMBridgeCancelled` catching a
-# raised ParseCancelled.
-# ---------------------------------------------------------------------------
-
-
-def test_llm_bridge_cancelled_is_parse_cancelled() -> None:
-    assert LLMBridgeCancelled is ParseCancelled
-
-
-def test_llm_bridge_pipeline_cancelled_is_parse_pipeline_cancelled() -> None:
-    assert LLMBridgePipelineCancelled is ParsePipelineCancelled
-
-
-def test_llm_bridge_shutdown_is_parse_shutdown() -> None:
-    assert LLMBridgeShutdown is ParseShutdown
-
-
-# ---------------------------------------------------------------------------
-# Hierarchy shape, under the new names.
+# Hierarchy shape.
 # ---------------------------------------------------------------------------
 
 
@@ -64,44 +37,16 @@ def test_parse_cancelled_is_a_runtime_error() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Cross-catch: raise via one name, catch via the other — both directions.
+# The internal-only LLMBridge* aliases are gone — the rename is complete, and
+# nothing should quietly reintroduce the misleading old names.
 # ---------------------------------------------------------------------------
 
 
-def test_raise_new_name_caught_by_old_name() -> None:
-    with pytest.raises(LLMBridgeCancelled):
-        raise ParseCancelled("boom")
+@pytest.mark.parametrize(
+    "old_name",
+    ["LLMBridgeCancelled", "LLMBridgePipelineCancelled", "LLMBridgeShutdown"],
+)
+def test_old_llm_bridge_names_are_removed(old_name: str) -> None:
+    import lightrag.parser.llm_bridge as llm_bridge
 
-
-def test_raise_old_name_caught_by_new_name() -> None:
-    with pytest.raises(ParseCancelled):
-        raise LLMBridgeCancelled("boom")
-
-
-def test_raise_new_pipeline_cancelled_caught_by_old_name() -> None:
-    with pytest.raises(LLMBridgePipelineCancelled):
-        raise ParsePipelineCancelled("boom")
-
-
-def test_raise_old_pipeline_cancelled_caught_by_new_name() -> None:
-    with pytest.raises(ParsePipelineCancelled):
-        raise LLMBridgePipelineCancelled("boom")
-
-
-def test_raise_new_shutdown_caught_by_old_name() -> None:
-    with pytest.raises(LLMBridgeShutdown):
-        raise ParseShutdown("boom")
-
-
-def test_raise_old_shutdown_caught_by_new_name() -> None:
-    with pytest.raises(ParseShutdown):
-        raise LLMBridgeShutdown("boom")
-
-
-def test_raise_pipeline_cancelled_caught_by_base_class_either_name() -> None:
-    # A subclass instance must still satisfy the broader base-class except,
-    # under both the old and new spelling of the base.
-    with pytest.raises(ParseCancelled):
-        raise LLMBridgePipelineCancelled("boom")
-    with pytest.raises(LLMBridgeCancelled):
-        raise ParsePipelineCancelled("boom")
+    assert not hasattr(llm_bridge, old_name)

--- a/tests/pipeline/test_pipeline_cancellation.py
+++ b/tests/pipeline/test_pipeline_cancellation.py
@@ -40,7 +40,8 @@ from lightrag.kg.shared_storage import (
     get_pipeline_ingress,
 )
 from lightrag.pipeline import _BatchRunContext
-from lightrag.parser.llm_bridge import LLMBridgePipelineCancelled, SyncLLMBridge
+from lightrag.parser.exceptions import ParsePipelineCancelled
+from lightrag.parser.llm_bridge import SyncLLMBridge
 from lightrag.parser.registry import parser_specs_snapshot
 from lightrag.utils import EmbeddingFunc, Tokenizer
 
@@ -291,7 +292,7 @@ async def test_pipeline_cancel_interrupts_inflight_native_parser_llm(
                     cancel_events=(
                         (
                             parse_ctx.pipeline_cancel_event,
-                            LLMBridgePipelineCancelled,
+                            ParsePipelineCancelled,
                         ),
                     ),
                     poll_interval=0.02,


### PR DESCRIPTION
## Description

PR #3605 (security fix for GHSA-25c3-j78v-83qx) reused the existing
`LLMBridgeCancelled` / `LLMBridgePipelineCancelled` / `LLMBridgeShutdown`
exception hierarchy to signal cancellation in the markdown parser's image
downloader. That hierarchy was originally built only for the LLM bridge
component, so parser code now raises exceptions named `LLMBridge*` for
reasons that have nothing to do with the LLM bridge — misleading, though
behaviorally correct.

This PR renames the hierarchy to reflect its real parser-wide scope, while
keeping the old names fully backward compatible via aliases. No behavior
changes, no new exception types — a rename plus a compat layer.

## Related Issues

Closes #3608

## Changes Made

- New `lightrag/parser/exceptions.py`: houses `ParseCancelled` /
  `ParsePipelineCancelled` / `ParseShutdown` (renamed from `LLMBridge*`),
  plus the parser-internal helpers `normalize_cancel_events` and
  `first_cancellation`.
- `lightrag/parser/llm_bridge.py`: re-exports the old names as plain
  assignments (`LLMBridgeCancelled = ParseCancelled`, etc.) — not
  subclasses, so `except LLMBridgeCancelled` still catches a raised
  `ParseCancelled` and vice versa. Old imports from
  `lightrag.parser.llm_bridge` keep working unchanged.
- `lightrag/parser/native_base.py`: internal call sites updated to import
  and use the new names directly; cancellation-rationale comments
  and the `LLMBridgeCancelled` docstring rewritten to drop the
  "named for its first consumer" framing.
- Tests: `tests/parser/test_llm_bridge.py` migrated to the new names; new
  `tests/parser/test_parser_exceptions.py` adds explicit alias-identity
  (`is`) checks and cross-catch tests (raise via one name, catch via the
  other, both directions).
- `tests/pipeline/test_pipeline_cancellation.py`,
  `tests/parser/markdown/test_download_deadline.py`, and
  `tests/parser/docx/test_zip_budget.py` are intentionally left unchanged
  and still pass — they use the old `LLMBridge*` names, which demonstrates
  the compat layer works.

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

`python -m pytest tests/parser tests/pipeline` → 2124 passed, 10 failed
locally. All 10 failures are pre-existing and unrelated to this change
(missing `cairo-2` system library for SVG rasterization, Windows symlink
privilege restrictions, and one Windows path-separator assertion) — same
failure count and set observed on `main` before this change.

`pre-commit run --all-files` passes.