### PR TITLE
fix(ollama): map max_tokens to num_predict

### DIFF
--- a/lightrag/llm/ollama.py
+++ b/lightrag/llm/ollama.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 import os
 import re
 import warnings
@@ -197,7 +197,16 @@ async def _ollama_model_if_cache(
         logger.debug("enable_cot=True is not supported for ollama and will be ignored.")
     stream = True if kwargs.get("stream") else False
 
-    kwargs.pop("max_tokens", None)
+    max_tokens = kwargs.pop("max_tokens", None)
+    if max_tokens is not None:
+        options = kwargs.get("options")
+        if options is None:
+            kwargs["options"] = {"num_predict": max_tokens}
+        elif isinstance(options, Mapping):
+            if options.get("num_predict") is None:
+                kwargs["options"] = {**options, "num_predict": max_tokens}
+        elif isinstance(options, ollama.Options) and options.num_predict is None:
+            kwargs["options"] = options.model_copy(update={"num_predict": max_tokens})
     # Deprecation shims: map legacy boolean flags to response_format only when
     # an explicit response_format was not supplied by the caller.
     if kwargs.get("response_format") is None:

--- a/tests/llm/ollama_impl/test_ollama_max_tokens.py
+++ b/tests/llm/ollama_impl/test_ollama_max_tokens.py
@@ -1,0 +1,91 @@
+"""Offline tests for Ollama's generic output-token alias."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import lightrag.llm.ollama as ollama_binding
+from lightrag.llm.ollama import _ollama_model_if_cache
+
+pytestmark = pytest.mark.offline
+
+
+def _make_fake_client():
+    return SimpleNamespace(
+        chat=AsyncMock(
+            return_value={"message": {"content": "ok"}, "done_reason": "stop"}
+        ),
+        _client=SimpleNamespace(aclose=AsyncMock()),
+    )
+
+
+async def _sent_options(**generation_kwargs):
+    fake_client = _make_fake_client()
+    with patch("lightrag.llm.ollama.ollama.AsyncClient", return_value=fake_client):
+        result = await _ollama_model_if_cache(
+            model="test-model",
+            prompt="hello",
+            **generation_kwargs,
+        )
+
+    assert result == "ok"
+    return fake_client.chat.call_args.kwargs.get("options")
+
+
+@pytest.mark.parametrize(
+    ("generation_kwargs", "expected_options"),
+    [
+        pytest.param(
+            {"max_tokens": 37},
+            {"num_predict": 37},
+            id="generic-limit-maps-to-num-predict",
+        ),
+        pytest.param(
+            {"max_tokens": 37, "options": {"temperature": 0.2}},
+            {"temperature": 0.2, "num_predict": 37},
+            id="generic-limit-preserves-other-options",
+        ),
+        pytest.param(
+            {"options": {"num_predict": 41}},
+            {"num_predict": 41},
+            id="native-limit-is-preserved",
+        ),
+        pytest.param(
+            {"max_tokens": 37, "options": {"num_predict": 41}},
+            {"num_predict": 41},
+            id="native-limit-takes-precedence",
+        ),
+    ],
+)
+async def test_max_tokens_alias_precedence(generation_kwargs, expected_options):
+    assert await _sent_options(**generation_kwargs) == expected_options
+
+
+async def test_mapping_options_are_not_mutated():
+    shared_options = {"temperature": 0.2}
+
+    assert await _sent_options(max_tokens=37, options=shared_options) == {
+        "temperature": 0.2,
+        "num_predict": 37,
+    }
+    assert shared_options == {"temperature": 0.2}
+
+
+async def test_ollama_options_object_is_copied_when_alias_is_applied():
+    shared_options = ollama_binding.ollama.Options(temperature=0.2)
+
+    sent_options = await _sent_options(max_tokens=37, options=shared_options)
+
+    assert sent_options.num_predict == 37
+    assert sent_options.temperature == 0.2
+    assert shared_options.num_predict is None
+
+
+async def test_native_value_in_ollama_options_object_takes_precedence():
+    shared_options = ollama_binding.ollama.Options(num_predict=41)
+
+    sent_options = await _sent_options(max_tokens=37, options=shared_options)
+
+    assert sent_options is shared_options
+    assert sent_options.num_predict == 41


### PR DESCRIPTION
## Description

The Ollama adapter discarded the generic `max_tokens` value before generation. This change maps it to Ollama’s native `options.num_predict` setting.

## Related Issues

No related issue.

## Changes Made

- Map `max_tokens` to `options.num_predict`.
- Preserve an explicitly configured native `num_predict` value.
- Avoid mutating caller-owned options.
- Add regression tests for mapping and precedence behaviour.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not required)
- [x] Unit tests added

## Test Results

- New regression tests: 7 passed
- Full Ollama test suite: 27 passed
- Fails-before behaviour reproduced on unmodified `main`
- `pre-commit run --all-files`: passed
- `git diff --check`: passed

## Additional Notes

Existing native Ollama configuration remains unchanged because `num_predict` takes precedence over the generic alias.