### PR TITLE
fix(gemini): map max_tokens to max_output_tokens

### DIFF
--- a/lightrag/llm/gemini.py
+++ b/lightrag/llm/gemini.py
@@ -301,6 +301,7 @@ async def gemini_complete_if_cache(
     generation_config: dict[str, Any] | None = None,
     timeout: int | None = None,
     image_inputs: list[Any] | None = None,
+    max_tokens: int | None = None,
     **_: Any,
 ) -> str | AsyncIterator[str]:
     """
@@ -346,6 +347,9 @@ async def gemini_complete_if_cache(
         hashing_kv: Storage interface (for interface parity with other bindings).
         enable_cot: Whether to include Chain of Thought content in the response.
         timeout: Request timeout in seconds (will be converted to milliseconds for Gemini API).
+        max_tokens: Generic output-length cap (as forwarded via LightRAG's
+            provider-agnostic ``llm_model_kwargs``). Mapped to Gemini's native
+            ``max_output_tokens`` unless ``generation_config`` already sets it.
         **_: Additional keyword arguments (ignored).
 
     Returns:
@@ -390,6 +394,14 @@ async def gemini_complete_if_cache(
         prompt_sections.append(history_block)
     prompt_sections.append(f"[user] {prompt}")
     combined_prompt = "\n".join(prompt_sections)
+
+    if max_tokens is not None and (
+        generation_config is None or generation_config.get("max_output_tokens") is None
+    ):
+        generation_config = {
+            **(generation_config or {}),
+            "max_output_tokens": max_tokens,
+        }
 
     config_obj = _build_generation_config(
         generation_config,

--- a/tests/llm/gemini_impl/test_gemini_llm.py
+++ b/tests/llm/gemini_impl/test_gemini_llm.py
@@ -464,3 +464,81 @@ async def test_gemini_counts_usage_before_the_empty_truncated_raise(
         "the exhausted request's tokens vanished from usage accounting "
         "because the raise preceded token_tracker.add_usage"
     )
+
+
+def _make_capturing_client(fake_response):
+    captured: dict = {}
+
+    async def _fake_generate_content(**kwargs):
+        captured.update(kwargs)
+        return fake_response
+
+    client = SimpleNamespace(
+        aio=SimpleNamespace(
+            models=SimpleNamespace(generate_content=_fake_generate_content)
+        )
+    )
+    return client, captured
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("generation_kwargs", "expected_max_output_tokens"),
+    [
+        pytest.param({"max_tokens": 37}, 37, id="generic-limit-maps-to-native-field"),
+        pytest.param(
+            {"max_tokens": 37, "generation_config": {"temperature": 0.2}},
+            37,
+            id="generic-limit-preserves-other-generation-config",
+        ),
+        pytest.param(
+            {"generation_config": {"max_output_tokens": 41}},
+            41,
+            id="native-limit-is-preserved",
+        ),
+        pytest.param(
+            {"max_tokens": 37, "generation_config": {"max_output_tokens": 41}},
+            41,
+            id="native-limit-takes-precedence",
+        ),
+    ],
+)
+async def test_gemini_max_tokens_alias_precedence(
+    monkeypatch, request, generation_kwargs, expected_max_output_tokens
+):
+    """LightRAG's generic max_tokens kwarg reaches Gemini's native config field."""
+    gemini_module = _load_gemini_module(monkeypatch, request)
+    fake_client, captured = _make_capturing_client(
+        _make_fake_gemini_response(regular_text="ok")
+    )
+    monkeypatch.setattr(gemini_module, "_get_gemini_client", lambda *args: fake_client)
+
+    await gemini_module.gemini_complete_if_cache(
+        model="gemini-model", prompt="hi", api_key="test-key", **generation_kwargs
+    )
+
+    assert captured["config"].kwargs.get("max_output_tokens") == (
+        expected_max_output_tokens
+    )
+    if "temperature" in generation_kwargs.get("generation_config", {}):
+        assert captured["config"].kwargs.get("temperature") == generation_kwargs[
+            "generation_config"
+        ].get("temperature")
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_gemini_no_max_tokens_builds_no_config(monkeypatch, request):
+    """Absent both the generic and native knobs, no config object is sent at all."""
+    gemini_module = _load_gemini_module(monkeypatch, request)
+    fake_client, captured = _make_capturing_client(
+        _make_fake_gemini_response(regular_text="ok")
+    )
+    monkeypatch.setattr(gemini_module, "_get_gemini_client", lambda *args: fake_client)
+
+    await gemini_module.gemini_complete_if_cache(
+        model="gemini-model", prompt="hi", api_key="test-key"
+    )
+
+    assert "config" not in captured


### PR DESCRIPTION
## Description

`gemini_complete_if_cache` (`lightrag/llm/gemini.py`) ends its signature with a `**_: Any` catch-all, so LightRAG's provider-agnostic `max_tokens` kwarg (forwarded via `llm_model_kwargs`, the same mechanism already fixed for ollama/lmdeploy/hf in #3690/#3689/#3687) never reaches the function body. No config object is built and no output-length limit is ever sent to the API.

Fixes #3695

## Changes Made

- Added an explicit `max_tokens` parameter to `gemini_complete_if_cache`.
- Before building the generation config, map `max_tokens` into the native `max_output_tokens` field, only when `generation_config` does not already set it (mirrors the "native value wins" precedence rule the ollama/lmdeploy/hf fixes already established, so `GEMINI_LLM_MAX_OUTPUT_TOKENS`/explicit `generation_config` callers are unaffected).

## Verification

- New regression tests in `tests/llm/gemini_impl/test_gemini_llm.py` drive the real `gemini_complete_if_cache`, mocking only the `google.genai` network boundary: generic `max_tokens` maps to `max_output_tokens`, an explicit `generation_config["max_output_tokens"]` takes precedence, other `generation_config` keys are preserved, and no config is built when neither is set. 2 of the 4 parametrized cases fail on unmodified `main` and pass on this branch (confirmed both ways via `git stash` in the same container).
- Full offline suite (`pytest tests/ -m offline`) in a clean `python:3.12-slim` and `python:3.14-slim` container (matching the CI matrix): 5749 passed, 2 pre-existing failures unrelated to this change (reproduce identically on unmodified `main`, `tests/pipeline/test_chunk_options_regex_scrub.py` and `tests/pipeline/test_strict_capability_gate.py`).
- `pre-commit run --files lightrag/llm/gemini.py tests/llm/gemini_impl/test_gemini_llm.py` (ruff format, ruff, trailing-whitespace, end-of-file-fixer): clean.
- Not verified: behavior against a live Gemini API. The fix and its tests only exercise the local kwarg-to-config mapping; the network boundary is mocked throughout.
