### PR TITLE
fix(lmdeploy): honor native max_new_tokens

### DIFF
--- a/lightrag/llm/lmdeploy.py
+++ b/lightrag/llm/lmdeploy.py
@@ -128,7 +128,8 @@ async def lmdeploy_model_if_cache(
             stacklevel=2,
         )
     kwargs.pop("response_format", None)
-    max_new_tokens = kwargs.pop("max_tokens", 512)
+    max_tokens = kwargs.pop("max_tokens", 512)
+    max_new_tokens = kwargs.pop("max_new_tokens", max_tokens)
     tp = kwargs.pop("tp", 1)
     skip_special_tokens = kwargs.pop("skip_special_tokens", True)
     do_preprocess = kwargs.pop("do_preprocess", True)

--- a/tests/llm/lmdeploy_impl/test_lmdeploy_do_sample.py
+++ b/tests/llm/lmdeploy_impl/test_lmdeploy_do_sample.py
@@ -85,6 +85,36 @@ async def test_do_sample_forwarded_unchanged_on_modern_lmdeploy(
 
 
 @pytest.mark.parametrize(
+    ("generation_kwargs", "expected_max_new_tokens"),
+    [
+        pytest.param({}, 512, id="omitted-defaults-to-512"),
+        pytest.param({"max_tokens": 37}, 37, id="generic-max-tokens"),
+        pytest.param({"max_new_tokens": 41}, 41, id="native-max-new-tokens"),
+        pytest.param(
+            {"max_tokens": 37, "max_new_tokens": 41},
+            41,
+            id="native-value-takes-precedence",
+        ),
+    ],
+)
+async def test_generation_token_limit_precedence(
+    monkeypatch, generation_kwargs, expected_max_new_tokens
+):
+    """The native setting wins over LightRAG's generic alias."""
+    captured = _install_fake_lmdeploy(monkeypatch, less_than_0_6_0=False)
+
+    result = await lmdeploy_model_if_cache(
+        model="lmdeploy-model",
+        prompt="hello",
+        **generation_kwargs,
+    )
+
+    assert result == "{}"
+    assert captured["max_new_tokens"] == expected_max_new_tokens
+    assert "max_tokens" not in captured
+
+
+@pytest.mark.parametrize(
     "do_sample_kwarg",
     [
         pytest.param({}, id="omitted"),


### PR DESCRIPTION
## Description

`lmdeploy_model_if_cache()` raised a duplicate-keyword error when callers supplied the native `max_new_tokens` option.

This change consumes both token-limit options before constructing `GenerationConfig`, with `max_new_tokens` taking precedence over the generic `max_tokens` alias.

## Related Issues

No related issue.

## Changes Made

* Support native `max_new_tokens`.
* Preserve `max_tokens` as the generic alias.
* Keep the existing default of 512 tokens.
* Add tests covering defaults, aliases and precedence.

## Checklist

* [x] Changes tested locally
* [x] Code reviewed
* [x] Documentation updated (not necessary)
* [x] Unit tests added

## Test Results

* LMDeploy tests: 10 passed
* Fails-before behaviour reproduced on unmodified `main`
* `pre-commit run --all-files`: passed
* `git diff --check`: passed

## Additional Notes

When both options are provided, the provider-native `max_new_tokens` value takes precedence.
