### PR TITLE
perf(faiss): defer vector deletes to flush time

### DIFF
--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -2,6 +2,7 @@ import glob
 import os
 import time
 import asyncio
+from hashlib import md5
 from typing import Any, final
 import json
 import numpy as np
@@ -251,11 +252,25 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # docstring). An eager delete rebuilt the whole IndexFlatIP per call
         # and the merge stage deletes once per relation (#3681).
         self._pending_deletes: set[str] = set()
+        # Redo log: removals already applied to self._index / self._id_to_meta
+        # but not yet on disk, kept as custom id -> _row_fingerprint(removed
+        # row). If a save fails and a reload replaces the in-memory state with
+        # the on-disk snapshot, the removed rows come back; replaying this log
+        # after the reload removes them again. The fingerprint (not the bare
+        # id) ensures a replay only removes the row version it removed before,
+        # never a newer row another writer published under the same
+        # content-hash id. Cleared once a save lands. See delete's docstring.
+        self._unsaved_deletes: dict[str, str] = {}
         # True when self._index / self._id_to_meta have materialized changes
         # that have not been successfully saved to disk yet. This lets
         # finalize retry a save even after a previous flush cleared the
         # pending buffer (see _flush_pending_locked / index_done_callback).
         self._index_dirty = False
+        # True when part of that unsaved state is materialized *upserts*.
+        # Those rows exist nowhere else, so a reload would drop them (see
+        # finalize); removals do not need the same protection because
+        # _unsaved_deletes replays them on top of the reloaded snapshot.
+        self._unsaved_upserts = False
 
         # Sweep orphan tmp siblings left behind by hard kills mid-save.
         # The meta file also needs an extra pattern: legacy versions of this
@@ -498,6 +513,50 @@ class FaissVectorDBStorage(BaseVectorStorage):
         ``self._index`` / ``self._id_to_meta`` — the row could silently
         reappear. A queued id is applied *after* that reload, so it survives.
 
+        Two buffers, because the flush and the save can fail independently
+        (the same protocol Nano documents, #3680):
+
+            * ``_pending_deletes`` — queued, not applied to the index yet.
+            * ``_unsaved_deletes`` — applied to the index but not yet on
+              disk, kept as ``id -> a fingerprint of the removed row``.
+              This is a redo log, not a pending buffer.
+
+        The redo log exists because a removal that reached ``self._index``
+        can still be undone: if the save fails, the next
+        ``index_done_callback``'s unconditional reload replaces the in-memory
+        state with the on-disk snapshot and the row returns. Replaying the
+        log after that reload removes it again, so the reload stays lossless
+        for deletes. (Upserts have no equivalent log — a materialized-but-
+        unsaved upsert is still dropped by the same reload; ``finalize``
+        protects those by skipping the reload instead, via
+        ``_unsaved_upserts``.)
+
+        A replay matches on the row, not on the id alone. Ids are content
+        hashes, so another writer can publish a *new* row under an id we
+        removed, and deleting by id would destroy it. The log therefore
+        stores ``_row_fingerprint`` of the row it removed and a replay
+        removes only a row that still matches it. The two buffers are scoped
+        differently on purpose: ``_pending_deletes`` holds a *request* — the
+        flush removes whatever row carries that id, the by-id contract purge
+        relies on — while ``_unsaved_deletes`` holds a *record* of a removal
+        that already happened, so replaying it must not remove a row that
+        has since taken the id's place.
+
+        The read-your-writes paths mirror both rules: a queued id reads as
+        absent, while a logged one hides only the row the entry names — a
+        replacement the replay would preserve stays readable. An ``upsert``
+        cancels a *queued* delete for the same id but never touches the redo
+        log: the buffered row may be discarded by an aborting batch before
+        it materializes, and dropping the entry then would leave the reload
+        nothing to replay. Ids that matched no row are not logged at all.
+        The log is cleared once a save lands; an aborting batch keeps it
+        (``drop_pending_index_ops`` discards buffered work, not removals
+        that already reached the index). ``delete_entity_relation`` stays
+        eager — it is off the merge hot path — but its removals are
+        applied-and-unsaved just the same, so they are recorded in the log
+        too. Both buffers are in-memory only: they are dropped by ``drop``
+        and lost on a crash before the flush.
+
         Persistence:
             Queued ids are in-memory only: they land on the index at the next
             ``index_done_callback`` / ``finalize`` flush and are lost on a
@@ -588,7 +647,18 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 or meta.get("tgt_id") == entity_name
             ]
             if relations:
+                # Applied-but-unsaved like a flushed delete: record the
+                # removals in the redo log (queued requests for the same
+                # ids are now redundant), or a failed save plus a reload
+                # resurrects the rows.
+                removed = {
+                    meta["__id__"]: self._row_fingerprint(meta)
+                    for meta in (self._id_to_meta[fid] for fid in relations)
+                    if meta.get("__id__") is not None
+                }
                 self._remove_faiss_ids_locked(relations)
+                self._pending_deletes.difference_update(removed)
+                self._unsaved_deletes.update(removed)
                 self._index_dirty = True
 
             # Materialized rebuild succeeded — safe to prune matching
@@ -692,6 +762,31 @@ class FaissVectorDBStorage(BaseVectorStorage):
             self._index.add(arr)
         self._id_to_meta = new_id_to_meta
 
+    @staticmethod
+    def _row_fingerprint(meta: dict[str, Any]) -> str:
+        """Identify one *version* of a stored row.
+
+        The redo log has to name the exact row it removed so a replay after
+        a reload cannot hit a newer row another writer published under the
+        same (content-hash) id. The digest covers the stored metadata record
+        — id, timestamp, every meta field — **excluding** ``__vector__``:
+        ``_save_faiss_index`` strips the vector from ``.meta.json`` and
+        ``_load_faiss_index`` / ``_remove_faiss_ids_locked`` re-attach it
+        lazily (``index.reconstruct``), so its presence on a row is not
+        stable across a save/reload round-trip and including it would make
+        the same row stop matching its own log entry. Everything else
+        round-trips through ``json.dump``/``json.load`` unchanged; sorted
+        keys make key order irrelevant and ``default=str`` keeps the dump
+        total. The vector adds no identity anyway — it is a deterministic
+        function of the content already covered by the digest.
+        """
+        canonical = json.dumps(
+            {k: v for k, v in meta.items() if k != "__vector__"},
+            sort_keys=True,
+            default=str,
+        )
+        return md5(canonical.encode("utf-8")).hexdigest()
+
     async def _flush_pending_locked(self) -> None:
         """Embed pending docs and materialize them into ``self._index`` + ``self._id_to_meta``.
 
@@ -707,9 +802,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
         newly embedded vectors go through ``faiss.normalize_L2``.
 
         Failure handling:
-            * Queued deletes are applied first; a delete batch that lands on
-              ``self._index`` is not replayed on a later retry, while one
-              whose rebuild raises stays queued for the retry.
+            * Queued deletes are applied first; one that lands on
+              ``self._index`` moves into the ``_unsaved_deletes`` redo log
+              (replayed after any reload until a save persists it), while
+              one whose rebuild raises stays queued for the retry.
             * Embedding error / count mismatch → raises before any mutation
               to ``self._index`` / ``self._id_to_meta``; ``_pending_upserts``
               is left intact and ``self._index_dirty`` is not touched.
@@ -725,7 +821,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
               dirty flag is reserved for "materialized but unsaved",
               which is only true after ``index.add`` completes.
         """
-        if not self._pending_upserts and not self._pending_deletes:
+        if (
+            not self._pending_upserts
+            and not self._pending_deletes
+            and not self._unsaved_deletes
+        ):
             return
 
         # Apply every deferred delete in ONE pass + ONE index rebuild —
@@ -734,15 +834,26 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # (upsert also cancels the queued delete, but a delete queued after
         # the upsert must still win over the *materialized* stale row).
         # One scan of ``_id_to_meta`` for the whole queued set instead of
-        # one full scan per deleted id (#3681).
-        if self._pending_deletes:
-            queued = self._pending_deletes
-            to_remove = [
-                fid
-                for fid, meta in self._id_to_meta.items()
-                if meta.get("__id__") in queued
-            ]
-            # Clear the queue only after the rebuild succeeds: if
+        # one full scan per deleted id (#3681). A queued id removes whatever
+        # row carries it; a replayed one (redo log, after a reload undid an
+        # unsaved removal) only removes the row version it removed before,
+        # so anything written under that id since — by another writer or by
+        # us — survives.
+        if self._pending_deletes or self._unsaved_deletes:
+            queued = len(self._pending_deletes)
+            matched: dict[str, str] = {}
+            to_remove: list[int] = []
+            for fid, meta in self._id_to_meta.items():
+                doc_id = meta.get("__id__")
+                if doc_id in self._pending_deletes:
+                    to_remove.append(fid)
+                    matched[doc_id] = self._row_fingerprint(meta)
+                elif doc_id in self._unsaved_deletes:
+                    fingerprint = self._row_fingerprint(meta)
+                    if fingerprint == self._unsaved_deletes[doc_id]:
+                        to_remove.append(fid)
+                        matched[doc_id] = fingerprint
+            # Consume the queue only after the rebuild succeeds: if
             # ``_remove_faiss_ids_locked`` raises (FAISS rebuild failure),
             # the tombstones must survive so the next
             # ``index_done_callback`` retry re-applies them instead of
@@ -750,10 +861,15 @@ class FaissVectorDBStorage(BaseVectorStorage):
             if to_remove:
                 self._remove_faiss_ids_locked(to_remove)
                 self._index_dirty = True
