### PR TITLE
feat: add explicit custom chunking selector

### DIFF
--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -119,7 +119,7 @@ LightRAG 的文件处理配置由两部分合成：内容抽取引擎决定原�
 
 ### 2.1 文件处理选项
 
-处理选项以文件为粒度控制多模态分析、知识图谱构建和文本分块的行为；既可在 `LIGHTRAG_PARSER` 中作为规则默认值批量设置（见 [§2.4](#24-默认规则lightrag_parser)），也可通过文件名 hint 对单个文件覆盖（见 [§2.5](#25-单文件覆盖文件名-hint)）。所有选项都是可选的；缺省值见下表。同一文件最多指定一种分块方式（F/R/V/P），其它选项可任意组合。
+处理选项以文件为粒度控制多模态分析、知识图谱构建和文本分块的行为；既可在 `LIGHTRAG_PARSER` 中作为规则默认值批量设置（见 [§2.4](#24-默认规则lightrag_parser)），也可通过文件名 hint 对单个文件覆盖（见 [§2.5](#25-单文件覆盖文件名-hint)）。所有选项都是可选的；缺省值见下表。同一文件最多指定一种分块方式（F/R/V/P/C），其它选项可任意组合。
 
 | 选项 | 类型 | 默认 | 含义 |
 | --- | --- | --- | --- |
@@ -131,6 +131,7 @@ LightRAG 的文件处理配置由两部分合成：内容抽取引擎决定原�
 | `R` | 分块 | - | Recursive/递归字符分块(RecursiveCharacterTextSplitter@LangChain)：接收一个分隔符列表（默认是 `["\n\n","\n","。","！","？","；","，"," ",""]`，按从语义最强到最弱排列）。优先按段落（双换行符）切分；如果切出的块依然超过 Token 限制，逐级降级使用单换行符 → 中文句末标点（`。！？`）→ 中文句中标点（`；，`）→ 空格 → 逐字符切分。**默认 cascade 包含中文标点**，使中文 / 中英混合文档能在语义边界切分。英文 `.?!` 故意排除（字面量匹配会误切 `0.95` / `e.g.`）。 |
 | `V` | 分块 | - | Vector/向量语义分块(SemanticChunker@LangChain)：首先按句子拆分文本（默认句子切分正则同时识别英文 `.?!` 与中文 `。？！`，使中文 / 中英混合文档能正确切句），计算相邻句子的 Embedding，然后根据指定的阈值策略（如百分位 percentile、标准差 standard_deviation 或四分位距 interquartile）寻找语义断层进行切分。`SemanticChunker` 本身没有 chunk size 上限——任何超过 `chunk_token_size` 的语义块在落库前会自动通过 R 二次切分（保留 V 的非重叠语义）。此分块策略不会出现文本块重叠的情况。 |
 | `P` | 分块 | - | Paragraph/段落语义分块（native）；优先按标题分割，严格避免上一标题底部内容与下一个标题内容混合破坏语义。适合对能够准确识别标题且标题结构清晰的文档进行分块。同一标题下的超长正文 fallback 到 R 时允许按 `CHUNK_P_OVERLAP_SIZE` 保留重叠；相邻大表格之间的桥接文字也可按该预算重复进入前后表格块。此分块方法只能运用在保存在 sidecar 目录的 `lightrag` 内容。如果 `lightrag` 内容不存在，将退化为使用 `R` 方法进行文本分块。此分块方法出现文本块重叠的情况远少于 `R策略` 和 `F策略`。 |
+| `C` | 分块 | - | Custom/自定义分块：显式调用已配置的 `LightRAG.chunking_func`，保持原有六参数契约不变，并复用 `fixed_token` 参数快照。已持久化或后台发现的 C 文档若处理时没有自定义回调，流水线会告警一次并走精确定长分块 fallback；新文本/上传请求则直接返回 422。 |
 
 > 多模态全局开关 `addon_params["enable_multimodal_pipeline"]` 已废弃，相关行为统一由文件级 `i/t/e` 选项控制。详见[附录 A](#附录-a从旧版升级的注意事项)。
 
@@ -142,7 +143,7 @@ LightRAG 的文件处理配置由两部分合成：内容抽取引擎决定原�
 | :-: | --- | --- |
 | i/t/e | Analyzing多模态分析 | 决定是否对 sidecar 中的图像 / 表格 / 公式调用 VLM 做摘要分析。**抽取阶段不受影响**：内容提取引擎按文档实际内容输出 `drawings.json` / `tables.json` / `equations.json` sidecar 文件。这样后续仅修改 `i`/`t`/`e` 选项触发"再分析"即可补做 VLM，无须重新解析原始文件。 |
 | ! | Extraction实体关系抽取 | 跳过实体/关系抽取与图谱写入；chunks 仍写入向量库以保留 naive / mix 检索能力。 |
-| F/R/V/P | Chunking文本分块 | 决定使用哪种分块策略；对解析阶段输出无影响。 |
+| F/R/V/P/C | Chunking文本分块 | 决定使用哪种分块策略；对解析阶段输出无影响。 |
 
 > 模态可用性以"sidecar 文件是否存在"为唯一信号，内容提取引擎不需要在 meta 中声明能力。某文档若没有任何图像/表格/公式，对应 sidecar 不会写入；用户即使开启了 `i/t/e`，对应模态也只会被静默跳过，但 `analyze_multimodal` 会在该篇文档落一行 INFO 级日志（`[analyze_multimodal] sidecar e:equations empty: doc—id ...`），便于排查"VLM 为何没跑"。这种情况不会报错。
 
@@ -227,7 +228,7 @@ notes.[-R].md
 
 ### 2.6 为分块策略附加参数
 
-分块策略选择符（`F` / `R` / `V` / `P`）——无论在 `LIGHTRAG_PARSER` 规则还是文件名 hint 中——都可以用圆括号附加该策略的分块参数。括号内逗号**只**用于分隔参数；规则切分是括号感知的，因此该逗号绝不会被误判为规则分隔符（`;` 与 `,` 都是合法的规则分隔符，但推荐 `;`）。
+分块策略选择符（`F` / `R` / `V` / `P` / `C`）——无论在 `LIGHTRAG_PARSER` 规则还是文件名 hint 中——都可以用圆括号附加该策略的分块参数。括号内逗号**只**用于分隔参数；规则切分是括号感知的，因此该逗号绝不会被误判为规则分隔符（`;` 与 `,` 都是合法的规则分隔符，但推荐 `;`）。
 
 ```text
 notes.[-R(chunk_ts=800,chunk_ol=80)].md                            # 文件名 hint
@@ -238,13 +239,15 @@ LIGHTRAG_PARSER=pdf:legacy-R(chunk_ts=800,chunk_ol=80);*:legacy-R  # 规则
 
 | 参数 | 别名 | 适用策略 | 类型 | 含义 |
 | --- | --- | --- | --- | --- |
-| `chunk_token_size` | `chunk_ts` | F / R / V / P | int（≥ 1） | 各策略的块大小 |
-| `chunk_overlap_token_size` | `chunk_ol` | F / R / P | int（≥ 0） | 块间重叠（V 无重叠） |
+| `chunk_token_size` | `chunk_ts` | F / R / V / P / C | int（≥ 1） | 各策略的块大小 |
+| `chunk_overlap_token_size` | `chunk_ol` | F / R / P / C | int（≥ 0） | 块间重叠（V 无重叠） |
 | `drop_references` | `drop_rf` | P | bool | 分块前丢弃匹配的参考文献块，如 `paper.[-P(drop_rf=true)].pdf`；布尔参数可省略取值，`paper.[-P(drop_rf)].pdf` 等价于 `drop_rf=true` |
 
 - `process_options` 仍是纯选择符字符串；每个参数会写入该策略的 `chunk_options`（见 §5），策略其它来自环境变量的参数保持不变。别名在内部统一归一化为全称。
 - 合并优先级：选择符仍遵循“文件名 hint 的非空选项整体覆盖规则选项”；参数按**同一策略**叠加——先规则参数，再文件名 hint 参数（同一键以文件名为准）。
 - 启动期（`LIGHTRAG_PARSER`）与上传期（文件名 hint）均严格校验：未知参数、类型错误、取值越界、把参数加到不支持的策略（如 `V` 上的 `chunk_ol`）都会给出友好报错。
+
+文本 API 以 `chunking.strategy="custom"` 暴露同一路径；`params` 使用完整的 fixed-token/legacy 参数契约（`chunk_token_size`、`chunk_overlap_token_size`、`split_by_character`、`split_by_character_only`）。如果没有替换 `LightRAG.chunking_func`，`/documents/text` 与 `/documents/texts` 会返回 422。
 
 > `drop_references` 检测调参 `CHUNK_P_REFERENCES_TAIL_N`（默认 `0`：扫描全部内容块；正数表示只扫描文末最后 N 块）/ `CHUNK_P_REFERENCES_HEADINGS`（竖线分隔，默认 `References\|Bibliography\|参考文献`）仅经环境变量、运行时实时读取。drop_references可以通过环境变量 `CHUNK_P_DROP_REFERENCES` 设置为全局默认值.
 
@@ -255,10 +258,11 @@ LIGHTRAG_PARSER=pdf:legacy-R(chunk_ts=800,chunk_ol=80);*:legacy-R  # 规则
 - 文件名 hint 的优先级高于 `LIGHTRAG_PARSER`。如果 hint 指定的引擎不支持该后缀，系统会回退到默认规则继续选择可用引擎。
 - 如果文件名 hint 提供了非空选项串，则以 hint 为准；否则使用 `LIGHTRAG_PARSER` 规则中匹配项的默认选项；都没有则使用全部默认。
 - 如果所有规则都不可用，文件内容提取方式会回退到 `legacy`；如果 `legacy` 也不支持对应的文件后缀，会向系统添加一个错误条目，上传文件保留在 `INPUT` 目录。
-- F/R/V/P至多出现一个；同一选项重复时只生效一次但不报错。
-- 大小写敏感：分块选项 F/R/V/P必须大写；其它选项 i/t/e小写。
+- F/R/V/P/C 至多出现一个；同一选项重复时只生效一次但不报错。
+- 大小写敏感：分块选项 F/R/V/P/C 必须大写；其它选项 i/t/e 小写。
 - 中括号内出现非法字符时，整个 hint 失效，引擎按默认规则解析，选项按 `LIGHTRAG_PARSER` 默认或全部默认；同时落日志 warning。
 - `P` 对任何能产出 `.blocks.jsonl` sidecar 的引擎（`native` / `mineru` / `docling`）抽取出的结构化结果有效；对 `legacy` 路径或无 sidecar 的输出会自动降级到 `R` 并记录 warning。
+- `C` 在有同步调用方的入口必须已经注入自定义回调。`/documents/upload` 会在写文件前同时检查文件名 hint 与命中的 `LIGHTRAG_PARSER` 规则；回调缺失时返回 422。目录扫描与重处理无法让调用方当场修正已持久化 selector，因此接受 C，每次处理告警一次并走 fixed-token fallback。
 
 ## 3. 文件解析引擎
 
@@ -578,7 +582,7 @@ MinerU 自己也有一轮 VLM，由 `MINERU_LOCAL_IMAGE_ANALYSIS` 开启。它�
 
 ### 5.1 process_options vs chunk_options 的职责
 
-`process_options` 选**用哪种**分块策略（F/R/V/P），`chunk_options` 决定那一路分块器**用哪些参数**。两者职责正交：前者是单字符 selector，后者是结构化字典。
+`process_options` 选**用哪种**分块策略（F/R/V/P/C），`chunk_options` 决定那一路分块器**用哪些参数**。两者职责正交：前者是单字符 selector，后者是结构化字典。C 刻意映射到 `fixed_token` 子字典，因为这些值正好填入 legacy callback 的六个参数。
 
 ```
 env vars                                                  (启动期一次性读取)
@@ -597,7 +601,7 @@ chunker(tokenizer, content, chunk_token_size, **strategy_kwargs)   (分块时按
 - **env vars** 在 `LightRAG.__init__` 阶段（由 `default_chunker_config()` 读取 strategy 特定 env，再由 `_apply_chunk_size_overlay` 兜底 legacy env）灌进 `addon_params["chunker"]`。
 - **`addon_params["chunker"]`** 是 `ObservableAddonParams` 字段；Server 部署只需通过 env / 重启即可让新值生效。若需要在 Python 进程内运行时改它（不重启）以及 per-file 覆盖，请见[第十一章 Python SDK 调用](#11-python-sdk-调用)。
 - **`full_docs.chunk_options`** 在 `apipeline_enqueue_documents` 入队时冻结：默认由 `resolve_chunk_options(self.addon_params, ...)` 现场拼装；若调用方传入 `chunk_options` 参数则原样持久化（SDK 用法，见 §11.4）。
-- **分块器调用**从 `full_docs.chunk_options` 取对应子字典，按 `process_options.chunking` selector 派发到 F/R/V/P。
+- **分块器调用**从 `full_docs.chunk_options` 取对应子字典，按 `process_options.chunking` selector 派发到 F/R/V/P/C。自定义 callback 可能改写原文，因此其输出不做 sidecar provenance 回填；C 的内置 fallback 会产生精确 source span，可以回填。
 
 ### 5.2 环境变量
 
@@ -738,7 +742,7 @@ chunker(tokenizer, content, chunk_token_size, **strategy_kwargs)   (分块时按
 }
 ```
 
-selector → 子字典映射：F → `fixed_token`，R → `recursive_character`，V → `semantic_vector`，P → `paragraph_semantic`；无 selector 默认 F。各子字典与对应分块器函数的 keyword-only 参数一一对应；新增参数时无需改 dispatcher，只在 chunker 函数添加 kwarg 即可。
+selector → 子字典映射：F → `fixed_token`，R → `recursive_character`，V → `semantic_vector`，P → `paragraph_semantic`，C → `fixed_token`；无 selector 默认 F。C 将 fixed-token 字段作为 legacy callback 的位置参数读取；其余内置策略仍把各自子字典映射到 chunker keyword 参数。
 
 ### 5.5 缺失兼容
 
@@ -760,8 +764,8 @@ selector → 子字典映射：F → `fixed_token`，R → `recursive_character`
 | `content_hash` | 内容 MD5，用于跨文件名查重。`parse_format=raw` 取 `sanitize_text_for_encoding` 后文本的 hash；`parse_format=lightrag` 取 `*.blocks.jsonl` 文件 hash；`parse_format=pending_parse` 不写入，待抽取完成后补上。 |
 | `lightrag_document_path` | `parse_format=lightrag` 时保存结构化 LightRAG Document 的路径；新记录优先保存为相对 `INPUT_DIR` 的路径，例如 `__parsed__/report.docx.parsed/report.blocks.jsonl`。注意路径中的子目录与 blocks 文件名都使用规范化 basename（不含 hint）。 |
 | `parse_engine` | 实际完成抽取的引擎：`legacy`, `native`, `mineru`, `docling`。对于待抽取文件，也可暂存目标引擎。 |
-| `process_options` | 入队时记录的原始处理选项串（不含引擎名和分隔 `-`），例如 `"iet"`、`"R!"`、`""`。下游各阶段以此字段为权威源，决定是否启用图像/表格/公式分析（`i/t/e`）、是否禁止知识图谱构建（`!`）以及分块方式（`F/R/V/P`）。空字符串等价于全部默认值。 |
-| `chunk_options` | 入队时**冻结**的分块器参数快照（精简字典：只保留 `process_options` 选中的那一路策略子字典，其它策略丢弃）。由 SDK 路径调用方传入或由 `resolve_chunk_options(self.addon_params, process_options=…)` 从实例字段（含 env 默认）兜底（见 §5.1）。`process_options` 选哪种分块策略（F/R/V/P），`chunk_options` 决定那一路分块器使用哪些参数。下游 `process_single_document` 在分块前从此字段读取专属 kwargs；持久化保证 env 变化、续跑、重启后老文档行为可复现。重新解析时与 `process_options` 一同改写。 |
+| `process_options` | 入队时记录的原始处理选项串（不含引擎名和分隔 `-`），例如 `"iet"`、`"R!"`、`"C"`、`""`。下游各阶段以此字段为权威源，决定是否启用图像/表格/公式分析（`i/t/e`）、是否禁止知识图谱构建（`!`）以及分块方式（`F/R/V/P/C`）。空字符串等价于全部默认值。 |
+| `chunk_options` | 入队时**冻结**的分块器参数快照（精简字典：只保留 `process_options` 选中的那一路策略子字典，其它策略丢弃）。由 SDK 路径调用方传入或由 `resolve_chunk_options(self.addon_params, process_options=…)` 从实例字段（含 env 默认）兜底（见 §5.1）。`process_options` 选哪种分块策略（F/R/V/P/C），`chunk_options` 决定那一路分块器使用哪些参数；C 复用 `fixed_token` 子字典。下游 `process_single_document` 在分块前读取该快照；持久化保证 env 变化、续跑、重启后老文档行为可复现。重新解析时与 `process_options` 一同改写。 |
 
 `pending_parse` 表示文件已经入队，但还没有完成抽取。抽取成功后会改写为 `raw` 或 `lightrag`，并补齐 `content_hash`。抽取失败时保留 `pending_parse` 和空 `content`，便于后续排查和重试。
 
@@ -1160,10 +1164,10 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼�
 | 引擎对比 | 若 `process_options` 隐含的引擎 ≠ `full_docs.parse_engine`，**仅 warn**，不重新解析。已抽取的内容是不可变事实，重新跑不同引擎会产生不一致。要切换引擎请先 delete 整个文档再重传。 |
 | 旧 chunks / 实体 / 关系清理 | 读 `status_doc.chunks_list` 收集旧 chunk id 集，调 `_purge_doc_chunks_and_kg(doc_id, chunk_ids)`：从 `chunks_vdb` / `text_chunks` 删除 chunk 行；按 `entity_chunks` / `relation_chunks` 反查受影响的实体 / 关系，对失去全部源的条目直接从图谱与向量库删除，对仍有其它文档贡献的条目调 `rebuild_knowledge_from_chunks` 用剩余 chunks 重建；最后删除 `full_entities` / `full_relations` 中本 doc 的索引行。purge 完成后 `status_doc.chunks_list = []` / `chunks_count = 0` 重置，避免后续 state-machine upsert 写回旧 ID。 |
 | `analyze_multimodal` | 对已启用模态，每次运行都会重新计算 sidecar item 分析并覆盖已有的 `llm_analyze_result`。由于 LLM cache 的存在重复计算通常会保持语义字段不变，只会重写 `analyze_time` 等运行时字段；cache miss，例如更换模型和提示词等，保存内容才可能与上次不同。 |
-| 重新分块 | 按新 `process_options.chunking` 选策略，参数从 `full_docs.chunk_options` 读取（入队快照，不会因续跑被覆盖；env 改动后老文档仍按入队那一刻的参数分块）。LightRAG Document path 在 `process_options=P` 时走 paragraph_semantic，否则按 selector 分发到 F/R/V。 |
+| 重新分块 | 按新 `process_options.chunking` 选策略，参数从 `full_docs.chunk_options` 读取（入队快照，不会因续跑被覆盖；env 改动后老文档仍按入队那一刻的参数分块）。P 走 paragraph_semantic，F/R/V 走对应内置 chunker，C 走自定义 callback；若 callback 已移除，则告警后走 fixed-token fallback。 |
 | 实体抽取 / KG-skip | 按新 `process_options.skip_kg` 决定 |
 
-> 这条规则保证：用户改 `i/t/e` 重传同名文档（先删旧 doc 再上传带新 hint 的文件）时，多模态分析能增量补齐；改 `F/R/V/P` 时 chunks 与图谱重建；改 `!` 时停掉或恢复 KG 构建。引擎变更被视为"重大变更"，统一由 delete + 重传完成，不在续跑路径里隐式发生。
+> 这条规则保证：用户改 `i/t/e` 重传同名文档（先删旧 doc 再上传带新 hint 的文件）时，多模态分析能增量补齐；改 `F/R/V/P/C` 时 chunks 与图谱重建；改 `!` 时停掉或恢复 KG 构建。引擎变更被视为"重大变更"，统一由 delete + 重传完成，不在续跑路径里隐式发生。
 
 ## 10. 常见问题排查
 

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -119,7 +119,7 @@ For backward compatibility, when the configuration is not modified, the upgraded
 
 ### 2.1 File Processing Options
 
-Processing options control, on a per-file basis, the behavior with respect to multimodal analysis, knowledge graph construction, and text chunking. They can be set as per-rule defaults in `LIGHTRAG_PARSER` (see [§2.4](#24-default-rules-lightrag_parser)) or overridden for an individual file via a filename hint (see [§2.5](#25-single-file-override-filename-hints)). All options are optional; defaults are shown in the table below. At most one chunking method (F/R/V/P) is specified per file; the other options can be combined arbitrarily.
+Processing options control, on a per-file basis, the behavior with respect to multimodal analysis, knowledge graph construction, and text chunking. They can be set as per-rule defaults in `LIGHTRAG_PARSER` (see [§2.4](#24-default-rules-lightrag_parser)) or overridden for an individual file via a filename hint (see [§2.5](#25-single-file-override-filename-hints)). All options are optional; defaults are shown in the table below. At most one chunking method (F/R/V/P/C) is specified per file; the other options can be combined arbitrarily.
 
 | Option | Type | Default | Meaning |
 | --- | --- | --- | --- |
@@ -131,6 +131,7 @@ Processing options control, on a per-file basis, the behavior with respect to mu
 | `R` | Chunking | - | Recursive / recursive character chunking (RecursiveCharacterTextSplitter@LangChain): takes a list of separators (default `["\n\n","\n","。","！","？","；","，"," ",""]`, ordered from strongest to weakest semantic boundary). Splits by paragraph (double newline) first; if a chunk is still over the token limit, falls back stepwise to single newline → Chinese sentence-ending punctuation (`。！？`) → Chinese mid-sentence punctuation (`；，`) → space → per-character split. **The default cascade includes Chinese punctuation**, letting Chinese / mixed Chinese-English documents split at semantic boundaries. English `.?!` is deliberately excluded (literal matching would mis-split `0.95` / `e.g.`). |
 | `V` | Chunking | - | Vector / semantic vector chunking (SemanticChunker@LangChain): first splits text into sentences (the default sentence splitting regex recognizes both English `.?!` and Chinese `。？！`, allowing correct sentence splitting in Chinese / mixed Chinese-English documents), computes embeddings of adjacent sentences, then finds semantic breakpoints based on the specified threshold strategy (e.g., percentile, standard_deviation, or interquartile) for splitting. `SemanticChunker` itself has no chunk size cap — any semantic chunk that exceeds `chunk_token_size` is automatically split again by R before persistence (preserving V's non-overlap semantics). This chunking strategy never produces overlapping chunks. |
 | `P` | Chunking | - | Paragraph / paragraph semantic chunking (native); splits by heading first and strictly avoids mixing content from the bottom of the previous heading with content from the next heading, which would break semantics. Suited for chunking documents that can accurately identify headings with a clear heading structure. When the body under the same heading is too long and falls back to R, overlap can be preserved according to `CHUNK_P_OVERLAP_SIZE`; bridging text between adjacent large tables can also be repeated into the surrounding table chunks within that budget. This chunking method can only be applied to `lightrag` content stored in the sidecar directory. If `lightrag` content does not exist, it degrades to chunking with `R`. This chunking method produces far fewer overlapping chunks than the `R` or `F` strategies. |
+| `C` | Chunking | - | Custom chunking: explicitly invokes the configured `LightRAG.chunking_func` with its unchanged six-argument legacy contract. It reuses the `fixed_token` parameter snapshot. If a persisted/background `C` document is processed without a custom callback, the pipeline warns once and uses the exact fixed-token fallback; new text/upload requests are rejected with 422 instead. |
 
 > The global multimodal switch `addon_params["enable_multimodal_pipeline"]` is deprecated; the related behavior is now uniformly controlled by the file-level `i/t/e` options. See [Appendix A](#appendix-a-notes-on-upgrading-from-legacy).
 
@@ -142,7 +143,7 @@ Different characters of processing options take effect at different stages of th
 | :-: | --- | --- |
 | i/t/e | Analyzing (multimodal analysis) | Determines whether VLM summarization analysis is invoked on the images / tables / equations in the sidecar. **The extraction stage is unaffected**: the content extraction engine outputs `drawings.json` / `tables.json` / `equations.json` sidecar files based on what the document actually contains. As a result, simply tweaking the `i`/`t`/`e` options to trigger "re-analysis" can complete VLM later without re-parsing the original file. |
 | ! | Extraction (entity-relation extraction) | Skips entity/relation extraction and graph writing; chunks are still written to the vector store to retain naive / mix retrieval capabilities. |
-| F/R/V/P | Chunking (text chunking) | Determines which chunking strategy to use; does not affect the output of the parsing stage. |
+| F/R/V/P/C | Chunking (text chunking) | Determines which chunking strategy to use; does not affect the output of the parsing stage. |
 
 > Modality availability is signaled solely by "whether the sidecar file exists"; the content extraction engine does not need to declare its capabilities in meta. If a given document contains no images/tables/equations, the corresponding sidecar is not written; even if the user has enabled `i/t/e`, the corresponding modality is silently skipped, but `analyze_multimodal` logs an INFO-level line for that document (`[analyze_multimodal] sidecar e:equations empty: doc—id ...`), making it easy to diagnose "why didn't the VLM run". This is not an error.
 
@@ -227,7 +228,7 @@ When parsing the hint, content without a hyphen must match an engine name exactl
 
 ### 2.6 Attaching chunk parameters
 
-A chunk-strategy selector (`F` / `R` / `V` / `P`) — in a `LIGHTRAG_PARSER` rule or a filename hint — may carry per-strategy chunking parameters in parentheses. Inside the parentheses a comma **only** separates parameters; rule splitting is parenthesis-aware, so this comma is never mistaken for a rule separator (both `;` and `,` remain valid rule separators, but `;` is recommended).
+A chunk-strategy selector (`F` / `R` / `V` / `P` / `C`) — in a `LIGHTRAG_PARSER` rule or a filename hint — may carry per-strategy chunking parameters in parentheses. Inside the parentheses a comma **only** separates parameters; rule splitting is parenthesis-aware, so this comma is never mistaken for a rule separator (both `;` and `,` remain valid rule separators, but `;` is recommended).
 
 ```text
 notes.[-R(chunk_ts=800,chunk_ol=80)].md                            # filename hint
@@ -238,13 +239,15 @@ Currently supported parameters (canonical name / short alias):
 
 | Parameter | Alias | Strategies | Type | Meaning |
 | --- | --- | --- | --- | --- |
-| `chunk_token_size` | `chunk_ts` | F / R / V / P | int (≥ 1) | Per-strategy chunk size |
-| `chunk_overlap_token_size` | `chunk_ol` | F / R / P | int (≥ 0) | Overlap between chunks (V has no overlap) |
+| `chunk_token_size` | `chunk_ts` | F / R / V / P / C | int (≥ 1) | Per-strategy chunk size |
+| `chunk_overlap_token_size` | `chunk_ol` | F / R / P / C | int (≥ 0) | Overlap between chunks (V has no overlap) |
 | `drop_references` | `drop_rf` | P | bool | Drop matching reference blocks before chunking, e.g. `paper.[-P(drop_rf=true)].pdf`. As a boolean it may be written bare: `paper.[-P(drop_rf)].pdf` means `drop_rf=true` |
 
 - `process_options` stays a pure selector string; each parameter is applied to that strategy's `chunk_options` (see §5) while the strategy's other env-derived parameters are kept. Aliases are normalized to their canonical name internally.
 - Merge priority: the selector still follows "a non-empty filename-hint options string wholesale-overrides the rule options"; parameters overlay **per strategy** — rule parameters first, then filename-hint parameters (filename wins on a shared key).
 - Validation is strict both at startup (`LIGHTRAG_PARSER`) and at upload (filename hint): an unknown parameter, a wrong type, an out-of-range value, or a parameter on a strategy that does not support it (e.g. `chunk_ol` on `V`) all raise a friendly error.
+
+The text APIs expose the same path as `chunking.strategy="custom"`. Its `params` object uses the complete fixed-token/legacy contract (`chunk_token_size`, `chunk_overlap_token_size`, `split_by_character`, and `split_by_character_only`). `/documents/text` and `/documents/texts` return 422 unless `LightRAG.chunking_func` was replaced with a non-default callback.
 
 > `drop_references` detection knobs `CHUNK_P_REFERENCES_TAIL_N` (default `0`: scan all content blocks; a positive value scans only the last N) / `CHUNK_P_REFERENCES_HEADINGS` (pipe-separated, default `References\|Bibliography\|参考文献`) are env-only and read live at run time. Global default can be set via env var `CHUNK_P_DROP_REFERENCES`.
 
@@ -255,10 +258,11 @@ Currently supported parameters (canonical name / short alias):
 - Filename hints have higher priority than `LIGHTRAG_PARSER`. If the engine specified in a hint does not support that extension, the system falls back to the default rules to continue selecting an available engine.
 - If the filename hint provides a non-empty options string, the hint takes precedence; otherwise the default options of the matching item in `LIGHTRAG_PARSER` are used; if neither is provided, all defaults are used.
 - If no rule is available, the file content extraction falls back to `legacy`; if `legacy` also does not support the file extension, an error entry is added to the system and the uploaded file remains in the `INPUT` directory.
-- At most one of F/R/V/P may appear; repeating the same option has effect only once but does not raise an error.
-- Case-sensitive: the chunking options F/R/V/P must be uppercase; other options i/t/e must be lowercase.
+- At most one of F/R/V/P/C may appear; repeating the same option has effect only once but does not raise an error.
+- Case-sensitive: the chunking options F/R/V/P/C must be uppercase; other options i/t/e must be lowercase.
 - If illegal characters appear inside the square brackets, the entire hint is invalidated, the engine follows the default rules, and the options fall back to `LIGHTRAG_PARSER` defaults or all defaults; a warning is also logged.
 - `P` is only effective for structured `LightRAG Document` results extracted by `native`; for the `legacy` path or unstructured output, it automatically degrades to `R` and logs a warning.
+- `C` requires an injected custom callback at synchronous request boundaries. `/documents/upload` validates both filename hints and matching `LIGHTRAG_PARSER` rules before writing the file and returns 422 when the callback is absent. Directory scans and reprocessing have no caller to correct a persisted selector, so they accept `C`, warn once per processing attempt, and use the fixed-token fallback.
 
 ## 3. File Parsing Engines
 
@@ -578,7 +582,7 @@ Doing step 3 in two halves is what produces the failure in §4.3 step 4. And bec
 
 ### 5.1 Responsibilities of process_options vs chunk_options
 
-`process_options` selects **which** chunking strategy (F/R/V/P), while `chunk_options` decides **which parameters** that chunker uses. The two responsibilities are orthogonal: the former is a single-character selector, the latter is a structured dictionary.
+`process_options` selects **which** chunking strategy (F/R/V/P/C), while `chunk_options` decides **which parameters** that chunker uses. The two responsibilities are orthogonal: the former is a single-character selector, the latter is a structured dictionary. `C` deliberately maps to the `fixed_token` sub-dictionary because those values populate the legacy callback's six arguments.
 
 ```
 env vars                                                  (read once at startup)
@@ -597,7 +601,7 @@ chunker(tokenizer, content, chunk_token_size, **strategy_kwargs)   (dispatched b
 - **env vars** are loaded into `addon_params["chunker"]` during the `LightRAG.__init__` stage (strategy-specific env is read by `default_chunker_config()`, then `_apply_chunk_size_overlay` fills in legacy env as a fallback).
 - **`addon_params["chunker"]`** is an `ObservableAddonParams` field; for Server deployments, you only need env / restart for the new values to take effect. To change it at runtime within the Python process (without restarting) and to do per-file overrides, see [Chapter 11: Python SDK Invocation](#11-python-sdk-invocation).
 - **`full_docs.chunk_options`** is frozen at `apipeline_enqueue_documents` enqueue time: by default it is assembled by `resolve_chunk_options(self.addon_params, ...)` on the spot; if the caller passes a `chunk_options` argument, it is persisted as-is (SDK usage, see §11.4).
-- **The chunker invocation** takes the corresponding sub-dictionary from `full_docs.chunk_options` and dispatches to F/R/V/P by the `process_options.chunking` selector.
+- **The chunker invocation** takes the corresponding sub-dictionary from `full_docs.chunk_options` and dispatches to F/R/V/P/C by the `process_options.chunking` selector. Custom callback output is not sidecar-backfilled because it may rewrite source text; C's built-in fallback is eligible because it emits exact source spans.
 
 ### 5.2 Environment Variables
 
@@ -738,7 +742,7 @@ Three layers of semantic guarantee:
 }
 ```
 
-selector → sub-dictionary mapping: F → `fixed_token`, R → `recursive_character`, V → `semantic_vector`, P → `paragraph_semantic`; without a selector, F is the default. Each sub-dictionary corresponds one-to-one with the keyword-only parameters of the corresponding chunker function; when adding new parameters, no dispatcher change is needed, just add a kwarg to the chunker function.
+selector → sub-dictionary mapping: F → `fixed_token`, R → `recursive_character`, V → `semantic_vector`, P → `paragraph_semantic`, C → `fixed_token`; without a selector, F is the default. C reads the fixed-token fields as positional values for the legacy callback contract; the built-in strategies otherwise map their sub-dictionaries to their chunker keyword arguments.
 
 ### 5.5 Backward Compatibility for Missing Fields
 
@@ -760,8 +764,8 @@ File enqueue and extraction results are written into `full_docs`:
 | `content_hash` | MD5 of the content, used for cross-filename deduplication. For `parse_format=raw`, takes the hash of text after `sanitize_text_for_encoding`; for `parse_format=lightrag`, takes the hash of the `*.blocks.jsonl` file; for `parse_format=pending_parse`, not written, filled in after extraction completes. |
 | `lightrag_document_path` | When `parse_format=lightrag`, saves the path to the structured LightRAG Document; new records prefer to save the path relative to `INPUT_DIR`, e.g., `__parsed__/report.docx.parsed/report.blocks.jsonl`. Note that the subdirectories and the blocks filename in the path both use the canonicalized basename (without hint). |
 | `parse_engine` | The engine that actually completed extraction: `legacy`, `native`, `mineru`, `docling`. For files awaiting extraction, can also temporarily store the target engine. |
-| `process_options` | The original processing options string recorded at enqueue time (without engine name and the separator `-`), e.g., `"iet"`, `"R!"`, `""`. Downstream stages take this field as the authoritative source for deciding whether to enable image / table / equation analysis (`i/t/e`), whether to disable knowledge graph construction (`!`), and the chunking method (`F/R/V/P`). An empty string is equivalent to all defaults. |
-| `chunk_options` | The **frozen** snapshot of chunker parameters at enqueue time (slim dictionary: only the strategy sub-dictionary selected by `process_options` is retained, others discarded). Passed in by the SDK-path caller or assembled by `resolve_chunk_options(self.addon_params, process_options=…)` from instance fields (containing env defaults) as a fallback (see §5.1). `process_options` chooses which chunking strategy (F/R/V/P); `chunk_options` decides which parameters that chunker uses. The downstream `process_single_document` reads strategy-specific kwargs from this field before chunking; persistence guarantees that old documents behave reproducibly across env changes, resumes, and restarts. Rewritten together with `process_options` when re-parsing. |
+| `process_options` | The original processing options string recorded at enqueue time (without engine name and the separator `-`), e.g., `"iet"`, `"R!"`, `"C"`, `""`. Downstream stages take this field as the authoritative source for deciding whether to enable image / table / equation analysis (`i/t/e`), whether to disable knowledge graph construction (`!`), and the chunking method (`F/R/V/P/C`). An empty string is equivalent to all defaults. |
+| `chunk_options` | The **frozen** snapshot of chunker parameters at enqueue time (slim dictionary: only the strategy sub-dictionary selected by `process_options` is retained, others discarded). Passed in by the SDK-path caller or assembled by `resolve_chunk_options(self.addon_params, process_options=…)` from instance fields (containing env defaults) as a fallback (see §5.1). `process_options` chooses which chunking strategy (F/R/V/P/C); `chunk_options` decides which parameters that chunker uses. C reuses the `fixed_token` sub-dictionary. The downstream `process_single_document` reads the snapshot before chunking; persistence guarantees that old documents behave reproducibly across env changes, resumes, and restarts. Rewritten together with `process_options` when re-parsing. |
 
 `pending_parse` indicates the file has been enqueued but extraction is not yet complete. After successful extraction, it is rewritten to `raw` or `lightrag`, and `content_hash` is filled in. On extraction failure, `pending_parse` and the empty `content` are kept, making subsequent troubleshooting and retry easier.
 
@@ -1160,10 +1164,10 @@ Go through the full pipeline (registry-dispatched parsing `get_parser(engine).pa
 | Engine comparison | If the engine implied by `process_options` ≠ `full_docs.parse_engine`, **only warn**, do not re-parse. The extracted content is an immutable fact; re-running a different engine would produce inconsistency. To switch engines, delete the whole document and re-upload it. |
 | Old chunks / entities / relations cleanup | Read `status_doc.chunks_list` to collect old chunk id set, call `_purge_doc_chunks_and_kg(doc_id, chunk_ids)`: delete chunk rows from `chunks_vdb` / `text_chunks`; reverse-lookup affected entities / relations by `entity_chunks` / `relation_chunks`, directly remove entries that have lost all sources from the graph and vector store, and call `rebuild_knowledge_from_chunks` to rebuild with the remaining chunks for entries still contributed by other documents; finally delete the index rows of this doc in `full_entities` / `full_relations`. After purge completes, `status_doc.chunks_list = []` / `chunks_count = 0` are reset to avoid the subsequent state-machine upsert writing back old IDs. |
 | `analyze_multimodal` | For enabled modalities, every run recomputes the sidecar item analysis and overwrites the existing `llm_analyze_result`. The LLM analysis cache still applies: a cache hit reuses the previous provider response, so semantic fields usually stay the same and only runtime fields such as `analyze_time` are rewritten. Cache misses, for example after changing the model or prompt, can produce different saved content. |
-| Re-chunk | Pick the strategy by the new `process_options.chunking`, with parameters read from `full_docs.chunk_options` (the enqueue snapshot; not overwritten by resume; env changes do not affect old documents that still chunk by the parameters from the moment of enqueue). The LightRAG Document path uses paragraph_semantic when `process_options=P`, otherwise dispatches to F/R/V by selector. |
+| Re-chunk | Pick the strategy by the new `process_options.chunking`, with parameters read from `full_docs.chunk_options` (the enqueue snapshot; not overwritten by resume; env changes do not affect old documents that still chunk by the parameters from the moment of enqueue). The LightRAG Document path uses paragraph_semantic for P, the built-in F/R/V chunkers for their selectors, and the custom callback for C (or its warned fixed-token fallback if the callback is no longer configured). |
 | Entity extraction / KG-skip | Determined by the new `process_options.skip_kg` |
 
-> This rule guarantees: when users change `i/t/e` and re-upload the same-named document (delete the old doc first, then upload the file with the new hint), multimodal analysis is incrementally filled in; when changing `F/R/V/P`, chunks and graph are rebuilt; when changing `!`, KG construction is stopped or restored. Engine changes are considered a "major change", uniformly handled by delete + re-upload, not implicitly happening on the resume path.
+> This rule guarantees: when users change `i/t/e` and re-upload the same-named document (delete the old doc first, then upload the file with the new hint), multimodal analysis is incrementally filled in; when changing `F/R/V/P/C`, chunks and graph are rebuilt; when changing `!`, KG construction is stopped or restored. Engine changes are considered a "major change", uniformly handled by delete + re-upload, not implicitly happening on the resume path.
 
 ## 10. Troubleshooting
 

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -108,7 +108,7 @@ Notes:
 | `language` | Non-empty string. Defaults to `SUMMARY_LANGUAGE`, then `English`. | Output language used in entity and relationship extraction, entity/relation summaries, keyword extraction, and multimodal analysis prompts. |
 | `entity_type_prompt_file` | `.yml` or `.yaml` file name only. Loaded from `${PROMPT_DIR:-./prompts}/entity_type`. | Loads an entity extraction prompt profile. The profile can define `entity_types_guidance`, `entity_extraction_examples`, and `entity_extraction_json_examples`. The active extraction mode must have matching examples: text mode needs `entity_extraction_examples`; JSON mode needs `entity_extraction_json_examples`. |
 | `entity_types_guidance` | Non-empty string. | Inline entity type guidance injected into extraction prompts. This overrides both the prompt profile file and the built-in default guidance. |
-| `chunker` | Dict with F/R/V/P chunking settings. | Runtime baseline for chunker parameters. Each document gets a slim `chunk_options` snapshot at enqueue time; later edits affect only future enqueues. |
+| `chunker` | Dict with F/R/V/P chunking settings (the `C` selector reuses the `fixed_token` sub-dictionary). | Runtime baseline for chunker parameters. Each document gets a slim `chunk_options` snapshot at enqueue time; later edits affect only future enqueues. |
 
 Compact `chunker` shape:
 

--- a/env.example
+++ b/env.example
@@ -279,10 +279,10 @@ ENTITY_EXTRACTION_USE_JSON=true
 ### below must be configured before server startup.
 ###
 ### Per-strategy chunk parameters may be attached in parentheses to a chunk
-### selector (F/R/V/P). Inside the parentheses a comma only separates parameters.
+### selector (F/R/V/P/C). Inside the parentheses a comma only separates parameters.
 ### Supported parameters (alias in brackets):
-###     chunk_token_size [chunk_ts]          F/R/V/P   e.g. R(chunk_ts=800)
-###     chunk_overlap_token_size [chunk_ol]  F/R/P     (V has no overlap)
+###     chunk_token_size [chunk_ts]          F/R/V/P/C   e.g. R(chunk_ts=800)
+###     chunk_overlap_token_size [chunk_ol]  F/R/P/C     (V has no overlap)
 ###     LIGHTRAG_PARSER=pdf:legacy-R(chunk_ts=800,chunk_ol=80);*:legacy-R
 ### The same syntax works in a filename hint, e.g. notes.[-R(chunk_ts=800)].md
 ### Boolean parameters may be written bare as a flag, on a chunk selector as

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -2767,6 +2767,7 @@ async def pipeline_index_texts(
     file_sources: List[str] = None,
     track_id: str = None,
     chunking: Optional[TextChunkingConfig] = None,
+    resolved_chunking: Optional[tuple[str, dict]] = None,
     admission_token: str | None = None,
 ):
     """Index a list of texts with track_id
@@ -2778,6 +2779,10 @@ async def pipeline_index_texts(
         track_id: Optional tracking ID
         chunking: Optional chunking strategy + params (already validated by
             the request model); when None, default fixed-token chunking is used
+        resolved_chunking: Optional preflight-frozen ``(process_options,
+            chunk_options)`` snapshot. Request handlers pass this so accepted
+            work cannot be invalidated by a callback/config change before its
+            managed task starts. Direct callers may omit it to resolve here.
         admission_token: the endpoint's pending-enqueue reservation, forwarded so
             the admission guard re-weights that token to the deduped count
             (LR2 §9.2)
@@ -2794,7 +2799,10 @@ async def pipeline_index_texts(
     if len(set(normalized_file_sources)) != len(normalized_file_sources):
         raise ValueError("File sources must be unique by filename")
 
-    process_options, chunk_options = _resolve_text_chunking(chunking, rag)
+    if resolved_chunking is None:
+        process_options, chunk_options = _resolve_text_chunking(chunking, rag)
+    else:
+        process_options, chunk_options = resolved_chunking
     enqueue_kwargs: dict[str, Any] = {
         "input": texts,
         "file_paths": normalized_file_sources,
@@ -5564,10 +5572,11 @@ def create_document_routes(
             # Resolve + validate chunking synchronously so an invalid
             # effective config (e.g. chunk_token_size below the inherited
             # overlap) fails with HTTP 422 here, before any background work is
-            # scheduled. pipeline_index_texts re-resolves from the same
-            # addon_params inside the task.
+            # scheduled. Keep the returned snapshot: the callback/config may
+            # change before the managed task starts, but an accepted request
+            # must enqueue the exact options that passed this preflight.
             try:
-                _resolve_text_chunking(request.chunking, rag)
+                resolved_chunking = _resolve_text_chunking(request.chunking, rag)
             except ValueError as exc:
                 # Controlled chunking-config validation message (numeric sizes
                 # only, no internal detail); kept as client-facing 422 feedback
@@ -5592,6 +5601,7 @@ def create_document_routes(
                         file_sources=[normalized_file_source],
                         track_id=track_id,
                         chunking=request.chunking,
+                        resolved_chunking=resolved_chunking,
                         admission_token=enqueue_token,
                     )
                 finally:
@@ -5719,10 +5729,11 @@ def create_document_routes(
             # Resolve + validate the shared chunking synchronously so an
             # invalid effective config (e.g. chunk_token_size below the
             # inherited overlap) fails with HTTP 422 here, before any
-            # background work is scheduled. pipeline_index_texts re-resolves
-            # from the same addon_params inside the task.
+            # background work is scheduled. Keep the returned snapshot: the
+            # callback/config may change before the managed task starts, but an
+            # accepted request must enqueue the exact options from preflight.
             try:
-                _resolve_text_chunking(request.chunking, rag)
+                resolved_chunking = _resolve_text_chunking(request.chunking, rag)
             except ValueError as exc:
                 # Controlled chunking-config validation message (numeric sizes
                 # only, no internal detail); kept as client-facing 422 feedback
@@ -5754,6 +5765,7 @@ def create_document_routes(
                         file_sources=normalized_file_sources,
                         track_id=track_id,
                         chunking=request.chunking,
+                        resolved_chunking=resolved_chunking,
                         admission_token=enqueue_token,
                     )
                 finally:

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -106,6 +106,7 @@ from lightrag.kg.scan_job_store import (
 )
 from lightrag.parser.routing import (
     FilenameParserHintError,
+    ParserDirectives,
     canonicalize_parser_hinted_basename,
     chunk_strategy_key,
     encode_parse_engine,
@@ -1616,7 +1617,9 @@ class DocumentManager:
     def mark_as_indexed(self, file_path: Path):
         self.indexed_files.add(file_path)
 
-    def is_supported_file(self, filename: str) -> bool:
+    def is_supported_file(
+        self, filename: str, *, directives: ParserDirectives | None = None
+    ) -> bool:
         """True when THIS filename routes to an engine that can parse it.
 
         Resolves the engine for the concrete name — so a per-file hint
@@ -1625,9 +1628,15 @@ class DocumentManager:
         default ``legacy`` engine is rejected here instead of failing later
         at the parse worker's suffix gate.
 
+        ``directives`` lets a caller that already resolved this filename
+        (upload does, to gate the ``C`` selector) reuse that resolution
+        instead of paying a second hint parse plus rule scan.
+
         Raises :class:`FilenameParserHintError` for a malformed hint —
         callers surface it (upload → HTTP 400 with the detailed message;
         scan passes the file through so enqueue emits an error document).
+        A caller passing ``directives`` has already resolved (and therefore
+        already surfaced) that error, so nothing is raised on that path.
         """
         from lightrag.parser.routing import (
             parser_engine_supports_suffix,
@@ -1635,7 +1644,11 @@ class DocumentManager:
             resolve_file_parser_engine,
         )
 
-        engine = resolve_file_parser_engine(filename)
+        engine = (
+            directives.engine
+            if directives is not None
+            else resolve_file_parser_engine(filename)
+        )
         return parser_engine_supports_suffix(engine, parser_suffix(filename))
 
 
@@ -5254,9 +5267,11 @@ def create_document_routes(
                 - status="success": File accepted and queued for processing
 
         Raises:
-            HTTPException: 400 unsupported file type, 409 same-name
-                conflict or scan-classifying / destructive job in
-                flight, 413 file too large, 500 other errors.
+            HTTPException: 400 unsupported file type or malformed filename
+                hint, 409 same-name conflict or scan-classifying /
+                destructive job in flight, 413 file too large, 422 invalid
+                chunking configuration (an explicit ``C`` selector without a
+                custom ``LightRAG.chunking_func``), 500 other errors.
         """
         from lightrag.kg.shared_storage import start_reserved_background_task
 
@@ -5279,14 +5294,20 @@ def create_document_routes(
             # Sanitize filename to prevent Path Traversal attacks
             safe_filename = sanitize_filename(file.filename, doc_manager.input_dir)
 
+            # Resolve engine + process options once and reuse the result for
+            # both gates below; each resolution costs a hint parse plus a
+            # LIGHTRAG_PARSER rule scan.
             try:
-                filename_supported = doc_manager.is_supported_file(safe_filename)
+                upload_directives = resolve_parser_directives(safe_filename)
             except FilenameParserHintError as hint_error:
                 # Reject malformed hints synchronously with the detailed
                 # message (previously surfaced asynchronously as an error
                 # document after the upload was accepted).
                 raise HTTPException(status_code=400, detail=str(hint_error))
-            if not filename_supported:
+
+            if not doc_manager.is_supported_file(
+                safe_filename, directives=upload_directives
+            ):
                 raise HTTPException(
                     status_code=400,
                     detail=f"Unsupported file type. Supported types: {doc_manager.supported_extensions}",
@@ -5296,12 +5317,9 @@ def create_document_routes(
             # an unusable explicit ``C`` selector. Reject before writing the
             # upload rather than silently accepting work that must fall back.
             try:
-                upload_directives = resolve_parser_directives(safe_filename)
                 _validate_custom_chunking_available(
                     upload_directives.process_options, rag
                 )
-            except FilenameParserHintError as hint_error:
-                raise HTTPException(status_code=400, detail=str(hint_error))
             except ValueError as exc:
                 raise HTTPException(
                     status_code=422,

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -85,6 +85,7 @@ from lightrag.constants import (
     MAX_R_SEPARATORS,
     PARSED_ARTIFACT_DIR_SUFFIXES,
     PARSED_DIR_NAME,
+    PROCESS_OPTION_CHUNK_CUSTOM,
     PROCESS_OPTION_CHUNK_FIXED,
     PROCESS_OPTION_CHUNK_PARAGRAH,
     PROCESS_OPTION_CHUNK_RECURSIVE,
@@ -616,6 +617,7 @@ TextChunkingStrategy = Literal[
     "recursive_character",
     "semantic_vector",
     "paragraph_semantic",
+    "custom",
 ]
 
 
@@ -760,6 +762,10 @@ _CHUNKING_PARAMS_MODEL: dict[str, type[_StrictChunkParams]] = {
     "recursive_character": RecursiveCharacterChunkParams,
     "semantic_vector": SemanticVectorChunkParams,
     "paragraph_semantic": ParagraphSemanticChunkParams,
+    # ``custom`` invokes LightRAG.chunking_func with the historical six
+    # arguments, so its request parameters are exactly the fixed-token fields
+    # that populate that signature.
+    "custom": FixedTokenChunkParams,
 }
 
 
@@ -770,6 +776,11 @@ class TextChunkingConfig(BaseModel):
     keys, wrong types, and out-of-range values all raise synchronously
     during request parsing (HTTP 422) — never later in the background
     indexing task, where the HTTP response has already been sent.
+
+    ``custom`` explicitly invokes ``LightRAG.chunking_func`` and reuses the
+    fixed-token parameter contract (split character, split-only flag, overlap,
+    and size). It is rejected unless the application injected a non-default
+    callback.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -2609,7 +2620,27 @@ _STRATEGY_TO_PROCESS_OPTION: Dict[str, str] = {
     "recursive_character": PROCESS_OPTION_CHUNK_RECURSIVE,
     "semantic_vector": PROCESS_OPTION_CHUNK_VECTOR,
     "paragraph_semantic": PROCESS_OPTION_CHUNK_PARAGRAH,
+    "custom": PROCESS_OPTION_CHUNK_CUSTOM,
 }
+
+
+def _validate_custom_chunking_available(process_options: str, rag: LightRAG) -> None:
+    """Require an injected callback for synchronous user-facing ``C`` ingress.
+
+    Background scans and reprocessing intentionally do not call this helper:
+    they may encounter an already-persisted ``C`` document after the callback
+    was removed, and the processing pipeline has an observable fixed-token
+    fallback for that case.
+    """
+    if parse_process_options(process_options).chunking != PROCESS_OPTION_CHUNK_CUSTOM:
+        return
+
+    from lightrag.chunker import chunking_by_token_size
+
+    if getattr(rag, "chunking_func", chunking_by_token_size) is chunking_by_token_size:
+        raise ValueError(
+            "custom chunking requires a non-default LightRAG.chunking_func"
+        )
 
 
 def _resolve_text_chunking(
@@ -2647,6 +2678,7 @@ def _resolve_text_chunking(
         )
 
     process_options = _STRATEGY_TO_PROCESS_OPTION[chunking.strategy]
+    _validate_custom_chunking_available(process_options, rag)
     chunk_options = resolve_chunk_options(
         rag.addon_params, process_options=process_options
     )
@@ -5250,6 +5282,22 @@ def create_document_routes(
                 raise HTTPException(
                     status_code=400,
                     detail=f"Unsupported file type. Supported types: {doc_manager.supported_extensions}",
+                )
+
+            # Unlike scans/reprocessing, this request has a caller to correct
+            # an unusable explicit ``C`` selector. Reject before writing the
+            # upload rather than silently accepting work that must fall back.
+            try:
+                upload_directives = resolve_parser_directives(safe_filename)
+                _validate_custom_chunking_available(
+                    upload_directives.process_options, rag
+                )
+            except FilenameParserHintError as hint_error:
+                raise HTTPException(status_code=400, detail=str(hint_error))
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Invalid chunking configuration: {exc}",
                 )
 
             # Check file size limit (if configured)

--- a/lightrag/chunker/__init__.py
+++ b/lightrag/chunker/__init__.py
@@ -11,12 +11,15 @@ Two contracts coexist intentionally:
 
     so externally-supplied :attr:`lightrag.LightRAG.chunking_func`
     implementations continue to work unchanged. The legacy contract is
-    only invoked when ``process_options`` does NOT specify a chunking
-    selector (i.e. ``chunking_explicit`` is False) — typically direct
-    :meth:`LightRAG.ainsert` calls with raw text.
+    invoked when ``process_options`` does NOT specify a chunking selector
+    (i.e. ``chunking_explicit`` is False) — typically direct
+    :meth:`LightRAG.ainsert` calls with raw text — and when the explicit
+    ``"C"`` selector requests the configured custom callback. If ``C`` is
+    processed without a custom callback, the dispatcher warns and invokes
+    :func:`chunking_by_fixed_token` instead.
 
   - **File-chunker contract** — for documents whose ``process_options``
-    explicitly selects a chunking strategy, the file-based dispatcher in
+    explicitly selects a built-in chunking strategy, the file-based dispatcher in
     ``_PipelineMixin.process_single_document`` reads
     ``doc_process_opts.chunking`` and routes to a chunker following the
     standardized signature
@@ -40,6 +43,11 @@ Two contracts coexist intentionally:
         Heading-aware semantic chunker; consumes the docx-native
         ``.blocks.jsonl`` sidecar. Falls back to R when the sidecar is
         missing or unreadable.
+
+    The explicit ``"C"`` selector is the bridge between the two contracts:
+    it uses the legacy callback signature and the ``fixed_token`` parameter
+    snapshot, while retaining the file pipeline's persisted selector and
+    observability.
 
 See ``docs/ParagraphSemanticChunking-zh.md`` for the algorithm behind
 the ``"P"`` strategy and ``docs/FileProcessingPipeline.md`` for

--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -443,7 +443,7 @@ PROCESS_OPTION_IMAGES = "i"  # Enable VLM analysis for drawings/images
 PROCESS_OPTION_TABLES = "t"  # Enable VLM analysis for tables
 PROCESS_OPTION_EQUATIONS = "e"  # Enable VLM analysis for equations
 PROCESS_OPTION_SKIP_KG = "!"  # Skip entity/relation extraction (no KG build)
-ProcessChunkingOption: TypeAlias = Literal["F", "R", "V", "P"]
+ProcessChunkingOption: TypeAlias = Literal["F", "R", "V", "P", "C"]
 PROCESS_OPTION_CHUNK_FIXED: ProcessChunkingOption = (
     "F"  # Fixed-length / separator chunking (default)
 )
@@ -456,6 +456,9 @@ PROCESS_OPTION_CHUNK_VECTOR: ProcessChunkingOption = (
 PROCESS_OPTION_CHUNK_PARAGRAH: ProcessChunkingOption = (
     "P"  # Paragrah-driven semantic chunking
 )
+PROCESS_OPTION_CHUNK_CUSTOM: ProcessChunkingOption = (
+    "C"  # Explicitly invoke LightRAG.chunking_func
+)
 
 PROCESS_OPTION_CHUNK_CHARS: frozenset[ProcessChunkingOption] = frozenset(
     {
@@ -463,6 +466,7 @@ PROCESS_OPTION_CHUNK_CHARS: frozenset[ProcessChunkingOption] = frozenset(
         PROCESS_OPTION_CHUNK_RECURSIVE,
         PROCESS_OPTION_CHUNK_VECTOR,
         PROCESS_OPTION_CHUNK_PARAGRAH,
+        PROCESS_OPTION_CHUNK_CUSTOM,
     }
 )
 SUPPORTED_PROCESS_OPTIONS = frozenset(
@@ -475,6 +479,7 @@ SUPPORTED_PROCESS_OPTIONS = frozenset(
         PROCESS_OPTION_CHUNK_RECURSIVE,
         PROCESS_OPTION_CHUNK_VECTOR,
         PROCESS_OPTION_CHUNK_PARAGRAH,
+        PROCESS_OPTION_CHUNK_CUSTOM,
     }
 )
 

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -569,8 +569,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     ``_PipelineMixin.process_single_document`` is driven by the
     document's ``process_options``:
 
-      - If ``process_options`` explicitly contains a chunking selector
-        char (``F``/``R``/``V``/``P``), the dispatcher routes to a
+      - If ``process_options`` explicitly contains a built-in chunking
+        selector (``F``/``R``/``V``/``P``), the dispatcher routes to a
         chunker that follows the new file-chunker contract — see
         :mod:`lightrag.chunker` (``chunking_by_fixed_token`` for ``F``,
         ``chunking_by_recursive_character`` for ``R``,
@@ -579,6 +579,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         ``chunking_func`` is NOT called in that case**. If it was replaced
         with a custom callable, the dispatcher logs a warning that the
         selected strategy is bypassing it.
+
+      - If ``process_options`` explicitly contains ``C``, the dispatcher
+        invokes this ``chunking_func`` with the same legacy 6-arg signature.
+        Sync and async callbacks both run on the event loop. If the callback
+        is still the built-in default, background/reprocessing work logs one
+        warning per attempt and uses the exact fixed-token file chunker as an
+        observable fallback instead. Synchronous text/upload API boundaries
+        reject that unavailable-custom configuration with HTTP 422.
 
       - If ``process_options`` does **not** name a chunking strategy
         (empty string, or only non-chunking flags such as ``i`` / ``t``
@@ -1787,8 +1795,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         The LightRAG **server / REST API does not call this method** — it
         ingests via :meth:`apipeline_enqueue_documents` +
         :meth:`apipeline_process_enqueue_documents` with a per-document
-        ``process_options`` selector, which is how F/R/V/P are chosen there.
-        To use R/V/P (or pass an explicit per-document ``chunk_options``) from
+        ``process_options`` selector, which is how F/R/V/P/C are chosen there.
+        To use R/V/P/C (or pass an explicit per-document ``chunk_options``) from
         the SDK, call those two methods directly with ``process_options=…``
         instead of ``ainsert``.
 

--- a/lightrag/parser/param_schema.py
+++ b/lightrag/parser/param_schema.py
@@ -323,7 +323,7 @@ def chunk_param_overlap_error(params: Mapping[str, Any]) -> str | None:
 # ---------------------------------------------------------------------------
 # Engine parameters (Phase 2) — per-file params attached to the engine token,
 # e.g. ``mineru(page_range=1-3,language=en)`` / ``docling(force_ocr=true)``.
-# Keyed by engine name (unlike chunk params, which are keyed by F/R/V/P).
+# Keyed by engine name (unlike chunk params, which are keyed by F/R/V/P/C).
 # ---------------------------------------------------------------------------
 
 _BOOL_TRUE = frozenset({"1", "true", "yes", "on", "t", "y"})
@@ -338,7 +338,7 @@ class EngineParamSpec:
     """Declares one tunable engine parameter (Phase 2).
 
     Separate from the chunk :class:`ParamSpec` (which requires a ``targets``
-    set of F/R/V/P selectors that is meaningless for engines).  ``kind`` is one
+    set of F/R/V/P/C selectors that is meaningless for engines).  ``kind`` is one
     of ``"str"`` / ``"enum"`` / ``"bool"``.  ``is_list`` marks a repeated-key
     parameter (``page_range``) whose canonical value is a comma-joined string.
     ``enum_values`` constrains an ``"enum"`` parameter.

--- a/lightrag/parser/param_schema.py
+++ b/lightrag/parser/param_schema.py
@@ -39,6 +39,7 @@ from lightrag.constants import (
     PARSER_ENGINE_DOCLING,
     PARSER_ENGINE_MINERU,
     PARSER_ENGINE_NATIVE,
+    PROCESS_OPTION_CHUNK_CUSTOM,
     PROCESS_OPTION_CHUNK_FIXED,
     PROCESS_OPTION_CHUNK_PARAGRAH,
     PROCESS_OPTION_CHUNK_RECURSIVE,
@@ -134,6 +135,7 @@ _ALL_CHUNK_SELECTORS = frozenset(
         PROCESS_OPTION_CHUNK_RECURSIVE,
         PROCESS_OPTION_CHUNK_VECTOR,
         PROCESS_OPTION_CHUNK_PARAGRAH,
+        PROCESS_OPTION_CHUNK_CUSTOM,
     }
 )
 
@@ -157,6 +159,7 @@ _CHUNK_PARAM_SPECS: tuple[ParamSpec, ...] = (
                 PROCESS_OPTION_CHUNK_FIXED,
                 PROCESS_OPTION_CHUNK_RECURSIVE,
                 PROCESS_OPTION_CHUNK_PARAGRAH,
+                PROCESS_OPTION_CHUNK_CUSTOM,
             }
         ),
         min_value=0,
@@ -197,7 +200,7 @@ def parse_chunk_params(
 
     ``text`` is the raw text inside ``(...)`` (parameter separators only —
     no surrounding parens).  ``selector`` is the chunk char the block is
-    attached to (``F``/``R``/``V``/``P``).  Returns ``(canonical_dict,
+    attached to (``F``/``R``/``V``/``P``/``C``).  Returns ``(canonical_dict,
     errors)``; ``errors`` is empty iff the block is fully valid.  Aliases are
     normalised to their canonical name in the returned dict.
 

--- a/lightrag/parser/routing.py
+++ b/lightrag/parser/routing.py
@@ -19,6 +19,7 @@ from lightrag.constants import (
     PARSER_ENGINE_LEGACY,
     PARSER_ENGINE_NATIVE,
     PROCESS_OPTION_CHUNK_CHARS,
+    PROCESS_OPTION_CHUNK_CUSTOM,
     PROCESS_OPTION_CHUNK_FIXED,
     PROCESS_OPTION_CHUNK_VECTOR,
     PROCESS_OPTION_CHUNK_PARAGRAH,
@@ -140,7 +141,7 @@ def decode_parse_engine(
 
 
 # ---------------------------------------------------------------------------
-# Per-file processing options (i/t/e/!/F/R/V/P)
+# Per-file processing options (i/t/e/!/F/R/V/P/C)
 # ---------------------------------------------------------------------------
 
 
@@ -210,7 +211,7 @@ def validate_process_options(
         errors.append(
             f"{label} specifies multiple chunking modes "
             f"({'/'.join(seen_chunkers)}); pick one of "
-            f"{PROCESS_OPTION_CHUNK_FIXED}/{PROCESS_OPTION_CHUNK_RECURSIVE}/{PROCESS_OPTION_CHUNK_VECTOR}/{PROCESS_OPTION_CHUNK_PARAGRAH}"
+            f"{PROCESS_OPTION_CHUNK_FIXED}/{PROCESS_OPTION_CHUNK_RECURSIVE}/{PROCESS_OPTION_CHUNK_VECTOR}/{PROCESS_OPTION_CHUNK_PARAGRAH}/{PROCESS_OPTION_CHUNK_CUSTOM}"
         )
     return errors
 
@@ -240,7 +241,7 @@ def parse_process_options(options: Any) -> ProcessOptions:
 
 # ---------------------------------------------------------------------------
 # Per-chunker parameter snapshot (chunk_options) — counterpart to the
-# F/R/V/P selector in ``ProcessOptions``.  ``process_options`` chooses
+# F/R/V/P/C selector in ``ProcessOptions``.  ``process_options`` chooses
 # the strategy; ``chunk_options`` carries the parameters the chosen
 # strategy reads.
 #
@@ -253,7 +254,7 @@ def parse_process_options(options: Any) -> ProcessOptions:
 # ---------------------------------------------------------------------------
 
 
-# Strategy selector (F/R/V/P) → snapshot sub-dict key.  Single source
+# Strategy selector (F/R/V/P/C) → snapshot sub-dict key.  Single source
 # of truth for the slim ``chunk_options`` shape — used by
 # :func:`resolve_chunk_options` to pick which strategy block to keep
 # and by :func:`slim_chunk_options` to project caller-supplied dicts
@@ -263,6 +264,9 @@ _CHUNK_STRATEGY_KEYS: dict[str, str] = {
     PROCESS_OPTION_CHUNK_RECURSIVE: "recursive_character",
     PROCESS_OPTION_CHUNK_VECTOR: "semantic_vector",
     PROCESS_OPTION_CHUNK_PARAGRAH: "paragraph_semantic",
+    # C deliberately reuses the fixed-token snapshot: those values map
+    # one-for-one to the six-argument legacy chunking_func contract.
+    PROCESS_OPTION_CHUNK_CUSTOM: "fixed_token",
 }
 
 
@@ -717,7 +721,7 @@ def _extract_param_blocks(
     * ``engine_param_text`` is the text inside an engine-level ``(...)`` block
       (before the engine/options ``-``) when present, else ``None``.  Engine
       parameters are not accepted in Phase 1; callers reject them.
-    * ``chunk_param_texts`` maps each chunk selector char (F/R/V/P) to the raw
+    * ``chunk_param_texts`` maps each chunk selector char (F/R/V/P/C) to the raw
       text of the block that immediately follows it.
     * ``errors`` collects structural problems (unbalanced parens, a block not
       following a chunk strategy, duplicate blocks on one char).
@@ -756,7 +760,7 @@ def _extract_param_blocks(
                     engine_param = block
             else:
                 errors.append(
-                    f"parameters '({block})' must follow a chunk strategy (F/R/V/P)"
+                    f"parameters '({block})' must follow a chunk strategy (F/R/V/P/C)"
                 )
             i = nxt
             prev_meaningful = None
@@ -1057,7 +1061,7 @@ def filename_parser_directives(file_path: str | Path) -> tuple[str | None, str]:
 def filename_chunk_params(file_path: str | Path) -> dict[str, dict[str, Any]]:
     """Return the per-selector chunk parameters decoded from a filename hint.
 
-    Maps a chunk selector char (F/R/V/P) to its canonical parameter dict;
+    Maps a chunk selector char (F/R/V/P/C) to its canonical parameter dict;
     empty when the hint carries no parameters or is not a usable hint.
     """
     found = _filename_hint_match(file_path)
@@ -1397,7 +1401,7 @@ def _matching_rule_directives(
 class ParserDirectives:
     """Fully resolved per-file parser directives.
 
-    ``process_options`` stays a pure selector string (``i/t/e/!/F/R/V/P``);
+    ``process_options`` stays a pure selector string (``i/t/e/!/F/R/V/P/C``);
     parameters live in separate fields.  ``chunk_params`` maps a chunk
     selector char to its canonical parameter dict and feeds the existing
     ``chunk_options`` channel.  ``engine_params`` is the flat, canonical
@@ -1428,7 +1432,7 @@ def resolve_parser_directives(
            specify.
         3. Default engine ``legacy`` with empty options.
 
-    Selector (``i/t/e/!/FRVP``) keeps the legacy "filename options wholesale
+    Selector (``i/t/e/!/FRVPC``) keeps the legacy "filename options wholesale
     override rule options" behaviour.  Chunk parameters overlay per selector
     char: rule parameters first, then filename-hint parameters (filename wins
     on a shared key).

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -453,6 +453,9 @@ _CHUNKING_METHOD_LABELS: dict[str, str] = {
     "P": "paragraph_semantic",
 }
 
+_CUSTOM_CHUNKING_METHOD = "custom_chunking_func"
+_CUSTOM_CHUNKING_FALLBACK_METHOD = "custom_chunking_fallback_fixed_token"
+
 
 _CHUNK_LOG_KEY_ALIASES: dict[str, str] = {
     "chunk_overlap_token_size": "overlap",
@@ -4882,13 +4885,17 @@ class _PipelineMixin:
 
                 # Chunker dispatch is driven by whether ``process_options``
                 # explicitly named a chunking strategy:
-                #   - Explicit selector (F/R/V/P present in the raw
+                #   - Explicit built-in selector (F/R/V/P present in the raw
                 #     options string): dispatch to a chunker that
                 #     follows the standardized file-chunker contract
                 #     ``(tokenizer, content, chunk_token_size, *,
                 #     <strategy kwargs>)``, with kwargs supplied from
                 #     the per-doc ``chunk_options`` snapshot persisted
                 #     at enqueue time.
+                #   - Explicit C selector: invoke ``self.chunking_func`` with
+                #     the legacy six-argument contract. If the callback is the
+                #     unmodified default, warn and use the exact fixed-token
+                #     file chunker so persisted/background work stays viable.
                 #   - No selector supplied: honor the
                 #     externally-customizable ``self.chunking_func``
                 #     with its legacy 6-arg signature so existing
@@ -4922,12 +4929,16 @@ class _PipelineMixin:
                 # ``doc_status.metadata['chunk_opts']`` via ``extraction_meta``
                 # so admin/list APIs can see the actual chunker params used.
                 chunk_opts_str: str = ""
+                chunk_method: str = "fixed_token_fallback"
+                sidecar_backfill_eligible = False
 
                 from lightrag.chunker import chunking_by_token_size
 
+                is_builtin_chunker = self.chunking_func is chunking_by_token_size
                 if (
                     doc_process_opts.chunking_explicit
-                    and self.chunking_func is not chunking_by_token_size
+                    and doc_process_opts.chunking != "C"
+                    and not is_builtin_chunker
                 ):
                     logger.warning(
                         "Custom chunking_func bypassed: process_options "
@@ -4947,7 +4958,76 @@ class _PipelineMixin:
                     )
 
                     strategy = doc_process_opts.chunking
-                    if strategy == "P":
+                    if strategy == "C":
+                        # C makes the legacy extension point explicit while
+                        # preserving its six positional arguments verbatim.
+                        # Its snapshot is intentionally the fixed-token one.
+                        c_opts = dict(chunk_opts.get("fixed_token") or {})
+                        c_chunk_size = int(
+                            c_opts.get("chunk_token_size", resolved_chunk_size)
+                        )
+                        c_args = (
+                            self.tokenizer,
+                            content,
+                            c_opts.get("split_by_character"),
+                            c_opts.get("split_by_character_only", False),
+                            c_opts.get(
+                                "chunk_overlap_token_size",
+                                self.chunk_overlap_token_size,
+                            ),
+                            c_chunk_size,
+                        )
+                        chunk_opts_str = _format_chunking_params(
+                            c_chunk_size,
+                            {
+                                "split_by_character": c_args[2],
+                                "split_by_character_only": c_args[3],
+                                "overlap": c_args[4],
+                            },
+                        )
+
+                        if is_builtin_chunker:
+                            logger.warning(
+                                "Custom chunking_func unavailable for selector C; "
+                                "using fixed-token fallback "
+                                f"for d-id: {doc_id}"
+                            )
+                            logger.info(
+                                "Chunking C(fallback F): "
+                                f"{chunk_opts_str}, doc_id: {doc_id}"
+                            )
+                            chunking_result = await run_in_chunking_executor(
+                                chunking_by_fixed_token,
+                                self.tokenizer,
+                                content,
+                                c_chunk_size,
+                                _emit_source_span=True,
+                                split_by_character=c_args[2],
+                                split_by_character_only=c_args[3],
+                                chunk_overlap_token_size=c_args[4],
+                            )
+                            chunk_method = _CUSTOM_CHUNKING_FALLBACK_METHOD
+                            sidecar_backfill_eligible = True
+                        else:
+                            logger.info(
+                                f"Chunking C(custom): {chunk_opts_str}, doc_id: {doc_id}"
+                            )
+                            try:
+                                # Keep the documented extension point on the
+                                # event loop; synchronous factories may touch
+                                # the running loop, while async callbacks are
+                                # awaited immediately. CPU-bound callbacks own
+                                # any desired thread offload.
+                                chunking_result = self.chunking_func(*c_args)
+                                if inspect.isawaitable(chunking_result):
+                                    chunking_result = await chunking_result
+                            except Exception as exc:
+                                raise RuntimeError(
+                                    "C custom chunking_func failed "
+                                    f"for d-id {doc_id}: {exc}"
+                                ) from exc
+                            chunk_method = _CUSTOM_CHUNKING_METHOD
+                    elif strategy == "P":
                         # P carries its own ``chunk_token_size`` (CHUNK_P_SIZE
                         # env or ``addon_params['chunker']['paragraph_semantic']``);
                         # pop it out of the kwargs so we don't pass it
@@ -4975,6 +5055,7 @@ class _PipelineMixin:
                             doc_id=doc_id,
                             **p_opts,
                         )
+                        chunk_method = _CHUNKING_METHOD_LABELS["P"]
                     elif strategy == "R":
                         # R carries its own optional ``chunk_token_size``
                         # override (CHUNK_R_SIZE env or
@@ -5021,6 +5102,8 @@ class _PipelineMixin:
                             r_chunk_size,
                             **r_opts,
                         )
+                        chunk_method = _CHUNKING_METHOD_LABELS["R"]
+                        sidecar_backfill_eligible = True
                     elif strategy == "V":
                         # V carries its own optional ``chunk_token_size``
                         # advisory ceiling override (CHUNK_V_SIZE env or
@@ -5047,6 +5130,8 @@ class _PipelineMixin:
                             embedding_func=self.embedding_func,
                             **v_opts,
                         )
+                        chunk_method = _CHUNKING_METHOD_LABELS["V"]
+                        sidecar_backfill_eligible = True
                     else:  # "F"
                         # F honors its own ``chunk_token_size`` override
                         # (``addon_params['chunker']['fixed_token']`` or a
@@ -5069,6 +5154,8 @@ class _PipelineMixin:
                             _emit_source_span=True,
                             **f_opts,
                         )
+                        chunk_method = _CHUNKING_METHOD_LABELS["F"]
+                        sidecar_backfill_eligible = True
                 else:
                     f_opts = chunk_opts.get("fixed_token") or {}
                     # Honor the F-strategy ``chunk_token_size`` override (from
@@ -5107,7 +5194,6 @@ class _PipelineMixin:
                     # private ``_emit_source_span`` kwarg; a user-supplied
                     # ``chunking_func`` must not receive it.
                     legacy_kwargs = {}
-                    is_builtin_chunker = self.chunking_func is chunking_by_token_size
                     if is_builtin_chunker:
                         legacy_kwargs["_emit_source_span"] = True
                     legacy_args = (
@@ -5141,6 +5227,8 @@ class _PipelineMixin:
                         chunking_result = self.chunking_func(
                             *legacy_args, **legacy_kwargs
                         )
+                    chunk_method = "legacy_chunking_func"
+                    sidecar_backfill_eligible = is_builtin_chunker
                 if inspect.isawaitable(chunking_result):
                     chunking_result = await chunking_result
 
@@ -5174,20 +5262,10 @@ class _PipelineMixin:
                     "parse_engine": resolve_doc_status_parse_engine(
                         persisted_format, persisted_engine
                     ),
-                    "chunk_method": (
-                        # Explicit selector in process_options: reflect
-                        # the dispatched strategy.  ``fixed_token_fallback``
-                        # is preserved as a defensive label in case a
-                        # future selector char slips past the validator.
-                        _CHUNKING_METHOD_LABELS.get(
-                            doc_process_opts.chunking, "fixed_token_fallback"
-                        )
-                        if doc_process_opts.chunking_explicit
-                        # No selector: chunking_func was invoked, which
-                        # defaults to chunking_by_token_size but may be
-                        # customized by the caller.
-                        else "legacy_chunking_func"
-                    ),
+                    # Set by the actual branch taken, not merely the persisted
+                    # selector. This distinguishes C custom success from its
+                    # fixed-token fallback after callback removal.
+                    "chunk_method": chunk_method,
                     # Mirrors the chunking start log line (params portion only,
                     # without the strategy prefix or file path) so admins can
                     # see the actual chunker params used.  Carried across
@@ -5263,29 +5341,17 @@ class _PipelineMixin:
                             f"{original_chunk_count} -> {len(chunking_result)}"
                         )
 
-                # Backfill block provenance for F/R/V chunks (P already carries
-                # sidecars; multimodal chunks too). Runs on the final, post-split
+                # Backfill block provenance for chunks produced by a built-in
+                # F/R/V path (including C's fixed-token fallback). P already
+                # carries sidecars; multimodal chunks do too. Runs on the final, post-split
                 # chunk list so each slice maps precisely to the block(s) its
                 # content covers. Raises ChunkBlockMatchError -> doc FAILED when a
                 # chunk cannot be located in blocks.jsonl.
                 #
-                # Gated to the built-in F/R/V strategies — or the legacy path only
-                # when ``chunking_func`` is still the unmodified default fixed-token
-                # chunker. A user-supplied ``chunking_func`` may emit summaries /
-                # rewritten text that cannot be located in blocks.jsonl, which would
-                # wrongly FAIL the document.
-                if doc_process_opts.chunking_explicit:
-                    sidecar_backfill_eligible = doc_process_opts.chunking in {
-                        "F",
-                        "R",
-                        "V",
-                    }
-                else:
-                    from lightrag.chunker import chunking_by_token_size
-
-                    sidecar_backfill_eligible = (
-                        self.chunking_func is chunking_by_token_size
-                    )
+                # Eligibility is set by the actual dispatch branch. A custom
+                # callback may emit summaries/rewritten text that cannot be
+                # located in blocks.jsonl and must never be backfilled merely
+                # because the persisted selector is C.
 
                 if blocks_path and sidecar_backfill_eligible:
                     from lightrag.sidecar import backfill_chunk_sidecars

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -698,7 +698,7 @@ class _PipelineMixin:
                 content-dedup happens after parsing). Ignored when ``ids``
                 is provided (see ``ids`` above).
             parse_engine: file extraction engine already used or target engine for pending_parse
-            process_options: per-document processing options string (i/t/e/!/F/R/V/P);
+            process_options: per-document processing options string (i/t/e/!/F/R/V/P/C);
                 accepted as a single string broadcast to every input or as a list
                 aligned with ``input``. Stored verbatim on ``full_docs`` and
                 mirrored to ``doc_status.metadata['process_options']``.

--- a/tests/api/routes/test_document_routes_chunking.py
+++ b/tests/api/routes/test_document_routes_chunking.py
@@ -18,6 +18,7 @@ Three concerns:
    scheduling any background work) for a malformed body.
 """
 
+import asyncio
 import importlib
 import sys
 from types import SimpleNamespace
@@ -580,6 +581,20 @@ class _FwdRag:
         self.doc_status = _FwdDocStatus()
 
 
+class _CallbackRemovalRag(_FwdRag):
+    def __init__(self, chunking_func):
+        super().__init__()
+        self.chunking_func = chunking_func
+        self.enqueued: list[dict] = []
+        self.process_calls = 0
+
+    async def apipeline_enqueue_documents(self, **kwargs):
+        self.enqueued.append(kwargs)
+
+    async def apipeline_process_enqueue_documents(self):
+        self.process_calls += 1
+
+
 _HEADERS = {"X-API-Key": "test-key"}
 
 
@@ -628,6 +643,51 @@ def _make_client(monkeypatch, addon_params=None, chunking_func=chunking_by_token
         create_document_routes(rag, SimpleNamespace(), api_key="test-key")
     )
     return TestClient(app), captured
+
+
+def _make_callback_removal_client(monkeypatch):
+    """Run managed work after removing the callback accepted at preflight."""
+
+    def custom(*args, **kwargs):
+        return []
+
+    rag = _CallbackRemovalRag(custom)
+
+    async def _noop_reserve(rag, token):
+        return False
+
+    async def _noop_release(rag, token):
+        return None
+
+    async def _noop_reweight(rag, token, weight):
+        return None
+
+    async def _run_after_callback_removal(background_tasks, *, work, backstop_release):
+        # This hook runs only after the endpoint's synchronous preflight. Model
+        # a runtime deployment change in the exact window called out by review:
+        # the accepted request must retain its frozen C snapshot even though the
+        # processing callback is gone by the time managed work starts.
+        rag.chunking_func = chunking_by_token_size
+        started = asyncio.Event()
+        await work(started)
+        assert started.is_set()
+
+    shared_storage = importlib.import_module("lightrag.kg.shared_storage")
+    monkeypatch.setattr(_dr, "_reserve_enqueue_slot", _noop_reserve)
+    monkeypatch.setattr(_dr, "_release_enqueue_slot", _noop_release)
+    monkeypatch.setattr(_dr, "_reweight_enqueue_slot", _noop_reweight)
+    monkeypatch.setattr(
+        shared_storage,
+        "start_reserved_background_task",
+        _run_after_callback_removal,
+    )
+
+    app = FastAPI()
+    app.state.background_tasks = set()
+    app.include_router(
+        create_document_routes(rag, SimpleNamespace(), api_key="test-key")
+    )
+    return TestClient(app), rag
 
 
 def test_insert_text_forwards_chunking(monkeypatch):
@@ -731,6 +791,51 @@ def test_text_ingress_accepts_custom_with_an_injected_callback(monkeypatch):
     assert response.status_code == 200
     assert captured["chunking"].strategy == "custom"
     assert captured["chunking"].params == {"chunk_token_size": 400}
+
+
+@pytest.mark.parametrize(
+    "path,payload,expected_inputs",
+    [
+        (
+            "/documents/text",
+            {
+                "text": "hello",
+                "file_source": "a.md",
+                "chunking": {
+                    "strategy": "custom",
+                    "params": {"chunk_token_size": 400},
+                },
+            },
+            ["hello"],
+        ),
+        (
+            "/documents/texts",
+            {
+                "texts": ["one", "two"],
+                "file_sources": ["a.md", "b.md"],
+                "chunking": {
+                    "strategy": "custom",
+                    "params": {"chunk_token_size": 400},
+                },
+            },
+            ["one", "two"],
+        ),
+    ],
+)
+def test_accepted_custom_request_keeps_preflight_snapshot_after_callback_removal(
+    monkeypatch, path, payload, expected_inputs
+):
+    client, rag = _make_callback_removal_client(monkeypatch)
+
+    response = client.post(path, headers=_HEADERS, json=payload)
+
+    assert response.status_code == 200
+    assert rag.process_calls == 1
+    assert len(rag.enqueued) == 1
+    enqueue = rag.enqueued[0]
+    assert enqueue["input"] == expected_inputs
+    assert enqueue["process_options"] == "C"
+    assert enqueue["chunk_options"]["fixed_token"]["chunk_token_size"] == 400
 
 
 def test_insert_text_returns_422_on_malformed_chunking_without_scheduling(monkeypatch):

--- a/tests/api/routes/test_document_routes_chunking.py
+++ b/tests/api/routes/test_document_routes_chunking.py
@@ -712,7 +712,9 @@ def test_text_ingress_rejects_custom_without_an_injected_callback(
 
 
 def test_text_ingress_accepts_custom_with_an_injected_callback(monkeypatch):
-    custom = lambda *args, **kwargs: []
+    def custom(*args, **kwargs):
+        return []
+
     client, captured = _make_client(monkeypatch, chunking_func=custom)
     response = client.post(
         "/documents/text",

--- a/tests/api/routes/test_document_routes_chunking.py
+++ b/tests/api/routes/test_document_routes_chunking.py
@@ -27,6 +27,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
+from lightrag.chunker import chunking_by_token_size
+
 _original_argv = sys.argv[:]
 sys.argv = [sys.argv[0]]
 _dr = importlib.import_module("lightrag.api.routers.document_routes")
@@ -275,7 +277,15 @@ def test_insert_text_request_rejects_malformed_chunking():
 
 def _stub_rag(addon_params=None):
     return SimpleNamespace(
-        addon_params=addon_params if addon_params is not None else {}
+        addon_params=addon_params if addon_params is not None else {},
+        chunking_func=chunking_by_token_size,
+    )
+
+
+def _stub_rag_with_custom_chunker(addon_params=None):
+    return SimpleNamespace(
+        addon_params=addon_params if addon_params is not None else {},
+        chunking_func=lambda *args, **kwargs: [],
     )
 
 
@@ -502,6 +512,55 @@ def test_resolve_null_size_does_not_erase_inherited_default(monkeypatch):
     assert chunk_options["fixed_token"]["chunk_token_size"] == 640
 
 
+def test_custom_chunking_reuses_the_fixed_token_parameter_contract():
+    cfg = TextChunkingConfig.model_validate(
+        {
+            "strategy": "custom",
+            "params": {
+                "chunk_token_size": 512,
+                "chunk_overlap_token_size": 32,
+                "split_by_character": "\n\n",
+                "split_by_character_only": False,
+            },
+        }
+    )
+    assert cfg.params == {
+        "chunk_token_size": 512,
+        "chunk_overlap_token_size": 32,
+        "split_by_character": "\n\n",
+        "split_by_character_only": False,
+    }
+
+
+def test_custom_chunking_rejects_params_outside_the_legacy_contract():
+    with pytest.raises(ValidationError):
+        TextChunkingConfig.model_validate(
+            {"strategy": "custom", "params": {"buffer_size": 2}}
+        )
+
+
+def test_resolve_custom_requires_a_non_default_callback():
+    cfg = TextChunkingConfig.model_validate({"strategy": "custom"})
+    with pytest.raises(ValueError, match="custom chunking requires"):
+        _resolve_text_chunking(cfg, _stub_rag())
+
+
+def test_resolve_custom_maps_to_c_and_a_fixed_token_snapshot():
+    cfg = TextChunkingConfig.model_validate(
+        {
+            "strategy": "custom",
+            "params": {"chunk_token_size": 333, "chunk_overlap_token_size": 11},
+        }
+    )
+    process_options, chunk_options = _resolve_text_chunking(
+        cfg, _stub_rag_with_custom_chunker()
+    )
+    assert process_options == "C"
+    assert set(chunk_options) <= {"chunk_token_size", "fixed_token"}
+    assert chunk_options["fixed_token"]["chunk_token_size"] == 333
+    assert chunk_options["fixed_token"]["chunk_overlap_token_size"] == 11
+
+
 # ---------------------------------------------------------------------------
 # 3. Route forwarding + synchronous 422
 # ---------------------------------------------------------------------------
@@ -515,6 +574,7 @@ class _FwdDocStatus:
 class _FwdRag:
     workspace = "chunk-fwd-test"
     addon_params: dict = {}
+    chunking_func = chunking_by_token_size
 
     def __init__(self):
         self.doc_status = _FwdDocStatus()
@@ -523,7 +583,7 @@ class _FwdRag:
 _HEADERS = {"X-API-Key": "test-key"}
 
 
-def _make_client(monkeypatch, addon_params=None):
+def _make_client(monkeypatch, addon_params=None, chunking_func=chunking_by_token_size):
     """Build a TestClient whose enqueue-slot guards are no-ops and whose
     ``pipeline_index_texts`` is a spy recording the forwarded args.
 
@@ -557,6 +617,7 @@ def _make_client(monkeypatch, addon_params=None):
 
     rag = _FwdRag()
     rag.addon_params = addon_params if addon_params is not None else {}
+    rag.chunking_func = chunking_func
 
     app = FastAPI()
     # The endpoints start reservation-holding work as managed asyncio tasks via
@@ -617,6 +678,57 @@ def test_insert_text_without_chunking_forwards_none(monkeypatch):
     )
     assert resp.status_code == 200
     assert captured["chunking"] is None
+
+
+@pytest.mark.parametrize(
+    "path,payload",
+    [
+        (
+            "/documents/text",
+            {
+                "text": "hello",
+                "file_source": "a.md",
+                "chunking": {"strategy": "custom"},
+            },
+        ),
+        (
+            "/documents/texts",
+            {
+                "texts": ["hello"],
+                "file_sources": ["a.md"],
+                "chunking": {"strategy": "custom"},
+            },
+        ),
+    ],
+)
+def test_text_ingress_rejects_custom_without_an_injected_callback(
+    monkeypatch, path, payload
+):
+    client, captured = _make_client(monkeypatch)
+    response = client.post(path, headers=_HEADERS, json=payload)
+    assert response.status_code == 422
+    assert "custom chunking requires" in str(response.json()["detail"])
+    assert captured == {}
+
+
+def test_text_ingress_accepts_custom_with_an_injected_callback(monkeypatch):
+    custom = lambda *args, **kwargs: []
+    client, captured = _make_client(monkeypatch, chunking_func=custom)
+    response = client.post(
+        "/documents/text",
+        headers=_HEADERS,
+        json={
+            "text": "hello",
+            "file_source": "a.md",
+            "chunking": {
+                "strategy": "custom",
+                "params": {"chunk_token_size": 400},
+            },
+        },
+    )
+    assert response.status_code == 200
+    assert captured["chunking"].strategy == "custom"
+    assert captured["chunking"].params == {"chunk_token_size": 400}
 
 
 def test_insert_text_returns_422_on_malformed_chunking_without_scheduling(monkeypatch):

--- a/tests/api/routes/test_document_routes_chunking.py
+++ b/tests/api/routes/test_document_routes_chunking.py
@@ -614,11 +614,13 @@ def _make_client(monkeypatch, addon_params=None, chunking_func=chunking_by_token
         file_sources=None,
         track_id=None,
         chunking=None,
+        resolved_chunking=None,
         admission_token=None,
     ):
         captured["texts"] = texts
         captured["file_sources"] = file_sources
         captured["chunking"] = chunking
+        captured["resolved_chunking"] = resolved_chunking
 
     async def _noop_reserve(rag, token):
         return False

--- a/tests/api/routes/test_document_routes_docx_archive.py
+++ b/tests/api/routes/test_document_routes_docx_archive.py
@@ -7,6 +7,8 @@ from uuid import uuid4
 
 import pytest
 
+from lightrag.chunker import chunking_by_token_size
+
 _original_argv = sys.argv[:]
 sys.argv = [sys.argv[0]]
 _document_routes = importlib.import_module("lightrag.api.routers.document_routes")
@@ -119,6 +121,7 @@ class _FakeRag:
         self.errors = []
         # _resolve_text_chunking reads addon_params; {} -> default chunker config.
         self.addon_params = {}
+        self.chunking_func = chunking_by_token_size
 
     async def apipeline_enqueue_documents(
         self,
@@ -335,9 +338,11 @@ class _ScanRag:
 
 
 class _DuplicateUploadRag:
-    def __init__(self, docs_by_path):
+    def __init__(self, docs_by_path, chunking_func=chunking_by_token_size):
         self.doc_status = _ScanDocStatus(docs_by_path)
         self.workspace = f"upload-test-{uuid4().hex}"
+        self.chunking_func = chunking_func
+        self.addon_params = {}
 
 
 class _DeleteDocStatus:
@@ -636,6 +641,26 @@ async def test_pipeline_enqueue_passes_process_options_from_filename_hint(
     ]
     # Native engine deferral keeps the source file in place for the parser.
     assert file_path.exists()
+
+
+async def test_scan_enqueue_accepts_c_hint_for_observable_runtime_fallback(
+    tmp_path, monkeypatch
+):
+    """Scan has no caller to receive a 422, so ``C`` remains persisted and the
+    runtime decides between the injected callback and warned F fallback."""
+    monkeypatch.setenv("LIGHTRAG_PARSER", "docx:native")
+    file_path = tmp_path / "report.[native-Cite].docx"
+    file_path.write_bytes(b"docx-bytes")
+    rag = _FakeRag()
+
+    enqueued = await pipeline_enqueue_scan_batch(
+        rag,
+        [_ScanCandidate(file_path, len(b"docx-bytes"))],
+        "track-custom-scan",
+    )
+
+    assert enqueued == 1
+    assert rag.enqueued[0]["process_options"] == "Cite"
 
 
 async def test_pipeline_enqueue_rejects_invalid_filename_hint(tmp_path, monkeypatch):
@@ -1414,6 +1439,68 @@ async def test_upload_rejects_malformed_hint_with_detail(tmp_path, monkeypatch):
         await upload_endpoint(set(), upload_file)
     assert excinfo.value.status_code == 400
     assert "multiple chunking modes" in excinfo.value.detail
+
+
+async def test_upload_rejects_c_without_custom_callback_before_writing(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        _document_routes, "global_args", SimpleNamespace(max_upload_size=None)
+    )
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _DuplicateUploadRag({})
+    router = create_document_routes(rag, doc_manager)
+    upload_endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "upload_to_input_dir"
+    ][-1]
+    upload_file = _document_routes.UploadFile(
+        filename="custom.[native-C].docx",
+        file=BytesIO(b"docx bytes"),
+    )
+
+    with pytest.raises(_document_routes.HTTPException) as excinfo:
+        await upload_endpoint(set(), upload_file)
+
+    assert excinfo.value.status_code == 422
+    assert "custom chunking requires" in str(excinfo.value.detail)
+    assert not (tmp_path / "custom.[native-C].docx").exists()
+
+
+async def test_upload_accepts_c_when_custom_callback_is_injected(tmp_path, monkeypatch):
+    import importlib
+
+    monkeypatch.setattr(
+        _document_routes, "global_args", SimpleNamespace(max_upload_size=None)
+    )
+    doc_manager = DocumentManager(str(tmp_path))
+    rag = _DuplicateUploadRag({}, chunking_func=lambda *args, **kwargs: [])
+
+    shared_storage = importlib.import_module("lightrag.kg.shared_storage")
+    await shared_storage.initialize_pipeline_status(workspace=rag.workspace)
+
+    async def _no_op_index(rag_arg, file_path, track_id=None, admission_token=None):
+        return None
+
+    monkeypatch.setattr(_document_routes, "pipeline_index_file", _no_op_index)
+    router = create_document_routes(rag, doc_manager)
+    upload_endpoint = [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "upload_to_input_dir"
+    ][-1]
+    upload_file = _document_routes.UploadFile(
+        filename="custom.[native-C].docx",
+        file=BytesIO(b"docx bytes"),
+    )
+
+    managed: set = set()
+    response = await upload_endpoint(managed, upload_file)
+    await _await_managed(managed)
+
+    assert response.status == "success"
+    assert (tmp_path / "custom.[native-C].docx").exists()
 
 
 async def test_upload_succeeds_concurrent_with_pipeline_busy(tmp_path, monkeypatch):

--- a/tests/pipeline/test_custom_chunking_selector.py
+++ b/tests/pipeline/test_custom_chunking_selector.py
@@ -1,0 +1,444 @@
+"""End-to-end contract for the explicit ``C`` custom-chunking selector.
+
+The legacy no-selector path remains backward compatible.  ``C`` is the
+explicit, persisted opt-in that routes to the same six-argument callback while
+making custom success and fixed-token fallback observable.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG, ROLES, RoleLLMConfig
+from lightrag.base import DocStatus
+from lightrag.chunker import chunking_by_token_size
+from lightrag.utils import EmbeddingFunc, Tokenizer
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(token) for token in tokens)
+
+
+async def _mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.random.rand(len(texts), 32)
+
+
+async def _mock_llm(prompt, **kwargs):
+    return '{"name":"x","summary":"s","detail_description":"d"}'
+
+
+_ROLE_FIELD_SUFFIXES = (
+    ("_llm_model_func", "func"),
+    ("_llm_model_kwargs", "kwargs"),
+    ("_llm_model_max_async", "max_async"),
+    ("_llm_timeout", "timeout"),
+)
+
+
+def _new_rag(tmp_path: Path, **kwargs) -> LightRAG:
+    role_configs: dict[str, RoleLLMConfig] = {}
+    for spec in ROLES:
+        bucket = {}
+        for suffix, target in _ROLE_FIELD_SUFFIXES:
+            key = f"{spec.name}{suffix}"
+            if key in kwargs:
+                bucket[target] = kwargs.pop(key)
+        if bucket:
+            role_configs[spec.name] = RoleLLMConfig(**bucket)
+    if role_configs:
+        kwargs["role_llm_configs"] = role_configs
+
+    return LightRAG(
+        working_dir=str(tmp_path),
+        workspace=f"custom-selector-{tmp_path.name}",
+        llm_model_func=_mock_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=32,
+            max_token_size=4096,
+            func=_mock_embedding,
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        **kwargs,
+    )
+
+
+class _ListHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def _metadata(row: dict) -> dict:
+    metadata = row.get("metadata")
+    assert isinstance(metadata, dict)
+    return metadata
+
+
+async def _ingest(
+    rag: LightRAG,
+    *,
+    doc_id: str,
+    process_options: str,
+    body: str = "Body for explicit custom chunking.",
+    chunk_options: dict | None = None,
+) -> dict:
+    await rag.apipeline_enqueue_documents(
+        body,
+        ids=[doc_id],
+        file_paths=[f"{doc_id}.txt"],
+        track_id=f"track-{doc_id}",
+        process_options=process_options,
+        chunk_options=chunk_options,
+    )
+    await rag.apipeline_process_enqueue_documents()
+    row = await rag.doc_status.get_by_id(doc_id)
+    assert isinstance(row, dict)
+    return row
+
+
+def _force_blocks_path(monkeypatch, blocks_path: Path) -> None:
+    """Inject a process-stage sidecar path without standing up a parser."""
+    import lightrag.pipeline as pipeline_mod
+
+    original = pipeline_mod._PipelineMixin.process_single_document
+
+    async def _patched(self, *, doc_id, status_doc, parsed_data, ctx):
+        parsed_data["blocks_path"] = str(blocks_path)
+        return await original(
+            self,
+            doc_id=doc_id,
+            status_doc=status_doc,
+            parsed_data=parsed_data,
+            ctx=ctx,
+        )
+
+    monkeypatch.setattr(
+        pipeline_mod._PipelineMixin,
+        "process_single_document",
+        _patched,
+    )
+
+
+@pytest.mark.offline
+def test_c_invokes_sync_custom_chunker_with_legacy_args_and_no_bypass_warning(
+    tmp_path,
+):
+    captured: dict = {"calls": 0}
+
+    def _custom(tokenizer, content, split_by, split_only, overlap, size):
+        captured.update(
+            {
+                "calls": captured["calls"] + 1,
+                "loop": asyncio.get_running_loop(),
+                "content": content,
+                "split_by": split_by,
+                "split_only": split_only,
+                "overlap": overlap,
+                "size": size,
+            }
+        )
+        return [{"tokens": len(content), "content": content, "chunk_order_index": 0}]
+
+    async def _run():
+        rag = _new_rag(tmp_path, chunking_func=_custom)
+        await rag.initialize_storages()
+        handler = _ListHandler()
+        logger = logging.getLogger("lightrag")
+        logger.addHandler(handler)
+        try:
+            row = await _ingest(
+                rag,
+                doc_id="doc-custom-sync",
+                process_options="C!",
+                chunk_options={
+                    "chunk_token_size": 1200,
+                    "fixed_token": {
+                        "chunk_token_size": 256,
+                        "split_by_character": "\n",
+                        "split_by_character_only": True,
+                        "chunk_overlap_token_size": 7,
+                    },
+                },
+            )
+            full_doc = await rag.full_docs.get_by_id("doc-custom-sync")
+        finally:
+            logger.removeHandler(handler)
+            await rag.finalize_storages()
+
+        assert DocStatus(row["status"]) is DocStatus.PROCESSED
+        assert captured == {
+            "calls": 1,
+            "loop": asyncio.get_running_loop(),
+            "content": "Body for explicit custom chunking.",
+            "split_by": "\n",
+            "split_only": True,
+            "overlap": 7,
+            "size": 256,
+        }
+        assert isinstance(full_doc, dict)
+        assert full_doc["process_options"] == "C!"
+        assert _metadata(row)["chunk_method"] == "custom_chunking_func"
+        assert not any(
+            "Custom chunking_func bypassed" in record.getMessage()
+            for record in handler.records
+        )
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_c_awaits_async_custom_chunker_on_the_event_loop(tmp_path):
+    captured: dict = {"calls": 0}
+
+    async def _custom(tokenizer, content, split_by, split_only, overlap, size):
+        captured["calls"] += 1
+        captured["loop"] = asyncio.get_running_loop()
+        await asyncio.sleep(0)
+        return [{"tokens": len(content), "content": content, "chunk_order_index": 0}]
+
+    async def _run():
+        rag = _new_rag(tmp_path, chunking_func=_custom)
+        await rag.initialize_storages()
+        try:
+            running_loop = asyncio.get_running_loop()
+            row = await _ingest(
+                rag,
+                doc_id="doc-custom-async",
+                process_options="C!",
+            )
+        finally:
+            await rag.finalize_storages()
+
+        assert DocStatus(row["status"]) is DocStatus.PROCESSED
+        assert captured == {"calls": 1, "loop": running_loop}
+        assert _metadata(row)["chunk_method"] == "custom_chunking_func"
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_c_without_custom_chunker_warns_once_and_runs_exact_f_fallback(
+    tmp_path, monkeypatch
+):
+    import lightrag.chunker as chunker_pkg
+    import lightrag.sidecar as sidecar_mod
+
+    fixed_calls: list[dict] = []
+    backfill_calls: list[str] = []
+
+    def _fixed(tokenizer, content, size, **kwargs):
+        fixed_calls.append({"content": content, "size": size, **kwargs})
+        return [
+            {
+                "tokens": len(content),
+                "content": content,
+                "chunk_order_index": 0,
+                "_source_span": {"start": 0, "end": len(content)},
+            }
+        ]
+
+    def _backfill(chunking_result, blocks_path):
+        backfill_calls.append(blocks_path)
+
+    monkeypatch.setattr(chunker_pkg, "chunking_by_fixed_token", _fixed)
+    monkeypatch.setattr(sidecar_mod, "backfill_chunk_sidecars", _backfill)
+    blocks_path = tmp_path / "fallback.blocks.jsonl"
+    _force_blocks_path(monkeypatch, blocks_path)
+
+    async def _run():
+        rag = _new_rag(tmp_path)
+        await rag.initialize_storages()
+        handler = _ListHandler()
+        logger = logging.getLogger("lightrag")
+        logger.addHandler(handler)
+        try:
+            row = await _ingest(
+                rag,
+                doc_id="doc-custom-fallback",
+                process_options="C!",
+            )
+        finally:
+            logger.removeHandler(handler)
+            await rag.finalize_storages()
+
+        warnings = [
+            record.getMessage()
+            for record in handler.records
+            if record.levelno == logging.WARNING
+            and "Custom chunking_func unavailable for selector C" in record.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert "doc-custom-fallback" in warnings[0]
+        assert len(fixed_calls) == 1
+        assert fixed_calls[0]["_emit_source_span"] is True
+        assert backfill_calls == [str(blocks_path)]
+        assert DocStatus(row["status"]) is DocStatus.PROCESSED
+        method = _metadata(row)["chunk_method"]
+        assert method == "custom_chunking_fallback_fixed_token"
+        assert method != "fixed_token_fallback"
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_c_callback_failure_fails_document_without_fallback(tmp_path, monkeypatch):
+    import lightrag.chunker as chunker_pkg
+
+    fixed_calls = 0
+
+    def _fixed(*args, **kwargs):
+        nonlocal fixed_calls
+        fixed_calls += 1
+        return []
+
+    def _custom(*args, **kwargs):
+        raise RuntimeError("custom chunker exploded")
+
+    monkeypatch.setattr(chunker_pkg, "chunking_by_fixed_token", _fixed)
+
+    async def _run():
+        rag = _new_rag(tmp_path, chunking_func=_custom)
+        await rag.initialize_storages()
+        try:
+            row = await _ingest(
+                rag,
+                doc_id="doc-custom-failure",
+                process_options="C!",
+            )
+        finally:
+            await rag.finalize_storages()
+
+        assert DocStatus(row["status"]) is DocStatus.FAILED
+        assert "C custom chunking_func failed" in row["error_msg"]
+        assert "custom chunker exploded" in row["error_msg"]
+        assert fixed_calls == 0
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_c_combines_with_multimodal_flags_without_enabling_backfill(
+    tmp_path, monkeypatch
+):
+    import lightrag.pipeline as pipeline_mod
+    import lightrag.sidecar as sidecar_mod
+
+    captured: dict = {"custom_calls": 0, "builder_options": None}
+
+    def _custom(tokenizer, content, split_by, split_only, overlap, size):
+        captured["custom_calls"] += 1
+        return [{"tokens": len(content), "content": content, "chunk_order_index": 0}]
+
+    def _mm_builder(self, **kwargs):
+        captured["builder_options"] = kwargs["process_options"]
+        base = kwargs["base_order_index"]
+        return [
+            {
+                "tokens": 1,
+                "content": f"modality-{index}",
+                "chunk_order_index": base + index,
+            }
+            for index in range(3)
+        ]
+
+    def _unexpected_backfill(*args, **kwargs):
+        raise AssertionError("custom callback output must not be sidecar-backfilled")
+
+    monkeypatch.setattr(
+        pipeline_mod._PipelineMixin,
+        "_build_mm_chunks_from_sidecars",
+        _mm_builder,
+    )
+    monkeypatch.setattr(sidecar_mod, "backfill_chunk_sidecars", _unexpected_backfill)
+    _force_blocks_path(monkeypatch, tmp_path / "multimodal.blocks.jsonl")
+
+    async def _run():
+        rag = _new_rag(tmp_path, chunking_func=_custom)
+        await rag.initialize_storages()
+        try:
+            row = await _ingest(
+                rag,
+                doc_id="doc-custom-multimodal",
+                process_options="Cite!",
+            )
+        finally:
+            await rag.finalize_storages()
+
+        assert DocStatus(row["status"]) is DocStatus.PROCESSED
+        assert captured == {"custom_calls": 1, "builder_options": "Cite!"}
+        assert row["chunks_count"] == 4
+        assert _metadata(row)["mm_chunks"] == 3
+        assert _metadata(row)["chunk_method"] == "custom_chunking_func"
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_reprocess_persisted_c_after_callback_removal_uses_observable_fallback(
+    tmp_path,
+):
+    custom_calls = 0
+
+    def _custom(tokenizer, content, split_by, split_only, overlap, size):
+        nonlocal custom_calls
+        custom_calls += 1
+        return [{"tokens": len(content), "content": content, "chunk_order_index": 0}]
+
+    async def _run():
+        rag = _new_rag(tmp_path, chunking_func=_custom)
+        await rag.initialize_storages()
+        try:
+            first = await _ingest(
+                rag,
+                doc_id="doc-custom-reprocess",
+                process_options="C!",
+            )
+            assert _metadata(first)["chunk_method"] == "custom_chunking_func"
+
+            persisted = await rag.full_docs.get_by_id("doc-custom-reprocess")
+            assert isinstance(persisted, dict)
+            assert persisted["process_options"] == "C!"
+
+            rag.chunking_func = chunking_by_token_size
+            pending = dict(first)
+            pending["status"] = DocStatus.PENDING.value
+            await rag.doc_status.upsert({"doc-custom-reprocess": pending})
+            await rag.doc_status.index_done_callback()
+
+            handler = _ListHandler()
+            logger = logging.getLogger("lightrag")
+            logger.addHandler(handler)
+            try:
+                await rag.apipeline_process_enqueue_documents()
+            finally:
+                logger.removeHandler(handler)
+
+            second = await rag.doc_status.get_by_id("doc-custom-reprocess")
+            assert isinstance(second, dict)
+            warnings = [
+                record.getMessage()
+                for record in handler.records
+                if "Custom chunking_func unavailable for selector C"
+                in record.getMessage()
+            ]
+        finally:
+            await rag.finalize_storages()
+
+        assert custom_calls == 1
+        assert DocStatus(second["status"]) is DocStatus.PROCESSED
+        assert _metadata(second)["chunk_method"] == (
+            "custom_chunking_fallback_fixed_token"
+        )
+        assert len(warnings) == 1
+
+    asyncio.run(_run())

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -173,6 +173,10 @@ def test_filename_parser_directives_decodes_engine_and_options():
 
     assert filename_parser_directives("paper.[native-iet].docx") == ("native", "iet")
     assert filename_parser_directives("memo.[native-R!].md") == ("native", "R!")
+    assert filename_parser_directives("custom.[native-Cite].docx") == (
+        "native",
+        "Cite",
+    )
     assert filename_parser_directives("report.[-!].pdf") == (None, "!")
     assert filename_parser_directives("doc.[mineru].docx") == ("mineru", "")
     assert filename_parser_directives("foo.docx") == (None, "")
@@ -256,6 +260,11 @@ def test_parse_process_options_decodes_flags():
     opts = parse_process_options("P")
     assert opts.chunking == "P"
 
+    opts = parse_process_options("Cite!")
+    assert opts.chunking == "C"
+    assert opts.chunking_explicit
+    assert opts.images and opts.tables and opts.equations and opts.skip_kg
+
     opts = parse_process_options("")
     assert not (opts.images or opts.tables or opts.equations or opts.skip_kg)
     assert opts.chunking == "F"
@@ -267,9 +276,13 @@ def test_validate_process_options_rejects_invalid_combos():
 
     assert validate_process_options("iet") == []
     assert validate_process_options("R!") == []
+    assert validate_process_options("Cite!") == []
     # F+R conflict is reported.
     errs = validate_process_options("FR")
     assert any("multiple chunking modes" in m for m in errs)
+    errs = validate_process_options("CF")
+    assert any("multiple chunking modes" in m for m in errs)
+    assert any("F/R/V/P/C" in m for m in errs)
     # Lowercase chunking selectors are not valid.
     errs = validate_process_options("f")
     assert any("'f'" in m for m in errs)
@@ -284,6 +297,7 @@ def test_lightrag_parser_rule_supports_options_suffix(monkeypatch):
     monkeypatch.delenv("DOCLING_ENDPOINT", raising=False)
     # Valid options suffix passes validation.
     validate_parser_routing_config("docx:native-iet,*:legacy")
+    validate_parser_routing_config("docx:native-Cite,*:legacy")
 
     # Invalid options suffix is rejected with the rule label and message.
     with pytest.raises(ParserRoutingConfigError, match="multiple chunking modes"):


### PR DESCRIPTION
## Description

Implements the maintainer-approved first slice of #3664: an explicit `C` selector that invokes an injected `LightRAG.chunking_func` through the existing six-argument contract, while keeping the undecided registry and callback-identity work out of scope.

## Related Issues

- First implementation slice of #3664
- Builds on the selector-bypass warning from #3662

## Changes Made

- Accept and persist `C` in process options, filename hints, parser rules, and chunk-option snapshots, with an explicit `C -> fixed_token` mapping.
- Add `chunking.strategy="custom"` to the text API. It reuses the fixed-token parameter schema and returns 422 when no non-default callback is configured.
- Reject upload hints/rules selecting `C` before writing the file when the callback is unavailable; retain warn-and-fallback behavior for scans, persisted rows, and reprocessing.
- Invoke synchronous and asynchronous custom callbacks on the event loop. Callback errors fail the document with context and never trigger fallback.
- Record the actual path as `custom_chunking_func` or `custom_chunking_fallback_fixed_token`, suppress the #3662 bypass warning for C, and derive sidecar-backfill eligibility from the path that actually ran.
- Document filename-hint and API behavior in English and Chinese.

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Validation on the rebased branch:

- `ruff check` on all touched Python files: passed
- focused C/API/pipeline contract suite: 254 passed
- related chunker/parser/API/pipeline regression suite: 880 passed

A full local test collection is not available in this checkout because optional provider/storage dependencies (for example Ollama, Neo4j, Milvus, MongoDB, Redis, PostgreSQL, Anthropic, and Bedrock clients) are not installed. The implementation intentionally does not add callback identity/version persistence, registry grammar, or a context-aware callback contract; those remain follow-up RFC work.