### PR TITLE
feat(llm): add openai_responses binding for the OpenAI Responses API

### DIFF
--- a/env.example
+++ b/env.example
@@ -939,7 +939,7 @@ MAX_PARALLEL_INSERT=3
 
 ###########################################################################
 ### Gloabal LLM Configuration
-###   LLM_BINDING type: openai, ollama, lollms, azure_openai, bedrock, gemini
+###   LLM_BINDING type: openai, openai_responses, ollama, lollms, azure_openai, bedrock, gemini
 ###   LLM_BINDING_HOST: Service endpoint (left empty if using the provider SDK default endpoint)
 ###   LLM_BINDING_API_KEY: api key
 ### If LightRAG deployed in Docker:
@@ -1070,6 +1070,23 @@ VLM_MIN_IMAGE_PIXEL=64
 
 ### Role-specific + Provider-sepecific LLM options
 # VLM_OPENAI_LLM_MAX_TOKENS=20000
+
+### OpenAI Responses API Specific Parameters (/v1/responses):
+###     LLM_BINDING=openai_responses
+###     LLM_BINDING_HOST=https://api.openai.com/v1
+###     LLM_MODEL=gpt-5.6
+### A sibling of the `openai` binding, not a replacement. Chat Completions
+### remains supported; Responses is worth choosing for better prompt-cache
+### utilisation on reasoning models, or for a gateway that exposes only
+### /v1/responses. Many OpenAI-compatible servers do not implement it, so the
+### `openai` binding stays the right default for those.
+### Options use their own OPENAI_RESPONSES_LLM_* namespace: the Responses API
+### spells these differently and does not accept the Chat Completions forms.
+# OPENAI_RESPONSES_LLM_MAX_OUTPUT_TOKENS=9000
+# OPENAI_RESPONSES_LLM_REASONING_EFFORT=minimal
+# OPENAI_RESPONSES_LLM_TEMPERATURE=0.9
+### Whether OpenAI retains the response server-side
+# OPENAI_RESPONSES_LLM_STORE=false
 
 ### Azure OpenAI Specific Parameters:
 ###     LLM_BINDING=azure_openai

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -16,6 +16,7 @@ from lightrag.llm.binding_options import (
     OllamaEmbeddingOptions,
     OllamaLLMOptions,
     OpenAILLMOptions,
+    OpenAIResponsesLLMOptions,
 )
 from lightrag.base import OllamaServerInfos
 import sys
@@ -81,6 +82,7 @@ def get_default_host(binding_type: str) -> str:
         "lollms": os.getenv("LLM_BINDING_HOST", "http://localhost:9600"),
         "azure_openai": os.getenv("AZURE_OPENAI_ENDPOINT", "https://api.openai.com/v1"),
         "openai": os.getenv("LLM_BINDING_HOST", "https://api.openai.com/v1"),
+        "openai_responses": os.getenv("LLM_BINDING_HOST", "https://api.openai.com/v1"),
         # Let boto3 select the regional Bedrock endpoint unless the user
         # explicitly overrides LLM_BINDING_HOST / EMBEDDING_BINDING_HOST.
         "bedrock": os.getenv("LLM_BINDING_HOST", "DEFAULT_BEDROCK_ENDPOINT"),
@@ -503,6 +505,7 @@ def parse_args() -> argparse.Namespace:
             "ollama",
             "openai",
             "openai-ollama",
+            "openai_responses",
             "azure_openai",
             "bedrock",
             "gemini",
@@ -556,6 +559,8 @@ def parse_args() -> argparse.Namespace:
         OllamaLLMOptions.add_args(parser)
     elif llm_binding_value in ["openai", "azure_openai"]:
         OpenAILLMOptions.add_args(parser)
+    elif llm_binding_value == "openai_responses":
+        OpenAIResponsesLLMOptions.add_args(parser)
     elif llm_binding_value == "gemini":
         GeminiLLMOptions.add_args(parser)
     elif llm_binding_value == "bedrock":
@@ -806,7 +811,7 @@ def parse_args() -> argparse.Namespace:
                 f"VLM_PROCESS_ENABLE=true but the effective VLM binding "
                 f"'{effective_vlm_binding}' does not support image inputs. "
                 "Configure VLM_LLM_BINDING (or LLM_BINDING) to one of: "
-                "openai, azure_openai, gemini, bedrock, ollama."
+                "openai, openai_responses, azure_openai, gemini, bedrock, ollama."
             )
 
     # Add environment variables that were previously read directly

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -547,6 +547,7 @@ class LLMConfigCache:
         self.ollama_llm_options = None
         self.ollama_embedding_options = None
         self.bedrock_llm_options = None
+        self.openai_responses_llm_options = None
 
         # Only initialize and log OpenAI options when using OpenAI-related bindings
         if args.llm_binding in ["openai", "azure_openai"]:
@@ -554,6 +555,18 @@ class LLMConfigCache:
 
             self.openai_llm_options = OpenAILLMOptions.options_dict(args)
             logger.info(f"OpenAI LLM Options: {self.openai_llm_options}")
+
+        # Responses keeps its own namespace so Chat Completions options
+        # (max_completion_tokens, flat reasoning_effort) cannot leak into it.
+        if args.llm_binding == "openai_responses":
+            from lightrag.llm.binding_options import OpenAIResponsesLLMOptions
+
+            self.openai_responses_llm_options = OpenAIResponsesLLMOptions.options_dict(
+                args
+            )
+            logger.info(
+                f"OpenAI Responses LLM Options: {self.openai_responses_llm_options}"
+            )
 
         if args.llm_binding == "gemini":
             from lightrag.llm.binding_options import GeminiLLMOptions
@@ -1399,6 +1412,7 @@ def create_app(args):
         "lollms",
         "ollama",
         "openai",
+        "openai_responses",
         "azure_openai",
         "bedrock",
         "gemini",
@@ -1786,6 +1800,40 @@ def create_app(args):
 
         return optimized_azure_openai_model_complete
 
+    def create_optimized_openai_responses_llm_func(
+        config_cache: LLMConfigCache, args, llm_timeout: int
+    ):
+        """Create optimized OpenAI Responses LLM function with pre-processed configuration"""
+
+        async def optimized_openai_responses_model_complete(
+            prompt,
+            system_prompt=None,
+            history_messages=None,
+            **kwargs,
+        ):
+            from lightrag.llm.openai_responses import (
+                openai_responses_complete_if_cache,
+            )
+
+            if history_messages is None:
+                history_messages = []
+
+            kwargs["timeout"] = llm_timeout
+            if config_cache.openai_responses_llm_options:
+                kwargs.update(config_cache.openai_responses_llm_options)
+
+            return await openai_responses_complete_if_cache(
+                args.llm_model,
+                prompt,
+                system_prompt=system_prompt,
+                history_messages=history_messages,
+                base_url=args.llm_binding_host,
+                api_key=args.llm_binding_api_key,
+                **kwargs,
+            )
+
+        return optimized_openai_responses_model_complete
+
     def create_optimized_gemini_llm_func(
         config_cache: LLMConfigCache, args, llm_timeout: int
     ):
@@ -1846,6 +1894,13 @@ def create_app(args):
                 )
             elif binding == "gemini":
                 return create_optimized_gemini_llm_func(config_cache, args, llm_timeout)
+            elif binding == "openai_responses":
+                # Explicit branch: the bare `else` below routes to Chat
+                # Completions, so omitting this would silently send Responses
+                # traffic to /v1/chat/completions with no error.
+                return create_optimized_openai_responses_llm_func(
+                    config_cache, args, llm_timeout
+                )
             else:  # openai and compatible
                 # Use optimized function with pre-processed configuration
                 return create_optimized_openai_llm_func(config_cache, args, llm_timeout)
@@ -1902,6 +1957,12 @@ def create_app(args):
                 from lightrag.llm.binding_options import OpenAILLMOptions
 
                 role_provider_options = OpenAILLMOptions.options_dict_for_role(
+                    args, role, is_cross_provider
+                )
+            elif role_binding == "openai_responses":
+                from lightrag.llm.binding_options import OpenAIResponsesLLMOptions
+
+                role_provider_options = OpenAIResponsesLLMOptions.options_dict_for_role(
                     args, role, is_cross_provider
                 )
             elif role_binding == "gemini":
@@ -2097,6 +2158,33 @@ def create_app(args):
                     )
 
                 return role_azure_openai_complete
+            if role_binding == "openai_responses":
+                from lightrag.llm.openai_responses import (
+                    openai_responses_complete_if_cache,
+                )
+
+                async def role_openai_responses_complete(
+                    prompt,
+                    system_prompt=None,
+                    history_messages=None,
+                    **kwargs,
+                ):
+                    if history_messages is None:
+                        history_messages = []
+                    kwargs["timeout"] = role_timeout
+                    if role_provider_options:
+                        kwargs.update(role_provider_options)
+                    return await openai_responses_complete_if_cache(
+                        role_model,
+                        prompt,
+                        system_prompt=system_prompt,
+                        history_messages=history_messages,
+                        base_url=role_host,
+                        api_key=role_apikey,
+                        **kwargs,
+                    )
+
+                return role_openai_responses_complete
             if role_binding == "gemini":
                 from lightrag.llm.gemini import gemini_complete_if_cache
 

--- a/lightrag/llm/binding_options.py
+++ b/lightrag/llm/binding_options.py
@@ -752,6 +752,47 @@ class OpenAILLMOptions(BindingOptions):
 
 
 # =============================================================================
+# Binding Options for OpenAI Responses API
+# =============================================================================
+#
+# Deliberately a separate namespace from ``openai_llm``: the Responses API
+# spells several parameters differently (``max_output_tokens`` rather than
+# ``max_completion_tokens``, a nested ``reasoning`` object rather than a flat
+# ``reasoning_effort``) and does not accept others at all. Sharing the
+# ``OPENAI_LLM_*`` namespace would let Chat Completions settings leak into the
+# Responses driver, where they are either wrong or rejected.
+# =============================================================================
+@dataclass
+class OpenAIResponsesLLMOptions(BindingOptions):
+    """Options for the OpenAI Responses API (``/v1/responses``)."""
+
+    # mandatory name of binding
+    _binding_name: ClassVar[str] = "openai_responses_llm"
+
+    # Sampling and generation parameters
+    max_output_tokens: int = None  # Maximum number of output tokens to generate
+    reasoning_effort: str = ""  # Reasoning effort level (minimal, low, medium, high)
+    service_tier: str = ""  # Service tier for API usage
+    store: bool = False  # Whether OpenAI retains the response server-side
+    temperature: float = DEFAULT_TEMPERATURE  # Controls randomness (0.0 to 2.0)
+    top_p: float = 1.0  # Nucleus sampling parameter (0.0 to 1.0)
+    truncation: str = ""  # Context-overflow strategy (auto, disabled)
+    extra_body: dict = None  # Extra body parameters for compatible gateways
+
+    # Help descriptions
+    _help: ClassVar[dict[str, str]] = {
+        "max_output_tokens": "Maximum number of output tokens to generate (optional, leave empty for model default)",
+        "reasoning_effort": "Reasoning effort for reasoning models (minimal, low, medium, high); sent as reasoning.effort",
+        "service_tier": "Service tier for API usage (optional)",
+        "store": "Whether OpenAI retains the response server-side for later retrieval",
+        "temperature": "Controls randomness (0.0-2.0, higher = more creative)",
+        "top_p": "Nucleus sampling parameter (0.0-1.0, lower = more focused)",
+        "truncation": "Context-overflow strategy (auto, disabled)",
+        "extra_body": 'Extra body parameters for OpenAI-compatible gateways (JSON dict, e.g., \'{"foo": "bar"}\')',
+    }
+
+
+# =============================================================================
 # Binding Options for AWS Bedrock
 # =============================================================================
 #

