### PR TITLE
fix(lollms): honour configured binding host

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1307,6 +1307,41 @@ def _build_scheduling_status(pipeline_snapshot: dict, ingress_counts: dict) -> d
     }
 
 
+def _create_llm_model_kwargs(binding: str, args, llm_timeout: int) -> dict:
+    """
+    Create LLM model kwargs based on binding type.
+    Uses lazy import for binding-specific options.
+    """
+    if binding in ["lollms", "ollama"]:
+        try:
+            from lightrag.llm.binding_options import OllamaLLMOptions
+
+            options = OllamaLLMOptions.options_dict(args)
+        except ImportError as e:
+            raise Exception(f"Failed to import {binding} options: {e}")
+        if binding == "ollama":
+            # Imported lazily (the module installs the ollama package on
+            # import) and only for the binding that actually forwards
+            # think= -- lollms never reaches the ollama client.
+            from lightrag.llm.ollama import ensure_think_supported
+
+            ensure_think_supported(options, context="the base LLM binding")
+        kwargs = {
+            "timeout": llm_timeout,
+            "options": options,
+            "api_key": args.llm_binding_api_key,
+        }
+        if binding == "lollms":
+            # lollms_model_if_cache()'s parameter is named base_url, not
+            # host -- unlike ollama's AsyncClient(host=...). Passing "host"
+            # here would silently land in its **kwargs and never be read.
+            kwargs["base_url"] = args.llm_binding_host
+        else:
+            kwargs["host"] = args.llm_binding_host
+        return kwargs
+    return {}
+
+
 def create_app(args):
     # Check frontend build first and get status
     webui_assets_exist, is_frontend_outdated = check_frontend_build()
@@ -1803,33 +1838,6 @@ def create_app(args):
         except ImportError as e:
             raise Exception(f"Failed to import {binding} LLM binding: {e}")
 
-    def create_llm_model_kwargs(binding: str, args, llm_timeout: int) -> dict:
-        """
-        Create LLM model kwargs based on binding type.
-        Uses lazy import for binding-specific options.
-        """
-        if binding in ["lollms", "ollama"]:
-            try:
-                from lightrag.llm.binding_options import OllamaLLMOptions
-
-                options = OllamaLLMOptions.options_dict(args)
-            except ImportError as e:
-                raise Exception(f"Failed to import {binding} options: {e}")
-            if binding == "ollama":
-                # Imported lazily (the module installs the ollama package on
-                # import) and only for the binding that actually forwards
-                # think= -- lollms never reaches the ollama client.
-                from lightrag.llm.ollama import ensure_think_supported
-
-                ensure_think_supported(options, context="the base LLM binding")
-            return {
-                "host": args.llm_binding_host,
-                "timeout": llm_timeout,
-                "options": options,
-                "api_key": args.llm_binding_api_key,
-            }
-        return {}
-
     def resolve_role_llm_settings(
         role: str, override_meta: dict | None = None
     ) -> dict[str, Any]:
@@ -2322,7 +2330,7 @@ def create_app(args):
             embedding_chunk_overlap_token_size=int(
                 args.embedding_chunk_overlap_token_size
             ),
