### PR TITLE
fix: warn when selectors bypass custom chunking

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -573,11 +573,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         char (``F``/``R``/``V``/``P``), the dispatcher routes to a
         chunker that follows the new file-chunker contract — see
         :mod:`lightrag.chunker` (``chunking_by_fixed_token`` for ``F``,
-        ``chunking_by_paragraph_semantic`` for ``P``; ``R``/``V`` are
-        not yet implemented and fall back to ``F``). **This
-        ``chunking_func`` is NOT called in that case** — it is a
-        legacy escape hatch and is intentionally bypassed when the user
-        opted into a specific strategy.
+        ``chunking_by_recursive_character`` for ``R``,
+        ``chunking_by_semantic_vector`` for ``V``, and
+        ``chunking_by_paragraph_semantic`` for ``P``). **This
+        ``chunking_func`` is NOT called in that case**. If it was replaced
+        with a custom callable, the dispatcher logs a warning that the
+        selected strategy is bypassing it.
 
       - If ``process_options`` does **not** name a chunking strategy
         (empty string, or only non-chunking flags such as ``i`` / ``t``

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -4923,6 +4923,18 @@ class _PipelineMixin:
                 # so admin/list APIs can see the actual chunker params used.
                 chunk_opts_str: str = ""
 
+                from lightrag.chunker import chunking_by_token_size
+
+                if (
+                    doc_process_opts.chunking_explicit
+                    and self.chunking_func is not chunking_by_token_size
+                ):
+                    logger.warning(
+                        "Custom chunking_func bypassed: process_options "
+                        f"explicitly selects strategy {doc_process_opts.chunking} "
+                        f"for d-id: {doc_id}"
+                    )
+
                 if doc_process_opts.chunking_explicit:
                     from lightrag.chunker import (
                         chunking_by_fixed_token,
@@ -5090,7 +5102,6 @@ class _PipelineMixin:
                     logger.info(
                         f"Chunking F(legacy): {chunk_opts_str}, doc_id: {doc_id}"
                     )
-                    from lightrag.chunker import chunking_by_token_size
 
                     # Only the unmodified default fixed-token chunker understands the
                     # private ``_emit_source_span`` kwarg; a user-supplied

--- a/tests/chunker/test_chunking_raw_lightrag_parity.py
+++ b/tests/chunker/test_chunking_raw_lightrag_parity.py
@@ -447,6 +447,60 @@ class _ListHandler(logging.Handler):
 
 
 @pytest.mark.offline
+@pytest.mark.parametrize("use_custom_chunker", [False, True])
+def test_explicit_selector_reports_custom_chunking_func_bypass(
+    tmp_path, use_custom_chunker
+):
+    """An explicit selector warns only when it bypasses a customization."""
+
+    custom_calls = 0
+
+    def _custom_chunker(*args, **kwargs):
+        nonlocal custom_calls
+        custom_calls += 1
+        return [{"tokens": 1, "content": "custom", "chunk_order_index": 0}]
+
+    async def _run():
+        kwargs = {"chunking_func": _custom_chunker} if use_custom_chunker else {}
+        rag = _new_rag(tmp_path, **kwargs)
+        await rag.initialize_storages()
+
+        lightrag_logger = logging.getLogger("lightrag")
+        list_handler = _ListHandler()
+        list_handler.setLevel(logging.WARNING)
+        lightrag_logger.addHandler(list_handler)
+        doc_id = f"doc-bypass-{'custom' if use_custom_chunker else 'builtin'}"
+        try:
+            await rag.apipeline_enqueue_documents(
+                "Body for explicit fixed-token chunking.",
+                ids=[doc_id],
+                file_paths=f"{doc_id}.txt",
+                track_id=f"track-{doc_id}",
+                process_options="F",
+            )
+            await rag.apipeline_process_enqueue_documents()
+        finally:
+            lightrag_logger.removeHandler(list_handler)
+            await rag.finalize_storages()
+
+        warnings = [
+            record.getMessage()
+            for record in list_handler.records
+            if record.levelno == logging.WARNING
+            and "Custom chunking_func bypassed" in record.getMessage()
+        ]
+        if use_custom_chunker:
+            assert custom_calls == 0
+            assert len(warnings) == 1
+            assert "strategy F" in warnings[0]
+            assert doc_id in warnings[0]
+        else:
+            assert warnings == []
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
 def test_explicit_R_dispatches_to_recursive_character(tmp_path, monkeypatch):
     """``process_options=R`` must invoke
     :func:`chunking_by_recursive_character` (the new file-chunker


### PR DESCRIPTION
## Description

Warn when an explicit F/R/V/P selector bypasses a user-supplied `chunking_func`, and update the field documentation to describe the implemented R and V strategies.

This implements only the immediate scope agreed in #3603. It does not add a chunker registry or a document-metadata contract.

## Related Issues

Related to #3603.

## Changes Made

- detect a non-default `chunking_func` at selector dispatch time and log the selected strategy plus document ID
- avoid warning when the built-in default is configured
- replace the stale R/V fallback text with the current recursive-character and semantic-vector implementations
- add an offline regression test for both the custom and built-in cases

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated
- [x] Unit tests added

## Validation

- `./scripts/test.sh tests/chunker/test_chunking_raw_lightrag_parity.py -q` — 10 passed
- exact new parametrized test — 2 passed
- `uv run ruff check ...` and `uv run ruff format --check ...`
- `uv run pre-commit run --files ...`

The optional spaCy language models were not installed; the test runner reported only the unrelated smart-heading skip notice.
