### PR TITLE
fix(hf): honor generation token limits

### DIFF
--- a/lightrag/llm/hf.py
+++ b/lightrag/llm/hf.py
@@ -75,6 +75,8 @@ async def hf_model_if_cache(
     messages.extend(history_messages)
     messages.append({"role": "user", "content": prompt})
     kwargs.pop("hashing_kv", None)
+    max_tokens = kwargs.pop("max_tokens", 512)
+    max_new_tokens = kwargs.pop("max_new_tokens", max_tokens)
     input_prompt = ""
     try:
         input_prompt = hf_tokenizer.apply_chat_template(
@@ -116,7 +118,10 @@ async def hf_model_if_cache(
     # so hf_model.device already reflects accelerate's placement.
     inputs = {k: v.to(hf_model.device) for k, v in input_ids.items()}
     output = hf_model.generate(
-        **inputs, max_new_tokens=512, num_return_sequences=1, early_stopping=True
+        **inputs,
+        max_new_tokens=max_new_tokens,
+        num_return_sequences=1,
+        early_stopping=True,
     )
     response_text = hf_tokenizer.decode(
         output[0][len(inputs["input_ids"][0]) :], skip_special_tokens=True

--- a/tests/llm/hf_impl/test_hf_model_if_cache_device_placement.py
+++ b/tests/llm/hf_impl/test_hf_model_if_cache_device_placement.py
@@ -225,3 +225,28 @@ async def test_prompt_length_slicing_excludes_prompt_tokens(monkeypatch):
     full_output = fake_model.received_kwargs is not None
     assert full_output
     assert result == "decoded:[901, 902]"  # prompt ids [1..5] sliced off
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("generation_kwargs", "expected_max_new_tokens"),
+    [
+        ({}, 512),
+        ({"max_tokens": 37}, 37),
+        ({"max_new_tokens": 41}, 41),
+        ({"max_tokens": 37, "max_new_tokens": 41}, 41),
+    ],
+)
+async def test_generation_token_limit_precedence(
+    monkeypatch, generation_kwargs, expected_max_new_tokens
+):
+    """The HF-native setting wins over LightRAG's generic alias, while
+    preserving the existing 512-token default when neither is supplied."""
+    hf_module, fake_model, _ = make_hf_module(
+        monkeypatch, model_device="cpu", host_has_cuda=False
+    )
+
+    await hf_module.hf_model_if_cache("fake-model", "hello world", **generation_kwargs)
+
+    assert fake_model.received_kwargs["max_new_tokens"] == expected_max_new_tokens
+    assert "max_tokens" not in fake_model.received_kwargs


### PR DESCRIPTION
## Description

`hf_model_if_cache()` always passed `max_new_tokens=512` to the Hugging Face model, ignoring both LightRAG’s generic `max_tokens` option and the Hugging Face-native `max_new_tokens` setting.

This meant callers could not control the generation length through either supported parameter.

This change resolves the generation limit using the following precedence:

1. Explicit `max_new_tokens`
2. Generic `max_tokens`
3. Existing default of `512`

## Related Issues

No related issue.

## Changes Made

* Honour the Hugging Face-native `max_new_tokens` setting.
* Map LightRAG’s generic `max_tokens` option to `max_new_tokens`.
* Give `max_new_tokens` precedence when both options are provided.
* Preserve the existing default of 512 tokens when neither option is supplied.
* Add regression tests covering the default, both individual options, and their precedence.

## Checklist

* [x] Changes tested locally
* [x] Code reviewed
* [x] Documentation updated (not necessary for this fix)
* [x] Unit tests added

## Test Results

* Device-placement and token-limit tests: 8 passed
* Full `tests/llm/hf_impl` suite: 16 passed
* Fails-before behaviour reproduced on unmodified code
* Default 512-token behaviour verified
* Generic `max_tokens` behaviour verified
* Native `max_new_tokens` behaviour verified
* Native-option precedence verified when both options are supplied
* `pre-commit run --all-files`: passed
* `git diff --check`: passed

## Additional Notes

This change only affects generation-token limit handling in `hf_model_if_cache()`. It does not modify model placement, `device_map`, quantisation, embeddings, pooling behaviour, or response decoding.