-            llm_model_kwargs=create_llm_model_kwargs(
+            llm_model_kwargs=_create_llm_model_kwargs(
                 args.llm_binding, args, llm_timeout
             ),
             embedding_func=embedding_func,

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1312,33 +1312,40 @@ def _create_llm_model_kwargs(binding: str, args, llm_timeout: int) -> dict:
     Create LLM model kwargs based on binding type.
     Uses lazy import for binding-specific options.
     """
-    if binding in ["lollms", "ollama"]:
+    if binding == "lollms":
+        return {
+            "timeout": llm_timeout,
+            # "options" is an Ollama-only payload; lollms_model_if_cache()
+            # never reads it. Pin it to an empty dict instead of deriving it
+            # from OllamaLLMOptions.options_dict(args), which only happens to
+            # return {} because its arguments are registered for the ollama
+            # binding alone.
+            "options": {},
+            "api_key": args.llm_binding_api_key,
+            # lollms_model_if_cache()'s parameter is named base_url, not
+            # host -- unlike ollama's AsyncClient(host=...). Passing "host"
+            # here would silently land in its **kwargs and never be read.
+            "base_url": args.llm_binding_host,
+        }
+    if binding == "ollama":
         try:
             from lightrag.llm.binding_options import OllamaLLMOptions
 
             options = OllamaLLMOptions.options_dict(args)
         except ImportError as e:
             raise Exception(f"Failed to import {binding} options: {e}")
-        if binding == "ollama":
-            # Imported lazily (the module installs the ollama package on
-            # import) and only for the binding that actually forwards
-            # think= -- lollms never reaches the ollama client.
-            from lightrag.llm.ollama import ensure_think_supported
+        # Imported lazily (the module installs the ollama package on import)
+        # and only for the binding that actually forwards think= -- lollms
+        # never reaches the ollama client.
+        from lightrag.llm.ollama import ensure_think_supported
 
-            ensure_think_supported(options, context="the base LLM binding")
-        kwargs = {
+        ensure_think_supported(options, context="the base LLM binding")
+        return {
             "timeout": llm_timeout,
             "options": options,
             "api_key": args.llm_binding_api_key,
+            "host": args.llm_binding_host,
         }
-        if binding == "lollms":
-            # lollms_model_if_cache()'s parameter is named base_url, not
-            # host -- unlike ollama's AsyncClient(host=...). Passing "host"
-            # here would silently land in its **kwargs and never be read.
-            kwargs["base_url"] = args.llm_binding_host
-        else:
-            kwargs["host"] = args.llm_binding_host
-        return kwargs
     return {}
 
 

--- a/tests/api/config/test_api_config_lollms_host.py
+++ b/tests/api/config/test_api_config_lollms_host.py
@@ -1,0 +1,136 @@
+"""_create_llm_model_kwargs(): lollms needs base_url, not host.
+
+lollms_model_if_cache()'s parameter is named base_url (unlike ollama's
+AsyncClient(host=...)); create_llm_model_kwargs() previously returned the
+same {"host": ...} shape for both bindings, so a configured LLM_BINDING_HOST
+for lollms silently landed in **kwargs and was never read -- the binding
+always talked to its own hardcoded http://localhost:9600 default regardless
+of configuration.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from lightrag.api.config import parse_args
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.fixture(autouse=True)
+def _lightrag_server_argv(monkeypatch):
+    """Importing lightrag.api.lightrag_server triggers auth.py's module-level
+    parse_args() against ambient sys.argv, so it must be pinned before that
+    module is ever imported -- see create_llm_model_kwargs below."""
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+
+
+@pytest.fixture
+def create_llm_model_kwargs(_lightrag_server_argv):
+    from lightrag.api.lightrag_server import _create_llm_model_kwargs
+
+    return _create_llm_model_kwargs
+
+
+@pytest.mark.parametrize(
+    "binding, expected_key, other_key, host",
+    [
+        ("lollms", "base_url", "host", "http://myserver:9999"),
+        ("ollama", "host", "base_url", "http://myserver:11434"),
+    ],
+)
+def test_custom_host_uses_the_binding_specific_key(
+    monkeypatch, create_llm_model_kwargs, binding, expected_key, other_key, host
+):
+    monkeypatch.setenv("LLM_BINDING", binding)
+    monkeypatch.setenv("LLM_BINDING_HOST", host)
+
+    kwargs = create_llm_model_kwargs(binding, parse_args(), llm_timeout=30)
+
+    assert kwargs[expected_key] == host
+    assert other_key not in kwargs
+
+
+def test_default_lollms_host_is_unchanged(monkeypatch, create_llm_model_kwargs):
+    monkeypatch.setenv("LLM_BINDING", "lollms")
+    monkeypatch.delenv("LLM_BINDING_HOST", raising=False)
+
+    kwargs = create_llm_model_kwargs("lollms", parse_args(), llm_timeout=30)
+
+    assert kwargs["base_url"] == "http://localhost:9600"
+    assert "host" not in kwargs
+
+
+def test_timeout_and_api_key_unchanged_for_both_bindings(
+    monkeypatch, create_llm_model_kwargs
+):
+    monkeypatch.setenv("LLM_BINDING", "lollms")
+    monkeypatch.setenv("LLM_BINDING_API_KEY", "secret")
+
+    kwargs = create_llm_model_kwargs("lollms", parse_args(), llm_timeout=42)
+
+    assert kwargs["timeout"] == 42
+    assert kwargs["api_key"] == "secret"
+    assert "options" in kwargs
+
+
+def test_unsupported_binding_returns_empty_dict(monkeypatch, create_llm_model_kwargs):
+    monkeypatch.setenv("LLM_BINDING", "openai")
+
+    assert create_llm_model_kwargs("openai", parse_args(), llm_timeout=30) == {}
+
+
+def test_configured_lollms_host_reaches_the_actual_request(
+    monkeypatch, create_llm_model_kwargs
+):
+    """End-to-end through the real _create_llm_model_kwargs() output, spread
+    into lollms_model_complete() the same way llm_roles.py's
+    _wrap_llm_role_func does: partial(raw_func, hashing_kv=..., **model_kwargs).
+    """
+    monkeypatch.setenv("LLM_BINDING", "lollms")
+    monkeypatch.setenv("LLM_BINDING_HOST", "http://myserver:9999")
+
+    model_kwargs = create_llm_model_kwargs("lollms", parse_args(), llm_timeout=30)
+
+    from lightrag.llm.lollms import lollms_model_complete
+
+    captured = {}
+
+    class FakeResponse:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def text(self):
+            return "ok"
+
+    class FakeSession:
+        def __init__(self, timeout=None, headers=None):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def post(self, url, json=None):
+            captured["url"] = url
+            return FakeResponse()
+
+    class FakeHashingKV:
+        global_config = {"llm_model_name": "fake-model"}
+
+    with patch("lightrag.llm.lollms.aiohttp.ClientSession", FakeSession):
+        import asyncio
+
+        asyncio.run(
+            lollms_model_complete("hello", hashing_kv=FakeHashingKV(), **model_kwargs)
+        )
+
+    assert captured["url"] == "http://myserver:9999/lollms_generate"