--- a/lightrag/llm/openai_responses.py
+++ b/lightrag/llm/openai_responses.py
@@ -1,0 +1,624 @@
+"""OpenAI Responses API (``/v1/responses``) LLM binding.
+
+This is a sibling of the ``openai`` binding, not a replacement for it. The
+``openai`` binding doubles as the generic OpenAI-*compatible* binding, and much
+of that ecosystem (vLLM, assorted gateways and third-party providers) does not
+implement ``/v1/responses``. Changing that binding's transport would regress
+those deployments, so the Responses transport lives here instead and is opted
+into explicitly with ``LLM_BINDING=openai_responses``.
+
+The public contract matches ``openai_complete_if_cache``: same arguments, a
+``str`` return for non-streaming calls and an ``AsyncIterator[str]`` for
+streaming ones, ``<think>`` tags around reasoning content, ``TruncatedResponse``
+for token-limit truncation, and ``token_tracker`` accounting. The *implementation*
+of those four behaviours cannot be shared with the Chat Completions driver
+because the wire shapes differ:
+
+===================  ==============================  ================================
+Concern              Chat Completions                Responses
+===================  ==============================  ================================
+System prompt        ``messages[0]`` role=system     ``instructions`` parameter
+Output budget        ``max_completion_tokens``       ``max_output_tokens``
+Reasoning control    ``reasoning_effort`` (flat)     ``reasoning: {"effort": ...}``
+Structured output    ``response_format``             ``text: {"format": ...}``
+Body text            ``choices[].message.content``   ``output[].content[].text``
+Reasoning text       ``message.reasoning_content``   ``output[]`` items of type
+                                                     ``reasoning``
+Truncation signal    ``finish_reason == "length"``   ``status == "incomplete"`` with
+                                                     ``incomplete_details.reason``
+Usage keys           ``prompt_tokens`` /             ``input_tokens`` /
+                     ``completion_tokens``           ``output_tokens``
+Streaming unit       ``choices[].delta``             typed events
+                                                     (``response.output_text.delta``)
+===================  ==============================  ================================
+
+Client construction *is* shared: ``create_openai_async_client`` is imported from
+the Chat Completions module so the two bindings cannot drift on base-URL
+resolution, default headers or the DashScope workspace header.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from typing import Any, Union
+
+import pipmaster as pm
+
+if not pm.is_installed("openai"):
+    pm.install("openai")
+
+from openai import (
+    APIConnectionError,
+    APITimeoutError,
+    BadRequestError,
+    InternalServerError,
+    RateLimitError,
+)
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from lightrag.exceptions import EmptyTruncatedResponseError
+from lightrag.utils import (
+    VERBOSE_DEBUG,
+    TruncatedResponse,
+    empty_length_truncated_hint,
+    logger,
+    safe_unicode_decode,
+    verbose_debug,
+)
+
+from .openai import (
+    InvalidResponseError,
+    TransientBadRequestError,
+    create_openai_async_client,
+)
+
+__all__ = [
+    "openai_responses_complete_if_cache",
+    "openai_responses_complete",
+]
+
+# Chat Completions spellings accepted for convenience, mapped onto their
+# Responses equivalents. Callers configured for the `openai` binding therefore
+# do not silently lose their output budget when switching binding.
+_MAX_TOKEN_ALIASES = ("max_output_tokens", "max_completion_tokens", "max_tokens")
+
+# Chat Completions parameters with no Responses equivalent. Forwarding them
+# would make the API reject the whole request, so they are dropped with a
+# warning rather than passed through.
+_UNSUPPORTED_KWARGS = (
+    "frequency_penalty",
+    "presence_penalty",
+    "logit_bias",
+    "n",
+    "stop",
+)
+
+
+def _translate_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Translate Chat Completions kwargs into Responses parameters.
+
+    Only the spellings that genuinely differ are rewritten; anything else is
+    forwarded untouched so provider-specific extras keep working.
+    """
+    translated = dict(kwargs)
+
+    # Output budget: first alias present wins, in declared precedence order.
+    max_tokens_value = None
+    for alias in _MAX_TOKEN_ALIASES:
+        if translated.get(alias) is not None and max_tokens_value is None:
+            max_tokens_value = translated[alias]
+        translated.pop(alias, None)
+    if max_tokens_value is not None:
+        translated["max_output_tokens"] = max_tokens_value
+
+    # Reasoning: flat `reasoning_effort` becomes nested `reasoning.effort`.
+    # An explicit `reasoning` dict always wins; the flat alias only fills a gap.
+    reasoning_effort = translated.pop("reasoning_effort", None)
+    if reasoning_effort:
+        reasoning = translated.get("reasoning")
+        if isinstance(reasoning, dict):
+            reasoning.setdefault("effort", reasoning_effort)
+        elif reasoning is None:
+            translated["reasoning"] = {"effort": reasoning_effort}
+
+    # Structured output: `response_format` becomes `text.format`.
+    response_format = translated.pop("response_format", None)
+    if isinstance(response_format, dict):
+        text_param = translated.get("text")
+        if isinstance(text_param, dict):
+            text_param.setdefault("format", response_format)
+        elif text_param is None:
+            translated["text"] = {"format": response_format}
+
+    for unsupported in _UNSUPPORTED_KWARGS:
+        if unsupported in translated:
+            value = translated.pop(unsupported)
+            # An unset default is not worth warning about; only a value the
+            # operator actually chose is being discarded.
+            if value not in (None, "", 0, 0.0, [], {}):
+                logger.warning(
+                    f"Dropping '{unsupported}' — the OpenAI Responses API has no "
+                    f"equivalent parameter (value was {value!r})"
+                )
+
+    return translated
+
+
+def _build_input(
+    prompt: str,
+    history_messages: list[dict[str, Any]],
+    image_inputs: list[Any] | None,
+) -> list[dict[str, Any]]:
+    """Build the Responses ``input`` list.
+
+    Responses distinguishes ``input_text`` from ``output_text``: history turns
+    spoken by the assistant must be tagged as output, everything else as input.
+    Tagging an assistant turn as ``input_text`` is rejected by the API.
+    """
+    api_input: list[dict[str, Any]] = []
+
+    for message in history_messages:
+        role = message.get("role", "user")
+        content = message.get("content", "")
+        part_type = "output_text" if role == "assistant" else "input_text"
+        if isinstance(content, str):
+            api_input.append(
+                {"role": role, "content": [{"type": part_type, "text": content}]}
+            )
+        else:
+            # Already in content-part form; forward it untouched.
+            api_input.append({"role": role, "content": content})
+
+    user_content: list[dict[str, Any]] = [{"type": "input_text", "text": prompt}]
+    if image_inputs:
+        from lightrag.llm._vision_utils import normalize_image_inputs
+
+        for img in normalize_image_inputs(image_inputs):
+            user_content.append(
+                {
+                    "type": "input_image",
+                    "image_url": f"data:{img.mime_type};base64,{img.base64_str}",
+                }
+            )
+    api_input.append({"role": "user", "content": user_content})
+    return api_input
+
+
+def _extract_text(response: Any) -> str:
+    """Extract assistant body text from a Responses payload.
+
+    Prefers the SDK's ``output_text`` convenience property and falls back to
+    walking ``output[]`` so the driver still works against OpenAI-compatible
+    servers whose SDK objects lack it.
+    """
+    output_text = getattr(response, "output_text", None)
+    if isinstance(output_text, str) and output_text:
+        return output_text
+
+    parts: list[str] = []
+    for item in getattr(response, "output", None) or []:
+        if getattr(item, "type", None) != "message":
+            continue
+        for part in getattr(item, "content", None) or []:
+            if getattr(part, "type", None) == "output_text":
+                text = getattr(part, "text", None)
+                if text:
+                    parts.append(text)
+    return "".join(parts)
+
+
+def _extract_reasoning(response: Any) -> str:
+    """Extract reasoning-summary text from a Responses payload.
+
+    Reasoning arrives as ``output[]`` items of type ``reasoning`` carrying a
+    ``summary`` list. Raw reasoning tokens are never returned by the API, so
+    this is a summary rather than the full trace.
+    """
+    parts: list[str] = []
+    for item in getattr(response, "output", None) or []:
+        if getattr(item, "type", None) != "reasoning":
+            continue
+        for summary in getattr(item, "summary", None) or []:
+            text = getattr(summary, "text", None)
+            if text:
+                parts.append(text)
+    return "".join(parts)
+
+
+def _is_truncated(response: Any) -> bool:
+    """Whether the response stopped because it hit the output-token budget."""
+    if getattr(response, "status", None) != "incomplete":
+        return False
+    details = getattr(response, "incomplete_details", None)
+    return getattr(details, "reason", None) == "max_output_tokens"
+
+
+def _usage_counts(usage: Any) -> dict[str, int]:
+    """Map Responses usage onto the TokenTracker's Chat Completions key names."""
+    return {
+        "prompt_tokens": getattr(usage, "input_tokens", 0) or 0,
+        "completion_tokens": getattr(usage, "output_tokens", 0) or 0,
+        "total_tokens": getattr(usage, "total_tokens", 0) or 0,
+    }
+
+
+async def _close_quietly(client: Any) -> None:
+    """Close the client, downgrading any close failure to a warning.
+
+    A failure to close must never mask the exception that is already
+    propagating, nor turn a successful call into a failed one.
+    """
+    try:
+        await client.close()
+    except Exception as close_error:  # noqa: BLE001 - cleanup must not raise
+        logger.warning(f"Failed to close OpenAI Responses client: {close_error}")
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=4, max=10),
+    retry=(
+        retry_if_exception_type(RateLimitError)
+        | retry_if_exception_type(APIConnectionError)
+        | retry_if_exception_type(APITimeoutError)
+        | retry_if_exception_type(InvalidResponseError)
+        | retry_if_exception_type(InternalServerError)
+        | retry_if_exception_type(TransientBadRequestError)
+    ),
+)
+async def openai_responses_complete_if_cache(
+    model: str,
+    prompt: str,
+    system_prompt: str | None = None,
+    history_messages: list[dict[str, Any]] | None = None,
+    enable_cot: bool = False,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    token_tracker: Any | None = None,
+    stream: bool | None = None,
+    timeout: int | None = None,
+    keyword_extraction: bool = False,
+    image_inputs: list[Any] | None = None,
+    **kwargs: Any,
+) -> Union[str, AsyncIterator[str]]:
+    """Complete a prompt through the OpenAI Responses API.
+
+    Mirrors the ``openai_complete_if_cache`` contract. See the module docstring
+    for the wire-shape differences that force a separate implementation.
+
+    Args:
+        model: Model identifier, e.g. ``gpt-5.6``.
+        prompt: The user prompt.
+        system_prompt: Sent as the Responses ``instructions`` parameter rather
+            than as a system message.
+        history_messages: Prior conversation turns.
+        enable_cot: Wrap reasoning-summary text in ``<think>`` tags.
+        base_url: API base URL. Defaults to ``OPENAI_API_BASE`` or the public
+            OpenAI endpoint.
+        api_key: API key. Defaults to ``OPENAI_API_KEY``.
+        token_tracker: Optional usage tracker.
+        stream: Whether to stream the response.
+        timeout: Request timeout in seconds.
+        keyword_extraction: Deprecated shim; maps to a JSON-object output
+            format when no explicit ``response_format`` is given.
+        image_inputs: Optional images, sent as ``input_image`` content parts.
+        **kwargs: Forwarded to the API. Chat Completions spellings
+            (``max_tokens``, ``reasoning_effort``, ``response_format``) are
+            translated; parameters with no Responses equivalent are dropped
+            with a warning.
+
+    Returns:
+        The completion text, or an async iterator of text chunks when
+        streaming. Token-limit-truncated output is wrapped in
+        ``TruncatedResponse`` so the cache layer skips persisting it.
+
+    Raises:
+        InvalidResponseError: The response carried no usable text.
+        EmptyTruncatedResponseError: Empty output caused by budget exhaustion.
+    """
+    if history_messages is None:
+        history_messages = []
+
+    # Keep the SDK's own DEBUG chatter out of the log unless explicitly asked
+    # for, matching the Chat Completions driver.
+    if not VERBOSE_DEBUG and logger.level == logging.DEBUG:
+        logging.getLogger("openai").setLevel(logging.INFO)
+
+    client_configs = kwargs.pop("openai_client_configs", {})
+    kwargs.pop("hashing_kv", None)
+    # Accepted for signature parity with the Chat Completions driver, which
+    # uses it only to pick a default response_format.
+    entity_extraction = kwargs.pop("entity_extraction", False)
+
+    if (entity_extraction or keyword_extraction) and kwargs.get(
+        "response_format"
+    ) is None:
+        kwargs["response_format"] = {"type": "json_object"}
+
+    response_format = kwargs.get("response_format")
+    if response_format is not None and not isinstance(response_format, dict):
+        raise ValueError(
+            "openai_responses binding accepts only dict response_format payloads; "
+            f"got {type(response_format).__name__}"
+        )
+    if response_format is not None:
+        # Structured output and <think> wrapping are mutually exclusive: the
+        # tags would corrupt the JSON the caller is about to parse.
+        enable_cot = False
+
+    api_kwargs = _translate_kwargs(kwargs)
+
+    client = create_openai_async_client(
+        api_key=api_key,
+        base_url=base_url,
+        timeout=timeout,
+        client_configs=client_configs,
+    )
+
+    api_input = _build_input(prompt, history_messages, image_inputs)
+
+    if system_prompt:
+        api_kwargs["instructions"] = system_prompt
+    if stream is not None:
+        api_kwargs["stream"] = stream
+    if timeout is not None:
+        api_kwargs["timeout"] = timeout
+
+    logger.debug("===== Entering func of LLM (openai_responses) =====")
+    logger.debug(f"Model: {model}   Base URL: {base_url}")
+    logger.debug(f"Additional kwargs: {api_kwargs}")
+    logger.debug(f"Num of history messages: {len(history_messages)}")
+    verbose_debug(f"System prompt: {system_prompt}")
+    verbose_debug(f"Query: {prompt}")
+    logger.debug("===== Sending Query to LLM =====")
+
+    try:
+        response = await client.responses.create(
+            model=model, input=api_input, **api_kwargs
+        )
+    except (APITimeoutError, APIConnectionError, RateLimitError) as e:
+        logger.error(f"OpenAI Responses API error: {e}")
+        await _close_quietly(client)
+        raise
+    except BadRequestError as e:
+        await _close_quietly(client)
+        # Same transient-400 recovery as the Chat Completions driver: a
+        # corrupted request body in transit surfaces as an unparseable-JSON
+        # 400 and succeeds on retry. Genuine 400s still fail fast.
+        if "could not parse" in str(e).lower():
+            logger.warning(
+                f"Transient JSON-parse 400 from OpenAI Responses, will retry: {e}"
+            )
+            raise TransientBadRequestError(str(e)) from e
+        raise
+    except Exception as e:
+        body = getattr(e, "body", None)
+        request_id = getattr(e, "request_id", None)
+        extra_parts = []
+        if body:
+            extra_parts.append(f"Response body: {body}")
+        if request_id:
+            extra_parts.append(f"Request ID: {request_id}")
+        extra = ("\n" + "\n".join(extra_parts)) if extra_parts else ""
+        logger.error(
+            f"OpenAI Responses API Call Failed,\nModel: {model},\n"
+            f"Params: {api_kwargs}, Got: {e}{extra}"
+        )
+        await _close_quietly(client)
+        raise
+
+    if hasattr(response, "__aiter__"):
+        return _stream_response(response, client, enable_cot, token_tracker)
+
+    return await _handle_non_streaming(response, client, enable_cot, token_tracker)
+
+
+async def _stream_response(
+    response: Any,
+    client: Any,
+    enable_cot: bool,
+    token_tracker: Any | None,
+) -> AsyncIterator[str]:
+    """Yield text chunks from a Responses event stream.
+
+    Responses emits typed events rather than ``choices[].delta`` chunks, so COT
+    state is driven by event *type* instead of by which delta field is
+    populated.
+    """
+    cot_active = False
+    body_text_seen = False
+    final_usage = None
+    closing_via_generator_exit = False
+
+    try:
+        async for event in response:
+            event_type = getattr(event, "type", "") or ""
+
+            if event_type == "response.completed":
+                completed = getattr(event, "response", None)
+                usage = getattr(completed, "usage", None)
+                if usage is not None:
+                    final_usage = usage
+                continue
+
+            if event_type == "response.reasoning_summary_text.delta":
+                if not enable_cot or body_text_seen:
+                    continue
+                delta = getattr(event, "delta", "") or ""
+                if not delta:
+                    continue
+                if not cot_active:
+                    yield "<think>"
+                    cot_active = True
+                if r"\u" in delta:
+                    delta = safe_unicode_decode(delta.encode("utf-8"))
+                yield delta
+                continue
+
+            if event_type == "response.output_text.delta":
+                delta = getattr(event, "delta", "") or ""
+                if not delta:
+                    continue
+                # First body text closes any open reasoning block, matching the
+                # Chat Completions rule that COT stops once content arrives.
+                if cot_active:
+                    yield "</think>"
+                    cot_active = False
+                body_text_seen = True
+                if r"\u" in delta:
+                    delta = safe_unicode_decode(delta.encode("utf-8"))
+                yield delta
+                continue
+
+            if event_type == "error":
+                message = getattr(event, "message", "") or "unknown streaming error"
+                raise InvalidResponseError(f"OpenAI Responses stream error: {message}")
+
+        if cot_active:
+            yield "</think>"
+            cot_active = False
+
+        if token_tracker and final_usage is not None:
+            counts = _usage_counts(final_usage)
+            token_tracker.add_usage(counts)
+            logger.debug(f"Streaming token usage (from API): {counts}")
+    except GeneratorExit:
+        # Consumer disconnected: the finally block must not yield, or cleanup
+        # aborts with "async generator ignored GeneratorExit".
+        closing_via_generator_exit = True
+        raise
+    except Exception as e:
+        if cot_active:
+            try:
+                yield "</think>"
+                cot_active = False
+            except Exception as close_error:  # noqa: BLE001 - cleanup only
+                logger.warning(f"Failed to close COT tag on error: {close_error}")
+        logger.error(f"Error in Responses stream: {e}")
+        raise
+    finally:
+        if cot_active and not closing_via_generator_exit:
+            try:
+                yield "</think>"
+            except Exception as final_error:  # noqa: BLE001 - cleanup only
+                logger.warning(f"Failed to close COT tag in finally: {final_error}")
+        aclose = getattr(response, "aclose", None)
+        if callable(aclose):
+            try:
+                await response.aclose()
+            except Exception as close_error:  # noqa: BLE001 - cleanup only
+                logger.debug(f"Stream close not supported by wrapper: {close_error}")
+        await _close_quietly(client)
+
+
+async def _handle_non_streaming(
+    response: Any,
+    client: Any,
+    enable_cot: bool,
+    token_tracker: Any | None,
+) -> str:
+    """Turn a non-streaming Responses payload into the driver's ``str`` result."""
+    try:
+        # Count usage before any validation raises: the request consumed its
+        # budget whether or not the output turned out to be usable, and a
+        # reasoning model that spent the whole budget on its trace is exactly
+        # the case that raises below.
+        usage = getattr(response, "usage", None)
+        if token_tracker and usage is not None:
+            token_tracker.add_usage(_usage_counts(usage))
+
+        content = _extract_text(response)
+        reasoning = _extract_reasoning(response) if enable_cot else ""
+
+        final_content = content or ""
+        if enable_cot and reasoning.strip() and not final_content.strip():
+            if r"\u" in reasoning:
+                reasoning = safe_unicode_decode(reasoning.encode("utf-8"))
+            final_content = f"<think>{reasoning}</think>{final_content}"
+
+        truncated = _is_truncated(response)
+
+        if not final_content or not final_content.strip():
+            status = getattr(response, "status", None)
+            details = getattr(response, "incomplete_details", None)
+            reason = getattr(details, "reason", None)
+            output_tokens = getattr(usage, "output_tokens", None)
+            usage_details = getattr(usage, "output_tokens_details", None)
+            reasoning_tokens = getattr(usage_details, "reasoning_tokens", None)
+            reasoning_len = len(reasoning.strip()) if reasoning else 0
+            diagnostics = (
+                f"status={status if status is not None else 'n/a'}, "
+                f"incomplete_reason={reason if reason is not None else 'n/a'}, "
+                f"output_tokens={output_tokens if output_tokens is not None else 'n/a'}, "
+                f"reasoning_tokens={reasoning_tokens if reasoning_tokens is not None else 'n/a'}, "
+                f"reasoning_content_len={reasoning_len}"
+            )
+            if truncated:
+                hint = empty_length_truncated_hint(
+                    "consider raising max_output_tokens or lowering reasoning effort",
+                    reasoning_consumed_budget=bool(reasoning_tokens),
+                )
+            elif reasoning_len:
+                hint = (
+                    "model returned reasoning-only output; "
+                    "consider disabling thinking mode for this role"
+                )
+            else:
+                hint = "model produced no output"
+            error_message = (
+                f"Received empty content from OpenAI Responses API "
+                f"({diagnostics}): {hint}"
+            )
+            logger.error(error_message)
+            # Budget exhaustion is deterministic for a given prompt and budget,
+            # so it raises the non-retryable type rather than buying two more
+            # full-budget generations. Other empty modes stay retryable.
+            if truncated:
+                raise EmptyTruncatedResponseError(error_message)
+            raise InvalidResponseError(error_message)
+
+        if r"\u" in final_content:
+            final_content = safe_unicode_decode(final_content.encode("utf-8"))
+
+        if truncated:
+            logger.warning(
+                "OpenAI Responses output truncated by token limit "
+                f"(content_len={len(final_content)}), returning partial content"
+            )
+            final_content = TruncatedResponse(final_content)
+
+        logger.debug(f"Response content len: {len(final_content)}")
+        verbose_debug(f"Response: {response}")
+        return final_content
+    finally:
+        await _close_quietly(client)
+
+
+async def openai_responses_complete(
+    prompt: str,
+    system_prompt: str | None = None,
+    history_messages: list[dict[str, Any]] | None = None,
+    keyword_extraction: bool = False,
+    entity_extraction: bool = False,
+    **kwargs: Any,
+) -> Union[str, AsyncIterator[str]]:
+    """LightRAG ``llm_model_func`` entry point for the Responses binding."""
+    if history_messages is None:
+        history_messages = []
+    entity_extraction = kwargs.pop("entity_extraction", entity_extraction)
+    model_name = kwargs["hashing_kv"].global_config["llm_model_name"]
+    return await openai_responses_complete_if_cache(
+        model_name,
+        prompt,
+        system_prompt=system_prompt,
+        history_messages=history_messages,
+        keyword_extraction=keyword_extraction,
+        entity_extraction=entity_extraction,
+        **kwargs,
+    )

