### PR TITLE
fix(webui): harden graph type color resolution against reserved property names

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -647,6 +647,62 @@ async def _summarize_descriptions(
     return summary
 
 
+# JavaScript Object.prototype member names. When such a value is stored as an
+# entity_type it crashes the WebUI knowledge-graph view: the type-color resolver
+# indexes a plain object with it and the Legend later calls a string method on
+# the resulting non-string map key (see graphColor.ts in the WebUI).
+# They are never valid entity types, so reject them at the extraction source.
+_RESERVED_ENTITY_TYPES = frozenset({"__proto__", "constructor", "prototype"})
+
+
+def _normalize_and_validate_entity_type(entity_type: str, context: str) -> str | None:
+    """Validate and normalize a sanitized entity_type extracted from an LLM.
+
+    Shared by the text (delimited-record) and JSON extraction paths so both
+    reject the same values. Expects ``entity_type`` to have already been passed
+    through ``sanitize_and_normalize_extracted_text``.
+
+    Returns the cleaned, space-stripped, lowercased type, or ``None`` when the
+    entity must be dropped:
+    - empty, or containing a structural delimiter character;
+    - all-empty after a comma split;
+    - a reserved JavaScript prototype member name (see ``_RESERVED_ENTITY_TYPES``).
+
+    ``context`` is a short caller-supplied descriptor included in warning logs.
+    """
+    if not entity_type.strip() or any(
+        char in entity_type for char in ["'", "(", ")", "<", ">", "|", "/", "\\"]
+    ):
+        logger.warning(f"Entity extraction error: invalid entity type in {context}")
+        return None
+
+    # Handle comma-separated entity types by finding the first non-empty token
+    if "," in entity_type:
+        original = entity_type
+        tokens = [t.strip() for t in entity_type.split(",")]
+        non_empty = [t for t in tokens if t]
+        if not non_empty:
+            logger.warning(
+                f"Entity extraction error: all tokens empty after comma-split in {context}: '{original}'"
+            )
+            return None
+        entity_type = non_empty[0]
+        logger.warning(
+            f"Entity type contains comma, taking first non-empty token in {context}: '{original}' -> '{entity_type}'"
+        )
+
+    # Remove spaces and convert to lowercase
+    entity_type = entity_type.replace(" ", "").lower()
+
+    if entity_type in _RESERVED_ENTITY_TYPES:
+        logger.warning(
+            f"Entity extraction error: reserved entity type '{entity_type}' rejected in {context}"
+        )
+        return None
+
+    return entity_type
+
+
 def _handle_single_entity_extraction(
     record_attributes: list[str],
     chunk_key: str,
@@ -675,32 +731,11 @@ def _handle_single_entity_extraction(
         entity_type = sanitize_and_normalize_extracted_text(
             record_attributes[2], remove_inner_quotes=True
         )
-
-        if not entity_type.strip() or any(
-            char in entity_type for char in ["'", "(", ")", "<", ">", "|", "/", "\\"]
-        ):
-            logger.warning(
-                f"Entity extraction error: invalid entity type in: {record_attributes}"
-            )
+        entity_type = _normalize_and_validate_entity_type(
+            entity_type, f"record {record_attributes}"
+        )
+        if entity_type is None:
             return None
-
-        # Handle comma-separated entity types by finding the first non-empty token
-        if "," in entity_type:
-            original = entity_type
-            tokens = [t.strip() for t in entity_type.split(",")]
-            non_empty = [t for t in tokens if t]
-            if not non_empty:
-                logger.warning(
-                    f"Entity extraction error: all tokens empty after comma-split: '{original}'"
-                )
-                return None
-            entity_type = non_empty[0]
-            logger.warning(
-                f"Entity type contains comma, taking first non-empty token: '{original}' -> '{entity_type}'"
-            )
-
-        # Remove spaces and convert to lowercase
-        entity_type = entity_type.replace(" ", "").lower()
 
         # Process entity description with same cleaning pipeline
         entity_description = sanitize_and_normalize_extracted_text(record_attributes[3])
@@ -934,16 +969,11 @@ async def _process_json_extraction_result(
             entity_type = sanitize_and_normalize_extracted_text(
                 str(entity_data.get("type", "")), remove_inner_quotes=True
             )
-            if not entity_type.strip() or any(
-                char in entity_type
-                for char in ["'", "(", ")", "<", ">", "|", "/", "\\"]
-            ):
-                logger.warning(
-                    f"{chunk_key}: Invalid entity type '{entity_type}' for entity '{entity_name}'"
-                )
+            entity_type = _normalize_and_validate_entity_type(
+                entity_type, f"{chunk_key}: entity '{entity_name}'"
+            )
+            if entity_type is None:
                 continue
-
-            entity_type = entity_type.replace(" ", "").lower()
 
             entity_description = sanitize_and_normalize_extracted_text(
                 str(entity_data.get("description", ""))

--- a/lightrag_webui/src/App.tsx
+++ b/lightrag_webui/src/App.tsx
@@ -17,6 +17,7 @@ import RetrievalView from '@/features/RetrievalView'
 import ApiSite from '@/features/ApiSite'
 
 import { Tabs, TabsContent } from '@/components/ui/Tabs'
+import ErrorBoundary from '@/components/ErrorBoundary'
 
 function App() {
   const message = useBackendState.use.message()
@@ -207,16 +208,24 @@ function App() {
               <SiteHeader />
               <div className="relative grow">
                 <TabsContent value="documents" className="absolute top-0 right-0 bottom-0 left-0 overflow-auto">
-                  <DocumentManager />
+                  <ErrorBoundary>
+                    <DocumentManager />
+                  </ErrorBoundary>
                 </TabsContent>
                 <TabsContent value="knowledge-graph" className="absolute top-0 right-0 bottom-0 left-0 overflow-hidden">
-                  <GraphViewer />
+                  <ErrorBoundary>
+                    <GraphViewer />
+                  </ErrorBoundary>
                 </TabsContent>
                 <TabsContent value="retrieval" className="absolute top-0 right-0 bottom-0 left-0 overflow-hidden">
-                  <RetrievalView />
+                  <ErrorBoundary>
+                    <RetrievalView />
+                  </ErrorBoundary>
                 </TabsContent>
                 <TabsContent value="api" className="absolute top-0 right-0 bottom-0 left-0 overflow-hidden">
-                  <ApiSite />
+                  <ErrorBoundary>
+                    <ApiSite />
+                  </ErrorBoundary>
                 </TabsContent>
               </div>
             </Tabs>

--- a/lightrag_webui/src/components/ErrorBoundary.tsx
+++ b/lightrag_webui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { ErrorBoundary as ReactErrorBoundary, type FallbackProps } from 'react-error-boundary'
+import { useTranslation } from 'react-i18next'
+import { AlertTriangleIcon } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/Alert'
+import Button from '@/components/ui/Button'
+
+/**
+ * Fallback rendered when a child subtree throws during render. It must never
+ * throw itself, so every translation lookup carries an inline English default
+ * (i18n keys may be missing in some locales, and the throw can happen before
+ * translations are ready).
+ */
+const DefaultFallback: React.FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
+  const { t } = useTranslation()
+  const message = error instanceof Error ? error.message : String(error)
+
+  return (
+    <div className="flex h-full w-full items-center justify-center p-4">
+      <Alert variant="destructive" className="max-w-md">
+        <AlertTriangleIcon className="h-4 w-4" />
+        <AlertTitle>{t('common.errorBoundaryTitle', 'Something went wrong')}</AlertTitle>
+        <AlertDescription className="flex flex-col gap-3">
+          <span>
+            {t(
+              'common.errorBoundaryDescription',
+              'This panel failed to render. Try again, or switch to another tab.'
+            )}
+          </span>
+          {message && <span className="text-xs opacity-70 break-words">{message}</span>}
+          <Button variant="outline" size="sm" className="self-start" onClick={resetErrorBoundary}>
+            {t('common.errorBoundaryRetry', 'Try again')}
+          </Button>
+        </AlertDescription>
+      </Alert>
+    </div>
+  )
+}
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode
+}
+
+/**
+ * Wraps a subtree so a render-time throw degrades to a recoverable fallback
+ * instead of unmounting the whole SPA (React tears down #root on an uncaught
+ * render error, and there is otherwise no boundary in the app).
+ */
+const ErrorBoundary: React.FC<ErrorBoundaryProps> = ({ children }) => (
+  <ReactErrorBoundary FallbackComponent={DefaultFallback}>{children}</ReactErrorBoundary>
+)
+
+export default ErrorBoundary

--- a/lightrag_webui/src/components/graph/Legend.tsx
+++ b/lightrag_webui/src/components/graph/Legend.tsx
@@ -28,7 +28,7 @@ const Legend: React.FC<LegendProps> = ({ className }) => {
                 style={{ backgroundColor: color }}
               />
               <span className="text-xs truncate" title={type}>
-                {t(`graphPanel.nodeTypes.${type.toLowerCase().replace(/\s+/g, '')}`, type)}
+                {t(`graphPanel.nodeTypes.${String(type).toLowerCase().replace(/\s+/g, '')}`, type)}
               </span>
             </div>
           ))}

--- a/lightrag_webui/src/hooks/useLightragGraph.tsx
+++ b/lightrag_webui/src/hooks/useLightragGraph.tsx
@@ -92,8 +92,10 @@ const createTypeColorResolver = () => {
   let mapUpdated = false
 
   return {
-    colorFor(entityType: string | undefined): string {
-      const key = entityType ?? ''
+    colorFor(entityType: unknown): string {
+      // entity_type is untrusted graph data and may be a non-string; keep the
+      // cache key a string and let resolveNodeColor handle the raw value.
+      const key = typeof entityType === 'string' ? entityType : ''
       let color = cache.get(key)
       if (color === undefined) {
         const resolved = resolveNodeColor(entityType, typeColorMap)
@@ -263,7 +265,7 @@ const createSigmaGraph = async (rawGraph: RawGraph | null): Promise<UndirectedGr
     if (graph.hasNode(rawNode.id)) continue
 
     const { x, y } = hashNodeIdToPosition(rawNode.id)
-    rawNode.color = typeColors.colorFor(rawNode.properties?.entity_type as string | undefined)
+    rawNode.color = typeColors.colorFor(rawNode.properties?.entity_type)
 
     graph.addNode(rawNode.id, {
       label: safeNodeLabel(rawNode.labels, rawNode.id),
@@ -708,7 +710,7 @@ const useLightrangeGraph = () => {
         const processedNodes: RawNodeType[] = []
         for (const node of extendedGraph.nodes) {
           const { x, y } = hashNodeIdToPosition(node.id)
-          const color = typeColors.colorFor(node.properties?.entity_type as string | undefined)
+          const color = typeColors.colorFor(node.properties?.entity_type)
 
           // Create a properly typed RawNodeType
           processedNodes.push({

--- a/lightrag_webui/src/locales/ar.json
+++ b/lightrag_webui/src/locales/ar.json
@@ -37,7 +37,10 @@
     "cancel": "إلغاء",
     "save": "حفظ",
     "saving": "جارٍ الحفظ...",
-    "saveFailed": "فشل الحفظ"
+    "saveFailed": "فشل الحفظ",
+    "errorBoundaryTitle": "حدث خطأ ما",
+    "errorBoundaryDescription": "فشل عرض هذه اللوحة. حاول مرة أخرى أو انتقل إلى علامة تبويب أخرى.",
+    "errorBoundaryRetry": "إعادة المحاولة"
   },
   "documentPanel": {
     "clearDocuments": {

--- a/lightrag_webui/src/locales/de.json
+++ b/lightrag_webui/src/locales/de.json
@@ -37,7 +37,10 @@
     "cancel": "Abbrechen",
     "save": "Speichern",
     "saving": "Speichern...",
-    "saveFailed": "Speichern fehlgeschlagen"
+    "saveFailed": "Speichern fehlgeschlagen",
+    "errorBoundaryTitle": "Etwas ist schiefgelaufen",
+    "errorBoundaryDescription": "Dieses Panel konnte nicht angezeigt werden. Versuchen Sie es erneut oder wechseln Sie zu einem anderen Tab.",
+    "errorBoundaryRetry": "Erneut versuchen"
   },
   "documentPanel": {
     "clearDocuments": {

--- a/lightrag_webui/src/locales/en.json
+++ b/lightrag_webui/src/locales/en.json
@@ -37,7 +37,10 @@
     "cancel": "Cancel",
     "save": "Save",
     "saving": "Saving...",
-    "saveFailed": "Save failed"
+    "saveFailed": "Save failed",
+    "errorBoundaryTitle": "Something went wrong",
+    "errorBoundaryDescription": "This panel failed to render. Try again, or switch to another tab.",
+    "errorBoundaryRetry": "Try again"
   },
   "documentPanel": {
     "clearDocuments": {

--- a/lightrag_webui/src/locales/fr.json
+++ b/lightrag_webui/src/locales/fr.json
@@ -37,7 +37,10 @@
     "cancel": "Annuler",
     "save": "Sauvegarder",
     "saving": "Sauvegarde en cours...",
-    "saveFailed": "Échec de la sauvegarde"
+    "saveFailed": "Échec de la sauvegarde",
+    "errorBoundaryTitle": "Une erreur s'est produite",
+    "errorBoundaryDescription": "Ce panneau n'a pas pu s'afficher. Réessayez ou passez à un autre onglet.",
+    "errorBoundaryRetry": "Réessayer"
   },
   "documentPanel": {
     "clearDocuments": {

--- a/lightrag_webui/src/locales/ja.json
+++ b/lightrag_webui/src/locales/ja.json
@@ -37,7 +37,10 @@
     "cancel": "キャンセル",
     "save": "保存",
     "saving": "保存中...",
-    "saveFailed": "保存に失敗しました"
+    "saveFailed": "保存に失敗しました",
+    "errorBoundaryTitle": "問題が発生しました",
+    "errorBoundaryDescription": "このパネルを表示できませんでした。もう一度試すか、別のタブに切り替えてください。",
+    "errorBoundaryRetry": "再試行"
   },
   "documentPanel": {
     "clearDocuments": {

--- a/lightrag_webui/src/locales/ko.json
+++ b/lightrag_webui/src/locales/ko.json
@@ -37,7 +37,10 @@
     "cancel": "취소",
     "save": "저장",
     "saving": "저장 중...",
-    "saveFailed": "저장 실패"
+    "saveFailed": "저장 실패",
+    "errorBoundaryTitle": "문제가 발생했습니다",
+    "errorBoundaryDescription": "이 패널을 표시하지 못했습니다. 다시 시도하거나 다른 탭으로 전환하세요.",
+    "errorBoundaryRetry": "다시 시도"
   },
   "documentPanel": {
     "clearDocuments": {

--- a/lightrag_webui/src/locales/ru.json
+++ b/lightrag_webui/src/locales/ru.json
@@ -37,7 +37,10 @@
     "cancel": "Отмена",
     "save": "Сохранить",
     "saving": "Сохранение...",
-    "saveFailed": "Ошибка сохранения"
+    "saveFailed": "Ошибка сохранения",
+    "errorBoundaryTitle": "Что-то пошло не так",
+    "errorBoundaryDescription": "Не удалось отобразить эту панель. Повторите попытку или перейдите на другую вкладку.",
+    "errorBoundaryRetry": "Повторить"
   },
   "documentPanel": {
     "clearDocuments": {

--- a/lightrag_webui/src/locales/uk.json
+++ b/lightrag_webui/src/locales/uk.json
@@ -37,7 +37,10 @@
     "cancel": "Скасувати",
     "save": "Зберегти",
     "saving": "Збереження...",
-    "saveFailed": "Збереження не вдалося"
+    "saveFailed": "Збереження не вдалося",
+    "errorBoundaryTitle": "Щось пішло не так",
+    "errorBoundaryDescription": "Не вдалося відобразити цю панель. Повторіть спробу або перейдіть на іншу вкладку.",
+    "errorBoundaryRetry": "Повторити"
   },
   "documentPanel": {
     "clearDocuments": {

--- a/lightrag_webui/src/locales/vi.json
+++ b/lightrag_webui/src/locales/vi.json
@@ -37,7 +37,10 @@
     "cancel": "Hủy",
     "save": "Lưu",
     "saving": "Đang lưu...",
-    "saveFailed": "Lưu thất bại"
+    "saveFailed": "Lưu thất bại",
+    "errorBoundaryTitle": "Đã xảy ra lỗi",
+    "errorBoundaryDescription": "Không thể hiển thị bảng này. Hãy thử lại hoặc chuyển sang tab khác.",
+    "errorBoundaryRetry": "Thử lại"
   },
   "documentPanel": {
     "clearDocuments": {

--- a/lightrag_webui/src/locales/zh.json
+++ b/lightrag_webui/src/locales/zh.json
@@ -37,7 +37,10 @@
     "cancel": "取消",
     "save": "保存",
     "saving": "保存中...",
-    "saveFailed": "保存失败"
+    "saveFailed": "保存失败",
+    "errorBoundaryTitle": "出错了",
+    "errorBoundaryDescription": "此面板渲染失败。请重试，或切换到其他标签页。",
+    "errorBoundaryRetry": "重试"
   },
   "documentPanel": {
     "clearDocuments": {

--- a/lightrag_webui/src/locales/zh_TW.json
+++ b/lightrag_webui/src/locales/zh_TW.json
@@ -37,7 +37,10 @@
     "cancel": "取消",
     "save": "儲存",
     "saving": "儲存中...",
-    "saveFailed": "儲存失敗"
+    "saveFailed": "儲存失敗",
+    "errorBoundaryTitle": "發生錯誤",
+    "errorBoundaryDescription": "此面板無法顯示。請重試，或切換到其他分頁。",
+    "errorBoundaryRetry": "重試"
   },
   "documentPanel": {
     "clearDocuments": {

--- a/lightrag_webui/src/utils/graphColor.test.ts
+++ b/lightrag_webui/src/utils/graphColor.test.ts
@@ -1,0 +1,81 @@
+/// <reference types="bun" />
+import { describe, expect, test } from 'bun:test'
+
+import { resolveNodeColor } from '@/utils/graphColor'
+
+// entity_type comes from extracted document text (or a caller of
+// ainsert_custom_kg), so it is untrusted. Two hazards must never crash the
+// Legend, which does `key.toLowerCase()` on every type-color map key:
+//   1a. A reserved *string* name (`__proto__`, `constructor`) used to index the
+//       plain-object synonym table and returned an INHERITED non-string value
+//       that was then stored as a Map key.
+//   1b. A genuinely non-string value (object/array/number/boolean) hit
+//       `nodeType.toLowerCase()` before any table lookup.
+// resolveNodeColor must return a string color and a Map whose keys are all
+// strings for every input.
+
+// The exact expression the Legend renders for each map key (Legend.tsx).
+const legendExpr = (key: unknown) =>
+  String(key).toLowerCase().replace(/\s+/g, '')
+
+const assertSafe = (nodeType: unknown) => {
+  const { color, map } = resolveNodeColor(nodeType, undefined)
+  expect(typeof color).toBe('string')
+  expect(color.length).toBeGreaterThan(0)
+  for (const key of map.keys()) {
+    // Regression: reserved names used to land here as object/function keys.
+    expect(typeof key).toBe('string')
+    // Regression: the Legend must not throw while rendering the key.
+    expect(() => legendExpr(key)).not.toThrow()
+  }
+}
+
+describe('resolveNodeColor — reserved string entity types (1a)', () => {
+  // The full Object.prototype member-name matrix.
+  const reservedNames = [
+    '__proto__',
+    'constructor',
+    'prototype',
+    'toString',
+    'valueOf',
+    'hasOwnProperty',
+    'isPrototypeOf'
+  ]
+
+  for (const name of reservedNames) {
+    test(`does not produce a non-string map key for "${name}"`, () => {
+      assertSafe(name)
+    })
+  }
+
+  test('legitimate types still resolve to their predefined color', () => {
+    expect(resolveNodeColor('person', undefined).color).toBe('#4169E1')
+    expect(resolveNodeColor('organization', undefined).color).toBe('#00cc00')
+    // Synonyms still map through.
+    expect(resolveNodeColor('company', undefined).color).toBe('#00cc00')
+  })
+
+  test('an unknown but ordinary type gets an extended color, not a crash', () => {
+    const { color, map } = resolveNodeColor('quokka', undefined)
+    expect(typeof color).toBe('string')
+    expect(map.has('quokka')).toBe(true)
+  })
+})
+
+describe('resolveNodeColor — non-string entity types (1b)', () => {
+  const nonStrings: Array<[string, unknown]> = [
+    ['number', 42],
+    ['object', {}],
+    ['array', []],
+    ['null', null],
+    ['boolean', true],
+    ['undefined', undefined]
+  ]
+
+  for (const [label, value] of nonStrings) {
+    test(`does not throw and returns a string color for a ${label} type`, () => {
+      expect(() => resolveNodeColor(value, undefined)).not.toThrow()
+      assertSafe(value)
+    })
+  }
+})

--- a/lightrag_webui/src/utils/graphColor.ts
+++ b/lightrag_webui/src/utils/graphColor.ts
@@ -1,6 +1,13 @@
 const DEFAULT_NODE_COLOR = '#5D6D7E'
 
-const TYPE_SYNONYMS: Record<string, string> = {
+// Null-prototype maps: keys come from extracted entity types, so they can
+// collide with Object.prototype members. On a plain object literal,
+// `TYPE_SYNONYMS['__proto__']` returns the inherited Object.prototype (an
+// object) and `['constructor']` returns the Object function instead of
+// undefined; those non-string values then flow into the type→color Map as
+// keys and crash the Legend (`key.toLowerCase()`). A null-prototype object has
+// no inherited members, so any unknown key reads as undefined.
+const TYPE_SYNONYMS: Record<string, string> = Object.assign(Object.create(null), {
   unknown: 'unknown',
   未知: 'unknown',
 
@@ -140,9 +147,9 @@ const TYPE_SYNONYMS: Record<string, string> = {
   地址: 'location',
   地理: 'location',
   地域: 'location'
-}
+})
 
-const NODE_TYPE_COLORS: Record<string, string> = {
+const NODE_TYPE_COLORS: Record<string, string> = Object.assign(Object.create(null), {
   person: '#4169E1',
   creature: '#bd7ebe',
   organization: '#00cc00',
@@ -156,7 +163,7 @@ const NODE_TYPE_COLORS: Record<string, string> = {
   naturalobject: '#b2e061',
   other: '#f4d371',
   unknown: '#b0b0b0'
-}
+})
 
 const EXTENDED_COLORS = [
   '#84a3e1',
@@ -181,11 +188,17 @@ interface ResolveNodeColorResult {
 }
 
 export const resolveNodeColor = (
-  nodeType: string | undefined,
+  nodeType: unknown,
   currentMap: Map<string, string> | undefined
 ): ResolveNodeColorResult => {
   const typeColorMap = currentMap ?? new Map<string, string>()
-  const normalizedType = nodeType ? nodeType.toLowerCase() : 'unknown'
+  // entity_type is untrusted graph data. ainsert_custom_kg() writes the
+  // caller-supplied value straight onto the node without type validation, so
+  // /graphs can serve an object, array, number or boolean here. Guard against
+  // any non-string before calling a string method on it, and fall back to
+  // 'unknown' for empty/non-string values.
+  const normalizedType =
+    typeof nodeType === 'string' && nodeType ? nodeType.toLowerCase() : 'unknown'
   const standardType = TYPE_SYNONYMS[normalizedType]
   const cacheKey = standardType || normalizedType
 

--- a/tests/extraction/test_reserved_entity_type_rejection.py
+++ b/tests/extraction/test_reserved_entity_type_rejection.py
@@ -1,0 +1,89 @@
+"""Reserved JavaScript prototype member names must never survive extraction.
+
+An ``entity_type`` of ``__proto__`` / ``constructor`` / ``prototype`` crashes the
+WebUI knowledge-graph view: the type-color resolver reads an inherited value off
+a plain object and the Legend later calls a string method on the resulting
+non-string map key. These names are never valid entity types, so both extraction
+paths (delimited-record text AND JSON) drop the whole entity.
+
+Covers both paths directly — a text-only test would pass even if the JSON path
+(``ENTITY_EXTRACTION_USE_JSON=true``) still let the value through.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.operate import (
+    _handle_single_entity_extraction,
+    _normalize_and_validate_entity_type,
+    _process_json_extraction_result,
+)
+
+pytestmark = pytest.mark.offline
+
+_RESERVED = ["__proto__", "constructor", "prototype"]
+
+
+# --- shared helper -----------------------------------------------------------
+
+
+@pytest.mark.parametrize("reserved", _RESERVED)
+def test_shared_helper_rejects_reserved_names(reserved: str) -> None:
+    assert _normalize_and_validate_entity_type(reserved, "ctx") is None
+
+
+def test_shared_helper_passes_ordinary_type() -> None:
+    assert _normalize_and_validate_entity_type("Organization", "ctx") == "organization"
+
+
+def test_shared_helper_takes_first_token_of_comma_list() -> None:
+    # Comma handling is now unified across both extraction paths.
+    assert _normalize_and_validate_entity_type("person, extra", "ctx") == "person"
+
+
+# --- text (delimited-record) path -------------------------------------------
+
+
+@pytest.mark.parametrize("reserved", _RESERVED)
+def test_text_path_drops_reserved_entity_type(reserved: str) -> None:
+    attrs = ["entity", "GLOBEX LTD", reserved, "Globex Ltd supplies equipment."]
+    assert _handle_single_entity_extraction(attrs, "chunk-1", 1, "doc.txt") is None
+
+
+def test_text_path_keeps_ordinary_entity() -> None:
+    attrs = ["entity", "GLOBEX LTD", "organization", "Globex Ltd supplies equipment."]
+    entity = _handle_single_entity_extraction(attrs, "chunk-1", 1, "doc.txt")
+    assert entity is not None
+    assert entity["entity_type"] == "organization"
+
+
+# --- JSON path ---------------------------------------------------------------
+
+
+def _json_with_type(entity_type: str) -> str:
+    return (
+        '{"entities":[{"name":"Globex","type":"' + entity_type + '",'
+        '"description":"Globex supplies equipment"}],"relationships":[]}'
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reserved", _RESERVED)
+async def test_json_path_drops_reserved_entity_type(reserved: str) -> None:
+    nodes, _edges = await _process_json_extraction_result(
+        _json_with_type(reserved), chunk_key="chunk-1", timestamp=1, file_path="doc.pdf"
+    )
+    assert "Globex" not in nodes
+
+
+@pytest.mark.asyncio
+async def test_json_path_keeps_ordinary_entity() -> None:
+    nodes, _edges = await _process_json_extraction_result(
+        _json_with_type("organization"),
+        chunk_key="chunk-1",
+        timestamp=1,
+        file_path="doc.pdf",
+    )
+    assert "Globex" in nodes
+    assert nodes["Globex"][0]["entity_type"] == "organization"


### PR DESCRIPTION
## Summary

Makes the knowledge-graph view resilient to an entity whose `entity_type` is a JavaScript `Object.prototype` member name (e.g. `__proto__`, `constructor`) or a non-string value. Previously such a value crashed the WebUI Legend during render, and with no error boundary anywhere in the app the whole SPA unmounted to a blank page.

## Motivation

`entity_type` is untrusted graph data — it comes out of LLM extraction of document text, and `ainsert_custom_kg()` writes a caller-supplied value onto the node without type validation. Two independent render-time crashes were possible:

1. **Reserved string name.** `resolveNodeColor()` indexed the plain-object synonym/color tables with the raw type. `TYPE_SYNONYMS['__proto__']` returned the *inherited* `Object.prototype` (an object) and `['constructor']` the `Object` function — both truthy non-strings — which were then stored as keys in the type→color `Map`. The Legend's `key.toLowerCase()` threw on the next render.
2. **Non-string value.** The resolver called `nodeType.toLowerCase()` before any lookup, so an object/array/number/boolean `entity_type` threw at the same point.

Because `lightrag_webui/src` has no error boundary, either throw tore down `#root`. `showLegend` persists in `localStorage`, so a reload reproduced the blank page — the affected operator could not click their way out.

## What's changed

- **`utils/graphColor.ts`** — build `TYPE_SYNONYMS` / `NODE_TYPE_COLORS` as null-prototype objects (matching the existing `Object.create(null)` idiom in `useLightragGraph.tsx`), and accept `unknown` in `resolveNodeColor`, lowercasing only genuine non-empty strings and mapping everything else to `unknown`. Removed the now-unnecessary `as string` casts at the call sites.
- **`components/ErrorBoundary.tsx` (new) + `App.tsx`** — a reusable boundary (built on the already-present `react-error-boundary` dependency) now wraps each tab's content, so any render-time throw degrades to a recoverable per-tab fallback with the site header and other tabs intact, instead of blanking the app.
- **`components/graph/Legend.tsx`** — `String()` the map key before `toLowerCase()` as defense in depth.
- **`operate.py`** — extracted a shared `normalize_and_validate_entity_type()` used by both the text (delimited-record) and JSON extraction paths, rejecting the reserved prototype member names at the source. This also unifies the previously text-only comma-token handling across both paths.

## What could break / how it behaves now

- A reserved or non-string `entity_type` now resolves to the default color and renders as a plain string in the Legend; nothing unmounts.
- Server-side, an entity extracted with a reserved type is dropped (same "discard the entity" semantics the existing type validation already used for invalid types) on both the text and JSON extraction paths.
- No behavior change for ordinary entity types.

## Tests

- `lightrag_webui/src/utils/graphColor.test.ts` (new) — pins `resolveNodeColor` against the full set of reserved string names and against non-string values; fails behaviorally on the pre-fix code.
- `tests/extraction/test_reserved_entity_type_rejection.py` (new) — pins rejection across **both** extraction paths and the shared helper.
- Full frontend suite (`bun test`, 107) and the backend `tests/extraction` subset (240) pass; `bun run lint` and `bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)