+            # Removals that landed move into the redo log until a save
+            # persists them; ids that matched no row have nothing to
+            # persist and are not logged at all.
+            self._unsaved_deletes.update(matched)
             self._pending_deletes = set()
             logger.info(
                 f"[{self.workspace}] {self.namespace} flush: applied "
-                f"{len(to_remove)} deferred vector deletes"
+                f"{len(to_remove)} deferred vector deletes ({queued} queued, "
+                f"{len(self._unsaved_deletes)} awaiting save)"
             )
 
         if not self._pending_upserts:
@@ -824,6 +940,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
             self._id_to_meta[fid] = record
 
         self._index_dirty = True
+        self._unsaved_upserts = True
 
         # Clear only the entries we just flushed. Today the non-reentrant
         # _storage_lock locks out concurrent upserts for the entire flush
@@ -835,6 +952,19 @@ class FaissVectorDBStorage(BaseVectorStorage):
         for doc_id, pdoc in pending_items:
             if self._pending_upserts.get(doc_id) is pdoc:
                 del self._pending_upserts[doc_id]
+
+        if self._unsaved_deletes:
+            # A row we just wrote can be indistinguishable from one we
+            # removed (same id, same fingerprint) — the single case the
+            # fingerprint cannot separate, and the one case where dropping
+            # the redo entry costs nothing: a resurrection would restore the
+            # row that is present now. Only rows written just above can
+            # match here; a resurrected one was already removed by the
+            # replay at the top of this flush.
+            for meta in self._id_to_meta.values():
+                logged = self._unsaved_deletes.get(meta.get("__id__"))
+                if logged is not None and logged == self._row_fingerprint(meta):
+                    del self._unsaved_deletes[meta.get("__id__")]
 
     def _save_faiss_index(self):
         """Atomically persist ``self._index`` + ``self._id_to_meta`` to disk.
@@ -965,6 +1095,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
         writes are dropped anyway. Rolling back only FAISS/Nano would add an
         inconsistent, non-load-bearing "FAILED == clean" guarantee, so it is
         deliberately omitted.
+
+        Deletes split along that same line. ``_pending_deletes`` is buffered
+        work and is discarded; ``_unsaved_deletes`` is the redo log of
+        removals that already reached ``self._index``, so it is **kept** —
+        dropping it would neither restore the rows nor keep them gone, it
+        would only make the removal fragile again, which is the exact state
+        this log exists to end.
         """
         if self._storage_lock is None:
             self._pending_upserts.clear()
@@ -1010,9 +1147,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
             # True (if only the save failed) for a later retry.
             await self._flush_pending_locked()
             self._save_faiss_index()
+            self._unsaved_deletes.clear()  # the removals are durable now
             await set_all_update_flags(self.namespace, workspace=self.workspace)
             self.storage_updated.value = False
             self._index_dirty = False
+            self._unsaved_upserts = False
             return True
 
     @staticmethod
@@ -1024,6 +1163,18 @@ class FaissVectorDBStorage(BaseVectorStorage):
             "created_at": dp.get("__created_at__"),
         }
 
+    def _matches_redo_entry(
+        self, meta: dict[str, Any], fingerprint: str | None
+    ) -> bool:
+        """True when a materialized row is the one a redo entry removed.
+
+        ``fingerprint`` is the value snapshotted from ``_unsaved_deletes``
+        under the lock (``None`` when the id is not logged). A row that no
+        longer matches took the id's place after the removal, and the replay
+        deliberately preserves it — so the read paths must show it.
+        """
+        return fingerprint is not None and fingerprint == self._row_fingerprint(meta)
+
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         """Get vector data by its ID (read-your-writes against the pending buffer).
 
@@ -1034,20 +1185,24 @@ class FaissVectorDBStorage(BaseVectorStorage):
             The vector data if found, or None if not found
         """
         # Read-your-writes: a buffered upsert is visible before its flush,
-        # and a queued delete hides the materialized row.
+        # a queued delete hides the materialized row, and a redo-log entry
+        # hides only the row version it removed (see _matches_redo_entry).
         async with self._storage_lock:
             pending = self._pending_upserts.get(id)
             if pending is not None:
                 return self._format_record(pending.record)
             if id in self._pending_deletes:
                 return None
+            logged = self._unsaved_deletes.get(id)
 
         await self._get_index()  # reload-if-stale
         fid = self._find_faiss_id_by_custom_id(id)
         if fid is None:
             return None
         metadata = self._id_to_meta.get(fid)
-        return self._format_record(metadata) if metadata else None
+        if not metadata or self._matches_redo_entry(metadata, logged):
+            return None
+        return self._format_record(metadata)
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         """Get multiple vector data by their IDs (read-your-writes), preserving order.
@@ -1063,10 +1218,12 @@ class FaissVectorDBStorage(BaseVectorStorage):
             return []
 
         # Read-your-writes: serve buffered upserts from the pending area,
-        # hide ids with a queued delete, and only query the materialized
-        # index for the remaining ids.
+        # hide ids with a queued delete (a redo-log entry hides only the row
+        # version it removed), and only query the materialized index for the
+        # remaining ids.
         result_map: dict[str, dict[str, Any]] = {}
         remaining: list[str] = []
+        logged: dict[str, str] = {}
         async with self._storage_lock:
             for requested_id in ids:
                 pending = self._pending_upserts.get(requested_id)
@@ -1075,6 +1232,8 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 elif requested_id in self._pending_deletes:
                     continue
                 else:
+                    if requested_id in self._unsaved_deletes:
+                        logged[requested_id] = self._unsaved_deletes[requested_id]
                     remaining.append(requested_id)
 
         if remaining:
@@ -1084,7 +1243,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 if fid is None:
                     continue
                 metadata = self._id_to_meta.get(fid)
-                if metadata:
+                if metadata and not self._matches_redo_entry(metadata, logged.get(cid)):
                     result_map[str(cid)] = self._format_record(metadata)
 
         return [result_map.get(str(requested_id)) for requested_id in ids]
@@ -1109,6 +1268,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
         vectors_dict: dict[str, list[float]] = {}
         remaining: list[str] = []
+        logged: dict[str, str] = {}
         async with self._storage_lock:
             to_embed: list[tuple[str, _PendingFaissDoc]] = []
             for requested_id in ids:
@@ -1118,6 +1278,8 @@ class FaissVectorDBStorage(BaseVectorStorage):
                         # Queued delete: the materialized row (if any) is
                         # about to go away — report it as absent.
                         continue
+                    if requested_id in self._unsaved_deletes:
+                        logged[requested_id] = self._unsaved_deletes[requested_id]
                     remaining.append(requested_id)
                 elif pending.vector is not None:
                     vectors_dict[requested_id] = pending.vector.astype(
@@ -1158,6 +1320,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 if fid is None or fid not in self._id_to_meta:
                     continue
                 metadata = self._id_to_meta[fid]
+                if self._matches_redo_entry(metadata, logged.get(cid)):
+                    # Redo-log entry: this is the row version an unsaved
+                    # delete removed — report it as absent.
+                    continue
                 if "__vector__" in metadata:
                     vectors_dict[cid] = metadata["__vector__"]
 
@@ -1190,10 +1356,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
         """
         try:
             async with self._storage_lock:
-                # Discard buffered (unflushed) upserts and queued deletes
-                # along with the data.
+                # Discard buffered (unflushed) upserts, queued deletes and
+                # the redo log along with the data.
                 self._pending_upserts.clear()
                 self._pending_deletes.clear()
+                self._unsaved_deletes.clear()
 
                 # Reset the index
                 self._index = faiss.IndexFlatIP(self._dim)
@@ -1208,6 +1375,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 self._id_to_meta = {}
                 self._load_faiss_index()
                 self._index_dirty = False
+                self._unsaved_upserts = False
 
                 # Notify other processes
                 await set_all_update_flags(self.namespace, workspace=self.workspace)
