### PR TITLE
fix(postgres): make AGE graph initialization idempotent

### DIFF
--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -456,6 +456,12 @@ class PostgreSQLDB:
         # Guard concurrent pool resets
         self._pool_reconnect_lock = asyncio.Lock()
 
+        # AGE graphs this process has already confirmed to exist.  Graph
+        # creation is one-time DDL, not connection session state, so it must
+        # not ride along on every AGE operation (issue #1866).
+        self._ensured_age_graphs: set[str] = set()
+        self._age_graph_ensure_lock = asyncio.Lock()
+
         self._transient_exceptions = TRANSIENT_DB_EXCEPTIONS
 
         # Connection retry configuration
@@ -1211,28 +1217,85 @@ class PostgreSQLDB:
             # rather than returning.
             logger.warning(f"Could not create AGE extension: {e}")
 
-    @staticmethod
-    async def configure_age(connection: asyncpg.Connection, graph_name: str) -> None:
-        """Set the Apache AGE environment and creates a graph if it does not exist.
+    async def configure_age(
+        self, connection: asyncpg.Connection, graph_name: str
+    ) -> None:
+        """Prepare a pooled connection for Apache AGE access.
 
-        This method:
-        - Sets the PostgreSQL `search_path` to include `ag_catalog`, ensuring that Apache AGE functions can be used without specifying the schema.
-        - Attempts to create a new graph with the provided `graph_name` if it does not already exist.
-        - Silently ignores errors related to the graph already existing.
+        Two very different things are needed before an AGE statement can run,
+        and they have very different lifetimes:
 