--- a/tests/api/config/test_api_config_lollms_host.py
+++ b/tests/api/config/test_api_config_lollms_host.py
@@ -16,20 +16,56 @@ from unittest.mock import patch
 import pytest
 
 from lightrag.api.config import parse_args
+from lightrag.llm_roles import ROLES
 
 pytestmark = pytest.mark.offline
 
 
+# Cleared so a developer-local .env cannot decide the outcome. Two parse_args()
+# guards SystemExit on ambient values: VLM_PROCESS_ENABLE=true rejects the lollms
+# binding these tests select, and any {ROLE}_LLM_BINDING differing from the base
+# one demands a role model and api key. The role names come from the registry so
+# a newly added role cannot silently reintroduce the leak.
+_ENV_VARS_TO_ISOLATE = (
+    "LLM_BINDING",
+    "LLM_BINDING_HOST",
+    "LLM_BINDING_API_KEY",
+    "LLM_MODEL",
+    "VLM_PROCESS_ENABLE",
+    *(
+        f"{spec.env_prefix}_{suffix}"
+        for spec in ROLES
+        for suffix in (
+            "LLM_BINDING",
+            "LLM_BINDING_HOST",
+            "LLM_BINDING_API_KEY",
+            "LLM_MODEL",
+        )
+    ),
+)
+
+
 @pytest.fixture(autouse=True)