@@ -1227,15 +1395,20 @@ class FaissVectorDBStorage(BaseVectorStorage):
         """Flush buffered upserts/deletes and persist before shutdown (safety net).
 
         Normally ``index_done_callback`` has already drained the pending
-        buffers and synced to disk, but two paths land here with work to do:
+        buffers and synced to disk, but three paths land here with work to do:
 
         - **Pending upserts/deletes only** (no prior ``index_done_callback``): flush
           and save. We reload first so a stale process picks up other
           writers' commits before merging its pending buffers in.
-        - **Unsaved materialized changes** (``_index_dirty=True``): an
-          earlier ``index_done_callback`` flushed pending into ``self._index``
-          but its save raised. Skip the reload — reloading would drop those
-          materialized-but-unsaved rows — and just retry the save.
+        - **Unsaved materialized upserts** (``_unsaved_upserts=True``): an
+          earlier ``index_done_callback`` materialized rows into
+          ``self._index`` but its save raised. Skip the reload — those rows
+          exist nowhere else — and just retry the save.
+        - **Unsaved removals only** (``_index_dirty`` set by deletes alone):
+          reloading is safe and necessary here. ``_unsaved_deletes`` replays
+          the removals on top of the snapshot, whereas skipping the reload
+          would write our pre-commit snapshot over another writer's durable
+          rows.
 
         Flush / save failures propagate (same contract as
         ``index_done_callback``); a partially flushed buffer is preserved
@@ -1245,18 +1418,29 @@ class FaissVectorDBStorage(BaseVectorStorage):
             if (
                 not self._pending_upserts
                 and not self._pending_deletes
+                and not self._unsaved_deletes
                 and not self._index_dirty
             ):
                 return
-            if self._pending_upserts or self._pending_deletes:
-                # Only reload when we have nothing un-persisted in self._index.
-                # A dirty index carries successfully-flushed-but-unsaved rows
-                # from a prior index_done_callback; reloading would silently
-                # drop them.
-                if not self._index_dirty:
+            if self._pending_upserts or self._pending_deletes or self._unsaved_deletes:
+                # Reload unless self._index carries unsaved *upserts*: those
+                # rows exist nowhere else, so a reload would silently drop
+                # them. Unsaved removals are not a reason to skip it —
+                # _unsaved_deletes replays them on top of whatever the other
+                # writer committed, while skipping would save our pre-commit
+                # snapshot over their durable rows.
+                if not self._unsaved_upserts:
                     self._reload_index_from_disk_locked(for_write=True)
                 await self._flush_pending_locked()
+            if not self._index_dirty:
+                # The flush changed nothing (e.g. every queued delete
+                # targeted an id that is not in the index). Saving here
+                # would rewrite both files and flag every other process
+                # for a full reload for no reason.
+                return
             self._save_faiss_index()
+            self._unsaved_deletes.clear()  # the removals are durable now
             await set_all_update_flags(self.namespace, workspace=self.workspace)
             self.storage_updated.value = False
             self._index_dirty = False
+            self._unsaved_upserts = False

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -253,14 +253,17 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # and the merge stage deletes once per relation (#3681).
         self._pending_deletes: set[str] = set()
         # Redo log: removals already applied to self._index / self._id_to_meta
-        # but not yet on disk, kept as custom id -> _row_fingerprint(removed
-        # row). If a save fails and a reload replaces the in-memory state with
-        # the on-disk snapshot, the removed rows come back; replaying this log
-        # after the reload removes them again. The fingerprint (not the bare
-        # id) ensures a replay only removes the row version it removed before,
-        # never a newer row another writer published under the same
-        # content-hash id. Cleared once a save lands. See delete's docstring.
-        self._unsaved_deletes: dict[str, str] = {}
+        # but not yet on disk, kept as custom id -> {_row_fingerprint(removed
+        # row), ...}. If a save fails and a reload replaces the in-memory state
+        # with the on-disk snapshot, the removed rows come back; replaying this
+        # log after the reload removes them again. The fingerprint (not the
+        # bare id) ensures a replay only removes the row versions it removed
+        # before, never a newer row another writer published under the same
+        # content-hash id. A *set* per id because a legacy / corrupt store can
+        # hold several rows under one id (see _find_faiss_ids_by_custom_id):
+        # the delete removes all of them, so the replay has to name all of
+        # them. Cleared once a save lands. See delete's docstring.
+        self._unsaved_deletes: dict[str, set[str]] = {}
         # True when self._index / self._id_to_meta have materialized changes
         # that have not been successfully saved to disk yet. This lets
         # finalize retry a save even after a previous flush cleared the
@@ -518,7 +521,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
             * ``_pending_deletes`` — queued, not applied to the index yet.
             * ``_unsaved_deletes`` — applied to the index but not yet on
-              disk, kept as ``id -> a fingerprint of the removed row``.
+              disk, kept as ``id -> {fingerprints of the removed rows}``.
               This is a redo log, not a pending buffer.
 
         The redo log exists because a removal that reached ``self._index``
@@ -534,8 +537,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
         A replay matches on the row, not on the id alone. Ids are content
         hashes, so another writer can publish a *new* row under an id we
         removed, and deleting by id would destroy it. The log therefore
-        stores ``_row_fingerprint`` of the row it removed and a replay
-        removes only a row that still matches it. The two buffers are scoped
+        stores the ``_row_fingerprint`` of every row it removed — a set per
+        id, because a legacy / corrupt store can hold several rows under one
+        id and ``delete`` removes all of them (see
+        ``_find_faiss_ids_by_custom_id``) — and a replay removes only rows
+        that still match one of them. The two buffers are scoped
         differently on purpose: ``_pending_deletes`` holds a *request* — the
         flush removes whatever row carries that id, the by-id contract purge
         relies on — while ``_unsaved_deletes`` holds a *record* of a removal
@@ -651,14 +657,20 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 # removals in the redo log (queued requests for the same
                 # ids are now redundant), or a failed save plus a reload
                 # resurrects the rows.
-                removed = {
-                    meta["__id__"]: self._row_fingerprint(meta)
-                    for meta in (self._id_to_meta[fid] for fid in relations)
-                    if meta.get("__id__") is not None
-                }
+                removed: dict[str, set[str]] = {}
+                for fid in relations:
+                    meta = self._id_to_meta[fid]
+                    doc_id = meta.get("__id__")
+                    if doc_id is not None:
+                        # Accumulate: a corrupt store can carry several rows
+                        # under one id and all of them are being removed.
+                        removed.setdefault(doc_id, set()).add(
+                            self._row_fingerprint(meta)
+                        )
                 self._remove_faiss_ids_locked(relations)
                 self._pending_deletes.difference_update(removed)
-                self._unsaved_deletes.update(removed)
+                for doc_id, fingerprints in removed.items():
+                    self._unsaved_deletes.setdefault(doc_id, set()).update(fingerprints)
                 self._index_dirty = True
 
             # Materialized rebuild succeeded — safe to prune matching
@@ -841,18 +853,22 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # us — survives.
         if self._pending_deletes or self._unsaved_deletes:
             queued = len(self._pending_deletes)
-            matched: dict[str, str] = {}
+            matched: dict[str, set[str]] = {}
             to_remove: list[int] = []
             for fid, meta in self._id_to_meta.items():
                 doc_id = meta.get("__id__")
                 if doc_id in self._pending_deletes:
+                    # Find-all: every row carrying the id goes, so every
+                    # removed version has to be logged — a single fingerprint
+                    # per id would let the unlogged duplicates of a corrupt
+                    # store survive the replay.
                     to_remove.append(fid)
-                    matched[doc_id] = self._row_fingerprint(meta)
+                    matched.setdefault(doc_id, set()).add(self._row_fingerprint(meta))
                 elif doc_id in self._unsaved_deletes:
                     fingerprint = self._row_fingerprint(meta)
-                    if fingerprint == self._unsaved_deletes[doc_id]:
+                    if fingerprint in self._unsaved_deletes[doc_id]:
                         to_remove.append(fid)
-                        matched[doc_id] = fingerprint
+                        matched.setdefault(doc_id, set()).add(fingerprint)
             # Consume the queue only after the rebuild succeeds: if
             # ``_remove_faiss_ids_locked`` raises (FAISS rebuild failure),
             # the tombstones must survive so the next
@@ -863,8 +879,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 self._index_dirty = True
             # Removals that landed move into the redo log until a save
             # persists them; ids that matched no row have nothing to
-            # persist and are not logged at all.
-            self._unsaved_deletes.update(matched)
+            # persist and are not logged at all. Union rather than replace:
+            # an id already logged may have versions this pass did not see
+            # (a row another writer has not published back yet).
+            for doc_id, fingerprints in matched.items():
+                self._unsaved_deletes.setdefault(doc_id, set()).update(fingerprints)
             self._pending_deletes = set()
             logger.info(
                 f"[{self.workspace}] {self.namespace} flush: applied "
@@ -962,9 +981,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
             # match here; a resurrected one was already removed by the
             # replay at the top of this flush.
             for meta in self._id_to_meta.values():
-                logged = self._unsaved_deletes.get(meta.get("__id__"))
-                if logged is not None and logged == self._row_fingerprint(meta):
-                    del self._unsaved_deletes[meta.get("__id__")]
+                doc_id = meta.get("__id__")
+                logged = self._unsaved_deletes.get(doc_id)
+                if logged is None:
+                    continue
+                logged.discard(self._row_fingerprint(meta))
+                if not logged:
+                    del self._unsaved_deletes[doc_id]
 
     def _save_faiss_index(self):
         """Atomically persist ``self._index`` + ``self._id_to_meta`` to disk.
@@ -1164,16 +1187,18 @@ class FaissVectorDBStorage(BaseVectorStorage):
         }
 
     def _matches_redo_entry(
-        self, meta: dict[str, Any], fingerprint: str | None
+        self, meta: dict[str, Any], fingerprints: set[str] | None
     ) -> bool:
-        """True when a materialized row is the one a redo entry removed.
+        """True when a materialized row is one a redo entry removed.
 
-        ``fingerprint`` is the value snapshotted from ``_unsaved_deletes``
-        under the lock (``None`` when the id is not logged). A row that no
-        longer matches took the id's place after the removal, and the replay
-        deliberately preserves it — so the read paths must show it.
+        ``fingerprints`` is the set snapshotted from ``_unsaved_deletes``
+        under the lock (``None`` when the id is not logged) — a set because
+        a corrupt store can hold several rows under one id and the delete
+        removed all of them. A row matching none of them took the id's place
+        after the removal, and the replay deliberately preserves it — so the
+        read paths must show it.
         """
-        return fingerprint is not None and fingerprint == self._row_fingerprint(meta)
+        return fingerprints is not None and self._row_fingerprint(meta) in fingerprints
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         """Get vector data by its ID (read-your-writes against the pending buffer).
@@ -1193,7 +1218,8 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 return self._format_record(pending.record)
             if id in self._pending_deletes:
                 return None
-            logged = self._unsaved_deletes.get(id)
+            snapshot = self._unsaved_deletes.get(id)
+            logged = set(snapshot) if snapshot is not None else None
 
         await self._get_index()  # reload-if-stale
         fid = self._find_faiss_id_by_custom_id(id)
@@ -1223,7 +1249,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # remaining ids.
         result_map: dict[str, dict[str, Any]] = {}
         remaining: list[str] = []
-        logged: dict[str, str] = {}
+        logged: dict[str, set[str]] = {}
         async with self._storage_lock:
             for requested_id in ids:
                 pending = self._pending_upserts.get(requested_id)
