### PR TITLE
fix(faiss): keep pending upserts as the replay record until the save succeeds

### DIFF
--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -773,16 +773,15 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
         self._index_dirty = True
 
-        # Clear only the entries we just flushed. Today the non-reentrant
-        # _storage_lock locks out concurrent upserts for the entire flush
-        # (including the asyncio.gather await), so the `is pdoc` identity
-        # check is always True — it's kept as defensive scaffolding so that
-        # if the lock scope is ever relaxed (e.g. embedding moved outside the
-        # lock), a concurrent upsert that re-set vector=None would not be
-        # silently dropped here.
-        for doc_id, pdoc in pending_items:
-            if self._pending_upserts.get(doc_id) is pdoc:
-                del self._pending_upserts[doc_id]
+        # NOTE: the flushed entries are intentionally NOT removed from
+        # ``_pending_upserts`` here — the CALLER clears them once the
+        # subsequent save succeeds. Until then the pending buffer is the
+        # replay record for the materialized-but-unsaved rows: if the save
+        # raises and another process commits, the next callback's
+        # reload-from-disk replaces ``self._index`` / ``self._id_to_meta``,
+        # and re-running this flush against the reloaded snapshot rebuilds
+        # exactly these rows (remove-by-custom-id + re-add is idempotent).
+        # Clearing here instead would silently drop them (#3688).
 
     def _save_faiss_index(self):
         """Atomically persist ``self._index`` + ``self._id_to_meta`` to disk.
@@ -954,8 +953,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
             # error). The exception propagates out of the lock so _insert_done
             # aborts the batch; pending stays intact and _index_dirty stays
             # True (if only the save failed) for a later retry.
+            flushed_ids = list(self._pending_upserts.keys())
             await self._flush_pending_locked()
             self._save_faiss_index()
+            # The save succeeded: the replay record is no longer needed.
+            # (All upserts run under this same non-reentrant lock, so the
+            # snapshot above is exactly what this flush materialized.)
+            for doc_id in flushed_ids:
+                self._pending_upserts.pop(doc_id, None)
             await set_all_update_flags(self.namespace, workspace=self.workspace)
             self.storage_updated.value = False
             self._index_dirty = False
@@ -1185,8 +1190,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 # drop them.
                 if not self._index_dirty:
                     self._reload_index_from_disk_locked(for_write=True)
+                flushed_ids = list(self._pending_upserts.keys())
                 await self._flush_pending_locked()
+            else:
+                flushed_ids = []
             self._save_faiss_index()
+            for doc_id in flushed_ids:
+                self._pending_upserts.pop(doc_id, None)
             await set_all_update_flags(self.namespace, workspace=self.workspace)
             self.storage_updated.value = False
             self._index_dirty = False

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -422,13 +422,14 @@ async def test_finalize_retries_save_after_flush_failure(tmp_path):
     with pytest.raises(OSError, match="boom"):
         await storage.finalize()
 
-    assert storage._pending_upserts == {}
+    assert "id1" in storage._pending_upserts, "replay record kept (#3688)"
     assert storage._index_dirty is True
 
     await storage.finalize()
 
     assert save_calls == 2
     assert storage._index_dirty is False
+    assert storage._pending_upserts == {}, "successful retry drains the buffer"
 
     reader = _make_storage(tmp_path, embed)
     await reader.initialize()
@@ -472,8 +473,9 @@ async def test_reupsert_after_flush_replaces_single_fid(tmp_path):
 @pytest.mark.offline
 @pytest.mark.asyncio
 async def test_index_done_callback_save_failure_raises(tmp_path):
-    """Save failure in index_done_callback must propagate, leave pending empty
-    (flush already succeeded), and keep _index_dirty=True so finalize retries."""
+    """Save failure in index_done_callback must propagate, keep the pending
+    buffer as the replay record (#3688), and keep _index_dirty=True so
+    finalize retries."""
     embed = _CountingEmbed()
     storage = _make_storage(tmp_path, embed)
     await storage.initialize()
@@ -490,7 +492,9 @@ async def test_index_done_callback_save_failure_raises(tmp_path):
     with pytest.raises(OSError, match="save boom"):
         await storage.index_done_callback()
 
-    assert storage._pending_upserts == {}, "flush succeeded so pending is empty"
+    assert "id1" in storage._pending_upserts, (
+        "pending survives the failed save as the replay record (#3688)"
+    )
     assert storage._index_dirty is True, "save failure preserves dirty for retry"
     assert storage._index.ntotal == 1, "materialized state is preserved"
     _assert_consistent(storage)
@@ -501,6 +505,7 @@ async def test_index_done_callback_save_failure_raises(tmp_path):
     await storage.finalize()
     assert embed.call_count == embed_before, "save retry must not re-embed"
     assert storage._index_dirty is False
+    assert storage._pending_upserts == {}, "successful retry drains the buffer"
 
     reader = _make_storage(tmp_path, embed)
     await reader.initialize()
@@ -808,7 +813,7 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     storage._save_faiss_index = fail_save
     with pytest.raises(OSError, match="save boom"):
         await storage.index_done_callback()
-    assert storage._pending_upserts == {}, "flush succeeded so pending is empty"
+    assert "id1" in storage._pending_upserts, "replay record kept (#3688)"
     assert storage._index_dirty is True
     assert storage._index.ntotal == 1, "id1 materialized, not saved"
 
@@ -818,7 +823,10 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
 
     await storage.drop_pending_index_ops()
 
-    assert storage._pending_upserts == {}, "pending id2 dropped"
+    # drop discards BOTH buffered entries (id2 and id1's replay record);
+    # id1 itself survives because it was already materialized and stays
+    # dirty for the next save retry.
+    assert storage._pending_upserts == {}, "pending buffer dropped"
     assert storage._index.ntotal == 1, "materialized id1 NOT rolled back"
     assert storage._index_dirty is True, "still dirty for a later save retry"
     _assert_consistent(storage)

--- a/tests/kg/faiss_impl/test_faiss_save_failure_replay.py
+++ b/tests/kg/faiss_impl/test_faiss_save_failure_replay.py
@@ -1,0 +1,138 @@
+"""Save-failure replay coverage for ``FaissVectorDBStorage`` (#3688).
+
+``index_done_callback`` used to clear ``_pending_upserts`` inside
+``_flush_pending_locked`` — before the save ran. When the save then raised
+and another process committed, the next callback's reload-from-disk replaced
+the materialized-but-unsaved rows while the (empty) pending buffer left
+nothing to replay them from: silent data loss. The pending buffer is now
+kept until the save succeeds, so it doubles as the replay record.
+"""
+
+import numpy as np
+import pytest
+
+faiss = pytest.importorskip("faiss")
+
+from lightrag.kg.faiss_impl import FaissVectorDBStorage  # noqa: E402
+from lightrag.kg.shared_storage import (  # noqa: E402
+    finalize_share_data,
+    initialize_share_data,
+)
+from lightrag.utils import EmbeddingFunc  # noqa: E402
+
+DIM = 8
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+class _CountingEmbed:
+    def __init__(self, dim: int = DIM):
+        self.dim = dim
+        self.embedded_texts: list[str] = []
+
+    async def __call__(self, texts, **kwargs):
+        self.embedded_texts.extend(texts)
+        return np.array(
+            [
+                np.full(self.dim, (abs(hash(t)) % 97) + 1, dtype=np.float32)
+                for t in texts
+            ]
+        )
+
+
+async def _make_storage(tmp_path, embed: _CountingEmbed) -> FaissVectorDBStorage:
+    storage = FaissVectorDBStorage(
+        namespace="test_vectors",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 32,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=embed),
+        meta_fields={"content"},
+    )
+    await storage.initialize()
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_save_failure_keeps_pending_for_replay(tmp_path, monkeypatch):
+    """After a failed save the pending buffer must survive, so a reload
+    triggered by another writer's commit can replay the lost rows."""
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    def failing_save():
+        raise OSError("disk full")
+
+    monkeypatch.setattr(storage, "_save_faiss_index", failing_save)
+
+    with pytest.raises(OSError, match="disk full"):
+        await storage.index_done_callback()
+
+    assert "id1" in storage._pending_upserts, (
+        "pending must survive a failed save — it is the replay record (#3688)"
+    )
+    assert storage._index_dirty is True
+
+    # Another process commits; the next callback reloads from disk.
+    monkeypatch.undo()
+    storage.storage_updated.value = True
+
+    assert await storage.index_done_callback() is True
+    assert storage._pending_upserts == {}, "successful save drains the buffer"
+
+    reloaded = await _make_storage(tmp_path, _CountingEmbed())
+    assert await reloaded.get_by_id("id1") is not None, (
+        "the row must survive the save failure + foreign reload cycle"
+    )
+
+
+@pytest.mark.asyncio
+async def test_successful_save_clears_pending(tmp_path):
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    assert "id1" in storage._pending_upserts
+    assert await storage.index_done_callback() is True
+    assert storage._pending_upserts == {}
+
+
+@pytest.mark.asyncio
+async def test_finalize_replays_after_save_failure(tmp_path, monkeypatch):
+    """The same guarantee through finalize(): a failed save keeps the buffer,
+    and the finalize retry persists the rows."""
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    calls = {"n": 0}
+
+    def failing_first_save():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError("disk full")
+        return original_save()
+
+    original_save = storage._save_faiss_index
+    monkeypatch.setattr(storage, "_save_faiss_index", failing_first_save)
+
+    with pytest.raises(OSError, match="disk full"):
+        await storage.index_done_callback()
+
+    assert "id1" in storage._pending_upserts
+
+    await storage.finalize()
+
+    assert storage._pending_upserts == {}
+    reloaded = await _make_storage(tmp_path, _CountingEmbed())
+    assert await reloaded.get_by_id("id1") is not None


### PR DESCRIPTION
## What?

The Faiss half of #3688: `_flush_pending_locked` cleared the pending upsert buffer **before** the save ran, so a failed save combined with another process's commit silently destroyed the materialized-but-unsaved rows — the empty pending buffer left nothing to replay them from. (The Nano half of the issue is being fixed in #3680; this PR covers the Faiss backend, whose structure is identical.)

Fixes the Faiss half of #3688

## The chain (pre-existing on main)

1. `index_done_callback` flushes: rows materialize into `self._index`/`_id_to_meta`, `_index_dirty = True`, **pending cleared**;
2. `_save_faiss_index` raises (IO error / full disk) — the exception propagates, pending stays empty, dirty stays True;
3. another process commits → `storage_updated` flips;
4. the next `index_done_callback`'s reload-from-disk **replaces** the in-memory index with the foreign snapshot — the materialized rows are gone, nothing replays them, the following save succeeds. Silent data loss.

The callback's own docstring already promised "a later `finalize` retries the save without re-embedding", but that self-healing only covered the no-other-writer case; any foreign commit between the failed save and the retry destroyed the rows instead.

## How?

The pending buffer now survives until the save **succeeds** — it doubles as the replay record:

- `_flush_pending_locked` no longer clears the entries it flushed (a NOTE explains why);
- both callers (`index_done_callback`, `finalize`) snapshot the flushed ids and drain them only **after** `_save_faiss_index` returns;
- a reload replaces `self._index`/`_id_to_meta` but never touches `_pending_upserts`, so re-running the flush against the reloaded snapshot rebuilds exactly those rows: `_remove_faiss_ids_locked` by custom-id + re-add is idempotent, and the cached vectors mean no re-embedding.

Read paths are unaffected: they run under the same non-reentrant `_storage_lock`, so the brief window where a row is both materialized and pending is invisible.

## Testing

New `tests/kg/faiss_impl/test_faiss_save_failure_replay.py`:

- a failed save keeps the buffer; a **foreign reload** (`storage_updated` flipped) followed by a retry persists the row — the exact #3688 chain;
- a successful save drains the buffer;
- `finalize` replays after a save failure and persists the row.

The three deferred-embedding tests that pinned the old contract ("pending is empty after a failed save") are updated to the replay contract.

**Differential**: on `main` the new replay test fails with `pending must survive a failed save — it is the replay record (#3688)`. With this change the full `tests/kg/faiss_impl` suite passes: 32/32.

Related: my open #3693 (deferred deletes) touches the delete paths of the same file; this PR is based on `main` and independent of it.