### PR TITLE
docs: document OrcaRouter as an OpenAI-compatible LLM binding

### DIFF
--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -778,7 +778,7 @@ lightrag-server --embedding-binding ollama --help
 lightrag-server --embedding-binding gemini --help
 ```
 
-> 请使用openai兼容方式访问OpenRouter、vLLM或SLang部署的LLM。可以通过 `OPENAI_LLM_EXTRA_BODY` 环境变量给OpenRouter、vLLM或SGLang推理框架传递额外的参数，实现推理模式的关闭或者其它个性化控制。
+> 请使用openai兼容方式访问OpenRouter、[OrcaRouter](https://www.orcarouter.ai)、vLLM或SGLang部署的LLM。可以通过 `OPENAI_LLM_EXTRA_BODY` 环境变量给这些提供商传递额外的参数，实现推理模式的关闭或者其它个性化控制。
 
 设置 `max_tokens` 参数旨在**防止在实体关系提取阶段出现LLM 响应输出过长或无休止的循环输出的问题**。设置 `max_tokens` 参数的目的是在超时发生之前截断 LLM 输出，从而防止文档提取失败。这解决了某些包含大量实体和关系的文本块（例如表格或引文）可能导致 LLM 产生过长甚至无限循环输出的问题。此设置对于本地部署的小参数模型尤为重要。`max_tokens` 值可以通过以下公式计算：`LLM_TIMEOUT * llm_output_tokens/second`（例如 `240s * 50 tokens/s = 12000`，此时 max_tokens 应小于 12000）。
 

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -778,7 +778,7 @@ lightrag-server --embedding-binding ollama --help
 lightrag-server --embedding-binding gemini --help
 ```
 
-> Please use OpenAI-compatible method to access LLMs deployed by OpenRouter or vLLM/SGLang. You can pass additional parameters to OpenRouter or vLLM/SGLang through the `OPENAI_LLM_EXTRA_BODY` environment variable to disable reasoning mode or achieve other personalized controls.
+> Please use OpenAI-compatible method to access LLMs deployed by OpenRouter, [OrcaRouter](https://www.orcarouter.ai), or vLLM/SGLang. You can pass additional parameters to these providers through the `OPENAI_LLM_EXTRA_BODY` environment variable to disable reasoning mode or achieve other personalized controls.
 
 Set the max_tokens to **prevent excessively long or endless output loop** during the entity relationship extraction phase for Large Language Model (LLM) responses.  The purpose of setting max_tokens parameter is to truncate LLM output before timeouts occur, thereby preventing document extraction failures. This addresses issues where certain text blocks (e.g., tables or citations) containing numerous entities and relationships can lead to overly long or even endless loop outputs from LLMs. This setting is particularly crucial for locally deployed, smaller-parameter models. Max tokens value can be calculated by this formula: `LLM_TIMEOUT * llm_output_tokens/second` (i.e. `240s * 50 tokens/s = 12000`, max_tokens should smaller than 12000)
 

--- a/env.docker-compose-full
+++ b/env.docker-compose-full
@@ -586,6 +586,11 @@ VLM_MAX_IMAGE_BYTES=5242880
 ###     LLM_BINDING=openai
 ###     LLM_BINDING_HOST=https://openrouter.ai/api/v1
 ###     LLM_MODEL=google/gemini-2.5-flash
+### OrcaRouter (OpenRouter-style AI gateway, OpenAI-compatible API):
+###     LLM_BINDING=openai
+###     LLM_BINDING_HOST=https://api.orcarouter.ai/v1
+###     LLM_BINDING_API_KEY=sk-orca-...
+###     LLM_MODEL=your-model
 # OPENAI_LLM_TEMPERATURE=0.9
 ### For vLLM/SGLang and most of OpenAI compatible API provider
 # OPENAI_LLM_MAX_TOKENS=9000

--- a/env.example
+++ b/env.example
@@ -1022,6 +1022,11 @@ VLM_MIN_IMAGE_PIXEL=64
 ###     LLM_BINDING=openai
 ###     LLM_BINDING_HOST=https://openrouter.ai/api/v1
 ###     LLM_MODEL=google/gemini-2.5-flash
+### OrcaRouter (OpenRouter-style AI gateway, OpenAI-compatible API):
+###     LLM_BINDING=openai
+###     LLM_BINDING_HOST=https://api.orcarouter.ai/v1
+###     LLM_BINDING_API_KEY=sk-orca-...
+###     LLM_MODEL=your-model
 # OPENAI_LLM_TEMPERATURE=0.9
 ### For vLLM/SGLang and most of OpenAI compatible API provider
 # OPENAI_LLM_MAX_TOKENS=9000


### PR DESCRIPTION
## Description

Adds [OrcaRouter](https://www.orcarouter.ai) as a documented, named option for accessing LLMs through LightRAG's existing `openai` binding. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

OrcaRouter already works out of the box through the generic `openai` binding (`LLM_BINDING_HOST=https://api.orcarouter.ai/v1`), so this PR mirrors the existing OpenRouter config example to make the endpoint visible and discoverable in the shipped templates and docs — purely additive, no code changes required.

I'm an engineer on the OrcaRouter team.

## Related Issues

N/A

## Changes Made

- **`env.example`**: named OrcaRouter config block under the OpenAI-compatible section, mirroring the existing OpenRouter block (`LLM_BINDING=openai`, `LLM_BINDING_HOST=https://api.orcarouter.ai/v1`, `LLM_BINDING_API_KEY=sk-orca-...`).
- **`env.docker-compose-full`**: same named OrcaRouter config block for container deployments.
- **`docs/LightRAG-API-Server.md`**: lists OrcaRouter alongside OpenRouter and vLLM/SGLang in the OpenAI-compatible access note.
- **`docs/LightRAG-API-Server-zh.md`**: matching Chinese translation update.

## Checklist

- [x] Changes tested locally (docs/config-only change; env templates remain valid comment-only additions)
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable) — docs-only, no code to test

## Additional Notes

Usage example:

```bash
LLM_BINDING=openai
LLM_BINDING_HOST=https://api.orcarouter.ai/v1
LLM_BINDING_API_KEY=sk-orca-...
LLM_MODEL=your-model
```

API keys are created at https://www.orcarouter.ai/console (keys start with `sk-orca-`); the full model catalog is at https://www.orcarouter.ai/models.