+        - ``SET search_path`` is genuine session state.  ``_reset_connection``
+          deliberately runs ``RESET ALL`` on every pool release so an AGE
+          search_path never leaks into a non-AGE checkout, which means it has
+          to be re-applied on every checkout.
+        - The graph itself is one-time DDL.  Creating it here unconditionally
+          made PostgreSQL log an ERROR/STATEMENT pair for *every* graph read
+          and write, because the server writes its log entry before the client
+          ever sees the error and can swallow it (issue #1866).  Graph
+          existence is now handled by :meth:`_ensure_age_graph`, which reaches
+          the database at most once per process.
         """
-        try:
-            await connection.execute(  # type: ignore
-                'SET search_path = ag_catalog, "$user", public'
+        await connection.execute(  # type: ignore
+            'SET search_path = ag_catalog, "$user", public'
+        )
+        await self._ensure_age_graph(connection, graph_name)
+
+    async def _ensure_age_graph(
+        self, connection: asyncpg.Connection, graph_name: str
+    ) -> None:
+        """Create the AGE graph if it does not exist, at most once per process.
+
+        Steady state is a set membership test and no SQL at all.  On a miss the
+        graph is looked up in ``ag_catalog.ag_graph`` and ``create_graph()`` is
+        only issued when it is genuinely absent, so a running server stops
+        producing "graph already exists" errors entirely.
+
+        Apache AGE takes no lock before its own existence check (see
+        ``create_graph_internal`` upstream), so concurrent first-time creation
+        can still race past the lookup.  Both known outcomes are tolerated:
+
+        - ``InvalidSchemaNameError`` (3F000) — AGE reports "graph already
+          exists" with ``ERRCODE_UNDEFINED_SCHEMA``.
+        - ``UniqueViolationError`` (23505) — the loser of the ``ag_graph``
+          name index race.
+
+        The graph is recorded as ensured only once it is known to exist.  A
+        transient failure must leave the cache untouched, otherwise a graph
+        that was never created would be assumed present for the lifetime of
+        the process and every later operation would fail with 3F000.
+        """
+        if graph_name in self._ensured_age_graphs:
+            return
+
+        async with self._age_graph_ensure_lock:
+            # A concurrent task may have ensured the graph while we waited.
+            if graph_name in self._ensured_age_graphs:
+                return
+
+            exists = await connection.fetchval(  # type: ignore
+                "SELECT 1 FROM ag_catalog.ag_graph WHERE name::text = $1",
+                graph_name,
             )
-            await connection.execute(  # type: ignore
-                f"select create_graph('{graph_name}')"
-            )
-        except (
-            asyncpg.exceptions.InvalidSchemaNameError,
-            asyncpg.exceptions.UniqueViolationError,
-        ):
-            pass
+            if exists is None:
+                try:
+                    await connection.execute(  # type: ignore
+                        f"select create_graph('{graph_name}')"
+                    )
+                    logger.info(f"PostgreSQL, AGE graph created: {graph_name}")
+                except (
+                    asyncpg.exceptions.InvalidSchemaNameError,
+                    asyncpg.exceptions.UniqueViolationError,
+                ) as e:
+                    # Lost the creation race: the graph exists now, which is
+                    # all this method promises.
+                    logger.debug(
+                        "PostgreSQL, AGE graph %s concurrently created elsewhere: %r",
+                        graph_name,
+                        e,
+                    )
+
+            self._ensured_age_graphs.add(graph_name)
 
     async def configure_vchordrq(self, connection: asyncpg.Connection) -> None:
         """Configure VCHORDRQ extension for vector similarity search.
@@ -7287,24 +7350,59 @@ class PGGraphStorage(BaseGraphStorage):
 
             await self.db._run_with_retry(_do_configure_age_extension)
 
-            # Execute each statement separately and ignore errors
+            # Only create the labels that are actually missing. create_vlabel /
+            # create_elabel have no IF NOT EXISTS form, so calling them for an
+            # existing label makes PostgreSQL log an ERROR on every startup
+            # (issue #1866). with_age=True here also guarantees the graph
+            # itself exists before we read its labels.
+            existing_labels = await self.db.query(
+                "SELECT l.name::text AS name "
+                "FROM ag_catalog.ag_label l "
+                "JOIN ag_catalog.ag_graph g ON l.graph = g.graphid "
+                "WHERE g.name::text = $1",
+                [self.graph_name],
+                multirows=True,
+                with_age=True,
+                graph_name=self.graph_name,
+            )
+            present_labels = {row["name"] for row in existing_labels or []}
+
+            # Execute each statement separately and ignore errors.
+            #
+            # create_graph() is deliberately absent: every statement below runs
+            # with with_age=True, and the first one to do so has already had
+            # PostgreSQLDB._ensure_age_graph() create the graph. Repeating it
+            # here would only add one more "graph already exists" line to the
+            # PostgreSQL log (issue #1866).
+            #
+            # The index statements carry IF NOT EXISTS for the same reason: a
+            # plain CREATE INDEX on an existing index is an ERROR the server
+            # logs before the client can ignore it, while IF NOT EXISTS
+            # downgrades it to a NOTICE that never reaches the log.
             queries = [
-                f"SELECT create_graph('{self.graph_name}')",
-                f"SELECT create_vlabel('{self.graph_name}', 'base');",
-                f"SELECT create_elabel('{self.graph_name}', 'DIRECTED');",
-                # f'CREATE INDEX CONCURRENTLY vertex_p_idx ON {self.graph_name}."_ag_label_vertex" (id)',
-                f'CREATE INDEX CONCURRENTLY vertex_idx_node_id ON {self.graph_name}."_ag_label_vertex" (ag_catalog.agtype_access_operator(properties, \'"entity_id"\'::agtype))',
-                # f'CREATE INDEX CONCURRENTLY edge_p_idx ON {self.graph_name}."_ag_label_edge" (id)',
-                f'CREATE INDEX CONCURRENTLY edge_sid_idx ON {self.graph_name}."_ag_label_edge" (start_id)',
-                f'CREATE INDEX CONCURRENTLY edge_eid_idx ON {self.graph_name}."_ag_label_edge" (end_id)',
-                f'CREATE INDEX CONCURRENTLY edge_seid_idx ON {self.graph_name}."_ag_label_edge" (start_id,end_id)',
-                f'CREATE INDEX CONCURRENTLY directed_p_idx ON {self.graph_name}."DIRECTED" (id)',
-                f'CREATE INDEX CONCURRENTLY directed_eid_idx ON {self.graph_name}."DIRECTED" (end_id)',
-                f'CREATE INDEX CONCURRENTLY directed_sid_idx ON {self.graph_name}."DIRECTED" (start_id)',
-                f'CREATE INDEX CONCURRENTLY directed_seid_idx ON {self.graph_name}."DIRECTED" (start_id,end_id)',
-                f'CREATE INDEX CONCURRENTLY entity_p_idx ON {self.graph_name}."base" (id)',
-                f'CREATE INDEX CONCURRENTLY entity_idx_node_id ON {self.graph_name}."base" (ag_catalog.agtype_access_operator(properties, \'"entity_id"\'::agtype))',
-                f'CREATE INDEX CONCURRENTLY entity_node_id_gin_idx ON {self.graph_name}."base" using gin(properties)',
+                *(
+                    [f"SELECT create_vlabel('{self.graph_name}', 'base');"]
+                    if "base" not in present_labels
+                    else []
+                ),
+                *(
+                    [f"SELECT create_elabel('{self.graph_name}', 'DIRECTED');"]
+                    if "DIRECTED" not in present_labels
+                    else []
+                ),
+                # f'CREATE INDEX CONCURRENTLY IF NOT EXISTS vertex_p_idx ON {self.graph_name}."_ag_label_vertex" (id)',
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS vertex_idx_node_id ON {self.graph_name}."_ag_label_vertex" (ag_catalog.agtype_access_operator(properties, \'"entity_id"\'::agtype))',
+                # f'CREATE INDEX CONCURRENTLY IF NOT EXISTS edge_p_idx ON {self.graph_name}."_ag_label_edge" (id)',
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS edge_sid_idx ON {self.graph_name}."_ag_label_edge" (start_id)',
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS edge_eid_idx ON {self.graph_name}."_ag_label_edge" (end_id)',
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS edge_seid_idx ON {self.graph_name}."_ag_label_edge" (start_id,end_id)',
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS directed_p_idx ON {self.graph_name}."DIRECTED" (id)',
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS directed_eid_idx ON {self.graph_name}."DIRECTED" (end_id)',
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS directed_sid_idx ON {self.graph_name}."DIRECTED" (start_id)',
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS directed_seid_idx ON {self.graph_name}."DIRECTED" (start_id,end_id)',
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS entity_p_idx ON {self.graph_name}."base" (id)',
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS entity_idx_node_id ON {self.graph_name}."base" (ag_catalog.agtype_access_operator(properties, \'"entity_id"\'::agtype))',
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS entity_node_id_gin_idx ON {self.graph_name}."base" using gin(properties)',
                 f'ALTER TABLE {self.graph_name}."DIRECTED" CLUSTER ON directed_sid_idx',
             ]
 

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -410,6 +410,12 @@ def _dollar_quote(s: str, tag_prefix: str = "AGE") -> str:
             return f"{wrapper}{s}{wrapper}"
 
 
+# PostgreSQL's `name` type (NAMEDATALEN - 1). Graph and label names are stored
+# as `name`, so anything longer is clipped on the way in and lookups have to
+# clip the value they compare against.
+_PG_NAME_MAX_BYTES = 63
+
+
 class PostgreSQLDB:
     def __init__(self, config: dict[str, Any], **kwargs: Any):
         self.host = config["host"]
@@ -1273,8 +1279,19 @@ class PostgreSQLDB:
             if graph_name in self._ensured_age_graphs:
                 return
 
+            # The parameter has to be truncated the same way the stored value
+            # was.  PostgreSQL's `name` type holds 63 bytes, and create_graph()
+            # below passes the name as a literal, which PostgreSQL silently
+            # clips -- so a workspace long enough to overflow is stored clipped
+            # and would never match an untruncated comparison.  Casting the
+            # bind parameter straight to `name` is not an option: for a
+            # parameter (unlike a literal) PostgreSQL raises 42622
+            # "identifier too long" instead of clipping.  left() is safe
+            # because _get_workspace_graph_name() reduces the name to
+            # [A-Za-z0-9_], where one character is one byte.
             exists = await connection.fetchval(  # type: ignore
-                "SELECT 1 FROM ag_catalog.ag_graph WHERE name::text = $1",
+                "SELECT 1 FROM ag_catalog.ag_graph "
+                f"WHERE name = left($1, {_PG_NAME_MAX_BYTES})::name",
                 graph_name,
             )
             if exists is None:
@@ -7359,7 +7376,7 @@ class PGGraphStorage(BaseGraphStorage):
                 "SELECT l.name::text AS name "
                 "FROM ag_catalog.ag_label l "
                 "JOIN ag_catalog.ag_graph g ON l.graph = g.graphid "
-                "WHERE g.name::text = $1",
+                f"WHERE g.name = left($1, {_PG_NAME_MAX_BYTES})::name",
                 [self.graph_name],
                 multirows=True,
                 with_age=True,

--- a/tests/kg/postgres_impl/test_postgres_age_graph_ensure.py
+++ b/tests/kg/postgres_impl/test_postgres_age_graph_ensure.py
@@ -26,7 +26,7 @@ import pytest
 from lightrag.kg.postgres_impl import PGGraphStorage, PostgreSQLDB
 
 SEARCH_PATH_SQL = 'SET search_path = ag_catalog, "$user", public'
-GRAPH_LOOKUP_SQL = "SELECT 1 FROM ag_catalog.ag_graph WHERE name::text = $1"
+GRAPH_LOOKUP_SQL = "SELECT 1 FROM ag_catalog.ag_graph WHERE name = left($1, 63)::name"
 
 
 def _make_db() -> PostgreSQLDB:
@@ -353,6 +353,99 @@ async def test_initialize_label_lookup_is_scoped_to_this_graph(monkeypatch):
     sql, params = db.query.await_args.args[0], db.query.await_args.args[1]
     assert "ag_catalog.ag_label" in sql
     assert "ag_catalog.ag_graph" in sql
+    # $1::name so PostgreSQL truncates the parameter the same way AGE did when
+    # it stored the graph name; name::text = $1 would never match a graph name
+    # longer than 63 bytes.
+    assert "g.name = left($1, 63)::name" in sql
+    assert "name::text = $1" not in sql
     assert params == ["space1_chunk_entity_relation"]
     assert db.query.await_args.kwargs["with_age"] is True
     assert db.query.await_args.kwargs["graph_name"] == "space1_chunk_entity_relation"
+
+
+# ---------------------------------------------------------------------------
+# Long graph names.  PostgreSQL's `name` type truncates at 63 bytes and AGE
+# stores graph names as `name`, so both catalog lookups must cast the
+# *parameter* to `name` rather than the stored value to `text`.  Comparing an
+# untruncated text parameter never matches, which would silently reinstate the
+# per-process create_graph and per-startup create_*label errors this PR removes.
+# ---------------------------------------------------------------------------
+
+# A workspace long enough that "<workspace>_chunk_entity_relation" exceeds 63 bytes.
+LONG_GRAPH_NAME = (
+    "verylongworkspacename_that_exceeds_the_limit_abcdefghij_chunk_entity_relation"
+)
+
+
+def test_long_graph_name_is_actually_over_the_identifier_limit():
+    """Guard the premise of the tests below."""
+    assert len(LONG_GRAPH_NAME.encode("utf-8")) > 63
+
+
+@pytest.mark.asyncio
+async def test_graph_lookup_casts_the_parameter_not_the_column():
+    db = _make_db()
+    conn = FakeConnection(graph_exists=True)
+
+    await db.configure_age(conn, LONG_GRAPH_NAME)
+
+    ((sql, args),) = conn.fetched
+    # left($1, 63), not $1::name: PostgreSQL raises 42622 "identifier too long"
+    # when a *bind parameter* is cast to name, while the literal AGE was given
+    # is clipped silently. The comparison has to clip the same way.
+    assert "name = left($1, 63)::name" in sql
+    assert "$1::name" not in sql
+    assert "name::text" not in sql
+    assert args == (LONG_GRAPH_NAME,)
+
+
+@pytest.mark.asyncio
+async def test_existing_long_named_graph_is_not_recreated():
+    """The truncation bug's user-visible symptom: one create_graph per process."""
+    db = _make_db()
+    conn = FakeConnection(graph_exists=True)
+
+    await db.configure_age(conn, LONG_GRAPH_NAME)
+
+    assert conn.create_graph_statements == []
+
+
+@pytest.mark.asyncio
+async def test_initialize_label_lookup_casts_the_parameter(monkeypatch):
+    monkeypatch.setattr(
+        "lightrag.kg.postgres_impl.get_data_init_lock", lambda: _null_lock()
+    )
+    storage, db = _make_graph_storage(["base", "DIRECTED"])
+    storage.workspace = "verylongworkspacename_that_exceeds_the_limit_abcdefghij"
+
+    await storage.initialize()
+
+    sql = db.query.await_args.args[0]
+    assert "g.name = left($1, 63)::name" in sql
+    assert db.query.await_args.args[1] == [LONG_GRAPH_NAME]
+    # And with both labels reported present, neither is recreated.
+    statements = [call.args[0] for call in db.execute.await_args_list]
+    assert not [s for s in statements if "create_vlabel" in s or "create_elabel" in s]
+
+
+def test_name_limit_constant_matches_postgres_namedatalen():
+    """NAMEDATALEN - 1. Both catalog lookups clip to this."""
+    from lightrag.kg.postgres_impl import _PG_NAME_MAX_BYTES
+
+    assert _PG_NAME_MAX_BYTES == 63
+
+
+def test_graph_names_are_ascii_so_bytes_equal_characters():
+    """left() clips by character; that is only equivalent for single-byte names.
+
+    _get_workspace_graph_name() guarantees it by reducing both the workspace and
+    the namespace to [A-Za-z0-9_].
+    """
+    storage = PGGraphStorage.__new__(PGGraphStorage)
+    storage.workspace = "工作区 with spaces/and-punct"
+    storage.namespace = "chunk_entity_relation"
+
+    name = storage._get_workspace_graph_name()
+
+    assert name.isascii(), name
+    assert len(name) == len(name.encode("utf-8"))

--- a/tests/kg/postgres_impl/test_postgres_age_graph_ensure.py
+++ b/tests/kg/postgres_impl/test_postgres_age_graph_ensure.py
@@ -1,0 +1,358 @@
+"""Regression tests for one-time AGE graph creation (issue #1866).
+
+`configure_age` used to issue `select create_graph(...)` on every pooled
+connection checkout, i.e. before every single AGE read and write.  PostgreSQL
+logs the resulting error *before* the client can swallow it, so a busy server
+filled the database log with `graph "..." already exists` ERROR/STATEMENT
+pairs.
+
+The contract pinned here:
+
+- `SET search_path` still runs on every checkout (RESET ALL clears it).
+- The graph is looked up in `ag_catalog.ag_graph`, and `create_graph()` only
+  runs when it is genuinely absent.
+- Once the graph is known to exist, no SQL is issued for it at all.
+- A creation race (3F000 / 23505) is tolerated.
+- A transient failure must NOT mark the graph as ensured.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+from lightrag.kg.postgres_impl import PGGraphStorage, PostgreSQLDB
+
+SEARCH_PATH_SQL = 'SET search_path = ag_catalog, "$user", public'
+GRAPH_LOOKUP_SQL = "SELECT 1 FROM ag_catalog.ag_graph WHERE name::text = $1"
+
+
+def _make_db() -> PostgreSQLDB:
+    """Build a PostgreSQLDB without touching __init__/connection setup."""
+    db = PostgreSQLDB.__new__(PostgreSQLDB)
+    db._ensured_age_graphs = set()
+    db._age_graph_ensure_lock = asyncio.Lock()
+    return db
+
+
+class FakeConnection:
+    """Minimal asyncpg.Connection stand-in that records issued statements."""
+
+    def __init__(
+        self, graph_exists: bool = False, create_error: Exception | None = None
+    ):
+        self.graph_exists = graph_exists
+        self.create_error = create_error
+        self.executed: list[str] = []
+        self.fetched: list[tuple[str, tuple]] = []
+
+    async def execute(self, sql: str, *args):
+        self.executed.append(sql)
+        if "create_graph" in sql and self.create_error is not None:
+            raise self.create_error
+        return "OK"
+
+    async def fetchval(self, sql: str, *args):
+        self.fetched.append((sql, args))
+        return 1 if self.graph_exists else None
+
+    @property
+    def create_graph_statements(self) -> list[str]:
+        return [sql for sql in self.executed if "create_graph" in sql]
+
+
+@pytest.mark.asyncio
+async def test_existing_graph_is_not_recreated():
+    """The defect itself: an existing graph must not trigger create_graph()."""
+    db = _make_db()
+    conn = FakeConnection(graph_exists=True)
+
+    await db.configure_age(conn, "space1_chunk_entity_relation")
+
+    assert conn.create_graph_statements == []
+    assert conn.fetched == [
+        (GRAPH_LOOKUP_SQL, ("space1_chunk_entity_relation",)),
+    ]
+    assert "space1_chunk_entity_relation" in db._ensured_age_graphs
+
+
+@pytest.mark.asyncio
+async def test_search_path_is_set_on_every_checkout():
+    """RESET ALL clears search_path, so it must be re-applied every time."""
+    db = _make_db()
+    conn = FakeConnection(graph_exists=True)
+
+    await db.configure_age(conn, "g")
+    await db.configure_age(conn, "g")
+    await db.configure_age(conn, "g")
+
+    assert conn.executed == [SEARCH_PATH_SQL] * 3
+
+
+@pytest.mark.asyncio
+async def test_missing_graph_is_created_once():
+    db = _make_db()
+    conn = FakeConnection(graph_exists=False)
+
+    await db.configure_age(conn, "g")
+
+    assert conn.create_graph_statements == ["select create_graph('g')"]
+    assert db._ensured_age_graphs == {"g"}
+
+
+@pytest.mark.asyncio
+async def test_ensured_graph_issues_no_further_sql():
+    """Steady state must not even probe ag_graph again."""
+    db = _make_db()
+    conn = FakeConnection(graph_exists=False)
+
+    await db.configure_age(conn, "g")
+    lookups_after_first = len(conn.fetched)
+
+    for _ in range(20):
+        await db.configure_age(conn, "g")
+
+    assert len(conn.fetched) == lookups_after_first
+    assert conn.create_graph_statements == ["select create_graph('g')"]
+
+
+@pytest.mark.asyncio
+async def test_graphs_are_tracked_independently():
+    db = _make_db()
+    conn = FakeConnection(graph_exists=False)
+
+    await db.configure_age(conn, "graph_a")
+    await db.configure_age(conn, "graph_b")
+    await db.configure_age(conn, "graph_a")
+
+    assert conn.create_graph_statements == [
+        "select create_graph('graph_a')",
+        "select create_graph('graph_b')",
+    ]
+    assert db._ensured_age_graphs == {"graph_a", "graph_b"}
+
+
+@pytest.mark.parametrize(
+    "race_error",
+    [
+        # AGE reports "graph already exists" with ERRCODE_UNDEFINED_SCHEMA (3F000).
+        asyncpg.exceptions.InvalidSchemaNameError('graph "g" already exists'),
+        # Loser of the ag_graph name index race (23505).
+        asyncpg.exceptions.UniqueViolationError("duplicate key value"),
+    ],
+    ids=["invalid_schema_name_3F000", "unique_violation_23505"],
+)
+@pytest.mark.asyncio
+async def test_creation_race_is_tolerated(race_error):
+    """AGE takes no lock before its own existence check, so races happen."""
+    db = _make_db()
+    conn = FakeConnection(graph_exists=False, create_error=race_error)
+
+    await db.configure_age(conn, "g")
+
+    # Race lost, but the graph exists now — that is all the method promises.
+    assert db._ensured_age_graphs == {"g"}
+
+
+@pytest.mark.asyncio
+async def test_transient_creation_failure_does_not_mark_graph_ensured():
+    """Caching an unconfirmed graph would break the process permanently."""
+    db = _make_db()
+    boom = asyncpg.exceptions.ConnectionDoesNotExistError("connection lost")
+    failing_conn = FakeConnection(graph_exists=False, create_error=boom)
+
+    with pytest.raises(asyncpg.exceptions.ConnectionDoesNotExistError):
+        await db.configure_age(failing_conn, "g")
+
+    assert db._ensured_age_graphs == set()
+
+    # The next attempt must retry creation rather than assume it happened.
+    retry_conn = FakeConnection(graph_exists=False)
+    await db.configure_age(retry_conn, "g")
+    assert retry_conn.create_graph_statements == ["select create_graph('g')"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_use_creates_graph_once():
+    """Startup fan-out must not turn into a create_graph stampede."""
+    db = _make_db()
+    conn = FakeConnection(graph_exists=False)
+
+    await asyncio.gather(*(db.configure_age(conn, "g") for _ in range(10)))
+
+    assert conn.create_graph_statements == ["select create_graph('g')"]
+    assert len(conn.fetched) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_with_retry_configures_age_before_the_operation():
+    """The graph must be ensured before the AGE statement runs, not after."""
+    db = _make_db()
+    order: list[str] = []
+
+    async def fake_configure_age(connection, graph_name):
+        order.append(f"configure_age:{graph_name}")
+
+    db.configure_age = AsyncMock(side_effect=fake_configure_age)
+    db.pool = _FakePool()
+    db._ensure_pool = AsyncMock()
+    db.connection_retry_attempts = 1
+    db.connection_retry_backoff = 0
+    db.connection_retry_backoff_max = 0
+    db._transient_exceptions = ()
+
+    async def operation(connection):
+        order.append("operation")
+        return "result"
+
+    result = await db._run_with_retry(
+        operation, with_age=True, graph_name="space1_chunk_entity_relation"
+    )
+
+    assert result == "result"
+    assert order == ["configure_age:space1_chunk_entity_relation", "operation"]
+
+
+@pytest.mark.asyncio
+async def test_run_with_retry_skips_age_setup_when_not_requested():
+    db = _make_db()
+    db.configure_age = AsyncMock()
+    db.pool = _FakePool()
+    db._ensure_pool = AsyncMock()
+    db.connection_retry_attempts = 1
+    db.connection_retry_backoff = 0
+    db.connection_retry_backoff_max = 0
+    db._transient_exceptions = ()
+
+    async def operation(connection):
+        return "result"
+
+    assert await db._run_with_retry(operation) == "result"
+    db.configure_age.assert_not_called()
+
+
+class _FakeAcquire:
+    def __init__(self, connection):
+        self._connection = connection
+
+    async def __aenter__(self):
+        return self._connection
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class _FakePool:
+    def __init__(self):
+        self.connection = FakeConnection(graph_exists=True)
+
+    def acquire(self):
+        return _FakeAcquire(self.connection)
+
+
+# ---------------------------------------------------------------------------
+# PGGraphStorage.initialize(): the DDL list must be idempotent too.
+#
+# Before the fix, every startup replayed create_graph, both create_*label calls
+# and 11 plain CREATE INDEX statements, so a server that had already been
+# initialised logged 14 ERROR lines on each boot (issue #1866).
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _null_lock():
+    yield
+
+
+def _make_graph_storage(existing_labels: list[str]) -> tuple[PGGraphStorage, AsyncMock]:
+    storage = PGGraphStorage.__new__(PGGraphStorage)
+    storage.workspace = "space1"
+    storage.namespace = "chunk_entity_relation"
+    storage.global_config = {"vector_storage": "PGVectorStorage"}
+
+    db = AsyncMock()
+    db.workspace = None
+    db.query = AsyncMock(return_value=[{"name": name} for name in existing_labels])
+    db.execute = AsyncMock()
+    db._run_with_retry = AsyncMock()
+    storage.db = db
+    return storage, db
+
+
+async def _run_initialize(monkeypatch, existing_labels: list[str]) -> list[str]:
+    """Run initialize() and return the DDL statements it issued."""
+    monkeypatch.setattr(
+        "lightrag.kg.postgres_impl.get_data_init_lock", lambda: _null_lock()
+    )
+    storage, db = _make_graph_storage(existing_labels)
+    await storage.initialize()
+    return [call.args[0] for call in db.execute.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_initialize_skips_labels_that_already_exist(monkeypatch):
+    statements = await _run_initialize(monkeypatch, ["base", "DIRECTED"])
+
+    assert not [s for s in statements if "create_vlabel" in s]
+    assert not [s for s in statements if "create_elabel" in s]
+
+
+@pytest.mark.asyncio
+async def test_initialize_creates_only_the_missing_label(monkeypatch):
+    statements = await _run_initialize(monkeypatch, ["base"])
+
+    assert not [s for s in statements if "create_vlabel" in s]
+    assert [s for s in statements if "create_elabel" in s] == [
+        "SELECT create_elabel('space1_chunk_entity_relation', 'DIRECTED');"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_initialize_creates_both_labels_on_a_fresh_graph(monkeypatch):
+    statements = await _run_initialize(monkeypatch, [])
+
+    assert statements[0] == (
+        "SELECT create_vlabel('space1_chunk_entity_relation', 'base');"
+    )
+    assert statements[1] == (
+        "SELECT create_elabel('space1_chunk_entity_relation', 'DIRECTED');"
+    )
+
+
+@pytest.mark.asyncio
+async def test_initialize_never_issues_create_graph(monkeypatch):
+    """_ensure_age_graph owns graph creation; initialize must not duplicate it."""
+    statements = await _run_initialize(monkeypatch, [])
+
+    assert not [s for s in statements if "create_graph" in s]
+
+
+@pytest.mark.asyncio
+async def test_initialize_index_statements_are_idempotent(monkeypatch):
+    statements = await _run_initialize(monkeypatch, ["base", "DIRECTED"])
+
+    index_statements = [s for s in statements if "CREATE INDEX" in s]
+    assert index_statements, "expected the graph indexes to still be created"
+    for statement in index_statements:
+        assert "CONCURRENTLY IF NOT EXISTS" in statement, statement
+
+
+@pytest.mark.asyncio
+async def test_initialize_label_lookup_is_scoped_to_this_graph(monkeypatch):
+    """Labels are per-graph, so the lookup must filter on the graph name."""
+    monkeypatch.setattr(
+        "lightrag.kg.postgres_impl.get_data_init_lock", lambda: _null_lock()
+    )
+    storage, db = _make_graph_storage(["base", "DIRECTED"])
+
+    await storage.initialize()
+
+    db.query.assert_awaited_once()
+    sql, params = db.query.await_args.args[0], db.query.await_args.args[1]
+    assert "ag_catalog.ag_label" in sql
+    assert "ag_catalog.ag_graph" in sql
+    assert params == ["space1_chunk_entity_relation"]
+    assert db.query.await_args.kwargs["with_age"] is True
+    assert db.query.await_args.kwargs["graph_name"] == "space1_chunk_entity_relation"


### PR DESCRIPTION
## Summary

`PGGraphStorage` asked PostgreSQL to create its AGE graph before **every single
graph read and write**, so a running server continuously logged
`graph "..." already exists`. This makes graph initialization idempotent: a
steady-state server now adds zero errors to the PostgreSQL log.

## Motivation

Reported in #1866 and confirmed still reproducible on PostgreSQL 18.6 +
Apache AGE 1.7.0 / LightRAG 1.5.6.

`configure_age()` issued two statements on every pooled connection checkout:

```python
await connection.execute('SET search_path = ag_catalog, "$user", public')
await connection.execute(f"select create_graph('{graph_name}')")
```

`_query()` is the single funnel for all AGE reads and writes and always passes
`with_age=True`, so the second statement ran once per graph operation. The
client-side `except ... : pass` hid nothing, because **PostgreSQL writes its log
entry before the client ever sees the error**.

Measured on a stack with the graph already created:

| | `graph already exists` errors |
|---|---|
| Server startup | 17 |
| Each `/graph/label/list` call | +1 |
| Each entity/relation upsert, BFS query, … | +1 |

Under concurrent ingestion this is the "large volume of ERROR/STATEMENT log
entries" from the issue. There is no server-side mitigation: `ERROR` outranks
the `log_min_messages` default of `warning`, and `log_min_error_statement`
defaults to `error`, which is also why every line is paired with a `STATEMENT`.

## What's changed

**The two statements in `configure_age()` have different lifetimes.**
`SET search_path` is session state that `_reset_connection` deliberately clears
via `RESET ALL` (so an AGE search_path never leaks into a non-AGE checkout), so
it genuinely has to be re-applied per checkout. Graph creation is one-time DDL
that was only riding along.

- `configure_age()` keeps setting `search_path` and delegates graph existence to
  the new `_ensure_age_graph()`.
- `_ensure_age_graph()` is a set-membership test in steady state — no SQL at
  all. On a miss it looks the graph up in `ag_catalog.ag_graph` and calls
  `create_graph()` only when it is genuinely absent.
- The creation race is still tolerated. Apache AGE takes no lock before its own
  existence check, and `create_graph_internal` reports "already exists" with
  `ERRCODE_UNDEFINED_SCHEMA` (3F000), so both `InvalidSchemaNameError` and the
  23505 loser of the `ag_graph` name index are caught as before.
- The graph is recorded as ensured **only once it is known to exist**. Caching an
  unconfirmed graph after, say, a dropped connection would make every later
  operation in that process fail with 3F000 and never self-heal.

**`initialize()` had the same defect in its DDL list**, replaying `create_graph`,
both `create_*label` calls and 11 plain `CREATE INDEX` statements on every boot
— 14 logged errors per startup on an initialised database.

- Dropped the redundant `create_graph` (the first `with_age=True` statement has
  already ensured the graph).
- Labels are now created only when missing, looked up via
  `ag_catalog.ag_label` joined to `ag_catalog.ag_graph`. `create_vlabel` /
  `create_elabel` have no `IF NOT EXISTS` form.
- Index statements carry `IF NOT EXISTS`, which downgrades the duplicate case to
  a `NOTICE` the server does not log. This matches what the `LIGHTRAG_DOC_STATUS`
  index migrations in this file already do.
- `ignore_if_exists=True` is retained on the loop as the concurrency backstop for
  two processes racing a first-time initialization.

## Verification

Unit tests: `tests/kg/postgres_impl/test_postgres_age_graph_ensure.py` (17 tests)
pins the whole contract — existing graph is not recreated, `search_path` is
still re-applied on every checkout, both race error codes are tolerated, a
transient failure does not poison the cache, concurrent first use creates once,
and the `initialize()` DDL list is idempotent. Every behavioural assertion fails
against the previous implementation (8 failures, all `AssertionError` on the
statements actually issued).

`./scripts/test.sh tests/kg` → 1980 passed, 184 skipped.

End-to-end on PostgreSQL 18.6 + Apache AGE 1.7.0:

| | before | after |
|---|---|---|
| Errors logged on startup | 17 (+13 label/index) | **0** |
| Errors per graph query | 1 | **0** |
| Fresh graph creation | graph + 2 labels + 11 indexes | **unchanged** |
| Repeated `initialize()` | 14 errors | **0** |

A fresh workspace was initialised from scratch to confirm the first-creation
path still produces the graph, both labels and all 11 indexes, and that a second
`initialize()` on it is silent.

## What could break

Two behaviour changes worth calling out:

- `configure_age()` is now an instance method instead of a `@staticmethod`
  (it needs the per-pool cache). Its signature and its only call site are
  unchanged; `query()` / `execute()` / `_run_with_retry()` keep their
  `with_age` and `graph_name` keyword arguments.
- `SET search_path` is no longer wrapped in the `except (InvalidSchemaNameError,
  UniqueViolationError)` block, which now guards only graph creation. Setting a
  search_path to a non-existent schema is not an error in PostgreSQL, so this
  narrows a catch that could only ever have masked a real problem.

Fixes #1866

## Review follow-up

A Codex review flagged that the two new catalog lookups compared
`name::text = $1`, which cannot match a graph name PostgreSQL had to clip at 63
bytes. Confirmed and fixed in f6989849e, with two measured corrections to the
suggested remedy:

- `$1::name` is not usable for a **bind parameter**: unlike a literal, a
  parameter cast to `name` raises 42622 `identifier too long` rather than
  clipping. The lookups now use `left($1, 63)::name`, which clips exactly like
  the stored value and still uses the `ag_graph` name index. `left()` counts
  characters, which is equivalent here because `_get_workspace_graph_name()`
  reduces the name to `[A-Za-z0-9_]` — a test pins that.
- The predicted symptom cannot occur in practice: graph names over 63 bytes are
  already unsupported, because AGE rejects them in `create_vlabel` /
  `create_elabel` with `graph name is invalid`, so `initialize()` fails outright
  both before and after this PR.

**Pre-existing gap, out of scope:** two workspaces whose graph names differ only
past byte 63 clip to the same AGE graph and would silently share it. That
predates this PR and needs its own fix.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
