### PR TITLE
fix: keep Nano/Faiss pending ops as a replay log until save is durable

### DIFF
--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -182,10 +182,12 @@ class FaissVectorDBStorage(BaseVectorStorage):
         unflushed pending data is intentionally not queryable.
 
         A flush failure (embedding error, count mismatch, or save IO
-        error) raises through ``index_done_callback``; the pending buffer
-        is preserved on flush failure, and if only the save failed
-        ``_index_dirty`` stays ``True`` so a subsequent ``finalize``
-        retries the save without re-embedding.
+        error) raises through ``index_done_callback``. The pending buffer
+        is a **replay log**: it is not cleared until the save is durable.
+        If only the save failed, ``_index_dirty`` stays ``True`` and the
+        buffered docs keep their already-normalized vectors so a later
+        commit can reload a foreign snapshot and re-apply our ops without
+        re-embedding (issue #3688).
 
     Non-pipeline write paths:
         The pipeline ``busy`` gate serializes ``upsert`` / ``delete`` /
@@ -241,15 +243,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # Maps <int faiss_id> → metadata (including your original ID).
         self._id_to_meta = {}
 
-        # Minimal pending area for deferred embedding: custom-id -> _PendingFaissDoc.
-        # Holds only records not yet embedded+materialized into self._index;
-        # it never duplicates rows already added to the Faiss index. Flushed
-        # under _storage_lock by _flush_pending_locked().
+        # Replay log for deferred embedding: custom-id -> _PendingFaissDoc.
+        # Cleared only after a durable save (issue #3688).
         self._pending_upserts: dict[str, _PendingFaissDoc] = {}
+        # Custom ids whose materialized delete has not been saved yet.
+        self._pending_deletes: set[str] = set()
         # True when self._index / self._id_to_meta have materialized changes
-        # that have not been successfully saved to disk yet. This lets
-        # finalize retry a save even after a previous flush cleared the
-        # pending buffer (see _flush_pending_locked / index_done_callback).
+        # that have not been successfully saved to disk yet.
         self._index_dirty = False
 
         # Sweep orphan tmp siblings left behind by hard kills mid-save.
@@ -303,6 +303,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
         self._id_to_meta = {}
         self._load_faiss_index()
         self.storage_updated.value = False
+        self._replay_pending_deletes_locked()
         return True
 
     async def _get_index(self):
@@ -378,6 +379,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # may have cached (content-version change -> must re-embed new content).
         async with self._storage_lock:
             for doc_id, record in pending:
+                self._pending_deletes.discard(doc_id)
                 self._pending_upserts[doc_id] = _PendingFaissDoc(record=record)
 
     async def query(
@@ -498,10 +500,15 @@ class FaissVectorDBStorage(BaseVectorStorage):
             # Use the find-all variant so legacy/corrupt stores with
             # duplicate __id__ rows still get fully cleaned.
             to_remove: list[int] = []
+            matched_ids: list[str] = []
             for cid in ids:
-                to_remove.extend(self._find_faiss_ids_by_custom_id(cid))
+                fids = self._find_faiss_ids_by_custom_id(cid)
+                if fids:
+                    matched_ids.append(cid)
+                    to_remove.extend(fids)
             if to_remove:
                 self._remove_faiss_ids_locked(to_remove)
+                self._pending_deletes.update(matched_ids)
                 self._index_dirty = True
 
         logger.debug(
@@ -569,9 +576,15 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 if meta.get("src_id") == entity_name
                 or meta.get("tgt_id") == entity_name
             ]
-            if relations:
-                self._remove_faiss_ids_locked(relations)
-                self._index_dirty = True
+        if relations:
+            deleted_custom_ids = []
+            for fid in relations:
+                meta = self._id_to_meta.get(fid)
+                if meta is not None and "__id__" in meta:
+                    deleted_custom_ids.append(meta["__id__"])
+            self._remove_faiss_ids_locked(relations)
+            self._pending_deletes.update(deleted_custom_ids)
+            self._index_dirty = True
 
             # Materialized rebuild succeeded — safe to prune matching
             # buffered upserts (their records carry src_id / tgt_id from
@@ -772,17 +785,8 @@ class FaissVectorDBStorage(BaseVectorStorage):
             self._id_to_meta[fid] = record
 
         self._index_dirty = True
-
-        # Clear only the entries we just flushed. Today the non-reentrant
-        # _storage_lock locks out concurrent upserts for the entire flush
-        # (including the asyncio.gather await), so the `is pdoc` identity
-        # check is always True — it's kept as defensive scaffolding so that
-        # if the lock scope is ever relaxed (e.g. embedding moved outside the
-        # lock), a concurrent upsert that re-set vector=None would not be
-        # silently dropped here.
-        for doc_id, pdoc in pending_items:
-            if self._pending_upserts.get(doc_id) is pdoc:
-                del self._pending_upserts[doc_id]
+        # Keep `_pending_upserts` as a replay log until `_commit_locked`
+        # observes a durable save (issue #3688).
 
     def _save_faiss_index(self):
         """Atomically persist ``self._index`` + ``self._id_to_meta`` to disk.
@@ -894,6 +898,39 @@ class FaissVectorDBStorage(BaseVectorStorage):
             self._index = faiss.IndexFlatIP(self._dim)
             self._id_to_meta = {}
 
+    def _replay_pending_deletes_locked(self) -> None:
+        """Re-apply unmatched-save deletes onto the current index.
+
+        Precondition: the caller already holds ``_storage_lock``. Invoked
+        after a foreign-commit reload replaces ``self._index``. Deletes are
+        idempotent. The set is cleared only after a durable save.
+        """
+        if not self._pending_deletes:
+            return
+        to_remove: list[int] = []
+        for cid in self._pending_deletes:
+            to_remove.extend(self._find_faiss_ids_by_custom_id(cid))
+        if not to_remove:
+            return
+        self._remove_faiss_ids_locked(to_remove)
+        self._index_dirty = True
+
+    async def _commit_locked(self) -> None:
+        """Reload if needed, replay unsaved ops, save, then drop the replay log.
+
+        Precondition: the caller already holds ``_storage_lock``. Pending is
+        a replay log, not a work queue drained before the save is durable
+        (issue #3688).
+        """
+        self._reload_index_from_disk_locked(for_write=True)
+        await self._flush_pending_locked()
+        self._save_faiss_index()
+        self._pending_upserts.clear()
+        self._pending_deletes.clear()
+        await set_all_update_flags(self.namespace, workspace=self.workspace)
+        self.storage_updated.value = False
+        self._index_dirty = False
+
     async def drop_pending_index_ops(self) -> None:
         """Discard buffered upserts on an aborting batch.
 
@@ -916,9 +953,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
         """
         if self._storage_lock is None:
             self._pending_upserts.clear()
+            self._pending_deletes.clear()
             return
         async with self._storage_lock:
             self._pending_upserts.clear()
+            self._pending_deletes.clear()
 
     async def index_done_callback(self) -> bool:
         """Flush deferred embeddings, commit to disk, and notify other processes.
@@ -933,14 +972,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
                kept, ``_index_dirty`` is not touched, nothing is written to
                the index.
             3. ``_save_faiss_index`` atomically writes ``.index`` and
-               ``.meta.json``. A failure here **also raises**;
-               ``_pending_upserts`` is already empty (flush succeeded) and
-               ``_index_dirty`` stays ``True`` so a later ``finalize``
-               retries the save without re-embedding.
-            4. ``set_all_update_flags`` flips every registered process's
-               ``storage_updated`` flag, then we immediately reset our own
-               flag to ``False`` so the writer does not self-reload on the
-               next call to ``_get_index``.
+               ``.meta.json``. A failure here **also raises**; the replay
+               log is left intact and ``_index_dirty`` stays ``True`` so a
+               later commit can reload a foreign snapshot and re-apply our
+               ops (issue #3688).
+            4. On success the replay log is cleared, ``set_all_update_flags``
+               flips every registered process's ``storage_updated`` flag, and
+               we immediately reset our own flag to ``False``.
 
         Either failure surfaces loudly through ``_insert_done`` so the
         caller can abort the document batch instead of silently losing
@@ -948,17 +986,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
         effectively always ``True`` on the success path.
         """
         async with self._storage_lock:
-            self._reload_index_from_disk_locked(for_write=True)
-
-            # Flush + save both raise on failure (embedding mismatch / save IO
-            # error). The exception propagates out of the lock so _insert_done
-            # aborts the batch; pending stays intact and _index_dirty stays
-            # True (if only the save failed) for a later retry.
-            await self._flush_pending_locked()
-            self._save_faiss_index()
-            await set_all_update_flags(self.namespace, workspace=self.workspace)
-            self.storage_updated.value = False
-            self._index_dirty = False
+            await self._commit_locked()
             return True
 
     @staticmethod
@@ -1128,6 +1156,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
             async with self._storage_lock:
                 # Discard buffered (unflushed) upserts along with the data.
                 self._pending_upserts.clear()
+                self._pending_deletes.clear()
 
                 # Reset the index
                 self._index = faiss.IndexFlatIP(self._dim)
@@ -1160,33 +1189,26 @@ class FaissVectorDBStorage(BaseVectorStorage):
     async def finalize(self):
         """Flush any buffered upserts and persist before shutdown (safety net).
 
-        Normally ``index_done_callback`` has already drained the pending
-        buffer and synced to disk, but two paths land here with work to do:
+        Normally ``index_done_callback`` has already committed. Two paths
+        still land here with work to do:
 
-        - **Pending upserts only** (no prior ``index_done_callback``): flush
-          and save. We reload first so a stale process picks up other
-          writers' commits before merging its pending buffer in.
+        - **Pending upserts only** (no prior commit): flush and save. Reload
+          first so a stale process picks up other writers' commits, then
+          merge the replay log.
         - **Unsaved materialized changes** (``_index_dirty=True``): an
-          earlier ``index_done_callback`` flushed pending into ``self._index``
-          but its save raised. Skip the reload — reloading would drop those
-          materialized-but-unsaved rows — and just retry the save.
+          earlier commit flushed into ``self._index`` but its save raised.
+          The replay log is still populated, so we can reload a foreign
+          commit and re-apply our ops instead of skipping the reload
+          (issue #3688).
 
-        Flush / save failures propagate (same contract as
-        ``index_done_callback``); a partially flushed buffer is preserved
-        for a future retry.
+        Flush / save failures propagate; the replay log is preserved for a
+        future retry.
         """
         async with self._storage_lock:
-            if not self._pending_upserts and not self._index_dirty:
+            if (
+                not self._pending_upserts
+                and not self._pending_deletes
+                and not self._index_dirty
+            ):
                 return
-            if self._pending_upserts:
-                # Only reload when we have nothing un-persisted in self._index.
-                # A dirty index carries successfully-flushed-but-unsaved rows
-                # from a prior index_done_callback; reloading would silently
-                # drop them.
-                if not self._index_dirty:
-                    self._reload_index_from_disk_locked(for_write=True)
-                await self._flush_pending_locked()
-            self._save_faiss_index()
-            await set_all_update_flags(self.namespace, workspace=self.workspace)
-            self.storage_updated.value = False
-            self._index_dirty = False
+            await self._commit_locked()

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -145,9 +145,12 @@ class NanoVectorDBStorage(BaseVectorStorage):
         ``client_storage`` see only data already materialized into
         ``self._client`` — unflushed pending data is intentionally not
         queryable. A flush failure (embedding error, count mismatch, or save
-        IO error) raises through ``index_done_callback``; the pending buffer
-        is preserved, and if only the save failed ``_client_dirty`` stays
-        ``True`` so a subsequent ``finalize`` retries the save.
+        IO error) raises through ``index_done_callback``. The pending buffer
+        is a **replay log**: it is not cleared until the save is durable.
+        If only the save failed, ``_client_dirty`` stays ``True`` and the
+        buffered docs keep their already-computed vectors so a later
+        ``index_done_callback`` / ``finalize`` can reload a foreign commit
+        and re-apply our ops without re-embedding (issue #3688).
     """
 
     def __post_init__(self):
@@ -195,14 +198,17 @@ class NanoVectorDBStorage(BaseVectorStorage):
             storage_file=self._client_file_name,
         )
 
-        # Minimal pending area for deferred embedding: id -> _PendingNanoDoc.
-        # Holds only records not yet embedded+materialized into self._client;
-        # it never duplicates rows already written to the client. Flushed
-        # under _storage_lock by _flush_pending_locked().
+        # Replay log for deferred embedding: id -> _PendingNanoDoc.
+        # Cleared only after a durable save (issue #3688). After a successful
+        # flush the same ids also live in self._client; read-your-writes
+        # still prefer this buffer and both views describe the same content.
         self._pending_upserts: dict[str, _PendingNanoDoc] = {}
+        # Custom ids whose materialized delete has not been saved yet.
+        # Replayed after a foreign-commit reload; cleared after a durable save.
+        # A delete that matched nothing is not retained.
+        self._pending_deletes: set[str] = set()
         # True when self._client has materialized changes that have not been
-        # successfully saved to disk yet. This lets finalize retry a save even
-        # after a previous flush cleared the pending buffer.
+        # successfully saved to disk yet.
         self._client_dirty = False
 
     async def initialize(self):
@@ -241,6 +247,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
             storage_file=self._client_file_name,
         )
         self.storage_updated.value = False
+        self._replay_pending_deletes_locked()
         return True
 
     async def _get_client(self):
@@ -311,6 +318,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
         # have cached (content-version change -> must re-embed new content).
         async with self._storage_lock:
             for doc_id, record in pending:
+                self._pending_deletes.discard(doc_id)
                 self._pending_upserts[doc_id] = _PendingNanoDoc(record=record)
 
     async def _flush_pending_locked(self) -> None:
@@ -383,12 +391,9 @@ class NanoVectorDBStorage(BaseVectorStorage):
 
         self._client.upsert(datas=list_data)
         self._client_dirty = True
-
-        # Clear only the entries we just flushed (an upsert that arrived after
-        # the snapshot would have re-set vector=None and must not be dropped).
-        for doc_id, pdoc in pending_items:
-            if self._pending_upserts.get(doc_id) is pdoc:
-                del self._pending_upserts[doc_id]
+        # Keep `_pending_upserts` as a replay log until `_commit_locked`
+        # observes a durable save. Clearing here is what #3688's silent
+        # drop is: a later unconditional reload has nothing to re-apply.
 
     def _save_to_disk_locked(self) -> None:
         """Atomically persist ``self._client`` and notify other processes.
@@ -483,19 +488,17 @@ class NanoVectorDBStorage(BaseVectorStorage):
             async with self._storage_lock:
                 self._reload_client_from_disk_locked(for_write=True)
 
-                for doc_id in ids:
-                    self._pending_upserts.pop(doc_id, None)
+            matched_ids: list[str] = []
+            for doc_id in ids:
+                self._pending_upserts.pop(doc_id, None)
+                if self._client.get([doc_id]):
+                    matched_ids.append(doc_id)
 
-                # Record count before deletion
-                before_count = len(self._client)
-
-                self._client.delete(ids)
-
-                # Calculate actual deleted count
-                after_count = len(self._client)
-                deleted_count = before_count - after_count
-                if deleted_count:
-                    self._client_dirty = True
+            if matched_ids:
+                self._client.delete(matched_ids)
+                self._pending_deletes.update(matched_ids)
+                self._client_dirty = True
+            deleted_count = len(matched_ids)
 
             logger.debug(
                 f"[{self.workspace}] Successfully deleted {deleted_count} vectors from {self.namespace}"
@@ -538,6 +541,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 # pending buffer intact for the caller's retry path.
                 if self._client.get([entity_id]):
                     self._client.delete([entity_id])
+                    self._pending_deletes.add(entity_id)
                     self._client_dirty = True
                     deleted = True
                 else:
@@ -602,9 +606,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
                     if dp.get("src_id") == entity_name
                     or dp.get("tgt_id") == entity_name
                 ]
-                if ids_to_delete:
-                    self._client.delete(ids_to_delete)
-                    self._client_dirty = True
+            if ids_to_delete:
+                self._client.delete(ids_to_delete)
+                self._pending_deletes.update(ids_to_delete)
+                self._client_dirty = True
 
                 # Materialized delete succeeded — safe to prune matching
                 # buffered upserts so a subsequent flush won't re-upsert
@@ -636,9 +641,12 @@ class NanoVectorDBStorage(BaseVectorStorage):
     async def drop_pending_index_ops(self) -> None:
         """Discard buffered upserts on an aborting batch.
 
-        Only the pending buffer is dropped; records already materialized into
-        ``self._client`` by a prior ``_flush_pending_locked`` whose save step
-        then failed (``_client_dirty=True``) are intentionally NOT rolled back.
+        Only the pending replay log is dropped; records already materialized
+        into ``self._client`` by a prior ``_flush_pending_locked`` whose save
+        step then failed (``_client_dirty=True``) are intentionally NOT
+        rolled back. Clearing the log means a later foreign-commit reload
+        cannot re-apply those ops; that is the abort contract — the file is
+        reprocessed and upserts are keyed by deterministic ids.
 
         The pipeline treats each file as an atomic unit: an abort marks the
         affected documents FAILED and the whole file is reprocessed on the
@@ -655,9 +663,55 @@ class NanoVectorDBStorage(BaseVectorStorage):
         """
         if self._storage_lock is None:
             self._pending_upserts.clear()
+            self._pending_deletes.clear()
             return
         async with self._storage_lock:
             self._pending_upserts.clear()
+            self._pending_deletes.clear()
+
+    def _replay_pending_deletes_locked(self) -> None:
+        """Re-apply unmatched-save deletes onto the current ``self._client``.
+
+        Precondition: the caller already holds ``_storage_lock``. Used after a
+        foreign-commit reload, which replaces the in-memory store and would
+        otherwise resurrect rows whose delete was applied but never saved.
+        Deletes are idempotent: a replayed id that is no longer present is a
+        no-op. The set is **not** cleared here — that happens only after a
+        durable save in ``_commit_locked``.
+        """
+        if not self._pending_deletes:
+            return
+        ids = [doc_id for doc_id in self._pending_deletes if self._client.get([doc_id])]
+        if not ids:
+            return
+        self._client.delete(ids)
+        self._client_dirty = True
+
+    async def _commit_locked(self) -> None:
+        """Reload if needed, replay unsaved ops, save, then drop the replay log.
+
+        Precondition: the caller already holds ``_storage_lock``.
+
+        Order:
+        1. Reload if another process committed (wholesale client replace).
+        2. If we reloaded, replay pending deletes onto that snapshot.
+        3. Flush pending upserts into ``self._client`` (vectors already on
+           a replayed doc are reused; no re-embed).
+        4. Atomically save. On failure the exception propagates, the replay
+           log is left intact, and ``_client_dirty`` stays ``True``.
+        5. On success, clear the replay log and notify other processes.
+
+        This is the #3688 contract: pending is a replay log, not a work
+        queue that is drained before the save is durable.
+        """
+        self._reload_client_from_disk_locked(for_write=True)
+        await self._flush_pending_locked()
+        self._save_to_disk_locked()
+        self._pending_upserts.clear()
+        self._pending_deletes.clear()
+        await set_all_update_flags(self.namespace, workspace=self.workspace)
+        self.storage_updated.value = False
+        self._client_dirty = False
 
     async def index_done_callback(self) -> bool:
         """Flush deferred embeddings, commit to disk, and notify other processes.
@@ -672,12 +726,13 @@ class NanoVectorDBStorage(BaseVectorStorage):
             3. ``_save_to_disk_locked`` (``atomic_write``) lays a tmp file
                beside the target and renames it into place — readers either
                see the previous file in full or the new file in full, never a
-               torn write. A failure here **also raises**; ``_client_dirty``
-               stays ``True`` so a later ``finalize`` retries the save.
-            4. ``set_all_update_flags`` flips every registered process's
-               ``storage_updated`` flag, then we immediately reset our own
-               flag to ``False`` so the writer does not self-reload on the
-               next call to ``_get_client``.
+               torn write. A failure here **also raises**; the replay log
+               (pending upserts and deletes) is left intact and
+               ``_client_dirty`` stays ``True`` so a later commit can reload
+               a foreign snapshot and re-apply our ops (issue #3688).
+            4. On success the replay log is cleared, ``set_all_update_flags``
+               flips every registered process's ``storage_updated`` flag, and
+               we immediately reset our own flag to ``False``.
 
         Either failure surfaces loudly through ``_insert_done`` so the caller
         can abort the document batch instead of silently losing vectors. The
@@ -685,17 +740,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
         ``True`` on the success path.
         """
         async with self._storage_lock:
-            self._reload_client_from_disk_locked(for_write=True)
-
-            # Flush + save both raise on failure (embedding mismatch / save IO
-            # error). The exception propagates out of the lock so _insert_done
-            # aborts the batch; pending stays intact and _client_dirty stays
-            # True (if only the save failed) for a later retry.
-            await self._flush_pending_locked()
-            self._save_to_disk_locked()
-            await set_all_update_flags(self.namespace, workspace=self.workspace)
-            self.storage_updated.value = False
-            self._client_dirty = False
+            await self._commit_locked()
             return True
 
     @staticmethod
@@ -859,6 +904,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
             async with self._storage_lock:
                 # Discard buffered (unflushed) upserts along with the data.
                 self._pending_upserts.clear()
+                self._pending_deletes.clear()
 
                 # delete _client_file_name
                 if os.path.exists(self._client_file_name):
@@ -886,33 +932,26 @@ class NanoVectorDBStorage(BaseVectorStorage):
     async def finalize(self):
         """Flush any buffered upserts and persist before shutdown (safety net).
 
-        Normally ``index_done_callback`` has already drained the pending buffer
-        and synced to disk, but two paths land here with work to do:
+        Normally ``index_done_callback`` has already committed. Two paths
+        still land here with work to do:
 
-        - **Pending upserts only** (no prior ``index_done_callback``): flush
-          and save. We reload first so a stale process picks up other writers'
-          commits before merging its pending buffer in.
-        - **Unsaved materialized changes** (``_client_dirty=True``): an earlier
-          ``index_done_callback`` flushed pending into ``self._client`` but
-          its save raised. Skip the reload — reloading would drop those
-          materialized-but-unsaved rows — and just retry the save.
+        - **Pending upserts only** (no prior commit): flush and save. Reload
+          first so a stale process picks up other writers' commits, then
+          merge the replay log.
+        - **Unsaved materialized changes** (``_client_dirty=True``): an
+          earlier commit flushed into ``self._client`` but its save raised.
+          The replay log is still populated, so we can reload a foreign
+          commit and re-apply our ops instead of skipping the reload
+          (issue #3688).
 
-        Flush / save failures propagate (same contract as
-        ``index_done_callback``); a partially flushed buffer is preserved for
-        a future retry.
+        Flush / save failures propagate; the replay log is preserved for a
+        future retry.
         """
         async with self._storage_lock:
-            if not self._pending_upserts and not self._client_dirty:
+            if (
+                not self._pending_upserts
+                and not self._pending_deletes
+                and not self._client_dirty
+            ):
                 return
-            if self._pending_upserts:
-                # Only reload when we have nothing un-persisted in self._client.
-                # A dirty client carries successfully-flushed-but-unsaved rows
-                # from a prior index_done_callback; reloading would silently
-                # drop them.
-                if not self._client_dirty:
-                    self._reload_client_from_disk_locked(for_write=True)
-                await self._flush_pending_locked()
-            self._save_to_disk_locked()
-            await set_all_update_flags(self.namespace, workspace=self.workspace)
-            self.storage_updated.value = False
-            self._client_dirty = False
+            await self._commit_locked()

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -9,8 +9,9 @@ live model or network. They mirror the protocol proven for
 - ``test_reupsert_after_flush_replaces_single_fid`` — Faiss has no in-place
   upsert; verify the rebuild keeps a single fid per custom id.
 - ``test_index_done_callback_save_failure_raises`` — flush succeeds, save IO
-  fails: pending is empty, ``_index_dirty`` stays True, the materialized index
-  is preserved for a finalize retry.
+  fails: the replay log is retained, ``_index_dirty`` stays True, and a
+  later commit can reload a foreign snapshot without re-embedding
+  (issue #3688).
 - ``test_reload_warns_on_index_meta_skew`` — ``index > meta`` on-disk skew
   (from a crash between the two atomic_writes) is logged on reload but **not**
   auto-repaired.
@@ -422,7 +423,8 @@ async def test_finalize_retries_save_after_flush_failure(tmp_path):
     with pytest.raises(OSError, match="boom"):
         await storage.finalize()
 
-    assert storage._pending_upserts == {}
+    assert "id1" in storage._pending_upserts
+    assert storage._pending_upserts["id1"].vector is not None
     assert storage._index_dirty is True
 
     await storage.finalize()
@@ -472,8 +474,8 @@ async def test_reupsert_after_flush_replaces_single_fid(tmp_path):
 @pytest.mark.offline
 @pytest.mark.asyncio
 async def test_index_done_callback_save_failure_raises(tmp_path):
-    """Save failure in index_done_callback must propagate, leave pending empty
-    (flush already succeeded), and keep _index_dirty=True so finalize retries."""
+    """Save failure in index_done_callback must propagate, keep the replay
+    log (so a later reload can re-apply), and keep _index_dirty=True."""
     embed = _CountingEmbed()
     storage = _make_storage(tmp_path, embed)
     await storage.initialize()
@@ -490,7 +492,10 @@ async def test_index_done_callback_save_failure_raises(tmp_path):
     with pytest.raises(OSError, match="save boom"):
         await storage.index_done_callback()
 
-    assert storage._pending_upserts == {}, "flush succeeded so pending is empty"
+    assert "id1" in storage._pending_upserts, (
+        "unsaved flush is retained as a replay log"
+    )
+    assert storage._pending_upserts["id1"].vector is not None
     assert storage._index_dirty is True, "save failure preserves dirty for retry"
     assert storage._index.ntotal == 1, "materialized state is preserved"
     _assert_consistent(storage)
@@ -799,7 +804,8 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     await storage.initialize()
 
     # Flush id1 into the index, then fail the save so it stays
-    # materialized-but-unsaved (dirty) and the pending buffer is emptied.
+    # materialized-but-unsaved (dirty). The pending buffer is retained as a
+    # replay log until a durable save (issue #3688).
     await storage.upsert({"id1": {"content": "alpha"}})
 
     def fail_save():
@@ -808,7 +814,10 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     storage._save_faiss_index = fail_save
     with pytest.raises(OSError, match="save boom"):
         await storage.index_done_callback()
-    assert storage._pending_upserts == {}, "flush succeeded so pending is empty"
+    assert "id1" in storage._pending_upserts, (
+        "unsaved flush is retained as a replay log"
+    )
+    assert storage._pending_upserts["id1"].vector is not None
     assert storage._index_dirty is True
     assert storage._index.ntotal == 1, "id1 materialized, not saved"
 
@@ -822,3 +831,101 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     assert storage._index.ntotal == 1, "materialized id1 NOT rolled back"
     assert storage._index_dirty is True, "still dirty for a later save retry"
     _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_index_done_replays_unsaved_upsert_after_foreign_commit(tmp_path):
+    """Issue #3688: a failed save must not lose our upserts when another
+    writer commits and the next index_done_callback reloads from disk."""
+    ours_embed = _CountingEmbed()
+    foreign_embed = _CountingEmbed()
+    ours = _make_storage(tmp_path, ours_embed)
+    foreign = _make_storage(tmp_path, foreign_embed)
+    await ours.initialize()
+    await foreign.initialize()
+
+    await ours.upsert({"ours": {"content": "ours-content"}})
+
+    original_save = ours._save_faiss_index
+
+    def fail_save():
+        raise OSError("save boom")
+
+    ours._save_faiss_index = fail_save
+    with pytest.raises(OSError, match="save boom"):
+        await ours.index_done_callback()
+    ours._save_faiss_index = original_save
+
+    assert "ours" in ours._pending_upserts
+    assert ours._pending_upserts["ours"].vector is not None
+    embed_after_fail = ours_embed.call_count
+
+    await foreign.upsert({"theirs": {"content": "theirs-content"}})
+    assert await foreign.index_done_callback() is True
+    assert ours.storage_updated.value is True
+
+    assert await ours.index_done_callback() is True
+    assert ours_embed.call_count == embed_after_fail, "replay must not re-embed"
+    assert ours._pending_upserts == {}
+
+    reader = _make_storage(tmp_path, ours_embed)
+    await reader.initialize()
+    rows = await reader.get_by_ids(["ours", "theirs"])
+    assert [row["id"] for row in rows] == ["ours", "theirs"]
+    _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_index_done_replays_unsaved_delete_after_foreign_commit(tmp_path):
+    """Issue #3688: an applied-but-unsaved delete must survive a foreign
+    commit's reload."""
+    embed = _CountingEmbed()
+    ours = _make_storage(tmp_path, embed)
+    foreign = _make_storage(tmp_path, embed)
+    await ours.initialize()
+    await foreign.initialize()
+
+    await ours.upsert(
+        {"keep": {"content": "keep-me"}, "gone": {"content": "delete-me"}}
+    )
+    assert await ours.index_done_callback() is True
+
+    original_save = ours._save_faiss_index
+
+    def fail_save():
+        raise OSError("save boom")
+
+    await ours.delete(["gone"])
+    assert "gone" in ours._pending_deletes
+    ours._save_faiss_index = fail_save
+    with pytest.raises(OSError, match="save boom"):
+        await ours.index_done_callback()
+    ours._save_faiss_index = original_save
+
+    await foreign.upsert({"theirs": {"content": "theirs-content"}})
+    assert await foreign.index_done_callback() is True
+
+    assert await ours.index_done_callback() is True
+    assert ours._pending_deletes == set()
+
+    reader = _make_storage(tmp_path, embed)
+    await reader.initialize()
+    assert await reader.get_by_id("gone") is None
+    assert (await reader.get_by_id("keep"))["id"] == "keep"
+    assert (await reader.get_by_id("theirs"))["id"] == "theirs"
+    _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_that_matches_nothing_is_not_retained(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.delete(["missing"])
+
+    assert storage._pending_deletes == set()
+    assert storage._index_dirty is False

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -382,7 +382,8 @@ async def test_finalize_retries_save_after_flush_failure(tmp_path):
     with pytest.raises(OSError, match="boom"):
         await storage.finalize()
 
-    assert storage._pending_upserts == {}
+    assert "id1" in storage._pending_upserts
+    assert storage._pending_upserts["id1"].vector is not None
     assert storage._client_dirty is True
 
     await storage.finalize()
@@ -426,7 +427,8 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     await storage.initialize()
 
     # Flush id1 into the in-memory client, then fail the save so it stays
-    # materialized-but-unsaved (dirty) and the pending buffer is emptied.
+    # materialized-but-unsaved (dirty). The pending buffer is retained as a
+    # replay log until a durable save (issue #3688).
     await storage.upsert({"id1": {"content": "alpha"}})
 
     def fail_save():
@@ -435,7 +437,10 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     storage._save_to_disk_locked = fail_save
     with pytest.raises(OSError, match="save boom"):
         await storage.index_done_callback()
-    assert storage._pending_upserts == {}, "flush succeeded so pending is empty"
+    assert "id1" in storage._pending_upserts, (
+        "unsaved flush is retained as a replay log"
+    )
+    assert storage._pending_upserts["id1"].vector is not None
     assert storage._client_dirty is True
     assert len(storage._client) == 1, "id1 materialized, not saved"
 
@@ -448,3 +453,99 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     assert storage._pending_upserts == {}, "pending id2 dropped"
     assert len(storage._client) == 1, "materialized id1 NOT rolled back"
     assert storage._client_dirty is True, "still dirty for a later save retry"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_index_done_replays_unsaved_upsert_after_foreign_commit(tmp_path):
+    """Issue #3688: a failed save must not lose our upserts when another
+    writer commits and the next index_done_callback reloads from disk."""
+    ours_embed = _CountingEmbed()
+    foreign_embed = _CountingEmbed()
+    ours = _make_storage(tmp_path, ours_embed)
+    foreign = _make_storage(tmp_path, foreign_embed)
+    await ours.initialize()
+    await foreign.initialize()
+
+    await ours.upsert({"ours": {"content": "ours-content"}})
+
+    original_save = ours._save_to_disk_locked
+
+    def fail_save():
+        raise OSError("save boom")
+
+    ours._save_to_disk_locked = fail_save
+    with pytest.raises(OSError, match="save boom"):
+        await ours.index_done_callback()
+    ours._save_to_disk_locked = original_save
+
+    assert "ours" in ours._pending_upserts
+    assert ours._pending_upserts["ours"].vector is not None
+    embed_after_fail = ours_embed.call_count
+
+    await foreign.upsert({"theirs": {"content": "theirs-content"}})
+    assert await foreign.index_done_callback() is True
+    assert ours.storage_updated.value is True
+
+    assert await ours.index_done_callback() is True
+    assert ours_embed.call_count == embed_after_fail, "replay must not re-embed"
+    assert ours._pending_upserts == {}
+
+    reader = _make_storage(tmp_path, ours_embed)
+    await reader.initialize()
+    rows = await reader.get_by_ids(["ours", "theirs"])
+    assert [row["id"] for row in rows] == ["ours", "theirs"]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_index_done_replays_unsaved_delete_after_foreign_commit(tmp_path):
+    """Issue #3688: an applied-but-unsaved delete must survive a foreign
+    commit's reload."""
+    embed = _CountingEmbed()
+    ours = _make_storage(tmp_path, embed)
+    foreign = _make_storage(tmp_path, embed)
+    await ours.initialize()
+    await foreign.initialize()
+
+    await ours.upsert(
+        {"keep": {"content": "keep-me"}, "gone": {"content": "delete-me"}}
+    )
+    assert await ours.index_done_callback() is True
+
+    original_save = ours._save_to_disk_locked
+
+    def fail_save():
+        raise OSError("save boom")
+
+    await ours.delete(["gone"])
+    assert "gone" in ours._pending_deletes
+    ours._save_to_disk_locked = fail_save
+    with pytest.raises(OSError, match="save boom"):
+        await ours.index_done_callback()
+    ours._save_to_disk_locked = original_save
+
+    await foreign.upsert({"theirs": {"content": "theirs-content"}})
+    assert await foreign.index_done_callback() is True
+
+    assert await ours.index_done_callback() is True
+    assert ours._pending_deletes == set()
+
+    reader = _make_storage(tmp_path, embed)
+    await reader.initialize()
+    assert await reader.get_by_id("gone") is None
+    assert (await reader.get_by_id("keep"))["id"] == "keep"
+    assert (await reader.get_by_id("theirs"))["id"] == "theirs"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_that_matches_nothing_is_not_retained(tmp_path):
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.delete(["missing"])
+
+    assert storage._pending_deletes == set()
+    assert storage._client_dirty is False


### PR DESCRIPTION
## Description

Treat Nano and Faiss pending upserts/deletes as a replay log that is cleared only after a durable save. `index_done_callback` currently materializes ops, drops the buffer, then reloads from disk unconditionally, so a failed save plus a foreign commit silently loses our rows (or overwrites the other writer on finalize).

## Related Issues

Fixes #3688

## Changes Made

- Keep `_pending_upserts` after flush; clear them only in `_commit_locked` after a successful save
- Retain matched deletes in `_pending_deletes` and replay them on foreign-commit reload
- Do not retain deletes that matched nothing
- `finalize` reloads and replays instead of skipping reload when dirty
- Offline tests for failed-save + foreign commit (upsert and delete) on both backends

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local gate matching CI: `uv run --no-sync pytest tests/kg/nano_impl tests/kg/faiss_impl -m offline` (54 passed). `ruff check` / `ruff format --check` on the four changed files passed. Full-repo `pre-commit run --all-files` was not used as the merge check because the requirements-txt-fixer hook rewrites `requirements-offline*.txt` line endings on Windows.