--- a/lightrag/llm/openai_responses.py
+++ b/lightrag/llm/openai_responses.py
@@ -26,6 +26,8 @@ Reasoning text       ``message.reasoning_content``   ``output[]`` items of type
                                                      ``reasoning``
 Truncation signal    ``finish_reason == "length"``   ``status == "incomplete"`` with
                                                      ``incomplete_details.reason``
+Refusal              ``message.refusal``             ``refusal`` content parts /
+                                                     ``response.refusal.*`` events
 Usage keys           ``prompt_tokens`` /             ``input_tokens`` /
                      ``completion_tokens``           ``output_tokens``
 Streaming unit       ``choices[].delta``             typed events
@@ -100,6 +102,31 @@ _UNSUPPORTED_KWARGS = (
 )
 
 
+def _normalize_text_format(response_format: dict[str, Any]) -> dict[str, Any]:
+    """Reshape a Chat Completions ``response_format`` into a Responses ``text.format``.
+
+    ``{"type": "json_object"}`` is spelled identically in both APIs. A json
+    schema is not: Chat Completions nests ``name`` / ``schema`` / ``strict``
+    under a ``json_schema`` key, while Responses expects them directly on the
+    format object. Forwarding the nested form unchanged is rejected with a 400,
+    so every schema-constrained request would fail on this binding.
+    """
+    if response_format.get("type") != "json_schema":
+        return response_format
+
+    json_schema = response_format.get("json_schema")
+    if not isinstance(json_schema, dict):
+        # Already flat -- i.e. the caller wrote the Responses spelling -- or a
+        # shape this driver does not recognise. Forward it rather than guess.
+        return response_format
+
+    flattened = {
+        key: value for key, value in response_format.items() if key != "json_schema"
+    }
+    flattened.update(json_schema)
+    return flattened
+
+
 def _translate_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     """Translate Chat Completions kwargs into Responses parameters.
 
@@ -127,14 +154,16 @@ def _translate_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
         elif reasoning is None:
             translated["reasoning"] = {"effort": reasoning_effort}
 
-    # Structured output: `response_format` becomes `text.format`.
+    # Structured output: `response_format` becomes `text.format`, after the
+    # json_schema payload is reshaped for this API.
     response_format = translated.pop("response_format", None)
     if isinstance(response_format, dict):
+        text_format = _normalize_text_format(response_format)
         text_param = translated.get("text")
         if isinstance(text_param, dict):
-            text_param.setdefault("format", response_format)
+            text_param.setdefault("format", text_format)
         elif text_param is None:
-            translated["text"] = {"format": response_format}
+            translated["text"] = {"format": text_format}
 
     for unsupported in _UNSUPPORTED_KWARGS:
         if unsupported in translated:
@@ -237,6 +266,32 @@ def _is_truncated(response: Any) -> bool:
         return False
     details = getattr(response, "incomplete_details", None)
     return getattr(details, "reason", None) == "max_output_tokens"
+
+
+def _incomplete_reason(terminal: Any) -> str:
+    """Why a Responses generation reported ``status: incomplete``."""
+    details = getattr(terminal, "incomplete_details", None)
+    reason = getattr(details, "reason", None)
+    return str(reason) if reason is not None else "unknown"
+
+
+def _extract_refusal(response: Any) -> str:
+    """Extract refusal text from a Responses payload.
+
+    A refused turn carries ``refusal`` content parts instead of ``output_text``
+    ones, so the body walk in :func:`_extract_text` sees nothing and the
+    payload would otherwise be diagnosed as empty output.
+    """
+    parts: list[str] = []
+    for item in getattr(response, "output", None) or []:
+        if getattr(item, "type", None) != "message":
+            continue
+        for part in getattr(item, "content", None) or []:
+            if getattr(part, "type", None) == "refusal":
+                text = getattr(part, "refusal", None)
+                if text:
+                    parts.append(text)
+    return "".join(parts)
 
 
 def _usage_counts(usage: Any) -> dict[str, int]:
@@ -342,7 +397,10 @@ async def openai_responses_complete_if_cache(
         cannot be re-wrapped.
 
     Raises:
-        InvalidResponseError: The response carried no usable text.
+        InvalidResponseError: The response carried no usable text, the
+            generation failed after the request was accepted, the model
+            refused, or the generation was stopped for a reason other than
+            the output budget.
         EmptyTruncatedResponseError: Empty output caused by budget exhaustion.
     """
     if history_messages is None:
