### PR TITLE
test(utils): cover validate_file_path_security and subtract_source_ids

### DIFF
--- a/tests/utils/test_subtract_source_ids.py
+++ b/tests/utils/test_subtract_source_ids.py
@@ -1,0 +1,107 @@
+"""Tests for ``subtract_source_ids`` removal semantics.
+
+The helper decides what a graph object still has attribution from after a purge
+removes chunks: ``lightrag/lightrag.py`` computes ``remaining_sources`` from it
+in both the entity and the relation branch of ``_purge_kg_contributions``, and
+an object whose remaining sources are empty is *deleted* while a non-empty
+result keeps it. Two properties are therefore load-bearing rather than cosmetic:
+
+* **Falsy ids are dropped.** A stray ``""`` surviving into the result would make
+  ``remaining_sources`` truthy and strand an object that owns no real chunk —
+  precisely the unattributable orphan the purge contract exists to prevent.
+* **Order is preserved.** The surviving list is written back as the object's
+  chunk attribution, and ``apply_source_ids_limit`` truncates it positionally,
+  so reordering would silently change which ids survive a later cap.
+
+It had no direct tests; this file pins both, alongside the sibling
+``test_merge_source_ids.py`` for the collection half of the same contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.utils import subtract_source_ids
+
+pytestmark = pytest.mark.offline
+
+
+class TestRemoval:
+    def test_listed_ids_are_removed(self):
+        assert subtract_source_ids(["a", "b", "c"], ["b"]) == ["a", "c"]
+
+    def test_removing_every_id_yields_an_empty_list(self):
+        # The caller reads this as "no attribution left" and deletes the object.
+        assert subtract_source_ids(["a", "b"], ["a", "b"]) == []
+
+    def test_ids_absent_from_the_source_are_ignored(self):
+        assert subtract_source_ids(["a"], ["b", "c"]) == ["a"]
+
+    def test_an_empty_removal_collection_keeps_every_real_id(self):
+        assert subtract_source_ids(["a", "b"], []) == ["a", "b"]
+
+    def test_an_empty_source_yields_an_empty_list(self):
+        assert subtract_source_ids([], ["a"]) == []
+
+
+class TestOrderIsPreserved:
+    def test_surviving_ids_keep_their_original_order(self):
+        source = ["d", "a", "c", "b"]
+
+        assert subtract_source_ids(source, ["c"]) == ["d", "a", "b"]
+
+    def test_order_is_not_derived_from_the_removal_collection(self):
+        # The removal argument is a set internally; its iteration order must not
+        # leak into the result.
+        assert subtract_source_ids(["a", "b", "c"], {"c", "a"}) == ["b"]
+
+    def test_duplicate_survivors_are_kept_as_is(self):
+        """Deduplication is not this helper's job.
+
+        ``merge_source_ids`` is the normalization point; collapsing duplicates
+        here would change the count that ``apply_source_ids_limit`` sees.
+        """
+        assert subtract_source_ids(["a", "a", "b"], ["b"]) == ["a", "a"]
+
+
+class TestFalsyIdsAreDropped:
+    @pytest.mark.parametrize(
+        "removal",
+        [
+            pytest.param([], id="empty-removal-fast-path"),
+            pytest.param(["x"], id="non-empty-removal-path"),
+        ],
+    )
+    def test_empty_strings_are_dropped_on_both_branches(self, removal):
+        """The no-removal fast path filters too.
+
+        The implementation returns early when the removal set is empty, so the
+        two paths filter falsy ids independently — an empty id leaking through
+        either one would keep an object alive with no real attribution.
+        """
+        assert subtract_source_ids(["a", "", "b"], removal) == ["a", "b"]
+
+    def test_an_all_empty_source_reduces_to_an_empty_list(self):
+        # Not "has attribution" — the object must still be deletable.
+        assert subtract_source_ids(["", ""], []) == []
+
+    def test_none_entries_are_dropped(self):
+        assert subtract_source_ids(["a", None, "b"], []) == ["a", "b"]
+
+
+class TestInputTypes:
+    def test_a_generator_source_is_accepted(self):
+        assert subtract_source_ids((sid for sid in ["a", "b"]), ["b"]) == ["a"]
+
+    def test_a_set_removal_collection_is_accepted(self):
+        assert subtract_source_ids(["a", "b"], {"a"}) == ["b"]
+
+    def test_a_tuple_removal_collection_is_accepted(self):
+        assert subtract_source_ids(["a", "b"], ("a",)) == ["b"]
+
+    def test_the_source_iterable_is_not_mutated(self):
+        source = ["a", "b", "c"]
+
+        subtract_source_ids(source, ["b"])
+
+        assert source == ["a", "b", "c"]

--- a/tests/utils/test_validate_file_path_security.py
+++ b/tests/utils/test_validate_file_path_security.py
@@ -1,0 +1,155 @@
+"""Tests for ``validate_file_path_security`` path-traversal containment.
+
+The helper is the containment boundary for two callers that turn
+externally-influenced strings into filesystem paths — the ``/documents`` upload
+and scan routes (``lightrag/api/routers/document_routes.py``) and sidecar
+artifact resolution (``lightrag/pipeline.py``, which delegates containment to it
+outright). Both feed it names that ultimately came from a client, so a hole here
+is a read outside the input directory. It had no direct tests.
+
+Assertions compare ``Path`` objects and use ``relative_to`` rather than string
+matching, because separators and resolution differ between POSIX and Windows.
+Inputs whose meaning is platform-specific — trailing-dot names such as ``"..."``,
+which Windows strips and POSIX keeps as a literal directory name — are
+deliberately not asserted on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lightrag.utils import validate_file_path_security
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.fixture
+def base_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+class TestAcceptedPaths:
+    def test_a_plain_filename_resolves_inside_the_base(self, base_dir):
+        result = validate_file_path_security("report.pdf", base_dir)
+
+        assert result is not None
+        assert result.relative_to(base_dir.resolve()) == Path("report.pdf")
+
+    def test_a_nested_relative_path_is_accepted(self, base_dir):
+        result = validate_file_path_security("sub/dir/report.pdf", base_dir)
+
+        assert result is not None
+        assert result.relative_to(base_dir.resolve()) == Path("sub/dir/report.pdf")
+
+    def test_a_leading_dot_segment_is_normalized_away(self, base_dir):
+        result = validate_file_path_security("./report.pdf", base_dir)
+
+        assert result is not None
+        assert result.relative_to(base_dir.resolve()) == Path("report.pdf")
+
+    def test_an_interior_dot_segment_is_normalized_away(self, base_dir):
+        result = validate_file_path_security("a/./b.pdf", base_dir)
+
+        assert result is not None
+        assert result.relative_to(base_dir.resolve()) == Path("a/b.pdf")
+
+    def test_backslashes_are_normalized_into_separators(self, base_dir):
+        # Windows-style input reaching a POSIX server must still land in the
+        # same place, so the helper rewrites separators before resolving.
+        result = validate_file_path_security(r"sub\dir\report.pdf", base_dir)
+
+        assert result is not None
+        assert result.relative_to(base_dir.resolve()) == Path("sub/dir/report.pdf")
+
+    def test_surrounding_whitespace_is_stripped(self, base_dir):
+        result = validate_file_path_security("  report.pdf  ", base_dir)
+
+        assert result is not None
+        assert result.relative_to(base_dir.resolve()) == Path("report.pdf")
+
+    def test_traversal_that_stays_inside_the_base_is_allowed(self, base_dir):
+        """``a/../b.pdf`` resolves to ``b.pdf``, which is still contained.
+
+        Containment is decided on the *resolved* path, not on the presence of a
+        ``..`` segment, so a path that walks up and back down without leaving
+        the base is legitimate. Pinned because tightening this into a blanket
+        ``".." in path`` rejection would look like hardening while actually
+        breaking ordinary inputs.
+        """
+        result = validate_file_path_security("a/../b.pdf", base_dir)
+
+        assert result is not None
+        assert result.relative_to(base_dir.resolve()) == Path("b.pdf")
+
+    def test_existence_is_not_checked(self, base_dir):
+        """A contained but absent path is returned, per the documented contract.
+
+        The caller decides what "inside but absent" means; conflating it with
+        "unsafe" here would make the two indistinguishable to callers.
+        """
+        result = validate_file_path_security("nope/missing.pdf", base_dir)
+
+        assert result is not None
+        assert not result.exists()
+
+
+class TestRejectedPaths:
+    @pytest.mark.parametrize(
+        "escaping_path",
+        [
+            "../etc/passwd",
+            "../../etc/passwd",
+            "a/../../escape.pdf",
+            "sub/../../escape.pdf",
+        ],
+    )
+    def test_paths_escaping_the_base_are_rejected(self, base_dir, escaping_path):
+        assert validate_file_path_security(escaping_path, base_dir) is None
+
+    @pytest.mark.parametrize(
+        "escaping_path",
+        [
+            r"..\windows\system32",
+            r"..\..\secret.txt",
+            r"sub\..\..\escape.pdf",
+        ],
+    )
+    def test_windows_style_traversal_is_rejected(self, base_dir, escaping_path):
+        assert validate_file_path_security(escaping_path, base_dir) is None
+
+    def test_a_bare_parent_reference_is_rejected(self, base_dir):
+        assert validate_file_path_security("..", base_dir) is None
+
+    def test_an_absolute_path_is_rejected(self, base_dir):
+        # An absolute operand makes `base_dir / value` discard the base
+        # entirely, so containment is what catches this rather than syntax.
+        assert validate_file_path_security("/etc/passwd", base_dir) is None
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t", "\n"])
+    def test_blank_input_is_rejected(self, base_dir, blank):
+        assert validate_file_path_security(blank, base_dir) is None
+
+    def test_none_is_rejected(self, base_dir):
+        assert validate_file_path_security(None, base_dir) is None
+
+
+class TestContainmentIsDecidedOnTheResolvedPath:
+    def test_a_sibling_directory_sharing_a_name_prefix_is_rejected(self, tmp_path):
+        """``/base_evil`` must not pass containment against base ``/base``.
+
+        A prefix comparison on the path *string* would accept it; the helper
+        uses ``Path.is_relative_to``, which compares whole components.
+        """
+        base = tmp_path / "base"
+        base.mkdir()
+        (tmp_path / "base_evil").mkdir()
+
+        assert validate_file_path_security("../base_evil/loot.txt", base) is None
+
+    def test_a_path_landing_exactly_on_the_base_is_contained(self, base_dir):
+        # `.` resolves to the base itself, which is relative to the base.
+        result = validate_file_path_security(".", base_dir)
+
+        assert result == base_dir.resolve()


