### PR TITLE
docs: fix broken example links in programming guide

### DIFF
--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -472,9 +472,9 @@ async def initialize_rag():
 
 **Further reading:**
 - [LlamaIndex Documentation](https://developers.llamaindex.ai/python/framework/)
-- [Direct OpenAI Example](examples/unofficial-sample/lightrag_llamaindex_direct_demo.py)
-- [LiteLLM Proxy Example](examples/unofficial-sample/lightrag_llamaindex_litellm_demo.py)
-- [LiteLLM Proxy with Opik Example](examples/unofficial-sample/lightrag_llamaindex_litellm_opik_demo.py)
+- [Direct OpenAI Example](../examples/unofficial-sample/lightrag_llamaindex_direct_demo.py)
+- [LiteLLM Proxy Example](../examples/unofficial-sample/lightrag_llamaindex_litellm_demo.py)
+- [LiteLLM Proxy with Opik Example](../examples/unofficial-sample/lightrag_llamaindex_litellm_opik_demo.py)
 
 #### Using Azure OpenAI Models
 
@@ -937,7 +937,7 @@ The `workspace` parameter ensures data isolation between different LightRAG inst
 
 Storage-specific workspace environment variables override the common `WORKSPACE` variable: `REDIS_WORKSPACE`, `MILVUS_WORKSPACE`, `QDRANT_WORKSPACE`, `MONGODB_WORKSPACE`, `POSTGRES_WORKSPACE`, `NEO4J_WORKSPACE`, `OPENSEARCH_WORKSPACE`.
 
-For a practical demonstration of managing multiple isolated knowledge bases, see [Workspace Demo](examples/lightrag_gemini_workspace_demo.py).
+For a practical demonstration of managing multiple isolated knowledge bases, see [Workspace Demo](../examples/lightrag_gemini_workspace_demo.py).
 
 
 ## Insert


### PR DESCRIPTION
## Description

`docs/ProgramingWithCore.md` contains four example links that resolve under `docs/examples/`, which does not exist. The referenced files are located in the repository's root `examples/` directory. This adds the missing `../` prefix so all four links resolve correctly.

## Related Issues

No related issue.

## Changes Made

- Fixed three LlamaIndex example links.
- Fixed the Gemini workspace demo link.
- Verified that all four corrected target files exist.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated
- [ ] Unit tests added, not applicable for this documentation-only change

## Additional Notes

`pre-commit run --all-files` and `git diff --check` completed successfully. One documentation file was changed, with no application code affected.