### PR TITLE
docs(env.example): add the missing EXTRACT role variables

### DIFF
--- a/env.example
+++ b/env.example
@@ -951,11 +951,18 @@ MAX_ASYNC_LLM=4
 ###########################################################################
 ### Role-specific LLM/VLM overrides
 ### Available roles: EXTRACT, KEYWORD, QUERY, VLM
-### If unset, each role falls back to gloabal LLM configuration above.
+### If unset, each role falls back to global LLM configuration above.
 ### For detail information, refer to:
 ###   docs/RoleSpecificLLMConfiguration.md
 ###   docs/RoleSpecificLLMConfiguration-zh.md
 ###########################################################################
+# EXTRACT_LLM_MODEL=gpt-5.4-mini
+# EXTRACT_MAX_ASYNC_LLM=4
+# EXTRACT_LLM_TIMEOUT=240
+# EXTRACT_LLM_BINDING=openai
+# EXTRACT_LLM_BINDING_HOST=https://api.openai.com/v1
+# EXTRACT_LLM_BINDING_API_KEY=your_api_key
+
 # KEYWORD_LLM_MODEL=gpt-5.4-nano
 KEYWORD_MAX_ASYNC_LLM=4
 # KEYWORD_LLM_TIMEOUT=60


### PR DESCRIPTION
## Description

`env.example` opens with its own contract:

> `### All configurable environment variable must show up in this sample file in active or comment out status`

The role-specific LLM section lists **EXTRACT** among the available roles, but the `EXTRACT_*` block itself is missing — `KEYWORD`, `QUERY` and `VLM` are all shown, `EXTRACT` is not.

This matters more than a usual doc gap because of how the names are built. `api/config.py` assembles them at runtime from `RoleSpec.env_prefix`:

```python
binding_key  = f"{prefix}_LLM_BINDING"
model_key    = f"{prefix}_LLM_MODEL"
host_key     = f"{prefix}_LLM_BINDING_HOST"
apikey_key   = f"{prefix}_LLM_BINDING_API_KEY"
max_async_key = f"{prefix}_MAX_ASYNC_LLM"
timeout_key  = f"{prefix}_LLM_TIMEOUT"
```

So `EXTRACT_LLM_BINDING` exists nowhere in the repository as a literal string. Grepping the source for it returns nothing, and `env.example` — the one place a reader would expect to find it — does not list it either. It is easy to conclude the option does not exist and go build a workaround instead. That is exactly what happened to us: we were about to put a routing proxy in front of the LLM endpoint before reading `llm_roles.py` and finding the role registry had covered it all along.

The concrete setup that led here, in case it is a useful example for others: a **cloud model for `EXTRACT`** (entity extraction is the quality-critical, one-off pass over a public corpus) with **local Ollama for `KEYWORD`/`QUERY`**, so that nothing derived from a user's question leaves the machine. `docs/RoleSpecificLLMConfiguration.md` documents the opposite direction (local extraction, cloud answers) and both are worth knowing about.

## Changes Made

- Add the commented-out `EXTRACT_*` block, mirroring the existing `KEYWORD`/`QUERY`/`VLM` blocks, with defaults matching the base LLM example above it
- Fix `gloabal` → `global` in the same section header

## Checklist

- [x] Changes tested locally
- [x] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable) — documentation only, no behaviour change

## Additional Notes

Documentation only; every added line is commented out, so generated `.env` files are unaffected. Verified against `api/config.py` that all six variable names match what the role loop reads, and that none of them were already defined elsewhere in the file.