### PR DESCRIPTION
## Description

Adds direct tests for two `lightrag/utils.py` helpers that guard behaviour with real consequences and had no test referencing them.

**Tests only — no production code is modified.** The diff is 262 insertions across two new files and zero deletions.

## Related Issues

None. `CONTRIBUTING.md` lists "Testing — add test coverage for untested code paths" as a way to contribute.

## Changes Made

### `validate_file_path_security`

The containment boundary for two callers that turn externally-influenced strings into filesystem paths: the `/documents` upload and scan routes (`document_routes.py`), and sidecar artifact resolution (`pipeline.py`, whose docstring delegates containment to it outright). A hole here is a read outside the input directory.

Covered:

- Accepted: plain and nested relative paths, `./` and interior `/./` normalization, backslash-to-separator normalization, surrounding whitespace.
- Rejected: parent traversal in both separator styles, a bare `..`, absolute paths, blank and `None` input.
- Two properties that are easy to break while *looking* like hardening:
  - `a/../b.pdf` resolves back inside the base and must stay **accepted** — containment is decided on the resolved path, not on the presence of a `..` segment. Replacing this with a blanket `".." in path` rejection would break ordinary inputs.
  - A sibling directory sharing a name prefix (`/base_evil` against base `/base`) is **not** contained. A prefix comparison on the path string would wrongly accept it; `Path.is_relative_to` compares whole components.
