### PR TITLE
Map the generic max_tokens kwarg to Gemini's max_output_tokens

### DIFF
--- a/lightrag/llm/gemini.py
+++ b/lightrag/llm/gemini.py
@@ -301,6 +301,7 @@ async def gemini_complete_if_cache(
     generation_config: dict[str, Any] | None = None,
     timeout: int | None = None,
     image_inputs: list[Any] | None = None,
+    max_tokens: int | None = None,
     **_: Any,
 ) -> str | AsyncIterator[str]:
     """
@@ -346,6 +347,9 @@ async def gemini_complete_if_cache(
         hashing_kv: Storage interface (for interface parity with other bindings).
         enable_cot: Whether to include Chain of Thought content in the response.
         timeout: Request timeout in seconds (will be converted to milliseconds for Gemini API).
+        max_tokens: Optional generic output-length cap, mapped to Gemini's
+            native ``max_output_tokens`` generation-config field when the
+            caller has not set a native value themselves.
         **_: Additional keyword arguments (ignored).
 
     Returns:
@@ -390,6 +394,15 @@ async def gemini_complete_if_cache(
         prompt_sections.append(history_block)
     prompt_sections.append(f"[user] {prompt}")
     combined_prompt = "\n".join(prompt_sections)
+
+    # Generic output-length knob: map LightRAG's provider-agnostic max_tokens
+    # to Gemini's native config field, with an explicitly configured native
+    # max_output_tokens taking precedence (#3695, same contract as the
+    # ollama/lmdeploy/hf bindings).
+    if max_tokens is not None:
+        generation_config = dict(generation_config or {})
+        if generation_config.get("max_output_tokens") is None:
+            generation_config["max_output_tokens"] = max_tokens
 
     config_obj = _build_generation_config(
         generation_config,

--- a/tests/llm/gemini_impl/test_gemini_max_tokens.py
+++ b/tests/llm/gemini_impl/test_gemini_max_tokens.py
@@ -1,0 +1,213 @@
+"""Offline tests for Gemini's generic output-token alias (#3695).
+
+LightRAG's provider-agnostic ``max_tokens`` knob used to vanish into the
+``**_`` catch-all of ``gemini_complete_if_cache`` — the request was sent with
+no output-length limit at all. The binding now maps it to Gemini's native
+``max_output_tokens`` generation-config field, with an explicitly configured
+native value taking precedence (same contract as the ollama/lmdeploy/hf
+bindings from #3687/#3689/#3690).
+"""
+
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+def _load_gemini_module(monkeypatch, request):
+    fake_pm = SimpleNamespace(
+        is_installed=lambda name: True,
+        install=lambda name: None,
+    )
+
+    class FakeGenerateContentConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeHttpOptions:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    fake_types = SimpleNamespace(
+        GenerateContentConfig=FakeGenerateContentConfig,
+        HttpOptions=FakeHttpOptions,
+        FinishReason=SimpleNamespace(MAX_TOKENS="MAX_TOKENS", STOP="STOP"),
+    )
+    fake_genai = SimpleNamespace(Client=lambda **kwargs: SimpleNamespace(kwargs=kwargs))
+    fake_google_module = ModuleType("google")
+    fake_google_module.genai = fake_genai
+    fake_api_exceptions = SimpleNamespace(
+        InternalServerError=type("InternalServerError", (Exception,), {}),
+        ServiceUnavailable=type("ServiceUnavailable", (Exception,), {}),
+        ResourceExhausted=type("ResourceExhausted", (Exception,), {}),
+        GatewayTimeout=type("GatewayTimeout", (Exception,), {}),
+        BadGateway=type("BadGateway", (Exception,), {}),
+        DeadlineExceeded=type("DeadlineExceeded", (Exception,), {}),
+        Aborted=type("Aborted", (Exception,), {}),
+        Unknown=type("Unknown", (Exception,), {}),
+    )
+    fake_google_api_core = ModuleType("google.api_core")
+    fake_google_api_core.exceptions = fake_api_exceptions
+
+    monkeypatch.setitem(sys.modules, "pipmaster", fake_pm)
+    monkeypatch.setitem(sys.modules, "google", fake_google_module)
+    monkeypatch.setitem(sys.modules, "google.genai", SimpleNamespace(types=fake_types))
+    monkeypatch.setitem(sys.modules, "google.api_core", fake_google_api_core)
+    monkeypatch.setitem(sys.modules, "google.api_core.exceptions", fake_api_exceptions)
+
+    parent = sys.modules.get("lightrag.llm")
+    original_gemini = sys.modules.get("lightrag.llm.gemini")
+    original_parent_attr = getattr(parent, "gemini", None) if parent else None
+    sys.modules.pop("lightrag.llm.gemini", None)
+    if parent is not None and hasattr(parent, "gemini"):
+        delattr(parent, "gemini")
+
+    def _restore_gemini():
+        if original_gemini is not None:
+            sys.modules["lightrag.llm.gemini"] = original_gemini
+        else:
+            sys.modules.pop("lightrag.llm.gemini", None)
+        if parent is not None:
+            if original_parent_attr is not None:
+                parent.gemini = original_parent_attr
+            elif hasattr(parent, "gemini"):
+                delattr(parent, "gemini")
+
+    request.addfinalizer(_restore_gemini)
+
+    return importlib.import_module("lightrag.llm.gemini")
+
+
+def _make_fake_response():
+    return SimpleNamespace(
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(
+                    parts=[SimpleNamespace(text="ok", thought=False)]
+                ),
+                finish_reason="STOP",
+            ),
+        ],
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=1,
+            candidates_token_count=1,
+            total_token_count=2,
+        ),
+    )
+
+
+def _make_capturing_client(captured):
+    async def _fake_generate_content(**kwargs):
+        captured.update(kwargs)
+        return _make_fake_response()
+
+    return SimpleNamespace(
+        aio=SimpleNamespace(
+            models=SimpleNamespace(generate_content=_fake_generate_content)
+        )
+    )
+
+
+async def _sent_config(gemini_module, monkeypatch, request, **generation_kwargs):
+    captured: dict = {}
+    fake_client = _make_capturing_client(captured)
+    monkeypatch.setattr(gemini_module, "_get_gemini_client", lambda *args: fake_client)
+
+    result = await gemini_module.gemini_complete_if_cache(
+        model="gemini-model",
+        prompt="hello",
+        api_key="test-key",
+        **generation_kwargs,
+    )
+    assert result == "ok"
+    return captured.get("config")
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_generic_limit_maps_to_max_output_tokens(monkeypatch, request):
+    gemini_module = _load_gemini_module(monkeypatch, request)
+
+    config = await _sent_config(gemini_module, monkeypatch, request, max_tokens=37)
+
+    assert config.kwargs["max_output_tokens"] == 37
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_generic_limit_preserves_other_generation_config(monkeypatch, request):
+    gemini_module = _load_gemini_module(monkeypatch, request)
+
+    config = await _sent_config(
+        gemini_module,
+        monkeypatch,
+        request,
+        max_tokens=37,
+        generation_config={"temperature": 0.2},
+    )
+
+    assert config.kwargs["max_output_tokens"] == 37
+    assert config.kwargs["temperature"] == 0.2
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_native_limit_is_preserved_without_alias(monkeypatch, request):
+    gemini_module = _load_gemini_module(monkeypatch, request)
+
+    config = await _sent_config(
+        gemini_module,
+        monkeypatch,
+        request,
+        generation_config={"max_output_tokens": 41},
+    )
+
+    assert config.kwargs["max_output_tokens"] == 41
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_native_limit_takes_precedence_over_alias(monkeypatch, request):
+    gemini_module = _load_gemini_module(monkeypatch, request)
+
+    config = await _sent_config(
+        gemini_module,
+        monkeypatch,
+        request,
+        max_tokens=37,
+        generation_config={"max_output_tokens": 41},
+    )
+
+    assert config.kwargs["max_output_tokens"] == 41
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_caller_generation_config_is_not_mutated(monkeypatch, request):
+    gemini_module = _load_gemini_module(monkeypatch, request)
+    shared_config = {"temperature": 0.2}
+
+    config = await _sent_config(
+        gemini_module,
+        monkeypatch,
+        request,
+        max_tokens=37,
+        generation_config=shared_config,
+    )
+
+    assert config.kwargs["max_output_tokens"] == 37
+    assert shared_config == {"temperature": 0.2}, (
+        "the caller's generation_config dict must not be mutated"
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_no_limit_sent_when_nothing_configured(monkeypatch, request):
+    gemini_module = _load_gemini_module(monkeypatch, request)
+
+    config = await _sent_config(gemini_module, monkeypatch, request)
+
+    # With nothing to configure the binding sends no config object at all.
+    assert config is None or "max_output_tokens" not in config.kwargs


### PR DESCRIPTION
Fixes #3695.

## Root cause

`gemini_complete_if_cache` ended its signature with a `**_: Any` catch-all, so LightRAG's provider-agnostic `max_tokens` knob — the same `llm_model_kwargs` mechanism documented for Ollama's `num_ctx`, and the output-loop safety cap the API-server docs recommend — never reached the function body. No warning, no error: the request was simply sent without any output-length limit.

This is the Gemini member of the family #3687 (hf) / #3689 (lmdeploy) / #3690 (ollama) already fixed.

## Fix

- `max_tokens` is accepted as an explicit kwarg (documented) instead of vanishing into `**_`;
- it maps to Gemini's native `max_output_tokens` generation-config field, with an explicitly configured native value taking precedence — the identical contract the sibling bindings implement;
- the caller's `generation_config` dict is copied before the merge, never mutated.

## Tests

`tests/llm/gemini_impl/test_gemini_max_tokens.py` (offline, fake `google.genai` namespace per the existing harness):

- generic limit maps to `max_output_tokens=37`;
- other generation-config fields (temperature) are preserved;
- a native value survives alone and takes precedence over the alias;
- the caller's dict is not mutated;
- nothing is injected when neither form is configured.

Differential: 3 of the 6 tests fail on `main` (alias dropped / native-only shapes pass). `tests/llm/gemini_impl/` is 19/19 green with the change.