-def _lightrag_server_argv(monkeypatch):
-    """Importing lightrag.api.lightrag_server triggers auth.py's module-level
-    parse_args() against ambient sys.argv, so it must be pinned before that
-    module is ever imported -- see create_llm_model_kwargs below."""
+def _isolated_config_env(monkeypatch):
+    """Pin sys.argv, then import the server module, then clear the environment.
+
+    The order is load-bearing. Importing lightrag.api.lightrag_server triggers
+    auth.py's module-level parse_args() against ambient sys.argv, so argv has to
+    be pinned first. That import also runs several module-level
+    load_dotenv(override=False) calls, which would re-populate anything deleted
+    beforehand straight back out of a developer-local .env -- so the deletions
+    only stick once every such module is in sys.modules.
+    """
     monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+
+    import lightrag.api.lightrag_server  # noqa: F401
+
+    for var in _ENV_VARS_TO_ISOLATE:
+        monkeypatch.delenv(var, raising=False)
 
 
 @pytest.fixture
-def create_llm_model_kwargs(_lightrag_server_argv):
+def create_llm_model_kwargs(_isolated_config_env):
     from lightrag.api.lightrag_server import _create_llm_model_kwargs
 
     return _create_llm_model_kwargs

--- a/tests/api/config/test_api_config_lollms_host.py
+++ b/tests/api/config/test_api_config_lollms_host.py
@@ -74,7 +74,10 @@ def test_timeout_and_api_key_unchanged_for_both_bindings(
 
     assert kwargs["timeout"] == 42
     assert kwargs["api_key"] == "secret"
-    assert "options" in kwargs
+    # Ollama-only payload, pinned explicitly rather than borrowed from
+    # OllamaLLMOptions.options_dict(), which is empty for lollms only as a
+    # side effect of where its arguments are registered.
+    assert kwargs["options"] == {}
 
 
 def test_unsupported_binding_returns_empty_dict(monkeypatch, create_llm_model_kwargs):


### PR DESCRIPTION
## Description

`create_llm_model_kwargs()` builds the same Ollama-shaped dictionary for both the `lollms` and `ollama` bindings, including a `host` key. Ollama accepts a `host` parameter, so this works correctly. The LoLLMs binding expects the corresponding parameter to be named `base_url`.

As a result, a configured `LLM_BINDING_HOST` for LoLLMs silently enters `**kwargs` and is never used. Requests therefore continue using the default `http://localhost:9600` endpoint regardless of the configured host.

This change moves the helper to module scope as `_create_llm_model_kwargs` and separates the binding-specific host keys. LoLLMs receives `base_url`, while Ollama continues receiving `host`. The existing `timeout`, `options` and `api_key` values remain unchanged.

## Related Issues

No related issue.

## Changes Made

- Move `create_llm_model_kwargs` out of `create_app()` to module scope as `_create_llm_model_kwargs`.
- Return `base_url` for the `lollms` binding while preserving `host` for `ollama`.
- Add tests covering custom and default LoLLMs hosts, Ollama behaviour, `timeout` and `api_key` preservation, and the final outgoing request URL.
- Leave `lightrag/llm/lollms.py` unchanged.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not necessary for this fix)
- [x] Unit tests added

## Test Results

- `tests/api/config/test_api_config_lollms_host.py`: 6 passed
- Full `tests/api/config` run: 128 passed, with 4 pre-existing failures caused by unavailable `aioboto3` and `voyageai` packages and reproduced identically on unmodified `main`
- `pre-commit run --all-files`: passed
- `git diff --check`: passed

## Additional Notes

The defect was reproduced through the real `create_app()` path. `LightRAG.__init__` was temporarily patched during testing to capture the received arguments. The unmodified code supplied `host` for LoLLMs, while the corrected code supplies `base_url`.