- The documented "does not check existence" contract: a contained but absent path is returned rather than conflated with unsafe.

### `subtract_source_ids`

Decides what attribution a graph object retains after a purge removes chunks — `_purge_kg_contributions` computes `remaining_sources` from it in both the entity and relation branch, and an empty result **deletes** the object while a non-empty one keeps it.

Covered:

- Falsy ids are dropped on **both** branches. The implementation returns early when the removal set is empty, so the two paths filter independently; an empty id leaking through either would keep an object alive with no real attribution — the unattributable orphan the purge contract exists to prevent.
- Surviving order is preserved and is not influenced by the removal collection's iteration order, because the result is written back as the object's chunk attribution and `apply_source_ids_limit` truncates it positionally.
- Duplicates are deliberately *not* collapsed (`merge_source_ids` is the normalization point; collapsing here would change the count the limit sees).
- Input types: generator source, set/tuple removal collections, and that the source iterable is not mutated.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary) — not applicable, tests only
- [x] Unit tests added

## Additional Notes

**The tests were verified to have teeth.** Rather than assume, each file was run against a deliberately mutated `lightrag/utils.py` before committing:

| Mutation | Result |
|---|---|
| `is_relative_to` containment check disabled | 7 tests fail |
| falsy-id filter removed from `subtract_source_ids` | 1 test fails |

`lightrag/utils.py` was restored afterwards and is untouched in this PR.

**Portability.** Assertions compare `Path` objects and use `relative_to` rather than string matching, since separators and resolution differ between POSIX and Windows. Inputs whose meaning is platform-specific — trailing-dot names such as `"..."`, which Windows strips and POSIX keeps as a literal directory name — are deliberately not asserted on.

**Verified locally** (per AGENTS.md, the directory mirroring the module under test):

- `pytest tests/utils -m offline` — 196 passed (156 before, +40 from these two files)
- `pre-commit run --files <the two new files>` — all hooks pass

**One observation, no change made.** `validate_file_path_security` reads `file_path_str.strip()` before entering its `try`, so a non-string argument raises `AttributeError` rather than returning `None` like every other invalid input. No current caller passes a non-string, so this is not reachable today and I have not changed it — flagging it in case you would prefer that guard moved inside the `try`.
