### PR TITLE
fix(rerank): reject negative chunk overlap

### DIFF
--- a/lightrag/rerank.py
+++ b/lightrag/rerank.py
@@ -57,6 +57,13 @@ def chunk_documents_for_rerank(
         # max_tokens=0 makes the chunk window zero-width and the loop never advances
         raise ValueError(f"max_tokens must be >= 1, got {max_tokens}")
 
+    if overlap_tokens < 0:
+        # Checked up front, before the tokenizer/fallback branching below, so a
+        # negative value is always rejected -- including for a short document
+        # that never enters either windowing loop and would otherwise let the
+        # invalid value pass through unnoticed.
+        raise ValueError(f"overlap_tokens must be non-negative, got {overlap_tokens}")
+
     # Clamp overlap_tokens to ensure the loop always advances.
     # If overlap_tokens >= max_tokens the loop would never progress. Recover by
     # clamping to max_tokens // 2 rather than max_tokens - 1: the latter leaves an

--- a/tests/chunker/test_rerank_chunking.py
+++ b/tests/chunker/test_rerank_chunking.py
@@ -29,6 +29,31 @@ class TestChunkDocumentsForRerank:
         assert docs == ["short"]
         assert idxs == [0]
 
+    def test_negative_overlap_tokens_raises(self):
+        """overlap_tokens < 0 has no sensible meaning and must raise up front,
+        before the tokenizer/fallback branching -- including for a short
+        document that never enters either windowing loop and would
+        otherwise let the value pass through silently.
+
+        Existing zero, positive, and upper-bound-clamp behaviour (see
+        test_overlap_validation.py) is unaffected: this guard only rejects
+        values below zero.
+        """
+        with pytest.raises(ValueError, match="overlap_tokens"):
+            chunk_documents_for_rerank(["short"], max_tokens=100, overlap_tokens=-1)
+
+        docs, idxs = chunk_documents_for_rerank(
+            ["short"], max_tokens=100, overlap_tokens=0
+        )
+        assert docs == ["short"]
+        assert idxs == [0]
+
+        docs, idxs = chunk_documents_for_rerank(
+            ["short"], max_tokens=100, overlap_tokens=10
+        )
+        assert docs == ["short"]
+        assert idxs == [0]
+
     def test_max_tokens_one_terminates(self):
         """max_tokens=1 is the boundary: overlap must clamp so the loop still terminates.
 


### PR DESCRIPTION
## Description

`chunk_documents_for_rerank()` calculates the next window start as `end - overlap_tokens`. When `overlap_tokens` is negative, the next window starts after the previous window ends. This silently drops content before documents are sent to the reranker. This change rejects negative overlap values before short-document handling and before the tokenizer or character-fallback paths are selected.

## Related Issues

No related issue.

## Changes Made

- Raise `ValueError` when `overlap_tokens` is negative.
- Add regression coverage confirming that negative overlap is rejected before conditional chunking.
- Preserve the existing upper-bound clamp-and-warning behaviour.
- Leave zero and valid positive overlap behaviour unchanged.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not necessary)
- [x] Unit tests added

## Test Results

- `tests/chunker/test_rerank_chunking.py`: 27 passed
- `tests/chunker/test_overlap_validation.py`: 7 passed
- Full `tests/chunker` run: 296 passed, with 3 pre-existing network-dependent failures reproduced identically on unmodified `main`
- `pre-commit run --all-files`: passed
- `git diff --check`: passed

## Additional Notes

The validation is placed at the start of `chunk_documents_for_rerank()` so it also covers short documents that do not enter either windowing loop. The asynchronous wrapper delegates directly to this function and requires no separate implementation.