### PR TITLE
refactor(neo4j): clarify batch edge read contract

### DIFF
--- a/lightrag/kg/neo4j_impl.py
+++ b/lightrag/kg/neo4j_impl.py
@@ -872,8 +872,12 @@ class Neo4JStorage(BaseGraphStorage):
             pairs: List of dictionaries, e.g. [{"src": "node1", "tgt": "node2"}, ...]
 
         Returns:
-            A dictionary mapping (src, tgt) tuples to their edge properties.
+            A dictionary mapping existing (src, tgt) tuples to their edge
+            properties. Missing pairs are omitted.
         """
+        if not pairs:
+            return {}
+
         workspace_label = self._get_workspace_label()
         async with self._driver.session(
             database=self._DATABASE, default_access_mode="READ"
@@ -889,26 +893,19 @@ class Neo4JStorage(BaseGraphStorage):
                 src = record["src_id"]
                 tgt = record["tgt_id"]
                 edges = record["edges"]
-                if edges and len(edges) > 0:
-                    edge_props = edges[0]  # choose the first if multiple exist
-                    # Ensure required keys exist with defaults
-                    for key, default in {
-                        "weight": 1.0,
-                        "source_id": None,
-                        "description": None,
-                        "keywords": None,
-                    }.items():
-                        if key not in edge_props:
-                            edge_props[key] = default
-                    edges_dict[(src, tgt)] = edge_props
-                else:
-                    # No edge found – set default edge properties
-                    edges_dict[(src, tgt)] = {
-                        "weight": 1.0,
-                        "source_id": None,
-                        "description": None,
-                        "keywords": None,
-                    }
+                # MATCH only emits records for existing relationships, so the
+                # aggregate always contains at least one relationship.
+                edge_props = dict(edges[0])  # choose the first if multiple exist
+                # Ensure required keys exist with defaults
+                for key, default in {
+                    "weight": 1.0,
+                    "source_id": None,
+                    "description": None,
+                    "keywords": None,
+                }.items():
+                    if key not in edge_props:
+                        edge_props[key] = default
+                edges_dict[(src, tgt)] = edge_props
             await result.consume()
             return edges_dict
 

--- a/tests/kg/neo4j_impl/test_neo4j_graph_read_contract.py
+++ b/tests/kg/neo4j_impl/test_neo4j_graph_read_contract.py
@@ -116,3 +116,41 @@ async def test_get_node_edges_returns_connected_pairs():
         ("Alpha", "Beta"),
         ("Alpha", "Gamma"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_get_edges_batch_skips_query_for_empty_input():
+    storage, calls = _make_storage([])
+
+    assert await storage.get_edges_batch([]) == {}
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_get_edges_batch_omits_missing_edges():
+    """A failed MATCH emits no row for the missing pair."""
+    storage, calls = _make_storage([])
+
+    assert await storage.get_edges_batch([{"src": "A", "tgt": "B"}]) == {}
+
+    query, params = calls[0]
+    assert "-[r:DIRECTED]-" in query
+    assert params == {"pairs": [{"src": "A", "tgt": "B"}]}
+
+
+@pytest.mark.asyncio
+async def test_get_edges_batch_returns_existing_edge_with_defaults():
+    stored_properties = {"weight": 2.0, "description": "A to B"}
+    storage, _ = _make_storage(
+        [{"src_id": "A", "tgt_id": "B", "edges": [stored_properties]}]
+    )
+
+    assert await storage.get_edges_batch([{"src": "A", "tgt": "B"}]) == {
+        ("A", "B"): {
+            "weight": 2.0,
+            "source_id": None,
+            "description": "A to B",
+            "keywords": None,
+        }
+    }
+    assert stored_properties == {"weight": 2.0, "description": "A to B"}


### PR DESCRIPTION
## Description

Clarify the `Neo4JStorage.get_edges_batch` contract without broadening the relationship types read from the graph. A regular Cypher `MATCH` emits no row for a missing relationship, so the previous empty-aggregate fallback was unreachable and misleading.

This keeps batch reads restricted to the `DIRECTED` relationship type created by LightRAG's Neo4j write paths.

## Related Issues

Supersedes #3606.

## Changes Made

- Remove the unreachable fallback that manufactured default edge properties for an empty aggregate.
- Return immediately for an empty input batch without opening a Neo4j session.
- Copy returned relationship properties before adding required defaults.
- Document that missing pairs are omitted from the result.
- Add regression coverage for empty input, the real zero-row missing-edge behavior, the `DIRECTED` relationship constraint, and property-copy isolation.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (method contract clarified; no user-facing documentation change required)
- [x] Unit tests added (if applicable)

## Additional Notes

Validation:

- `./scripts/test.sh tests/kg/neo4j_impl --test-workers 1` (`46 passed, 6 skipped`)
- `.venv/bin/ruff check lightrag/kg/neo4j_impl.py tests/kg/neo4j_impl/test_neo4j_graph_read_contract.py`
- `git diff --check`

A storage-backend contract review found no actionable issues.
