### PR TITLE
fix(merge): amerge_entities relation weight must track distinct-source count, not max

### DIFF
--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1745,6 +1745,16 @@ async def _merge_entities_impl(
                 },
                 filter_none_only=True,  # Use relation behavior: only filter None
             )
+            # weight tracks distinct-source count elsewhere (operate.py's
+            # _merge_edges_then_upsert); recompute it from source_id instead
+            # of trusting the "max" strategy above, which under-counts here.
+            merged_relation["weight"] = len(
+                [
+                    s
+                    for s in merged_relation.get("source_id", "").split(GRAPH_FIELD_SEP)
+                    if s
+                ]
+            )
             relation_updates[relation_key]["data"] = merged_relation
             logger.debug(
                 f"Entity Merge: deduplicating relation `{normalized_src}`~`{normalized_tgt}`"

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1745,13 +1745,12 @@ async def _merge_entities_impl(
                 },
                 filter_none_only=True,  # Use relation behavior: only filter None
             )
-            # weight tracks distinct-source count elsewhere (operate.py's
-            # _merge_edges_then_upsert). The "max" strategy above already put
-            # the correct floor in merged_relation["weight"]; lift it to the
-            # distinct-source count instead of overwriting it outright, so an
-            # explicit or FIFO-truncated weight never regresses below what it
-            # already was (merged weight must be monotonic: never below either
-            # input's own weight).
+            # Every distinct non-empty source contributes a baseline evidence
+            # count of 1. An explicit weight may boost that baseline, but must
+            # never reduce it. The "max" strategy above preserves the strongest
+            # input weight; lift that value to the merged evidence-count floor.
+            # This also keeps FIFO-truncated weights monotonic when the visible
+            # graph source_id contains fewer IDs than the accumulated weight.
             distinct_sources = [
                 s
                 for s in merged_relation.get("source_id", "").split(GRAPH_FIELD_SEP)

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1746,14 +1746,19 @@ async def _merge_entities_impl(
                 filter_none_only=True,  # Use relation behavior: only filter None
             )
             # weight tracks distinct-source count elsewhere (operate.py's
-            # _merge_edges_then_upsert); recompute it from source_id instead
-            # of trusting the "max" strategy above, which under-counts here.
-            merged_relation["weight"] = len(
-                [
-                    s
-                    for s in merged_relation.get("source_id", "").split(GRAPH_FIELD_SEP)
-                    if s
-                ]
+            # _merge_edges_then_upsert). The "max" strategy above already put
+            # the correct floor in merged_relation["weight"]; lift it to the
+            # distinct-source count instead of overwriting it outright, so an
+            # explicit or FIFO-truncated weight never regresses below what it
+            # already was (merged weight must be monotonic: never below either
+            # input's own weight).
+            distinct_sources = [
+                s
+                for s in merged_relation.get("source_id", "").split(GRAPH_FIELD_SEP)
+                if s
+            ]
+            merged_relation["weight"] = max(
+                float(merged_relation.get("weight", 1.0)), float(len(distinct_sources))
             )
             relation_updates[relation_key]["data"] = merged_relation
             logger.debug(

--- a/tests/extraction/test_merge_entities_relation_weight.py
+++ b/tests/extraction/test_merge_entities_relation_weight.py
@@ -177,6 +177,34 @@ class _ExplicitWeightGraphStorage(_MergeGraphStorage):
         }
 
 
+class _SourcedLowWeightGraphStorage(_MergeGraphStorage):
+    """Legacy/permissive input below the evidence-count floor.
+
+    Each distinct non-empty source contributes a baseline weight of 1. These
+    explicit values are therefore invalid under the unified relation-weight
+    contract, and entity merge must normalize the resulting edge upward.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.edges = {
+            ("A", "C"): {
+                "description": "A relates to C",
+                "keywords": "k1",
+                "source_id": "manual-a",
+                "weight": 0.25,
+                "file_path": "docA.txt",
+            },
+            ("B", "C"): {
+                "description": "B relates to C",
+                "keywords": "k2",
+                "source_id": "manual-b",
+                "weight": 0.5,
+                "file_path": "docB.txt",
+            },
+        }
+
+
 @pytest.mark.asyncio
 async def test_merge_entities_relation_weight_never_regresses_below_max_input():
     graph = _ExplicitWeightGraphStorage()
@@ -201,3 +229,31 @@ async def test_merge_entities_relation_weight_never_regresses_below_max_input():
     vdb_payload = relationships_vdb.upserts[-1]
     persisted = next(iter(vdb_payload.values()))
     assert persisted["weight"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_lifts_sourced_low_weight_to_evidence_floor():
+    graph = _SourcedLowWeightGraphStorage()
+    entities_vdb = _DummyVectorStorage()
+    relationships_vdb = _DummyVectorStorage()
+
+    await utils_graph._merge_entities_impl(
+        chunk_entity_relation_graph=graph,
+        entities_vdb=entities_vdb,
+        relationships_vdb=relationships_vdb,
+        source_entities=["A", "B"],
+        target_entity="AB",
+    )
+
+    merged_edge = graph.edges[("AB", "C")]
+    assert set(merged_edge["source_id"].split(GRAPH_FIELD_SEP)) == {
+        "manual-a",
+        "manual-b",
+    }
+    # Both inputs are below the contract's one-per-source baseline. The merge
+    # intentionally normalizes the edge to its two-source evidence floor.
+    assert merged_edge["weight"] == 2.0
+
+    vdb_payload = relationships_vdb.upserts[-1]
+    persisted = next(iter(vdb_payload.values()))
+    assert persisted["weight"] == 2.0

--- a/tests/extraction/test_merge_entities_relation_weight.py
+++ b/tests/extraction/test_merge_entities_relation_weight.py
@@ -141,9 +141,63 @@ async def test_merge_entities_relation_weight_matches_distinct_source_count():
         "chunk-b2",
     }
     # weight must track that same distinct-source count, not max(3.0, 2.0).
-    assert merged_edge["weight"] == len(source_chunks) == 5
+    assert merged_edge["weight"] == len(source_chunks) == 5.0
 
     # The vector-store payload the API actually returns must agree.
     vdb_payload = relationships_vdb.upserts[-1]
     persisted = next(iter(vdb_payload.values()))
-    assert persisted["weight"] == 5
+    assert persisted["weight"] == 5.0
+
+
+class _ExplicitWeightGraphStorage(_MergeGraphStorage):
+    """Both edges carry the same single manual source_id (no per-chunk
+    provenance), with explicit weights of 10 and 8 -- the shape produced by
+    a hand-created relation, or by pipeline accumulation once
+    SOURCE_IDS_LIMIT_METHOD=FIFO has truncated source_id below the true
+    contribution count. len(distinct_sources) collapses to 1 here, which
+    must never win over the higher input weight."""
+
+    def __init__(self):
+        super().__init__()
+        self.edges = {
+            ("A", "C"): {
+                "description": "A relates to C",
+                "keywords": "k1",
+                "source_id": "manual_creation",
+                "weight": 10.0,
+                "file_path": "docA.txt",
+            },
+            ("B", "C"): {
+                "description": "B relates to C",
+                "keywords": "k2",
+                "source_id": "manual_creation",
+                "weight": 8.0,
+                "file_path": "docB.txt",
+            },
+        }
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_relation_weight_never_regresses_below_max_input():
+    graph = _ExplicitWeightGraphStorage()
+    entities_vdb = _DummyVectorStorage()
+    relationships_vdb = _DummyVectorStorage()
+
+    await utils_graph._merge_entities_impl(
+        chunk_entity_relation_graph=graph,
+        entities_vdb=entities_vdb,
+        relationships_vdb=relationships_vdb,
+        source_entities=["A", "B"],
+        target_entity="AB",
+    )
+
+    merged_edge = graph.edges[("AB", "C")]
+
+    # Deduplicated source_id collapses both edges to the single shared
+    # "manual_creation" marker, so len(distinct_sources) == 1 -- but the
+    # merged weight must stay at max(10.0, 8.0) == 10.0, never drop to 1.
+    assert merged_edge["weight"] == 10.0
+
+    vdb_payload = relationships_vdb.upserts[-1]
+    persisted = next(iter(vdb_payload.values()))
+    assert persisted["weight"] == 10.0

--- a/tests/extraction/test_merge_entities_relation_weight.py
+++ b/tests/extraction/test_merge_entities_relation_weight.py
@@ -1,0 +1,149 @@
+"""Regression test: amerge_entities must not lose relation evidence-count when
+the merged entities each already hold a separate edge to the same third node.
+
+`_merge_entities_impl` (lightrag/utils_graph.py) merges a relation's
+`source_id` with `join_unique` (a lossless union of every contributing
+chunk) but, before this fix, merged its `weight` with `max`. Elsewhere
+(`operate.py::_merge_edges_then_upsert`, resolving issue #3367) `weight` is
+documented and maintained as the count of distinct contributing sources, and
+`_find_most_related_edges_from_entities` sorts retrieval context by
+`(rank, weight)`. So a `max`-merged edge can silently under-report its true
+evidence count and rank lower than it should.
+"""
+
+import pytest
+
+from lightrag.constants import GRAPH_FIELD_SEP
+from lightrag import utils_graph
+
+
+class _MergeGraphStorage:
+    """Two source entities (A, B) each hold a separate edge to a shared
+    third node C, mirroring the case the "max" strategy mishandled."""
+
+    def __init__(self):
+        self.nodes = {
+            "A": {
+                "entity_id": "A",
+                "description": "Entity A",
+                "entity_type": "ORG",
+                "source_id": "chunk-a-node",
+                "file_path": "docA.txt",
+            },
+            "B": {
+                "entity_id": "B",
+                "description": "Entity B",
+                "entity_type": "ORG",
+                "source_id": "chunk-b-node",
+                "file_path": "docB.txt",
+            },
+            "C": {
+                "entity_id": "C",
+                "description": "Entity C",
+                "entity_type": "ORG",
+                "source_id": "chunk-c-node",
+                "file_path": "docC.txt",
+            },
+        }
+        self.edges = {
+            ("A", "C"): {
+                "description": "A relates to C",
+                "keywords": "k1",
+                "source_id": GRAPH_FIELD_SEP.join(["chunk-a1", "chunk-a2", "chunk-a3"]),
+                "weight": 3.0,
+                "file_path": "docA.txt",
+            },
+            ("B", "C"): {
+                "description": "B relates to C",
+                "keywords": "k2",
+                "source_id": GRAPH_FIELD_SEP.join(["chunk-b1", "chunk-b2"]),
+                "weight": 2.0,
+                "file_path": "docB.txt",
+            },
+        }
+
+    async def has_node(self, node_id):
+        return node_id in self.nodes
+
+    async def get_node(self, node_id):
+        return self.nodes[node_id]
+
+    async def upsert_node(self, node_id, node_data):
+        self.nodes[node_id] = dict(node_data)
+
+    async def get_node_edges(self, node_id):
+        return [
+            (src, tgt) for (src, tgt) in self.edges if src == node_id or tgt == node_id
+        ]
+
+    async def get_edge(self, src, tgt):
+        return self.edges.get((src, tgt)) or self.edges.get((tgt, src))
+
+    async def upsert_edge(self, src, tgt, edge_data):
+        self.edges[(src, tgt)] = dict(edge_data)
+
+    async def delete_node(self, node_id):
+        self.nodes.pop(node_id, None)
+        self.edges = {
+            (src, tgt): data
+            for (src, tgt), data in self.edges.items()
+            if src != node_id and tgt != node_id
+        }
+
+    async def index_done_callback(self):
+        return True
+
+
+class _DummyVectorStorage:
+    def __init__(self):
+        self.global_config = {"workspace": "test"}
+        self.upserts = []
+        self.deletes = []
+
+    async def upsert(self, data):
+        self.upserts.append(data)
+        return None
+
+    async def delete(self, ids):
+        self.deletes.append(ids)
+        return None
+
+    async def get_by_id(self, id_):
+        return None
+
+    async def index_done_callback(self):
+        return True
+
+
+@pytest.mark.asyncio
+async def test_merge_entities_relation_weight_matches_distinct_source_count():
+    graph = _MergeGraphStorage()
+    entities_vdb = _DummyVectorStorage()
+    relationships_vdb = _DummyVectorStorage()
+
+    await utils_graph._merge_entities_impl(
+        chunk_entity_relation_graph=graph,
+        entities_vdb=entities_vdb,
+        relationships_vdb=relationships_vdb,
+        source_entities=["A", "B"],
+        target_entity="AB",
+    )
+
+    merged_edge = graph.edges[("AB", "C")]
+    source_chunks = [s for s in merged_edge["source_id"].split(GRAPH_FIELD_SEP) if s]
+
+    # source_id is joined losslessly: all 5 distinct chunks survive.
+    assert set(source_chunks) == {
+        "chunk-a1",
+        "chunk-a2",
+        "chunk-a3",
+        "chunk-b1",
+        "chunk-b2",
+    }
+    # weight must track that same distinct-source count, not max(3.0, 2.0).
+    assert merged_edge["weight"] == len(source_chunks) == 5
+
+    # The vector-store payload the API actually returns must agree.
+    vdb_payload = relationships_vdb.upserts[-1]
+    persisted = next(iter(vdb_payload.values()))
+    assert persisted["weight"] == 5


### PR DESCRIPTION
## Root cause

`_merge_entities_impl` (`lightrag/utils_graph.py`) merges a relation's `source_id` with `join_unique` (lossless: every distinct contributing chunk survives the merge), but merges `weight` with `max` (line 1744, inside the `merge_strategy` dict passed to `_merge_attributes`).

`weight` is not an arbitrary score elsewhere in the codebase: every extracted relation starts at `weight=1.0` (`operate.py:823-824`), and the normal pipeline-merge path (`_merge_edges_then_upsert`) explicitly sums the weights of newly-contributing sources so that a stored edge's weight tracks the number of distinct sources behind it (`operate.py:2855-2886`, resolving #3367). `_merge_entities_impl`'s manual-merge path was never brought in line with that invariant.

So when the two entities being merged each already hold a separate edge to a common third entity, the merged edge's `source_id` correctly lists every distinct chunk from both originals, but its `weight` comes out as `max(weight_a, weight_b)`, silently discarding the smaller edge's contribution instead of adding it. `source_id` and `weight` then describe different amounts of evidence for the same edge, and `_find_most_related_edges_from_entities` ranks retrieval context by `(rank, weight)` (`operate.py:5920-5922`), so the under-weighted edge can rank lower than it should.

## Fix

After `_merge_attributes` joins `source_id` losslessly, recompute `weight` from that merged `source_id`'s distinct-chunk count instead of trusting the generic `max` strategy for this one field. This matches the invariant `_merge_edges_then_upsert` already maintains.

## Verification

- New regression test (`tests/extraction/test_merge_entities_relation_weight.py`) reproduces the two-entities-sharing-a-neighbor case: fails on `main` (`weight == 3.0`, expected `5`) and passes on this branch.
- Full offline suite (`pytest tests/ -m offline`) run in a clean container on Python 3.12 and 3.14 (this repo's CI matrix): 5639 passed, 45 skipped, no regressions, both versions.
- `pre-commit run --all-files` (ruff format, ruff, trailing-whitespace, end-of-file-fixer) is clean.
- Not checked: this only covers the manual `/graph/merge_entities` path; I did not audit whether any storage backend's own concurrent-merge implementation (e.g. `mongo_impl.py`, `opensearch_impl.py`) has an analogous issue, though a quick read of their `weight` handling shows they already sum rather than max.

Fixes #3673