@@ -464,11 +522,25 @@ async def _stream_response(
     with ``response.failed``, which is neither of those terminals nor the
     separate ``error`` event. It raises, so a provider failure never reaches
     the consumer as a short-but-successful answer.
+
+    Stopped generations: ``response.incomplete`` also carries reasons other
+    than the output budget, ``content_filter`` chief among them. Those are not
+    truncation, so they raise rather than ending the iterator on whatever text
+    had been yielded.
+
+    Refusal: a refused turn streams ``response.refusal.*`` events and can still
+    end with ``response.completed``. The refusal text is collected and raised
+    after the terminal, rather than being dropped for want of an
+    ``output_text`` delta.
     """
     cot_active = False
     body_text_seen = False
     reasoning_text_seen = False
     truncated = False
+    incomplete_reason: str | None = None
+    refusal_parts: list[str] = []
+    refusal_seen = False
+    final_terminal = None
     final_usage = None
     closing_via_generator_exit = False
 
@@ -481,11 +553,20 @@ async def _stream_response(
                 # `response.incomplete` instead of `response.completed`. Both
                 # carry the terminal usage; only the latter is a clean finish.
                 terminal = getattr(event, "response", None)
+                final_terminal = terminal
                 usage = getattr(terminal, "usage", None)
                 if usage is not None:
                     final_usage = usage
                 if event_type == "response.incomplete":
                     truncated = _is_truncated(terminal)
+                    if not truncated:
+                        # An incomplete terminal for any reason other than the
+                        # output budget is not truncation; it is a generation
+                        # that was stopped, most often by a content filter. A
+                        # terminal this driver cannot read reports "unknown"
+                        # and takes the same path: incomplete is not complete,
+                        # and guessing which reason it was would be worse.
+                        incomplete_reason = _incomplete_reason(terminal)
                 continue
 
             if event_type == "response.reasoning_summary_text.delta":
@@ -518,6 +599,31 @@ async def _stream_response(
                 yield delta
                 continue
 
+            if event_type == "response.refusal.delta":
+                # A refusal streams on its own event type and never as body
+                # text, so an unhandled one ends the iterator successfully with
+                # nothing yielded. It is collected here and raised after the
+                # terminal, so the terminal usage is still accounted.
+                #
+                # The event and its text are tracked apart: an empty delta is
+                # still a refusal, and letting it stand in for the text would
+                # both suppress the raise and disarm the `.done` fallback.
+                refusal_seen = True
+                delta = getattr(event, "delta", "") or ""
+                if delta:
+                    refusal_parts.append(delta)
+                continue
+
+            if event_type == "response.refusal.done":
+                # Carries the whole refusal. Only used when the deltas carried
+                # no text, since otherwise it would duplicate them.
+                refusal_seen = True
+                if not refusal_parts:
+                    done_text = getattr(event, "refusal", "") or ""
+                    if done_text:
+                        refusal_parts.append(done_text)
+                continue
+
             if event_type == "response.failed":
                 # A request the transport accepted can still fail during
                 # generation. That terminates the stream with `response.failed`
@@ -540,6 +646,38 @@ async def _stream_response(
             cot_active = False
 
         _account_stream_usage(token_tracker, final_usage)
+
+        refusal = "".join(refusal_parts).strip()
+        if not refusal:
+            # Same fallback as `_extract_text`: a server that populates the
+            # terminal payload but does not emit the refusal events would
+            # otherwise end the iterator empty and successful.
+            refusal = _extract_refusal(final_terminal).strip()
+        if refusal or refusal_seen:
+            error_message = (
+                "OpenAI Responses stream refused the request: "
+                f"{refusal or 'no reason given'}"
+            )
+            logger.error(error_message)
+            # Retryable, like the `error` and `response.failed` terminals: a
+            # refusal is a provider verdict this driver cannot distinguish from
+            # a transient safety-stack failure, and the retry set is the
+            # module's default for everything except budget exhaustion, whose
+            # outcome is fixed by the caller's own max_output_tokens.
+            raise InvalidResponseError(error_message)
+
+        if incomplete_reason is not None:
+            # Text already yielded is the tail of a generation that did not
+            # finish, so ending here would present it as a complete answer. The
+            # budget case below is the one incomplete reason that keeps its
+            # partial output, because the model chose where to stop within a
+            # limit the caller set.
+            error_message = (
+                "OpenAI Responses stream stopped before completion "
+                f"(incomplete_reason={incomplete_reason})"
+            )
+            logger.error(error_message)
+            raise InvalidResponseError(error_message)
 
         if truncated:
             if body_text_seen or reasoning_text_seen:
@@ -631,6 +769,31 @@ async def _handle_non_streaming(
             logger.error(error_message)
             raise InvalidResponseError(error_message)
 
+        # Sibling of the `response.refusal.*` events on the streaming path: a
+        # refused turn carries `refusal` content parts, which the body walk
+        # skips, so without this the refusal would be reported as "model
+        # produced no output" and its reason discarded.
+        refusal = _extract_refusal(response).strip()
+        if refusal:
+            error_message = f"OpenAI Responses request was refused: {refusal}"
+            logger.error(error_message)
+            raise InvalidResponseError(error_message)
+
+        truncated = _is_truncated(response)
+
+        # Sibling of the non-budget `response.incomplete` terminal on the
+        # streaming path. Budget truncation keeps its partial output below,
+        # because the model chose where to stop within a limit the caller set;
+        # any other incomplete reason is a generation that was stopped, and
+        # returning its tail would present it as a complete answer.
+        if getattr(response, "status", None) == "incomplete" and not truncated:
+            error_message = (
+                "OpenAI Responses request stopped before completion "
+                f"(incomplete_reason={_incomplete_reason(response)})"
+            )
+            logger.error(error_message)
+            raise InvalidResponseError(error_message)
+
         content = _extract_text(response)
         reasoning = _extract_reasoning(response) if enable_cot else ""
 
@@ -639,8 +802,6 @@ async def _handle_non_streaming(
             if r"\u" in reasoning:
                 reasoning = safe_unicode_decode(reasoning.encode("utf-8"))
             final_content = f"<think>{reasoning}</think>{final_content}"
-
-        truncated = _is_truncated(response)
 
         if not final_content or not final_content.strip():
             status = getattr(response, "status", None)

--- a/lightrag/llm/openai_responses.py
+++ b/lightrag/llm/openai_responses.py
@@ -532,6 +532,12 @@ async def _stream_response(
     end with ``response.completed``. The refusal text is collected and raised
     after the terminal, rather than being dropped for want of an
     ``output_text`` delta.
+
+    Usable output: a clean ``response.completed`` with no body text and no
+    reasoning text at all (a forwarded ``tools`` request that only produced a
+    function call, or a compatible gateway supplying an empty terminal)
+    raises rather than ending the iterator on nothing, matching the
+    non-streaming path's rule for the same payload.
     """
     cot_active = False
     body_text_seen = False
@@ -710,6 +716,20 @@ async def _stream_response(
                 # budget, so it raises the non-retryable type rather than
                 # buying two more full-budget generations.
                 raise EmptyTruncatedResponseError(error_message)
+        elif not body_text_seen and not reasoning_text_seen:
+            # A clean `response.completed` with no output_text delta and no
+            # reasoning delta at all -- a forwarded `tools` request that only
+            # produced a function call, or a compatible gateway supplying an
+            # empty terminal -- is exactly the payload `_handle_non_streaming`
+            # raises InvalidResponseError for. Without this check the
+            # generator simply ends here, reporting a clean success with
+            # nothing yielded to the caller.
+            error_message = (
+                "OpenAI Responses stream completed with no usable output "
+                "(no body text and no reasoning text)"
+            )
+            logger.error(error_message)
+            raise InvalidResponseError(error_message)
     except GeneratorExit:
         # Consumer disconnected: the finally block must not yield, or cleanup
         # aborts with "async generator ignored GeneratorExit".

--- a/lightrag/llm/openai_responses.py
+++ b/lightrag/llm/openai_responses.py
@@ -315,8 +315,10 @@ async def openai_responses_complete_if_cache(
 
     Returns:
         The completion text, or an async iterator of text chunks when
-        streaming. Token-limit-truncated output is wrapped in
-        ``TruncatedResponse`` so the cache layer skips persisting it.
+        streaming. Token-limit-truncated non-streaming output is wrapped in
+        ``TruncatedResponse`` so the cache layer skips persisting it; a
+        truncated stream logs a warning instead, since chunks already yielded
+        cannot be re-wrapped.
 
     Raises:
         InvalidResponseError: The response carried no usable text.
@@ -430,9 +432,17 @@ async def _stream_response(
     Responses emits typed events rather than ``choices[].delta`` chunks, so COT
     state is driven by event *type* instead of by which delta field is
     populated.
+
+    Truncation: a stream that exhausts ``max_output_tokens`` terminates with
+    ``response.incomplete`` rather than ``response.completed``. Partial output
+    is kept and a warning logged; a truncated stream that yielded nothing
+    raises ``EmptyTruncatedResponseError``, matching the non-streaming path's
+    rule that budget exhaustion with no usable text is non-retryable.
     """
     cot_active = False
     body_text_seen = False
+    reasoning_text_seen = False
+    truncated = False
     final_usage = None
     closing_via_generator_exit = False
 
@@ -440,11 +450,16 @@ async def _stream_response(
         async for event in response:
             event_type = getattr(event, "type", "") or ""
 
-            if event_type == "response.completed":
-                completed = getattr(event, "response", None)
-                usage = getattr(completed, "usage", None)
+            if event_type in ("response.completed", "response.incomplete"):
+                # Exhausting max_output_tokens terminates the stream with
+                # `response.incomplete` instead of `response.completed`. Both
+                # carry the terminal usage; only the latter is a clean finish.
+                terminal = getattr(event, "response", None)
+                usage = getattr(terminal, "usage", None)
                 if usage is not None:
                     final_usage = usage
+                if event_type == "response.incomplete":
+                    truncated = _is_truncated(terminal)
                 continue
 
             if event_type == "response.reasoning_summary_text.delta":
@@ -458,6 +473,7 @@ async def _stream_response(
                     cot_active = True
                 if r"\u" in delta:
                     delta = safe_unicode_decode(delta.encode("utf-8"))
+                reasoning_text_seen = True
                 yield delta
                 continue
 
@@ -484,10 +500,44 @@ async def _stream_response(
             yield "</think>"
             cot_active = False
 
+        # Account usage before any validation raises: the request consumed its
+        # budget whether or not the output turned out to be usable.
         if token_tracker and final_usage is not None:
             counts = _usage_counts(final_usage)
             token_tracker.add_usage(counts)
             logger.debug(f"Streaming token usage (from API): {counts}")
+
+        if truncated:
+            if body_text_seen or reasoning_text_seen:
+                # Partial output already reached the consumer, so raising here
+                # would discard text it can still salvage. Mirrors the
+                # non-streaming path, which returns partial content wrapped in
+                # TruncatedResponse - a wrapper a generator cannot apply to
+                # chunks it has already yielded.
+                logger.warning(
+                    "OpenAI Responses stream truncated by token limit, "
+                    "returning partial content"
+                )
+            else:
+                output_tokens = getattr(final_usage, "output_tokens", None)
+                usage_details = getattr(final_usage, "output_tokens_details", None)
+                reasoning_tokens = getattr(usage_details, "reasoning_tokens", None)
+                hint = empty_length_truncated_hint(
+                    "consider raising max_output_tokens or lowering reasoning effort",
+                    reasoning_consumed_budget=bool(reasoning_tokens),
+                )
+                error_message = (
+                    "Received empty content from OpenAI Responses stream "
+                    "(status=incomplete, incomplete_reason=max_output_tokens, "
+                    f"output_tokens={output_tokens if output_tokens is not None else 'n/a'}, "
+                    f"reasoning_tokens={reasoning_tokens if reasoning_tokens is not None else 'n/a'}"
+                    f"): {hint}"
+                )
+                logger.error(error_message)
+                # Budget exhaustion is deterministic for a given prompt and
+                # budget, so it raises the non-retryable type rather than
+                # buying two more full-budget generations.
+                raise EmptyTruncatedResponseError(error_message)
     except GeneratorExit:
         # Consumer disconnected: the finally block must not yield, or cleanup
         # aborts with "async generator ignored GeneratorExit".

--- a/lightrag/llm/openai_responses.py
+++ b/lightrag/llm/openai_responses.py
@@ -248,6 +248,27 @@ def _usage_counts(usage: Any) -> dict[str, int]:
     }
 
 
+def _failure_reason(terminal: Any) -> str:
+    """Human-readable reason a Responses generation reported ``status: failed``."""
+    error = getattr(terminal, "error", None)
+    message = getattr(error, "message", None) or "unknown failure"
+    code = getattr(error, "code", None)
+    return f"code={code if code is not None else 'n/a'}, {message}"
+
+
+def _account_stream_usage(token_tracker: Any, usage: Any) -> None:
+    """Record what the attempt spent, before any validation raises.
+
+    The request consumed its budget whether or not the output turned out to be
+    usable, and a failed generation is billed the same way a truncated one is.
+    """
+    if token_tracker is None or usage is None:
+        return
+    counts = _usage_counts(usage)
+    token_tracker.add_usage(counts)
+    logger.debug(f"Streaming token usage (from API): {counts}")
+
+
 async def _close_quietly(client: Any) -> None:
     """Close the client, downgrading any close failure to a warning.
 
@@ -438,6 +459,11 @@ async def _stream_response(
     is kept and a warning logged; a truncated stream that yielded nothing
     raises ``EmptyTruncatedResponseError``, matching the non-streaming path's
     rule that budget exhaustion with no usable text is non-retryable.
+
+    Failure: a generation that fails after the request was accepted terminates
+    with ``response.failed``, which is neither of those terminals nor the
+    separate ``error`` event. It raises, so a provider failure never reaches
+    the consumer as a short-but-successful answer.
     """
     cot_active = False
     body_text_seen = False
@@ -492,6 +518,19 @@ async def _stream_response(
                 yield delta
                 continue
 
+            if event_type == "response.failed":
+                # A request the transport accepted can still fail during
+                # generation. That terminates the stream with `response.failed`
+                # -- neither a completed/incomplete terminal nor the separate
+                # `error` event -- so without this branch the iterator would end
+                # successfully on whatever partial text had already been
+                # yielded, discarding the provider's reason.
+                terminal = getattr(event, "response", None)
+                _account_stream_usage(token_tracker, getattr(terminal, "usage", None))
+                raise InvalidResponseError(
+                    f"OpenAI Responses stream failed ({_failure_reason(terminal)})"
+                )
+
             if event_type == "error":
                 message = getattr(event, "message", "") or "unknown streaming error"
                 raise InvalidResponseError(f"OpenAI Responses stream error: {message}")
@@ -500,12 +539,7 @@ async def _stream_response(
             yield "</think>"
             cot_active = False
 
-        # Account usage before any validation raises: the request consumed its
-        # budget whether or not the output turned out to be usable.
-        if token_tracker and final_usage is not None:
-            counts = _usage_counts(final_usage)
-            token_tracker.add_usage(counts)
-            logger.debug(f"Streaming token usage (from API): {counts}")
+        _account_stream_usage(token_tracker, final_usage)
 
         if truncated:
             if body_text_seen or reasoning_text_seen:
@@ -582,6 +616,20 @@ async def _handle_non_streaming(
         usage = getattr(response, "usage", None)
         if token_tracker and usage is not None:
             token_tracker.add_usage(_usage_counts(usage))
+
+        # Same terminal as `response.failed` on the streaming path: a request
+        # accepted at the transport layer that failed during generation returns
+        # status "failed" with the reason in `error`, rather than raising from
+        # responses.create(). Checked before the content walk so the provider's
+        # reason is reported instead of a bare empty-output diagnosis, and so a
+        # failed generation that carried partial output is not returned as a
+        # successful short answer.
+        if getattr(response, "status", None) == "failed":
+            error_message = (
+                f"OpenAI Responses request failed ({_failure_reason(response)})"
+            )
+            logger.error(error_message)
+            raise InvalidResponseError(error_message)
 
         content = _extract_text(response)
         reasoning = _extract_reasoning(response) if enable_cot else ""

--- a/tests/api/config/test_api_config_openai_responses.py
+++ b/tests/api/config/test_api_config_openai_responses.py
@@ -1,0 +1,133 @@
+"""Config wiring for the openai_responses binding.
+
+``create_llm_model_func()`` ends in a bare ``else:  # openai and compatible``,
+so a binding missing from any one of the exact in-list checks does not raise —
+it silently routes to ``/v1/chat/completions``. These tests pin the wiring that
+prevents that, and pin the namespace separation that keeps Chat Completions
+options from leaking into the Responses driver.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from lightrag.api.config import get_default_host, parse_args
+from lightrag.llm.binding_options import OpenAIResponsesLLMOptions
+
+pytestmark = pytest.mark.offline
+
+# Env that a developer-local .env could otherwise use to decide the outcome.
+_AMBIENT_ENV = (
+    "LLM_BINDING",
+    "LLM_BINDING_HOST",
+    "VLM_PROCESS_ENABLE",
+    "OPENAI_LLM_MAX_COMPLETION_TOKENS",
+    "OPENAI_LLM_REASONING_EFFORT",
+    "OPENAI_RESPONSES_LLM_MAX_OUTPUT_TOKENS",
+    "OPENAI_RESPONSES_LLM_REASONING_EFFORT",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Pin argv and clear ambient binding env.
+
+    parse_args() reads sys.argv, and importing the server module runs a
+    module-level parse_args(), so argv must be pinned before either happens.
+    """
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    for name in _AMBIENT_ENV:
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+def test_binding_is_an_accepted_llm_binding_choice(clean_env):
+    clean_env.setenv("LLM_BINDING", "openai_responses")
+
+    # An unlisted value would make argparse exit with SystemExit(2).
+    assert parse_args().llm_binding == "openai_responses"
+
+
+def test_default_host_is_the_openai_endpoint(clean_env):
+    # Without this mapping the binding falls back to the catch-all Ollama
+    # default (http://localhost:11434) and every request fails at connect time.
+    assert get_default_host("openai_responses") == "https://api.openai.com/v1"
+
+
+def test_binding_host_override_is_honoured(clean_env):
+    clean_env.setenv("LLM_BINDING_HOST", "https://gateway.example/v1")
+
+    assert get_default_host("openai_responses") == "https://gateway.example/v1"
+
+
+def test_options_use_their_own_env_namespace(clean_env):
+    clean_env.setenv("LLM_BINDING", "openai_responses")
+    clean_env.setenv("OPENAI_RESPONSES_LLM_MAX_OUTPUT_TOKENS", "4096")
+
+    options = OpenAIResponsesLLMOptions.options_dict(parse_args())
+
+    assert options["max_output_tokens"] == 4096
+
+
+def test_chat_completions_options_do_not_leak_into_responses(clean_env):
+    """OPENAI_LLM_* must not reach the Responses driver.
+
+    ``max_completion_tokens`` does not exist on the Responses API, and a flat
+    ``reasoning_effort`` is rejected where a nested ``reasoning`` object is
+    expected — so a leak is a request-level failure, not a cosmetic one.
+    """
+    clean_env.setenv("LLM_BINDING", "openai_responses")
+    clean_env.setenv("OPENAI_LLM_MAX_COMPLETION_TOKENS", "999")
+
+    options = OpenAIResponsesLLMOptions.options_dict(parse_args())
+
+    assert "max_completion_tokens" not in options
+    assert options.get("max_output_tokens") != 999
+
+
+def test_the_responses_binding_does_not_reach_the_chat_completions_fallthrough(
+    clean_env,
+):
+    """The dispatch branch must precede the bare Chat Completions ``else``.
+
+    Adding the binding to the argparse choices but not to the dispatch chain
+    produces no error at all — requests just go to the wrong endpoint. This is
+    the guard the issue explicitly asked for.
+    """
+    import inspect
+
+    from lightrag.api import lightrag_server
+
+    source = inspect.getsource(lightrag_server)
+
+    # There are two `else:  # openai and compatible` fallthroughs: the earlier
+    # one is the *embedding* dispatch, which this binding never reaches because
+    # openai_responses is not an embedding choice (the Responses API does not
+    # replace /v1/embeddings). The LLM dispatch is the later one.
+    dispatch_index = source.index('elif binding == "openai_responses":')
+    llm_fallthrough_index = source.rindex("else:  # openai and compatible")
+
+    assert dispatch_index < llm_fallthrough_index, (
+        "the openai_responses branch must precede the Chat Completions "
+        "fallthrough, or Responses traffic is silently sent to "
+        "/v1/chat/completions"
+    )
+    # Pin the assumption above: if a third fallthrough is ever added, this
+    # test's rindex could start pointing at the wrong one.
+    assert source.count("else:  # openai and compatible") == 2
+
+
+def test_binding_is_in_the_server_startup_allow_list(clean_env):
+    """Startup rejects any binding absent from its allow-list."""
+    import inspect
+
+    from lightrag.api import lightrag_server
+
+    source = inspect.getsource(lightrag_server)
+    allow_list_start = source.index("if args.llm_binding not in [")
+    allow_list_end = source.index('raise Exception("llm binding not supported")')
+    allow_list = source[allow_list_start:allow_list_end]
+
+    assert '"openai_responses"' in allow_list

--- a/tests/llm/openai_responses_impl/test_openai_responses_llm.py
+++ b/tests/llm/openai_responses_impl/test_openai_responses_llm.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from tenacity import RetryError
 
 from lightrag.exceptions import EmptyTruncatedResponseError
 from lightrag.llm.openai_responses import (
@@ -526,3 +527,144 @@ async def test_streaming_reasoning_only_truncation_is_not_treated_as_empty(monke
     )
 
     assert await _collect(result) == "<think>thinking</think>"
+
+
+async def test_streaming_failed_terminal_raises_with_the_provider_reason(monkeypatch):
+    """`response.failed` is neither a completed/incomplete terminal nor the
+    separate `error` event, so an unhandled one would end the iterator
+    successfully on the partial text it had already yielded."""
+    stream = _FakeStream(
+        [
+            _delta("response.output_text.delta", "partial"),
+            SimpleNamespace(
+                type="response.failed",
+                response=SimpleNamespace(
+                    status="failed",
+                    error=SimpleNamespace(
+                        code="server_error", message="upstream exploded"
+                    ),
+                    usage=_usage(3, 4),
+                ),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    with pytest.raises(InvalidResponseError) as excinfo:
+        await _collect(result)
+    assert "server_error" in str(excinfo.value)
+    assert "upstream exploded" in str(excinfo.value)
+
+
+async def test_streaming_failed_terminal_still_counts_usage(monkeypatch):
+    """The attempt was billed whether or not it produced a usable answer,
+    matching how the truncated terminal accounts before raising."""
+    stream = _FakeStream(
+        [
+            SimpleNamespace(
+                type="response.failed",
+                response=SimpleNamespace(
+                    status="failed",
+                    error=SimpleNamespace(code="server_error", message="boom"),
+                    usage=_usage(3, 4),
+                ),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+    recorded: list[dict[str, int]] = []
+    tracker = SimpleNamespace(add_usage=recorded.append)
+
+    result = await openai_responses_complete_if_cache(
+        "gpt-5.6", "hi", stream=True, token_tracker=tracker
+    )
+
+    with pytest.raises(InvalidResponseError):
+        await _collect(result)
+    assert recorded == [{"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7}]
+
+
+async def test_streaming_failed_terminal_closes_an_open_think_tag(monkeypatch):
+    """Reasoning already opened `<think>`; the error path must still close it
+    so the consumer is not left holding an unterminated tag."""
+    chunks: list[str] = []
+    stream = _FakeStream(
+        [
+            _delta("response.reasoning_summary_text.delta", "thinking"),
+            SimpleNamespace(
+                type="response.failed",
+                response=SimpleNamespace(
+                    status="failed",
+                    error=SimpleNamespace(code="server_error", message="boom"),
+                    usage=None,
+                ),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache(
+        "gpt-5.6", "hi", stream=True, enable_cot=True
+    )
+
+    with pytest.raises(InvalidResponseError):
+        async for chunk in result:
+            chunks.append(chunk)
+    assert "".join(chunks) == "<think>thinking</think>"
+
+
+async def _non_streaming_failure(monkeypatch, payload, **kwargs) -> BaseException:
+    """Return the exception a non-streaming call ends on.
+
+    `InvalidResponseError` is in the driver's retry set, so the decorator
+    exhausts its attempts and re-raises as `RetryError`; the real error is only
+    reachable through the last attempt.
+    """
+    _patch_client(monkeypatch, payload)
+
+    with pytest.raises(RetryError) as excinfo:
+        await openai_responses_complete_if_cache("gpt-5.6", "hi", **kwargs)
+    return excinfo.value.last_attempt.exception()
+
+
+async def test_failed_status_raises_rather_than_reporting_empty_output(monkeypatch):
+    """The non-streaming sibling of `response.failed`: a request accepted at
+    the transport layer that failed during generation comes back as a payload
+    with status "failed", not as an exception from responses.create()."""
+    payload = _response(status="failed")
+    payload.error = SimpleNamespace(code="server_error", message="upstream exploded")
+
+    error = await _non_streaming_failure(monkeypatch, payload)
+
+    assert isinstance(error, InvalidResponseError)
+    assert "server_error" in str(error)
+    assert "upstream exploded" in str(error)
+
+
+async def test_failed_status_is_not_masked_by_partial_output(monkeypatch):
+    """Content on a failed payload is the tail of a generation that did not
+    finish, so returning it would present a failure as a short answer."""
+    payload = _response(output=[_message("partial")], status="failed")
+    payload.error = SimpleNamespace(code="server_error", message="boom")
+
+    error = await _non_streaming_failure(monkeypatch, payload)
+
+    assert isinstance(error, InvalidResponseError)
+
+
+async def test_failed_status_counts_usage_before_raising(monkeypatch):
+    payload = _response(status="failed", usage=_usage(5, 2))
+    payload.error = SimpleNamespace(code="server_error", message="boom")
+    recorded: list[dict[str, int]] = []
+    tracker = SimpleNamespace(add_usage=recorded.append)
+
+    await _non_streaming_failure(monkeypatch, payload, token_tracker=tracker)
+
+    # One entry per attempt: each retry is a separately billed request.
+    assert recorded
+    assert all(
+        counts == {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}
+        for counts in recorded
+    )

--- a/tests/llm/openai_responses_impl/test_openai_responses_llm.py
+++ b/tests/llm/openai_responses_impl/test_openai_responses_llm.py
@@ -432,3 +432,97 @@ async def test_streaming_records_usage_from_completed_event(monkeypatch):
     await _collect(result)
 
     assert recorded == [{"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7}]
+
+
+async def test_streaming_records_usage_from_incomplete_event(monkeypatch):
+    stream = _FakeStream(
+        [
+            _delta("response.output_text.delta", "partial"),
+            SimpleNamespace(
+                type="response.incomplete",
+                response=SimpleNamespace(
+                    status="incomplete",
+                    incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+                    usage=_usage(3, 4),
+                ),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+    recorded: list[dict[str, int]] = []
+    tracker = SimpleNamespace(add_usage=recorded.append)
+
+    result = await openai_responses_complete_if_cache(
+        "gpt-5.6", "hi", stream=True, token_tracker=tracker
+    )
+
+    assert await _collect(result) == "partial", "partial output is kept"
+    assert recorded == [{"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7}]
+
+
+async def test_streaming_empty_truncation_raises_non_retryable(monkeypatch):
+    stream = _FakeStream(
+        [
+            SimpleNamespace(
+                type="response.incomplete",
+                response=SimpleNamespace(
+                    status="incomplete",
+                    incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+                    usage=_usage(3, 120, reasoning_tokens=120),
+                ),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    with pytest.raises(EmptyTruncatedResponseError):
+        await _collect(result)
+
+
+async def test_streaming_incomplete_without_budget_reason_does_not_raise(monkeypatch):
+    """`response.incomplete` also covers non-budget stops (e.g. content filter),
+    which are not token-limit truncation and must not take the raise path."""
+    stream = _FakeStream(
+        [
+            SimpleNamespace(
+                type="response.incomplete",
+                response=SimpleNamespace(
+                    status="incomplete",
+                    incomplete_details=SimpleNamespace(reason="content_filter"),
+                    usage=_usage(3, 0),
+                ),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    assert await _collect(result) == ""
+
+
+async def test_streaming_reasoning_only_truncation_is_not_treated_as_empty(monkeypatch):
+    """Reasoning text already reached the consumer inside <think>, so the
+    stream ends normally rather than raising."""
+    stream = _FakeStream(
+        [
+            _delta("response.reasoning_summary_text.delta", "thinking"),
+            SimpleNamespace(
+                type="response.incomplete",
+                response=SimpleNamespace(
+                    status="incomplete",
+                    incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+                    usage=_usage(3, 9, reasoning_tokens=9),
+                ),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache(
+        "gpt-5.6", "hi", stream=True, enable_cot=True
+    )
+
+    assert await _collect(result) == "<think>thinking</think>"

--- a/tests/llm/openai_responses_impl/test_openai_responses_llm.py
+++ b/tests/llm/openai_responses_impl/test_openai_responses_llm.py
@@ -955,3 +955,50 @@ async def test_budget_truncation_still_returns_its_partial_content(monkeypatch):
 
     assert result == "partial"
     assert is_truncated_response(result)
+
+
+async def test_streaming_completed_with_no_text_raises_like_non_streaming(
+    monkeypatch,
+):
+    """A clean `response.completed` with no output_text delta and no
+    reasoning delta at all (a forwarded `tools` request that only produced a
+    function call, or a compatible gateway supplying an empty terminal) must
+    not end the iterator successfully on nothing -- `_handle_non_streaming`
+    already raises InvalidResponseError for the equivalent empty,
+    non-truncated payload (see test_empty_output_without_truncation_raises_retryable)."""
+    stream = _FakeStream(
+        [
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(usage=_usage(3, 0)),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+    with pytest.raises(InvalidResponseError) as excinfo:
+        await _collect(result)
+
+    assert not isinstance(excinfo.value, EmptyTruncatedResponseError)
+
+
+async def test_streaming_completed_with_reasoning_only_does_not_raise(monkeypatch):
+    """The empty-output check must key on body OR reasoning text, not body
+    text alone -- a reasoning-only completed turn is still usable output."""
+    stream = _FakeStream(
+        [
+            _delta("response.reasoning_summary_text.delta", "trace"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(usage=_usage(3, 4)),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache(
+        "gpt-5.6", "hi", stream=True, enable_cot=True
+    )
+
+    assert await _collect(result) == "<think>trace</think>"

--- a/tests/llm/openai_responses_impl/test_openai_responses_llm.py
+++ b/tests/llm/openai_responses_impl/test_openai_responses_llm.py
@@ -50,6 +50,13 @@ def _message(text: str) -> SimpleNamespace:
     )
 
 
+def _refusal(text: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="message",
+        content=[SimpleNamespace(type="refusal", refusal=text)],
+    )
+
+
 def _reasoning(text: str) -> SimpleNamespace:
     return SimpleNamespace(type="reasoning", summary=[SimpleNamespace(text=text)])
 
@@ -179,6 +186,47 @@ async def test_response_format_becomes_text_format(monkeypatch):
     call = client.responses.calls[0]
     assert call["text"] == {"format": {"type": "json_object"}}
     assert "response_format" not in call
+
+
+async def test_json_schema_response_format_is_flattened_for_text_format(monkeypatch):
+    """Chat Completions nests the schema under `json_schema`; Responses wants
+    its keys directly on the format object and 400s on the nested form."""
+    client = _patch_client(monkeypatch, _response(output=[_message('{"a":1}')]))
+    schema = {"type": "object", "properties": {"a": {"type": "integer"}}}
+
+    await openai_responses_complete_if_cache(
+        "gpt-5.6",
+        "hi",
+        response_format={
+            "type": "json_schema",
+            "json_schema": {"name": "answer", "schema": schema, "strict": True},
+        },
+    )
+
+    assert client.responses.calls[0]["text"] == {
+        "format": {
+            "type": "json_schema",
+            "name": "answer",
+            "schema": schema,
+            "strict": True,
+        }
+    }
+
+
+async def test_flat_json_schema_response_format_is_forwarded_untouched(monkeypatch):
+    """A caller who already wrote the Responses spelling must not be reshaped."""
+    client = _patch_client(monkeypatch, _response(output=[_message('{"a":1}')]))
+    text_format = {
+        "type": "json_schema",
+        "name": "answer",
+        "schema": {"type": "object"},
+    }
+
+    await openai_responses_complete_if_cache(
+        "gpt-5.6", "hi", response_format=dict(text_format)
+    )
+
+    assert client.responses.calls[0]["text"] == {"format": text_format}
 
 
 async def test_unsupported_chat_completions_params_are_dropped(monkeypatch):
@@ -482,18 +530,84 @@ async def test_streaming_empty_truncation_raises_non_retryable(monkeypatch):
         await _collect(result)
 
 
-async def test_streaming_incomplete_without_budget_reason_does_not_raise(monkeypatch):
-    """`response.incomplete` also covers non-budget stops (e.g. content filter),
-    which are not token-limit truncation and must not take the raise path."""
+def _incomplete(reason: str, usage: Any = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="response.incomplete",
+        response=SimpleNamespace(
+            status="incomplete",
+            incomplete_details=SimpleNamespace(reason=reason),
+            usage=usage,
+        ),
+    )
+
+
+async def test_streaming_non_budget_incomplete_terminal_raises(monkeypatch):
+    """`response.incomplete` also covers stops that are not token-limit
+    truncation. Without a branch of its own, a content-filtered stream with no
+    text ends successfully and empty."""
+    _patch_client(
+        monkeypatch, _FakeStream([_incomplete("content_filter", _usage(3, 0))])
+    )
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    with pytest.raises(InvalidResponseError) as excinfo:
+        await _collect(result)
+    assert "content_filter" in str(excinfo.value)
+
+
+async def test_streaming_non_budget_incomplete_is_not_masked_by_partial_text(
+    monkeypatch,
+):
+    """Text yielded before a stopped terminal is the tail of a generation that
+    did not finish, so it must not be presented as a complete answer."""
     stream = _FakeStream(
         [
+            _delta("response.output_text.delta", "par"),
+            _incomplete("content_filter"),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    chunks: list[str] = []
+    with pytest.raises(InvalidResponseError):
+        async for chunk in result:
+            chunks.append(chunk)
+    assert "".join(chunks) == "par"
+
+
+async def test_streaming_non_budget_incomplete_still_counts_usage(monkeypatch):
+    """A stopped generation spent its budget like any other attempt."""
+    _patch_client(
+        monkeypatch, _FakeStream([_incomplete("content_filter", _usage(4, 1))])
+    )
+    recorded: list[dict[str, int]] = []
+
+    result = await openai_responses_complete_if_cache(
+        "gpt-5.6",
+        "hi",
+        stream=True,
+        token_tracker=SimpleNamespace(add_usage=recorded.append),
+    )
+
+    with pytest.raises(InvalidResponseError):
+        await _collect(result)
+    # The attempt spent its budget whether or not the output was usable.
+    assert recorded == [{"prompt_tokens": 4, "completion_tokens": 1, "total_tokens": 5}]
+
+
+async def test_streaming_refusal_deltas_raise_with_the_refusal_text(monkeypatch):
+    """A refusal streams on its own event type and can still end with
+    `response.completed`, so an unhandled one ends the iterator empty."""
+    stream = _FakeStream(
+        [
+            _delta("response.refusal.delta", "I cannot "),
+            _delta("response.refusal.delta", "help with that"),
             SimpleNamespace(
-                type="response.incomplete",
-                response=SimpleNamespace(
-                    status="incomplete",
-                    incomplete_details=SimpleNamespace(reason="content_filter"),
-                    usage=_usage(3, 0),
-                ),
+                type="response.completed",
+                response=SimpleNamespace(status="completed", usage=_usage(6, 4)),
             ),
         ]
     )
@@ -501,7 +615,132 @@ async def test_streaming_incomplete_without_budget_reason_does_not_raise(monkeyp
 
     result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
 
-    assert await _collect(result) == ""
+    with pytest.raises(InvalidResponseError) as excinfo:
+        await _collect(result)
+    assert "I cannot help with that" in str(excinfo.value)
+
+
+async def test_streaming_refusal_done_event_is_used_when_no_deltas_arrived(
+    monkeypatch,
+):
+    """`response.refusal.done` carries the whole refusal, so it is the fallback
+    rather than an addition - using both would duplicate the text."""
+    stream = _FakeStream(
+        [
+            SimpleNamespace(type="response.refusal.done", refusal="policy: no"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed", usage=None),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    with pytest.raises(InvalidResponseError) as excinfo:
+        await _collect(result)
+    assert str(excinfo.value).count("policy: no") == 1
+
+
+async def test_streaming_empty_refusal_delta_does_not_disarm_the_done_fallback(
+    monkeypatch,
+):
+    """An empty delta is still a refusal, but it is not the refusal *text*.
+    Letting it stand in for the text would suppress the raise and skip the
+    `.done` event that carries the actual reason."""
+    stream = _FakeStream(
+        [
+            _delta("response.refusal.delta", ""),
+            SimpleNamespace(type="response.refusal.done", refusal="policy: no"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed", usage=None),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    with pytest.raises(InvalidResponseError) as excinfo:
+        await _collect(result)
+    assert "policy: no" in str(excinfo.value)
+
+
+async def test_streaming_textless_refusal_still_raises(monkeypatch):
+    """A refusal event with no text anywhere is still a refusal; ending the
+    iterator on it would report the refused turn as an empty answer."""
+    stream = _FakeStream(
+        [
+            _delta("response.refusal.delta", ""),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed", usage=None),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    with pytest.raises(InvalidResponseError):
+        await _collect(result)
+
+
+async def test_streaming_refusal_falls_back_to_the_terminal_content_parts(monkeypatch):
+    """Sibling of the `_extract_text` fallback: a server that populates the
+    terminal payload without emitting the refusal events must not end the
+    iterator empty and successful."""
+    stream = _FakeStream(
+        [
+            SimpleNamespace(
+                type="response.completed",
+                response=_response(output=[_refusal("I will not answer that")]),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    with pytest.raises(InvalidResponseError) as excinfo:
+        await _collect(result)
+    assert "I will not answer that" in str(excinfo.value)
+
+
+async def test_streaming_unreadable_incomplete_terminal_raises(monkeypatch):
+    """A terminal this driver cannot read reports "unknown" and takes the
+    stopped-generation path: incomplete is not complete, and guessing which
+    reason it was would be worse."""
+    stream = _FakeStream([SimpleNamespace(type="response.incomplete", response=None)])
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    with pytest.raises(InvalidResponseError) as excinfo:
+        await _collect(result)
+    assert "unknown" in str(excinfo.value)
+
+
+async def test_streaming_refusal_done_does_not_duplicate_the_deltas(monkeypatch):
+    stream = _FakeStream(
+        [
+            _delta("response.refusal.delta", "no can do"),
+            SimpleNamespace(type="response.refusal.done", refusal="no can do"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed", usage=None),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    with pytest.raises(InvalidResponseError) as excinfo:
+        await _collect(result)
+    assert str(excinfo.value).count("no can do") == 1
 
 
 async def test_streaming_reasoning_only_truncation_is_not_treated_as_empty(monkeypatch):
@@ -668,3 +907,51 @@ async def test_failed_status_counts_usage_before_raising(monkeypatch):
         counts == {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}
         for counts in recorded
     )
+
+
+async def test_refusal_content_part_raises_rather_than_reporting_empty_output(
+    monkeypatch,
+):
+    """The non-streaming sibling of the refusal events: a refused turn carries
+    `refusal` content parts, which the body walk skips, so the payload would
+    otherwise be diagnosed as "model produced no output"."""
+    payload = _response(output=[_refusal("I will not answer that")])
+
+    error = await _non_streaming_failure(monkeypatch, payload)
+
+    assert isinstance(error, InvalidResponseError)
+    assert "I will not answer that" in str(error)
+
+
+async def test_non_budget_incomplete_status_raises(monkeypatch):
+    """The non-streaming sibling of the stopped terminal: content on a payload
+    stopped by a content filter is the tail of a generation that did not
+    finish, so returning it would present it as a complete answer."""
+    payload = _response(
+        output=[_message("partial")],
+        status="incomplete",
+        incomplete_reason="content_filter",
+    )
+
+    error = await _non_streaming_failure(monkeypatch, payload)
+
+    assert isinstance(error, InvalidResponseError)
+    assert "content_filter" in str(error)
+
+
+async def test_budget_truncation_still_returns_its_partial_content(monkeypatch):
+    """The one incomplete reason that keeps its output: the model chose where
+    to stop within a limit the caller set."""
+    _patch_client(
+        monkeypatch,
+        _response(
+            output=[_message("partial")],
+            status="incomplete",
+            incomplete_reason="max_output_tokens",
+        ),
+    )
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi")
+
+    assert result == "partial"
+    assert is_truncated_response(result)

--- a/tests/llm/openai_responses_impl/test_openai_responses_llm.py
+++ b/tests/llm/openai_responses_impl/test_openai_responses_llm.py
@@ -1,0 +1,434 @@
+"""Offline tests for the OpenAI Responses (``/v1/responses``) LLM binding.
+
+The driver is exercised against a fake client so the whole file runs in the
+offline CI job with no network and no API key.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from lightrag.exceptions import EmptyTruncatedResponseError
+from lightrag.llm.openai_responses import (
+    InvalidResponseError,
+    openai_responses_complete_if_cache,
+)
+from lightrag.utils import TruncatedResponse, is_truncated_response
+
+pytestmark = [pytest.mark.offline, pytest.mark.asyncio]
+
+
+class _FakeResponses:
+    """Captures the create() call and returns a canned payload."""
+
+    def __init__(self, payload: Any):
+        self._payload = payload
+        self.calls: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, payload: Any):
+        self.responses = _FakeResponses(payload)
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _message(text: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="message",
+        content=[SimpleNamespace(type="output_text", text=text)],
+    )
+
+
+def _reasoning(text: str) -> SimpleNamespace:
+    return SimpleNamespace(type="reasoning", summary=[SimpleNamespace(text=text)])
+
+
+def _response(
+    *,
+    output: list[Any] | None = None,
+    status: str = "completed",
+    incomplete_reason: str | None = None,
+    usage: Any = None,
+    output_text: str | None = None,
+) -> SimpleNamespace:
+    payload = SimpleNamespace(
+        output=output or [],
+        status=status,
+        incomplete_details=(
+            SimpleNamespace(reason=incomplete_reason) if incomplete_reason else None
+        ),
+        usage=usage,
+    )
+    # `output_text` is an SDK convenience property; omitting it exercises the
+    # fallback walk over output[].
+    if output_text is not None:
+        payload.output_text = output_text
+    return payload
+
+
+def _usage(input_tokens: int, output_tokens: int, reasoning_tokens: int = 0):
+    return SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+        output_tokens_details=SimpleNamespace(reasoning_tokens=reasoning_tokens),
+    )
+
+
+def _patch_client(monkeypatch, payload: Any) -> _FakeClient:
+    client = _FakeClient(payload)
+    monkeypatch.setattr(
+        "lightrag.llm.openai_responses.create_openai_async_client",
+        lambda **kwargs: client,
+    )
+    return client
+
+
+async def test_returns_output_text_and_closes_client(monkeypatch):
+    client = _patch_client(monkeypatch, _response(output=[_message("hello")]))
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi")
+
+    assert result == "hello"
+    assert client.closed, "client must be closed on the non-streaming path"
+
+
+async def test_system_prompt_is_sent_as_instructions(monkeypatch):
+    client = _patch_client(monkeypatch, _response(output=[_message("ok")]))
+
+    await openai_responses_complete_if_cache("gpt-5.6", "hi", system_prompt="be terse")
+
+    call = client.responses.calls[0]
+    assert call["instructions"] == "be terse"
+    # Responses has no system role; a leaked system message would be a bug.
+    assert all(item["role"] != "system" for item in call["input"])
+
+
+async def test_history_assistant_turn_uses_output_text_part(monkeypatch):
+    client = _patch_client(monkeypatch, _response(output=[_message("ok")]))
+
+    await openai_responses_complete_if_cache(
+        "gpt-5.6",
+        "next",
+        history_messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply"},
+        ],
+    )
+
+    api_input = client.responses.calls[0]["input"]
+    assert api_input[0]["content"][0]["type"] == "input_text"
+    # The API rejects an assistant turn tagged as input_text.
+    assert api_input[1]["content"][0]["type"] == "output_text"
+    assert api_input[-1]["content"][0]["type"] == "input_text"
+
+
+@pytest.mark.parametrize(
+    "alias", ["max_output_tokens", "max_completion_tokens", "max_tokens"]
+)
+async def test_output_budget_aliases_map_to_max_output_tokens(monkeypatch, alias):
+    client = _patch_client(monkeypatch, _response(output=[_message("ok")]))
+
+    await openai_responses_complete_if_cache("gpt-5.6", "hi", **{alias: 321})
+
+    call = client.responses.calls[0]
+    assert call["max_output_tokens"] == 321
+    # The Chat Completions spellings must not reach the Responses API.
+    assert "max_completion_tokens" not in call
+    assert "max_tokens" not in call
+
+
+async def test_reasoning_effort_becomes_nested_reasoning(monkeypatch):
+    client = _patch_client(monkeypatch, _response(output=[_message("ok")]))
+
+    await openai_responses_complete_if_cache("gpt-5.6", "hi", reasoning_effort="low")
+
+    call = client.responses.calls[0]
+    assert call["reasoning"] == {"effort": "low"}
+    assert "reasoning_effort" not in call
+
+
+async def test_explicit_reasoning_dict_wins_over_flat_alias(monkeypatch):
+    client = _patch_client(monkeypatch, _response(output=[_message("ok")]))
+
+    await openai_responses_complete_if_cache(
+        "gpt-5.6", "hi", reasoning={"effort": "high"}, reasoning_effort="low"
+    )
+
+    assert client.responses.calls[0]["reasoning"] == {"effort": "high"}
+
+
+async def test_response_format_becomes_text_format(monkeypatch):
+    client = _patch_client(monkeypatch, _response(output=[_message('{"a":1}')]))
+
+    await openai_responses_complete_if_cache(
+        "gpt-5.6", "hi", response_format={"type": "json_object"}
+    )
+
+    call = client.responses.calls[0]
+    assert call["text"] == {"format": {"type": "json_object"}}
+    assert "response_format" not in call
+
+
+async def test_unsupported_chat_completions_params_are_dropped(monkeypatch):
+    client = _patch_client(monkeypatch, _response(output=[_message("ok")]))
+
+    await openai_responses_complete_if_cache(
+        "gpt-5.6", "hi", frequency_penalty=0.5, presence_penalty=0.2, n=2
+    )
+
+    call = client.responses.calls[0]
+    for dropped in ("frequency_penalty", "presence_penalty", "n"):
+        assert dropped not in call, f"{dropped} would be rejected by the API"
+
+
+async def test_cot_wraps_reasoning_when_body_is_empty(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _response(output=[_reasoning("thinking hard"), _message("")]),
+    )
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", enable_cot=True)
+
+    assert result == "<think>thinking hard</think>"
+
+
+async def test_cot_is_ignored_when_body_text_present(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _response(output=[_reasoning("trace"), _message("answer")]),
+    )
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", enable_cot=True)
+
+    assert result == "answer", "reasoning is dropped once body text exists"
+
+
+async def test_structured_output_disables_cot(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _response(output=[_reasoning("trace"), _message('{"a": 1}')]),
+    )
+
+    result = await openai_responses_complete_if_cache(
+        "gpt-5.6",
+        "hi",
+        enable_cot=True,
+        response_format={"type": "json_object"},
+    )
+
+    # <think> tags would corrupt JSON the caller is about to parse.
+    assert result == '{"a": 1}'
+
+
+async def test_token_tracker_maps_responses_usage_keys(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _response(output=[_message("ok")], usage=_usage(11, 7)),
+    )
+    recorded: list[dict[str, int]] = []
+    tracker = SimpleNamespace(add_usage=recorded.append)
+
+    await openai_responses_complete_if_cache("gpt-5.6", "hi", token_tracker=tracker)
+
+    assert recorded == [
+        {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}
+    ]
+
+
+async def test_truncated_output_is_wrapped_for_the_cache_layer(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _response(
+            output=[_message('{"partial": ')],
+            status="incomplete",
+            incomplete_reason="max_output_tokens",
+        ),
+    )
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi")
+
+    assert isinstance(result, TruncatedResponse)
+    assert is_truncated_response(result), "cache layer must skip persisting this"
+    assert str(result) == '{"partial": '
+
+
+async def test_empty_truncated_output_raises_non_retryable(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _response(
+            output=[],
+            status="incomplete",
+            incomplete_reason="max_output_tokens",
+            usage=_usage(10, 500, reasoning_tokens=500),
+        ),
+    )
+
+    # Budget exhaustion is deterministic, so it must not buy two more retries.
+    with pytest.raises(EmptyTruncatedResponseError) as excinfo:
+        await openai_responses_complete_if_cache("gpt-5.6", "hi")
+
+    assert "max_output_tokens" in str(excinfo.value)
+
+
+async def test_empty_output_without_truncation_raises_retryable(monkeypatch):
+    _patch_client(monkeypatch, _response(output=[_message("")]))
+
+    with pytest.raises((InvalidResponseError, Exception)) as excinfo:
+        await openai_responses_complete_if_cache("gpt-5.6", "hi")
+
+    assert not isinstance(excinfo.value, EmptyTruncatedResponseError)
+
+
+async def test_usage_is_counted_even_when_output_is_unusable(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _response(
+            output=[],
+            status="incomplete",
+            incomplete_reason="max_output_tokens",
+            usage=_usage(9, 400, reasoning_tokens=400),
+        ),
+    )
+    recorded: list[dict[str, int]] = []
+    tracker = SimpleNamespace(add_usage=recorded.append)
+
+    with pytest.raises(EmptyTruncatedResponseError):
+        await openai_responses_complete_if_cache("gpt-5.6", "hi", token_tracker=tracker)
+
+    # The request burned its budget whether or not the output was usable.
+    assert recorded == [
+        {"prompt_tokens": 9, "completion_tokens": 400, "total_tokens": 409}
+    ]
+
+
+async def test_output_text_property_is_preferred(monkeypatch):
+    _patch_client(
+        monkeypatch,
+        _response(output=[_message("from-walk")], output_text="from-property"),
+    )
+
+    assert await openai_responses_complete_if_cache("gpt-5.6", "hi") == (
+        "from-property"
+    )
+
+
+# --------------------------------------------------------------------------
+# Streaming
+# --------------------------------------------------------------------------
+
+
+class _FakeStream:
+    def __init__(self, events: list[Any]):
+        self._events = events
+        self.aclosed = False
+
+    def __aiter__(self):
+        async def gen():
+            for event in self._events:
+                yield event
+
+        return gen()
+
+    async def aclose(self) -> None:
+        self.aclosed = True
+
+
+def _delta(event_type: str, delta: str) -> SimpleNamespace:
+    return SimpleNamespace(type=event_type, delta=delta)
+
+
+async def _collect(agen) -> str:
+    return "".join([chunk async for chunk in agen])
+
+
+async def test_streaming_yields_output_text_deltas(monkeypatch):
+    stream = _FakeStream(
+        [
+            _delta("response.output_text.delta", "hel"),
+            _delta("response.output_text.delta", "lo"),
+        ]
+    )
+    client = _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    assert await _collect(result) == "hello"
+    assert stream.aclosed
+    assert client.closed
+
+
+async def test_streaming_wraps_reasoning_in_think_tags(monkeypatch):
+    stream = _FakeStream(
+        [
+            _delta("response.reasoning_summary_text.delta", "step one"),
+            _delta("response.output_text.delta", "answer"),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache(
+        "gpt-5.6", "hi", stream=True, enable_cot=True
+    )
+
+    # The reasoning block must be closed as soon as body text starts.
+    assert await _collect(result) == "<think>step one</think>answer"
+
+
+async def test_streaming_closes_think_tag_when_no_body_text_follows(monkeypatch):
+    stream = _FakeStream(
+        [_delta("response.reasoning_summary_text.delta", "only thinking")]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache(
+        "gpt-5.6", "hi", stream=True, enable_cot=True
+    )
+
+    assert await _collect(result) == "<think>only thinking</think>"
+
+
+async def test_streaming_drops_reasoning_when_cot_disabled(monkeypatch):
+    stream = _FakeStream(
+        [
+            _delta("response.reasoning_summary_text.delta", "trace"),
+            _delta("response.output_text.delta", "answer"),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+
+    result = await openai_responses_complete_if_cache("gpt-5.6", "hi", stream=True)
+
+    assert await _collect(result) == "answer"
+
+
+async def test_streaming_records_usage_from_completed_event(monkeypatch):
+    stream = _FakeStream(
+        [
+            _delta("response.output_text.delta", "ok"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(usage=_usage(3, 4)),
+            ),
+        ]
+    )
+    _patch_client(monkeypatch, stream)
+    recorded: list[dict[str, int]] = []
+    tracker = SimpleNamespace(add_usage=recorded.append)
+
+    result = await openai_responses_complete_if_cache(
+        "gpt-5.6", "hi", stream=True, token_tracker=tracker
+    )
+    await _collect(result)
+
+    assert recorded == [{"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7}]


### PR DESCRIPTION
## Description

Adds `openai_responses` as an additional LLM binding talking to the OpenAI Responses API (`/v1/responses`), alongside the existing `openai` binding rather than replacing its transport.

This is deliberately **additive**. The `openai` binding doubles as the generic OpenAI-*compatible* binding, and much of that ecosystem (vLLM, gateways, third-party providers) does not implement `/v1/responses` — changing its transport would regress those deployments. The new transport is opted into explicitly with `LLM_BINDING=openai_responses`, and `lightrag/llm/openai.py` is not modified at all.

## Related Issues

Refs #3657 (approach and open questions confirmed in a comment on the issue before implementing)

## Changes Made

- **`lightrag/llm/openai_responses.py`** (new): the driver, matching the `openai_complete_if_cache` contract. Client construction is imported from the Chat Completions module so the two bindings cannot drift on base-URL resolution, default headers, or the DashScope workspace header.
- **`lightrag/llm/binding_options.py`**: `OpenAIResponsesLLMOptions` under its own `openai_responses_llm` namespace, deriving `OPENAI_RESPONSES_LLM_*` and the role-scoped forms.
- **`lightrag/api/config.py`**: `get_default_host()` mapping, `--llm-binding` choice, options selection branch.
- **`lightrag/api/lightrag_server.py`**: `LLMConfigCache` init, startup allow-list, dispatch branch, role-binding branch, and the role-level completion function.
- **`env.example`**: a dedicated section documenting when to prefer this binding.

Four behaviours are reimplemented rather than reused, because the wire shapes differ:

| Concern | Chat Completions | Responses |
|---|---|---|
| System prompt | `messages[0]` role=system | `instructions` parameter |
| Output budget | `max_completion_tokens` | `max_output_tokens` |
| Reasoning | flat `reasoning_effort` | nested `reasoning: {effort}` |
| Structured output | `response_format` | `text: {format}` |
| Truncation | `finish_reason == "length"` | `status` + `incomplete_details.reason` |
| Usage | `prompt_tokens` / `completion_tokens` | `input_tokens` / `output_tokens` |
| Streaming | `choices[].delta` | typed events |

### The silent-fallthrough guard

`create_llm_model_func()` ends in a bare `else:  # openai and compatible`, so a binding missing from any one exact in-list check produces **no error** — it just sends requests to `/v1/chat/completions`. The binding is added to every one of those checks, and `test_the_responses_binding_does_not_reach_the_chat_completions_fallthrough` asserts the dispatch branch precedes the fallthrough so a future regression fails loudly.

Note there are two such fallthroughs; the earlier one is the *embedding* dispatch, which this binding never reaches because it is not an embedding choice. Embeddings are unchanged — `/v1/embeddings` is not affected by this API.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (`env.example`)
- [x] Unit tests added

## Additional Notes

**Scope** — LLM role only, per the open questions in the issue:

- **Embeddings**: out of scope, `/v1/embeddings` is unchanged.
- **VLM role**: out of scope. Image input is `input_image` on Responses, a different content-part shape; the driver handles it, but wiring the VLM role is better as a follow-up once the text path is settled.
- **Azure Responses**: out of scope, and suggested to stay a separate binding rather than a flag — mirroring how `azure_openai` is its own binding rather than a switch on `openai`.

**No behaviour change to existing paths.** The diff is 1344 insertions against 2 deletions, and both deleted lines are documentation strings that gained the new binding name — no existing logic was removed. Verified by running `tests/llm` + `tests/api` before and after the change: identical failure set, `1098 → 1129` passing, i.e. exactly the 31 new tests and nothing else moved.

**Verified locally** (per AGENTS.md, the directories mirroring the changed modules):

- `pytest tests/llm/openai_responses_impl tests/api/config/test_api_config_openai_responses.py -m offline` — 31 passed
- `pytest tests/llm tests/api -m offline` — 1129 passed, with the same 9 pre-existing failures as on an unmodified checkout (Windows-only: they shell out to `bash`)
- `pre-commit run --files <the eight changed files>` — all hooks pass