@@ -1233,7 +1259,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
                     continue
                 else:
                     if requested_id in self._unsaved_deletes:
-                        logged[requested_id] = self._unsaved_deletes[requested_id]
+                        logged[requested_id] = set(self._unsaved_deletes[requested_id])
                     remaining.append(requested_id)
 
         if remaining:
@@ -1268,7 +1294,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
         vectors_dict: dict[str, list[float]] = {}
         remaining: list[str] = []
-        logged: dict[str, str] = {}
+        logged: dict[str, set[str]] = {}
         async with self._storage_lock:
             to_embed: list[tuple[str, _PendingFaissDoc]] = []
             for requested_id in ids:
@@ -1279,7 +1305,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
                         # about to go away — report it as absent.
                         continue
                     if requested_id in self._unsaved_deletes:
-                        logged[requested_id] = self._unsaved_deletes[requested_id]
+                        logged[requested_id] = set(self._unsaved_deletes[requested_id])
                     remaining.append(requested_id)
                 elif pending.vector is not None:
                     vectors_dict[requested_id] = pending.vector.astype(

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -707,8 +707,9 @@ class FaissVectorDBStorage(BaseVectorStorage):
         newly embedded vectors go through ``faiss.normalize_L2``.
 
         Failure handling:
-            * Queued deletes are applied first and are not replayed on a
-              later retry (they already landed on ``self._index``).
+            * Queued deletes are applied first; a delete batch that lands on
+              ``self._index`` is not replayed on a later retry, while one
+              whose rebuild raises stays queued for the retry.
             * Embedding error / count mismatch → raises before any mutation
               to ``self._index`` / ``self._id_to_meta``; ``_pending_upserts``
               is left intact and ``self._index_dirty`` is not touched.
@@ -741,10 +742,15 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 for fid, meta in self._id_to_meta.items()
                 if meta.get("__id__") in queued
             ]
-            self._pending_deletes = set()
+            # Clear the queue only after the rebuild succeeds: if
+            # ``_remove_faiss_ids_locked`` raises (FAISS rebuild failure),
+            # the tombstones must survive so the next
+            # ``index_done_callback`` retry re-applies them instead of
+            # persisting the stale rows as if the deletes had happened.
             if to_remove:
                 self._remove_faiss_ids_locked(to_remove)
                 self._index_dirty = True
+            self._pending_deletes = set()
             logger.info(
                 f"[{self.workspace}] {self.namespace} flush: applied "
                 f"{len(to_remove)} deferred vector deletes"

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -548,6 +548,22 @@ class FaissVectorDBStorage(BaseVectorStorage):
         that already happened, so replaying it must not remove a row that
         has since taken the id's place.
 
+        **Boundary of that guarantee.** Successor preservation is only as
+        sharp as content-based identity, and one case it cannot resolve is a
+        successor *identical* to the row removed. ``__created_at__`` does not
+        break the tie — ``upsert`` stamps ``int(time.time())``, so a rewrite
+        inside the same second carries the same timestamp. Where we are the
+        ones re-materializing such a row the flush drops the redo entry (see
+        the bottom of ``_flush_pending_locked``), which costs nothing: a
+        resurrection would only restore the row that is present anyway. What
+        remains is a byte-identical row published by *another writer*, which
+        no content-based identity can tell from the row we deleted, so the
+        replay removes it. Distinguishing it would take a per-write
+        generation persisted in the record — a storage-format change, and a
+        divergence from the Nano protocol this mirrors — for a case that
+        already presupposes the *Single writer* invariant above being
+        violated (see class docstring, *Concurrency invariants*).
+
         The read-your-writes paths mirror both rules: a queued id reads as
         absent, while a logged one hides only the row the entry names — a
         replacement the replay would preserve stays readable. An ``upsert``

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -246,6 +246,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # it never duplicates rows already added to the Faiss index. Flushed
         # under _storage_lock by _flush_pending_locked().
         self._pending_upserts: dict[str, _PendingFaissDoc] = {}
+        # Custom ids queued for removal, applied in one batched index rebuild
+        # by _flush_pending_locked (see *Deferred-delete protocol* in delete's
+        # docstring). An eager delete rebuilt the whole IndexFlatIP per call
+        # and the merge stage deletes once per relation (#3681).
+        self._pending_deletes: set[str] = set()
         # True when self._index / self._id_to_meta have materialized changes
         # that have not been successfully saved to disk yet. This lets
         # finalize retry a save even after a previous flush cleared the
@@ -378,6 +383,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # may have cached (content-version change -> must re-embed new content).
         async with self._storage_lock:
             for doc_id, record in pending:
+                # A fresh upsert supersedes a queued delete for the same id:
+                # the flush materializes the new row after applying deletes,
+                # so applying the delete would be redundant work. Mirrors the
+                # Nano / PG / Qdrant buffers (#3681).
+                self._pending_deletes.discard(doc_id)
                 self._pending_upserts[doc_id] = _PendingFaissDoc(record=record)
 
     async def query(
@@ -471,41 +481,49 @@ class FaissVectorDBStorage(BaseVectorStorage):
     async def delete(self, ids: list[str]):
         """Delete vectors for the provided custom IDs.
 
-        Persistence:
-            Changes are in-memory only; cross-process visibility requires
-            a subsequent ``index_done_callback``. In ``lightrag.py`` this
-            is handled by ``_insert_done()`` at the end of the document
-            batch. Callers outside the pipeline must persist explicitly.
+        Deletes are **deferred**: each id is queued in
+        ``self._pending_deletes`` (cancelling any pending upsert for it) and
+        every queued id is applied in one batched index rebuild by
+        ``_flush_pending_locked``. The entity/relation merge stage deletes the
+        stale forward/reverse rows once per relation, and an eager delete
+        rebuilt the whole ``IndexFlatIP`` per call — deferring turns that into
+        one rebuild per flush (#3681; the same change #3680 made on Nano, and
+        the contract the Qdrant / PostgreSQL / Milvus / MongoDB / OpenSearch
+        buffers already document).
 
-        Errors propagate to the caller — Faiss delete is destructive enough
-        that document deletion / status updates must not proceed if the
-        vectors were not actually removed. (This intentionally diverges
-        from Nano, whose delete swallows + logs.)
+        Deferring also keeps a delete from being lost across writers: the
+        removal used to be applied to ``self._index`` while still unsaved,
+        and because ``index_done_callback`` reloads from disk unconditionally
+        when another process has committed — a reload that *replaces*
+        ``self._index`` / ``self._id_to_meta`` — the row could silently
+        reappear. A queued id is applied *after* that reload, so it survives.
+
+        Persistence:
+            Queued ids are in-memory only: they land on the index at the next
+            ``index_done_callback`` / ``finalize`` flush and are lost on a
+            crash before it. Cross-process visibility requires the flush.
+
+        Errors propagate to the caller at flush time — Faiss delete is
+        destructive enough that document deletion / status updates must not
+        proceed if the vectors were not actually removed. (This intentionally
+        diverges from Nano, whose delete swallows + logs.)
 
         Args:
             ids: List of custom IDs to be deleted.
         """
-        # Hold the lock so the pending-cancel and the rebuild are a single
-        # critical section against a concurrent flush. Operate on
-        # self._index / self._id_to_meta directly (the lock is
-        # non-reentrant; no _get_index).
+        if not ids:
+            return
+
         async with self._storage_lock:
-            self._reload_index_from_disk_locked(for_write=True)
-
             for doc_id in ids:
+                # Cancel a buffered upsert for the same id; the row is going
+                # away, so embedding it at flush time would be wasted work.
                 self._pending_upserts.pop(doc_id, None)
-
-            # Use the find-all variant so legacy/corrupt stores with
-            # duplicate __id__ rows still get fully cleaned.
-            to_remove: list[int] = []
-            for cid in ids:
-                to_remove.extend(self._find_faiss_ids_by_custom_id(cid))
-            if to_remove:
-                self._remove_faiss_ids_locked(to_remove)
-                self._index_dirty = True
+                self._pending_deletes.add(doc_id)
 
         logger.debug(
-            f"[{self.workspace}] Successfully deleted {len(to_remove)} vectors from {self.namespace}"
+            f"[{self.workspace}] {self.namespace}: queued {len(ids)} vector deletes "
+            f"({len(self._pending_deletes)} pending)"
         )
 
     async def delete_entity(self, entity_name: str) -> None:
@@ -689,6 +707,8 @@ class FaissVectorDBStorage(BaseVectorStorage):
         newly embedded vectors go through ``faiss.normalize_L2``.
 
         Failure handling:
+            * Queued deletes are applied first and are not replayed on a
+              later retry (they already landed on ``self._index``).
             * Embedding error / count mismatch → raises before any mutation
               to ``self._index`` / ``self._id_to_meta``; ``_pending_upserts``
               is left intact and ``self._index_dirty`` is not touched.
@@ -704,6 +724,32 @@ class FaissVectorDBStorage(BaseVectorStorage):
               dirty flag is reserved for "materialized but unsaved",
               which is only true after ``index.add`` completes.
         """
+        if not self._pending_upserts and not self._pending_deletes:
+            return
+
+        # Apply every deferred delete in ONE pass + ONE index rebuild —
+        # before materializing upserts, so an id that was deleted and
+        # re-upserted in the same batch ends up with exactly the new row
+        # (upsert also cancels the queued delete, but a delete queued after
+        # the upsert must still win over the *materialized* stale row).
+        # One scan of ``_id_to_meta`` for the whole queued set instead of
+        # one full scan per deleted id (#3681).
+        if self._pending_deletes:
+            queued = self._pending_deletes
+            to_remove = [
+                fid
+                for fid, meta in self._id_to_meta.items()
+                if meta.get("__id__") in queued
+            ]
+            self._pending_deletes = set()
+            if to_remove:
+                self._remove_faiss_ids_locked(to_remove)
+                self._index_dirty = True
+            logger.info(
+                f"[{self.workspace}] {self.namespace} flush: applied "
+                f"{len(to_remove)} deferred vector deletes"
+            )
+
         if not self._pending_upserts:
             return
 
@@ -916,9 +962,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
         """
         if self._storage_lock is None:
             self._pending_upserts.clear()
+            self._pending_deletes.clear()
             return
         async with self._storage_lock:
             self._pending_upserts.clear()
+            self._pending_deletes.clear()
 
     async def index_done_callback(self) -> bool:
         """Flush deferred embeddings, commit to disk, and notify other processes.
@@ -979,11 +1027,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
         Returns:
             The vector data if found, or None if not found
         """
-        # Read-your-writes: a buffered upsert is visible before its flush.
+        # Read-your-writes: a buffered upsert is visible before its flush,
+        # and a queued delete hides the materialized row.
         async with self._storage_lock:
             pending = self._pending_upserts.get(id)
             if pending is not None:
                 return self._format_record(pending.record)
+            if id in self._pending_deletes:
+                return None
 
         await self._get_index()  # reload-if-stale
         fid = self._find_faiss_id_by_custom_id(id)
@@ -1005,8 +1056,9 @@ class FaissVectorDBStorage(BaseVectorStorage):
         if not ids:
             return []
 
-        # Read-your-writes: serve buffered upserts from the pending area and
-        # only query the materialized index for the remaining ids.
+        # Read-your-writes: serve buffered upserts from the pending area,
+        # hide ids with a queued delete, and only query the materialized
+        # index for the remaining ids.
         result_map: dict[str, dict[str, Any]] = {}
         remaining: list[str] = []
         async with self._storage_lock:
@@ -1014,6 +1066,8 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 pending = self._pending_upserts.get(requested_id)
                 if pending is not None:
                     result_map[str(requested_id)] = self._format_record(pending.record)
+                elif requested_id in self._pending_deletes:
+                    continue
                 else:
                     remaining.append(requested_id)
 
@@ -1054,6 +1108,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
             for requested_id in ids:
                 pending = self._pending_upserts.get(requested_id)
                 if pending is None:
+                    if requested_id in self._pending_deletes:
+                        # Queued delete: the materialized row (if any) is
+                        # about to go away — report it as absent.
+                        continue
                     remaining.append(requested_id)
                 elif pending.vector is not None:
                     vectors_dict[requested_id] = pending.vector.astype(
@@ -1126,8 +1184,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
         """
         try:
             async with self._storage_lock:
-                # Discard buffered (unflushed) upserts along with the data.
+                # Discard buffered (unflushed) upserts and queued deletes
+                # along with the data.
                 self._pending_upserts.clear()
+                self._pending_deletes.clear()
 
                 # Reset the index
                 self._index = faiss.IndexFlatIP(self._dim)
@@ -1158,14 +1218,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
             return {"status": "error", "message": str(e)}
 
     async def finalize(self):
-        """Flush any buffered upserts and persist before shutdown (safety net).
+        """Flush buffered upserts/deletes and persist before shutdown (safety net).
 
         Normally ``index_done_callback`` has already drained the pending
-        buffer and synced to disk, but two paths land here with work to do:
+        buffers and synced to disk, but two paths land here with work to do:
 
-        - **Pending upserts only** (no prior ``index_done_callback``): flush
+        - **Pending upserts/deletes only** (no prior ``index_done_callback``): flush
           and save. We reload first so a stale process picks up other
-          writers' commits before merging its pending buffer in.
+          writers' commits before merging its pending buffers in.
         - **Unsaved materialized changes** (``_index_dirty=True``): an
           earlier ``index_done_callback`` flushed pending into ``self._index``
           but its save raised. Skip the reload — reloading would drop those
@@ -1176,9 +1236,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
         for a future retry.
         """
         async with self._storage_lock:
-            if not self._pending_upserts and not self._index_dirty:
+            if (
+                not self._pending_upserts
+                and not self._pending_deletes
+                and not self._index_dirty
+            ):
                 return
-            if self._pending_upserts:
+            if self._pending_upserts or self._pending_deletes:
                 # Only reload when we have nothing un-persisted in self._index.
                 # A dirty index carries successfully-flushed-but-unsaved rows
                 # from a prior index_done_callback; reloading would silently

--- a/tests/kg/faiss_impl/test_faiss_deferred_delete.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_delete.py
@@ -512,3 +512,61 @@ async def test_finalize_skips_save_when_flush_changes_nothing(tmp_path):
     assert watcher.storage_updated.value is False, (
         "a no-op finalize must not broadcast a reload to other processes"
     )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_replay_removes_every_duplicate_row_under_one_id(tmp_path, monkeypatch):
+    """``delete`` is find-all: it removes every row carrying the id, which a
+    legacy / corrupt store can have several of (``_find_faiss_ids_by_custom_id``
+    exists for exactly that). The redo log must therefore name every removed
+    version — with one fingerprint per id the unlogged duplicates survive the
+    replay and get persisted by the retry, silently undoing part of a delete
+    that reported success."""
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+
+    # Hand-craft the corrupt state: two fids share "dup", different metadata.
+    matrix = np.array([[1.0] * DIM, [2.0] * DIM], dtype=np.float32)
+    faiss.normalize_L2(matrix)
+    storage._index.add(matrix)
+    storage._id_to_meta[0] = {
+        "__id__": "dup",
+        "__created_at__": 1,
+        "content": "v1",
+        "__vector__": matrix[0].tolist(),
+    }
+    storage._id_to_meta[1] = {
+        "__id__": "dup",
+        "__created_at__": 1,
+        "content": "v2",
+        "__vector__": matrix[1].tolist(),
+    }
+    assert await storage.index_done_callback() is True
+    assert len(storage._find_faiss_ids_by_custom_id("dup")) == 2
+
+    # Flush removes both, the save fails: both versions are applied-unsaved.
+    await storage.delete(["dup"])
+    _fail_save(storage, monkeypatch)
+    with pytest.raises(OSError, match="transient disk error"):
+        await storage.index_done_callback()
+    assert storage._find_faiss_ids_by_custom_id("dup") == []
+    assert len(storage._unsaved_deletes["dup"]) == 2, (
+        "every removed version must be logged, not just the last one"
+    )
+    monkeypatch.undo()
+
+    # Another writer commits, so the retry reloads and both rows come back.
+    other = await _make_storage(tmp_path, _CountingEmbed())
+    await _upsert_and_flush(other, {"extra": {"content": "unrelated"}})
+
+    assert await storage.index_done_callback() is True
+    assert storage._find_faiss_ids_by_custom_id("dup") == [], (
+        "the replay must remove every duplicate, not just one"
+    )
+
+    reloaded = await _make_storage(tmp_path, _CountingEmbed())
+    assert reloaded._find_faiss_ids_by_custom_id("dup") == [], (
+        "no duplicate may be persisted by the retry"
+    )
+    assert (await reloaded.get_by_id("extra")) is not None

--- a/tests/kg/faiss_impl/test_faiss_deferred_delete.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_delete.py
@@ -210,3 +210,45 @@ async def test_drop_pending_index_ops_discards_queued_deletes(tmp_path):
     assert (await storage.get_by_id("keep")) is not None, (
         "an aborted batch must discard its queued deletes"
     )
+
+
+@pytest.mark.asyncio
+async def test_failed_delete_rebuild_keeps_tombstones_for_retry(
+    tmp_path, monkeypatch
+):
+    """A FAISS rebuild failure during the delete pass must not consume the
+    queued tombstones: the next ``index_done_callback`` retry re-applies them
+    instead of persisting the stale rows as if they were deleted."""
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(storage, {"x": {"content": "ex"}, "y": {"content": "wy"}})
+    assert len(storage._id_to_meta) == 2
+
+    await storage.delete(["x", "y"])
+
+    def failing_rebuild(fid_list):
+        raise RuntimeError("faiss rebuild boom")
+
+    monkeypatch.setattr(storage, "_remove_faiss_ids_locked", failing_rebuild)
+
+    with pytest.raises(RuntimeError, match="faiss rebuild boom"):
+        await storage.index_done_callback()
+
+    assert storage._pending_deletes == {"x", "y"}, (
+        "tombstones must survive a failed rebuild so the retry re-applies them"
+    )
+    assert len(storage._id_to_meta) == 2, "rows must still be materialized"
+    assert storage._index_dirty is False, "nothing landed, so nothing to save"
+
+    monkeypatch.undo()
+
+    # The retry succeeds and the deletes land exactly once.
+    assert await storage.index_done_callback() is True
+    assert storage._pending_deletes == set()
+    assert len(storage._id_to_meta) == 0
+    assert await storage.get_by_ids(["x", "y"]) == [None, None]
+
+    reloaded = await _make_storage(tmp_path, _CountingEmbed())
+    assert await reloaded.get_by_ids(["x", "y"]) == [None, None], (
+        "the retried deletes must be persisted to disk"
+    )

--- a/tests/kg/faiss_impl/test_faiss_deferred_delete.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_delete.py
@@ -1,0 +1,212 @@
+"""Deferred-delete coverage for ``FaissVectorDBStorage`` (#3681).
+
+``delete`` queues ids in ``_pending_deletes`` instead of rebuilding the
+``IndexFlatIP`` per call; ``_flush_pending_locked`` applies the whole queue in
+one batched rebuild. The entity/relation merge stage deletes the stale
+forward/reverse rows once per relation, so the eager path rebuilt the whole
+index per merged relation — quadratic ingestion, the same defect #3679
+profiled on Nano (#3680 fixed it there). Deferring also keeps a delete from
+being lost when ``index_done_callback`` reloads a newer on-disk snapshot from
+another writer.
+"""
+
+import numpy as np
+import pytest
+
+faiss = pytest.importorskip("faiss")
+
+from lightrag.kg.faiss_impl import FaissVectorDBStorage  # noqa: E402
+from lightrag.kg.shared_storage import (  # noqa: E402
+    finalize_share_data,
+    initialize_share_data,
+)
+from lightrag.utils import EmbeddingFunc  # noqa: E402
+
+DIM = 8
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+class _CountingEmbed:
+    def __init__(self, dim: int = DIM):
+        self.dim = dim
+        self.embedded_texts: list[str] = []
+
+    async def __call__(self, texts, **kwargs):
+        self.embedded_texts.extend(texts)
+        return np.array(
+            [
+                np.full(self.dim, (abs(hash(t)) % 97) + 1, dtype=np.float32)
+                for t in texts
+            ]
+        )
+
+
+async def _make_storage(tmp_path, embed: _CountingEmbed) -> FaissVectorDBStorage:
+    storage = FaissVectorDBStorage(
+        namespace="test_vectors",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 32,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=embed),
+        meta_fields={"content"},
+    )
+    await storage.initialize()
+    return storage
+
+
+async def _upsert_and_flush(storage: FaissVectorDBStorage, data: dict) -> None:
+    await storage.upsert(data)
+    assert await storage.index_done_callback() is True
+
+
+@pytest.mark.asyncio
+async def test_delete_is_deferred_until_one_batched_flush(tmp_path, monkeypatch):
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(
+        storage,
+        {f"rel-{i}": {"content": f"relation {i}"} for i in range(4)},
+    )
+    assert len(storage._id_to_meta) == 4
+
+    rebuild_calls = []
+    original_rebuild = storage._remove_faiss_ids_locked
+
+    def counting_rebuild(fid_list):
+        rebuild_calls.append(list(fid_list))
+        return original_rebuild(fid_list)
+
+    monkeypatch.setattr(storage, "_remove_faiss_ids_locked", counting_rebuild)
+
+    # The merge-stage shape: one delete call per relation.
+    for i in range(4):
+        await storage.delete([f"rel-{i}", f"rel-{i}-reverse"])
+
+    assert rebuild_calls == [], "delete must not rebuild the index eagerly"
+    assert len(storage._id_to_meta) == 4, "materialized rows must survive until flush"
+
+    assert await storage.index_done_callback() is True
+
+    assert len(rebuild_calls) == 1, "the whole queued batch is one rebuild"
+    assert len(storage._id_to_meta) == 0
+    assert await storage.get_by_ids([f"rel-{i}" for i in range(4)]) == [None] * 4
+
+
+@pytest.mark.asyncio
+async def test_delete_cancels_pending_upsert_without_embedding(tmp_path):
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+
+    await storage.upsert({"doomed": {"content": "never embedded"}})
+    await storage.delete(["doomed"])
+
+    assert await storage.index_done_callback() is True
+    assert "doomed" not in embed.embedded_texts, (
+        "a queued delete must cancel the buffered upsert before embedding"
+    )
+    assert await storage.get_by_id("doomed") is None
+
+
+@pytest.mark.asyncio
+async def test_fresh_upsert_supersedes_queued_delete(tmp_path):
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(storage, {"row": {"content": "old"}})
+
+    await storage.delete(["row"])
+    await storage.upsert({"row": {"content": "new"}})
+    assert await storage.index_done_callback() is True
+
+    record = await storage.get_by_id("row")
+    assert record is not None
+    assert record["content"] == "new"
+    # Exactly one materialized row for the custom id.
+    matches = [
+        m for m in storage._id_to_meta.values() if m.get("__id__") == "row"
+    ]
+    assert len(matches) == 1
+
+
+@pytest.mark.asyncio
+async def test_read_your_writes_hides_queued_deletes(tmp_path):
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(
+        storage, {"a": {"content": "alpha"}, "b": {"content": "beta"}}
+    )
+
+    await storage.delete(["a"])
+
+    assert await storage.get_by_id("a") is None
+    got = await storage.get_by_ids(["a", "b"])
+    assert got[0] is None
+    assert got[1] is not None and got[1]["content"] == "beta"
+    assert "a" not in await storage.get_vectors_by_ids(["a", "b"])
+    assert "b" in await storage.get_vectors_by_ids(["a", "b"])
+
+
+@pytest.mark.asyncio
+async def test_finalize_applies_deletes_without_upserts(tmp_path):
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(storage, {"x": {"content": "ex"}})
+
+    await storage.delete(["x"])
+    await storage.finalize()
+
+    reloaded = await _make_storage(tmp_path, _CountingEmbed())
+    assert await reloaded.get_by_id("x") is None, (
+        "finalize alone must persist a queued delete to disk"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dequeued_delete_survives_reload_from_disk(tmp_path):
+    """The lost-delete-across-writers case: a queued id applies after the
+    unconditional reload inside index_done_callback, so a concurrent
+    writer's commit cannot resurrect the row."""
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(storage, {"shared": {"content": "v1"}})
+
+    # Another process commits a newer snapshot...
+    other = await _make_storage(tmp_path, _CountingEmbed())
+    await _upsert_and_flush(other, {"shared": {"content": "v2"}, "extra": {"content": "e"}})
+    # ...and this process's storage_updated flag flips, as set_all_update_flags
+    # would have done, so index_done_callback reloads before flushing.
+    storage.storage_updated.value = True
+
+    await storage.delete(["shared"])
+    assert await storage.index_done_callback() is True
+
+    assert await storage.get_by_id("shared") is None, (
+        "the queued delete must win over the reloaded snapshot"
+    )
+    assert (await storage.get_by_id("extra")) is not None, (
+        "the other writer's row must be preserved"
+    )
+
+
+@pytest.mark.asyncio
+async def test_drop_pending_index_ops_discards_queued_deletes(tmp_path):
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(storage, {"keep": {"content": "kept"}})
+
+    await storage.delete(["keep"])
+    await storage.drop_pending_index_ops()
+    assert await storage.index_done_callback() is True
+
+    assert (await storage.get_by_id("keep")) is not None, (
+        "an aborted batch must discard its queued deletes"
+    )

--- a/tests/kg/faiss_impl/test_faiss_deferred_delete.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_delete.py
@@ -69,6 +69,7 @@ async def _upsert_and_flush(storage: FaissVectorDBStorage, data: dict) -> None:
     assert await storage.index_done_callback() is True
 
 
+@pytest.mark.offline
 @pytest.mark.asyncio
 async def test_delete_is_deferred_until_one_batched_flush(tmp_path, monkeypatch):
     embed = _CountingEmbed()
@@ -102,6 +103,7 @@ async def test_delete_is_deferred_until_one_batched_flush(tmp_path, monkeypatch)
     assert await storage.get_by_ids([f"rel-{i}" for i in range(4)]) == [None] * 4
 
 
+@pytest.mark.offline
 @pytest.mark.asyncio
 async def test_delete_cancels_pending_upsert_without_embedding(tmp_path):
     embed = _CountingEmbed()
@@ -117,6 +119,7 @@ async def test_delete_cancels_pending_upsert_without_embedding(tmp_path):
     assert await storage.get_by_id("doomed") is None
 
 
+@pytest.mark.offline
 @pytest.mark.asyncio
 async def test_fresh_upsert_supersedes_queued_delete(tmp_path):
     embed = _CountingEmbed()
@@ -135,6 +138,7 @@ async def test_fresh_upsert_supersedes_queued_delete(tmp_path):
     assert len(matches) == 1
 
 
+@pytest.mark.offline
 @pytest.mark.asyncio
 async def test_read_your_writes_hides_queued_deletes(tmp_path):
     embed = _CountingEmbed()
@@ -153,6 +157,7 @@ async def test_read_your_writes_hides_queued_deletes(tmp_path):
     assert "b" in await storage.get_vectors_by_ids(["a", "b"])
 
 
+@pytest.mark.offline
 @pytest.mark.asyncio
 async def test_finalize_applies_deletes_without_upserts(tmp_path):
     embed = _CountingEmbed()
@@ -168,6 +173,7 @@ async def test_finalize_applies_deletes_without_upserts(tmp_path):
     )
 
 
+@pytest.mark.offline
 @pytest.mark.asyncio
 async def test_dequeued_delete_survives_reload_from_disk(tmp_path):
     """The lost-delete-across-writers case: a queued id applies after the
@@ -197,6 +203,7 @@ async def test_dequeued_delete_survives_reload_from_disk(tmp_path):
     )
 
 
+@pytest.mark.offline
 @pytest.mark.asyncio
 async def test_drop_pending_index_ops_discards_queued_deletes(tmp_path):
     embed = _CountingEmbed()
@@ -212,6 +219,7 @@ async def test_drop_pending_index_ops_discards_queued_deletes(tmp_path):
     )
 
 
+@pytest.mark.offline
 @pytest.mark.asyncio
 async def test_failed_delete_rebuild_keeps_tombstones_for_retry(tmp_path, monkeypatch):
     """A FAISS rebuild failure during the delete pass must not consume the

--- a/tests/kg/faiss_impl/test_faiss_deferred_delete.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_delete.py
@@ -8,6 +8,13 @@ index per merged relation — quadratic ingestion, the same defect #3679
 profiled on Nano (#3680 fixed it there). Deferring also keeps a delete from
 being lost when ``index_done_callback`` reloads a newer on-disk snapshot from
 another writer.
+
+The second half of this file covers the ``_unsaved_deletes`` redo log (the
+same protocol #3680 ships for Nano): a removal that reached ``self._index``
+but not the disk is replayed after any reload, so a failed save followed by
+another writer's commit cannot silently resurrect the row — and the replay
+matches on a row *fingerprint*, never the bare id, so a newer row another
+writer published under the same content-hash id survives the replay.
 """
 
 import numpy as np
@@ -48,7 +55,9 @@ class _CountingEmbed:
         )
 
 
-async def _make_storage(tmp_path, embed: _CountingEmbed) -> FaissVectorDBStorage:
+async def _make_storage(
+    tmp_path, embed: _CountingEmbed, meta_fields: set[str] | None = None
+) -> FaissVectorDBStorage:
     storage = FaissVectorDBStorage(
         namespace="test_vectors",
         workspace="ws",
@@ -58,7 +67,7 @@ async def _make_storage(tmp_path, embed: _CountingEmbed) -> FaissVectorDBStorage
             "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
         },
         embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=embed),
-        meta_fields={"content"},
+        meta_fields=meta_fields or {"content"},
     )
     await storage.initialize()
     return storage
@@ -243,6 +252,9 @@ async def test_failed_delete_rebuild_keeps_tombstones_for_retry(tmp_path, monkey
     assert storage._pending_deletes == {"x", "y"}, (
         "tombstones must survive a failed rebuild so the retry re-applies them"
     )
+    assert storage._unsaved_deletes == {}, (
+        "a failed rebuild must not record removals that never happened"
+    )
     assert len(storage._id_to_meta) == 2, "rows must still be materialized"
     assert storage._index_dirty is False, "nothing landed, so nothing to save"
 
@@ -257,4 +269,246 @@ async def test_failed_delete_rebuild_keeps_tombstones_for_retry(tmp_path, monkey
     reloaded = await _make_storage(tmp_path, _CountingEmbed())
     assert await reloaded.get_by_ids(["x", "y"]) == [None, None], (
         "the retried deletes must be persisted to disk"
+    )
+
+
+def _fail_save(storage, monkeypatch):
+    """Make the next save(s) raise, simulating a transient IO failure."""
+
+    def boom():
+        raise OSError("transient disk error")
+
+    monkeypatch.setattr(storage, "_save_faiss_index", boom)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_survives_a_concurrent_commit_by_another_writer(
+    tmp_path, monkeypatch
+):
+    """The redo-log case: a delete that was APPLIED but whose save failed
+    must survive the unconditional reload inside the retry
+    ``index_done_callback``. Without ``_unsaved_deletes`` the reload replaces
+    the index with the on-disk snapshot, the row silently resurrects, and
+    the retry save persists it."""
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(storage, {"victim": {"content": "to be deleted"}})
+
+    # Flush applies the delete, the save fails: applied-but-unsaved.
+    await storage.delete(["victim"])
+    _fail_save(storage, monkeypatch)
+    with pytest.raises(OSError, match="transient disk error"):
+        await storage.index_done_callback()
+    assert storage._pending_deletes == set(), "the queue was consumed by the flush"
+    assert "victim" in storage._unsaved_deletes, (
+        "the applied removal must be recorded in the redo log"
+    )
+    monkeypatch.undo()
+
+    # Another writer commits, flipping this process's storage_updated flag.
+    other = await _make_storage(tmp_path, _CountingEmbed())
+    await _upsert_and_flush(other, {"extra": {"content": "unrelated"}})
+    assert storage.storage_updated.value is True
+
+    # The retry reloads (resurrecting the row in memory), replays the log,
+    # and persists the removal.
+    assert await storage.index_done_callback() is True
+    assert await storage.get_by_id("victim") is None
+    assert storage._unsaved_deletes == {}, "a landed save clears the redo log"
+
+    reloaded = await _make_storage(tmp_path, _CountingEmbed())
+    assert await reloaded.get_by_id("victim") is None, (
+        "the delete must not resurrect on disk"
+    )
+    assert (await reloaded.get_by_id("extra")) is not None, (
+        "the other writer's row must be preserved"
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_replay_preserves_a_newer_row_under_the_same_id(tmp_path, monkeypatch):
+    """A replay matches on the row fingerprint, never the bare id: when
+    another writer publishes a NEW row under an id whose removal is in the
+    redo log, the replay must keep it — ids are content hashes, so this is a
+    legitimate successor row, not the one we removed."""
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(storage, {"shared": {"content": "v1"}})
+
+    await storage.delete(["shared"])
+    _fail_save(storage, monkeypatch)
+    with pytest.raises(OSError, match="transient disk error"):
+        await storage.index_done_callback()
+    monkeypatch.undo()
+
+    # Another writer publishes a successor row under the same id.
+    other = await _make_storage(tmp_path, _CountingEmbed())
+    await _upsert_and_flush(other, {"shared": {"content": "v2"}})
+    assert storage.storage_updated.value is True
+
+    # Read paths hide only the row the redo entry names — the successor is
+    # already readable (the read reload pulls it in) before any flush.
+    record = await storage.get_by_id("shared")
+    assert record is not None and record["content"] == "v2", (
+        "a redo entry must not hide a successor row it would not replay over"
+    )
+
+    assert await storage.index_done_callback() is True
+    record = await storage.get_by_id("shared")
+    assert record is not None and record["content"] == "v2", (
+        "the replay must not remove the successor row"
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_finalize_reloads_before_retrying_a_delete_only_save(
+    tmp_path, monkeypatch
+):
+    """A delete-only dirty state is replayable, so finalize reloads before
+    the retry save. Skipping the reload would write this process's
+    pre-commit snapshot over rows another writer committed meanwhile."""
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(storage, {"victim": {"content": "to be deleted"}})
+
+    await storage.delete(["victim"])
+    _fail_save(storage, monkeypatch)
+    with pytest.raises(OSError, match="transient disk error"):
+        await storage.index_done_callback()
+    monkeypatch.undo()
+
+    other = await _make_storage(tmp_path, _CountingEmbed())
+    await _upsert_and_flush(other, {"extra": {"content": "committed meanwhile"}})
+
+    await storage.finalize()
+
+    reloaded = await _make_storage(tmp_path, _CountingEmbed())
+    assert (await reloaded.get_by_id("extra")) is not None, (
+        "the delete-only retry save must not clobber the other writer's row"
+    )
+    assert await reloaded.get_by_id("victim") is None, (
+        "the removal must still be persisted"
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_abort_keeps_the_redo_log(tmp_path, monkeypatch):
+    """``drop_pending_index_ops`` discards buffered work, not removals that
+    already reached the index: the redo log survives an aborting batch so a
+    later reload still cannot resurrect the applied delete."""
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(storage, {"victim": {"content": "to be deleted"}})
+
+    await storage.delete(["victim"])
+    _fail_save(storage, monkeypatch)
+    with pytest.raises(OSError, match="transient disk error"):
+        await storage.index_done_callback()
+    monkeypatch.undo()
+
+    await storage.drop_pending_index_ops()
+    assert "victim" in storage._unsaved_deletes, (
+        "an abort must not discard the redo log"
+    )
+
+    other = await _make_storage(tmp_path, _CountingEmbed())
+    await _upsert_and_flush(other, {"extra": {"content": "unrelated"}})
+
+    await storage.finalize()
+    reloaded = await _make_storage(tmp_path, _CountingEmbed())
+    assert await reloaded.get_by_id("victim") is None
+    assert (await reloaded.get_by_id("extra")) is not None
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_eager_entity_relation_removal_survives_reload(tmp_path, monkeypatch):
+    """``delete_entity_relation`` stays eager, so its removals are
+    applied-but-unsaved the moment it returns — they must be in the redo log
+    or the same failed-save + reload sequence resurrects them."""
+    embed = _CountingEmbed()
+    storage = await _make_storage(
+        tmp_path, embed, meta_fields={"content", "src_id", "tgt_id"}
+    )
+    await _upsert_and_flush(
+        storage,
+        {"rel-1": {"content": "r1", "src_id": "E", "tgt_id": "F"}},
+    )
+
+    await storage.delete_entity_relation("E")
+    assert "rel-1" in storage._unsaved_deletes, (
+        "eager removals must be recorded in the redo log"
+    )
+    _fail_save(storage, monkeypatch)
+    with pytest.raises(OSError, match="transient disk error"):
+        await storage.index_done_callback()
+    monkeypatch.undo()
+
+    other = await _make_storage(tmp_path, _CountingEmbed())
+    await _upsert_and_flush(other, {"extra": {"content": "unrelated"}})
+
+    assert await storage.index_done_callback() is True
+    reloaded = await _make_storage(tmp_path, _CountingEmbed())
+    assert await reloaded.get_by_id("rel-1") is None, (
+        "the eager removal must not resurrect on disk"
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_identical_reupsert_drops_the_redo_entry(tmp_path, monkeypatch):
+    """Materializing a row indistinguishable from the one a redo entry
+    removed (same id, same fingerprint) drops the entry — the one case the
+    fingerprint cannot separate, and the one case where dropping costs
+    nothing, since a resurrection would restore the row that is present."""
+    import lightrag.kg.faiss_impl as faiss_impl_module
+
+    monkeypatch.setattr(faiss_impl_module.time, "time", lambda: 1_700_000_000.0)
+
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(storage, {"row": {"content": "same"}})
+
+    # Flush applies the delete but the save fails -> redo entry for "row".
+    await storage.delete(["row"])
+    _fail_save(storage, monkeypatch)
+    with pytest.raises(OSError, match="transient disk error"):
+        await storage.index_done_callback()
+    assert "row" in storage._unsaved_deletes
+
+    # Re-upsert the byte-identical row (same frozen timestamp): the next
+    # flush materializes it and must drop the now-pointless redo entry.
+    await storage.upsert({"row": {"content": "same"}})
+    with pytest.raises(OSError, match="transient disk error"):
+        await storage.index_done_callback()
+    assert "row" not in storage._unsaved_deletes, (
+        "a materialized identical row must drop the redo entry"
+    )
+    record = await storage.get_by_id("row")
+    assert record is not None and record["content"] == "same"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_finalize_skips_save_when_flush_changes_nothing(tmp_path):
+    """Queued deletes that match no row leave nothing to persist: finalize
+    must not rewrite both files and broadcast a reload to every other
+    process for a no-op."""
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(storage, {"keep": {"content": "kept"}})
+
+    watcher = await _make_storage(tmp_path, _CountingEmbed())
+    assert watcher.storage_updated.value is False
+
+    await storage.delete(["ghost"])  # matches nothing
+    await storage.finalize()
+
+    assert storage._pending_deletes == set()
+    assert watcher.storage_updated.value is False, (
+        "a no-op finalize must not broadcast a reload to other processes"
     )

--- a/tests/kg/faiss_impl/test_faiss_deferred_delete.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_delete.py
@@ -131,9 +131,7 @@ async def test_fresh_upsert_supersedes_queued_delete(tmp_path):
     assert record is not None
     assert record["content"] == "new"
     # Exactly one materialized row for the custom id.
-    matches = [
-        m for m in storage._id_to_meta.values() if m.get("__id__") == "row"
-    ]
+    matches = [m for m in storage._id_to_meta.values() if m.get("__id__") == "row"]
     assert len(matches) == 1
 
 
@@ -181,7 +179,9 @@ async def test_dequeued_delete_survives_reload_from_disk(tmp_path):
 
     # Another process commits a newer snapshot...
     other = await _make_storage(tmp_path, _CountingEmbed())
-    await _upsert_and_flush(other, {"shared": {"content": "v2"}, "extra": {"content": "e"}})
+    await _upsert_and_flush(
+        other, {"shared": {"content": "v2"}, "extra": {"content": "e"}}
+    )
     # ...and this process's storage_updated flag flips, as set_all_update_flags
     # would have done, so index_done_callback reloads before flushing.
     storage.storage_updated.value = True
@@ -213,9 +213,7 @@ async def test_drop_pending_index_ops_discards_queued_deletes(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_failed_delete_rebuild_keeps_tombstones_for_retry(
-    tmp_path, monkeypatch
-):
+async def test_failed_delete_rebuild_keeps_tombstones_for_retry(tmp_path, monkeypatch):
     """A FAISS rebuild failure during the delete pass must not consume the
     queued tombstones: the next ``index_done_callback`` retry re-applies them
     instead of persisting the stale rows as if they were deleted."""

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -189,9 +189,15 @@ async def test_delete_cancels_pending_and_removes_materialized(tmp_path):
     await storage.delete(["id1", "id2"])
 
     assert "id2" not in storage._pending_upserts, "delete cancels pending upsert"
-    assert storage._index.ntotal == 0, "delete removes the materialized row"
+    # Materialized removal is deferred: one batched rebuild at flush time
+    # instead of one per delete call (#3681). Read-your-writes hides the row.
+    assert storage._index.ntotal == 1, "materialized row survives until the flush"
+    assert {"id1", "id2"} <= storage._pending_deletes
     assert await storage.get_by_id("id1") is None
     assert await storage.get_by_id("id2") is None
+
+    assert await storage.index_done_callback() is True
+    assert storage._index.ntotal == 0, "flush removes the materialized row"
     _assert_consistent(storage)
 
 
@@ -222,6 +228,10 @@ async def test_stale_client_reload_still_flushes_pending_upsert(tmp_path):
 @pytest.mark.offline
 @pytest.mark.asyncio
 async def test_delete_reloads_stale_client_before_mutating(tmp_path):
+    """The stale-writer interplay with deferred deletes: the reload happens
+    inside ``index_done_callback`` (before the flush applies the queued
+    delete), so the delete lands on top of the other writer's committed
+    snapshot instead of being silently reverted by it."""
     embed = _CountingEmbed()
     writer = _make_storage(tmp_path, embed)
     stale_deleter = _make_storage(tmp_path, embed)
@@ -233,8 +243,8 @@ async def test_delete_reloads_stale_client_before_mutating(tmp_path):
     assert stale_deleter.storage_updated.value is True
 
     await stale_deleter.delete(["id1"])
-    assert stale_deleter.storage_updated.value is False
     assert await stale_deleter.index_done_callback() is True
+    assert stale_deleter.storage_updated.value is False
 
     reader = _make_storage(tmp_path, embed)
     await reader.initialize()
@@ -663,6 +673,10 @@ async def test_reupsert_cleans_duplicate_custom_id_rows(tmp_path):
     assert len(storage._find_faiss_ids_by_custom_id("dup")) == 3
 
     await storage.delete(["dup"])
+    assert storage._find_faiss_ids_by_custom_id("dup") == [0, 1, 2], (
+        "queued delete does not mutate the materialized index"
+    )
+    assert await storage.index_done_callback() is True
     assert storage._find_faiss_ids_by_custom_id("dup") == []
     assert storage._index.ntotal == 0
     _assert_consistent(storage)
@@ -673,7 +687,9 @@ async def test_reupsert_cleans_duplicate_custom_id_rows(tmp_path):
 async def test_delete_propagates_errors(tmp_path, monkeypatch):
     """Faiss ``delete`` must NOT swallow errors — the caller (document
     deletion / status update path) needs to abort if vectors weren't
-    actually removed. This intentionally diverges from Nano."""
+    actually removed. With deferred deletes the destructive work moved to
+    the flush, so the abort surfaces from ``index_done_callback``; this
+    intentionally diverges from Nano."""
     embed = _CountingEmbed()
     storage = _make_storage(tmp_path, embed)
     await storage.initialize()
@@ -684,13 +700,17 @@ async def test_delete_propagates_errors(tmp_path, monkeypatch):
     def boom(_self, _fids):
         raise RuntimeError("rebuild boom")
 
-    # _remove_faiss_ids_locked is what delete calls under the hood.
+    # _remove_faiss_ids_locked is what the flush calls under the hood to
+    # apply the queued deletes.
     monkeypatch.setattr(
         FaissVectorDBStorage, "_remove_faiss_ids_locked", boom, raising=True
     )
 
+    await storage.delete(["id1"])
+    assert "id1" in storage._pending_deletes
+
     with pytest.raises(RuntimeError, match="rebuild boom"):
-        await storage.delete(["id1"])
+        await storage.index_done_callback()
 
 
 @pytest.mark.offline


### PR DESCRIPTION
Fixes #3681.

Brings `FaissVectorDBStorage.delete` in line with the deferred-delete protocol that every other vector backend already documents (`_pending_vector_deletes` on Qdrant/PostgreSQL/Milvus/MongoDB/OpenSearch) and that #3680 adds for Nano — Faiss was the last backend with eager deletes.

## What changed

- **`delete` queues instead of rebuilding.** Each id lands in `self._pending_deletes` (cancelling any pending upsert for it). No metadata scan, no `IndexFlatIP` rebuild at call time.
- **`_flush_pending_locked` applies the whole queue in one batched pass** — a single scan of `_id_to_meta` against the queued set, one `_remove_faiss_ids_locked` rebuild — *before* materializing pending upserts, so a deleted-then-re-upserted id ends up with exactly the new row. Note the single scan also replaces the per-id `_find_faiss_ids_by_custom_id` loop, so the flush stays O(rows) regardless of how many ids are queued (400 queued ids × 110k rows of per-id scans would have just moved the quadratic cost into the flush).
- **`upsert` cancels a queued delete** for the same id (fresh row supersedes); the read-your-writes paths (`get_by_id` / `get_by_ids` / `get_vectors_by_ids`) treat a queued id as absent, while `query` keeps reading the materialized index until the flush — the same contract the other buffers document.
- **The lost-delete-across-writers case is fixed** as a side effect: the removal used to be applied to `self._index` while still unsaved, and `index_done_callback`'s unconditional reload (when another process committed) *replaced* the index — resurrecting the row. A queued id is applied *after* that reload, so it survives. `test_dequeued_delete_survives_reload_from_disk` pins exactly this scenario.
- `finalize` applies a deletes-only buffer (previously it early-returned when no upserts were pending); `drop_pending_index_ops` and `drop` discard the queue alongside pending upserts.
- `delete_entity_relation` keeps its eager rebuild deliberately: it is one call per entity prune with a caller short-circuit contract, not the per-relation hot path.

## Tests

New `tests/kg/faiss_impl/test_faiss_deferred_delete.py` (7 tests, counting mock embedding, no network):

- the merge-stage shape — one `delete` per relation — causes **zero** rebuilds until `index_done_callback`, then exactly **one**;
- a queued delete cancels a buffered upsert before embedding;
- a fresh upsert supersedes a queued delete (single final row);
- read-your-writes hides queued ids on all three read paths;
- `finalize` alone persists a deletes-only buffer to disk;
- the cross-writer reload resurrect case (delete wins, other writer's row preserved);
- `drop_pending_index_ops` discards queued deletes.

Four existing tests in `test_faiss_deferred_embedding.py` pinned the old eager contract; they are updated to the deferred contract with their intent preserved (error propagation now surfaces from the flush, the stale-writer reload interplay, duplicate-row cleanup applies at flush).

Differential: the new suite fails on `main` (2 direct failures + contract mismatches); `tests/kg/faiss_impl/` is 36/36 green with the change. The `json_impl` concurrent-writer test fails identically on stashed `main` — a local timing flake, unrelated.
