### PR TITLE
feat(llm): add native Cloudflare Workers AI LLM and embedding support

### DIFF
--- a/examples/lightrag_cloudflare_demo.py
+++ b/examples/lightrag_cloudflare_demo.py
@@ -1,0 +1,116 @@
+"""LightRAG Demo with Cloudflare Workers AI Models.
+
+This example demonstrates how to use LightRAG with Cloudflare Workers AI for
+both text generation (e.g. Llama 3.3 70B Instruct) and text embeddings (BGE-M3).
+
+Prerequisites:
+    1. Set CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID environment variables:
+       export CLOUDFLARE_API_TOKEN='your-api-token'
+       export CLOUDFLARE_ACCOUNT_ID='your-account-id'
+
+    2. Prepare a text file named 'book.txt' in the current directory
+       (or modify BOOK_FILE constant to point to your text file)
+
+Usage:
+    python examples/lightrag_cloudflare_demo.py
+"""
+
+import os
+import asyncio
+import nest_asyncio
+
+from lightrag import LightRAG, QueryParam
+from lightrag.llm.cloudflare import cloudflare_complete_if_cache, cloudflare_embed
+from lightrag.utils import wrap_embedding_func_with_attrs
+
+nest_asyncio.apply()
+
+WORKING_DIR = "./rag_storage"
+BOOK_FILE = "./book.txt"
+
+# Validate Cloudflare credentials
+CLOUDFLARE_API_TOKEN = os.environ.get("CLOUDFLARE_API_TOKEN") or os.environ.get("CLOUDFLARE_API_KEY")
+CLOUDFLARE_ACCOUNT_ID = os.environ.get("CLOUDFLARE_ACCOUNT_ID")
+
+if not CLOUDFLARE_API_TOKEN or not CLOUDFLARE_ACCOUNT_ID:
+    raise ValueError(
+        "CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID environment variables must be set.\n"
+        "Export them with:\n"
+        "  export CLOUDFLARE_API_TOKEN='your-api-token'\n"
+        "  export CLOUDFLARE_ACCOUNT_ID='your-account-id'"
+    )
+
+if not os.path.exists(WORKING_DIR):
+    os.makedirs(WORKING_DIR, exist_ok=True)
+
+
+# --------------------------------------------------
+# LLM Function
+# --------------------------------------------------
+async def llm_model_func(prompt, system_prompt=None, history_messages=None, **kwargs):
+    return await cloudflare_complete_if_cache(
+        model="@cf/meta/llama-3.3-70b-instruct",
+        prompt=prompt,
+        system_prompt=system_prompt,
+        history_messages=history_messages or [],
+        api_key=CLOUDFLARE_API_TOKEN,
+        account_id=CLOUDFLARE_ACCOUNT_ID,
+        **kwargs,
+    )
+
+
+# --------------------------------------------------
+# Embedding Function
+# --------------------------------------------------
+@wrap_embedding_func_with_attrs(
+    embedding_dim=1024,
+    max_token_size=8192,
+    supports_asymmetric=False,
+    model_name="@cf/baai/bge-m3",
+)
+async def embedding_func(texts: list[str]) -> list[list[float]]:
+    return await cloudflare_embed(
+        texts,
+        model="@cf/baai/bge-m3",
+        api_key=CLOUDFLARE_API_TOKEN,
+        account_id=CLOUDFLARE_ACCOUNT_ID,
+    )
+
+
+async def main():
+    rag = LightRAG(
+        working_dir=WORKING_DIR,
+        llm_model_func=llm_model_func,
+        embedding_func=embedding_func,
+    )
+
+    await rag.initialize_storages()
+
+    sample_text = (
+        "Artificial Intelligence (AI) is intelligence demonstrated by machines, "
+        "unlike the natural intelligence displayed by humans and animals. "
+        "LightRAG is an innovative dual-level retrieval-augmented generation system "
+        "that combines graph-based knowledge indexing with vector search."
+    )
+
+    if os.path.exists(BOOK_FILE):
+        with open(BOOK_FILE, "r", encoding="utf-8") as f:
+            content = f.read()
+    else:
+        content = sample_text
+
+    print("Indexing document...")
+    await rag.ainsert(content)
+    print("Indexing completed!")
+
+    print("\n--- Naive Search ---")
+    res_naive = await rag.aquery("What is LightRAG?", param=QueryParam(mode="naive"))
+    print(res_naive)
+
+    print("\n--- Hybrid Search ---")
+    res_hybrid = await rag.aquery("What is LightRAG?", param=QueryParam(mode="hybrid"))
+    print(res_hybrid)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/lightrag/llm/binding_options.py
+++ b/lightrag/llm/binding_options.py
@@ -782,6 +782,40 @@ class BedrockLLMOptions(BindingOptions):
 
 
 # =============================================================================
+# Cloudflare Workers AI Options Classes
+# =============================================================================
+@dataclass
+class CloudflareLLMOptions(BindingOptions):
+    """Options for Cloudflare Workers AI text generation."""
+
+    _binding_name: ClassVar[str] = "cloudflare_llm"
+
+    temperature: float = DEFAULT_TEMPERATURE
+    max_tokens: int | None = None
+    top_p: float = 1.0
+    top_k: int | None = None
+    repetition_penalty: float | None = None
+    seed: int | None = None
+
+    _help: ClassVar[dict[str, str]] = {
+        "temperature": "Controls randomness in output generation (0.0-2.0)",
+        "max_tokens": "Maximum number of tokens to generate",
+        "top_p": "Nucleus sampling probability threshold (0.0-1.0)",
+        "top_k": "Top-k sampling threshold",
+        "repetition_penalty": "Penalty for repeating tokens (typically 1.0-2.0)",
+        "seed": "Random seed for reproducible outputs",
+    }
+
+
+@dataclass
+class CloudflareEmbeddingOptions(BindingOptions):
+    """Options for Cloudflare Workers AI text embeddings."""
+
+    _binding_name: ClassVar[str] = "cloudflare_embedding"
+
+
+
+# =============================================================================
 # Main Section - For Testing and Sample Generation
 # =============================================================================
 #

--- a/lightrag/llm/cloudflare.py
+++ b/lightrag/llm/cloudflare.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Union
+from collections.abc import AsyncIterator
+
+import httpx
+import numpy as np
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from lightrag.utils import (
+    logger,
+    safe_unicode_decode,
+    verbose_debug,
+    wrap_embedding_func_with_attrs,
+)
+from lightrag.api import __api_version__
+
+
+class CloudflareAPIError(Exception):
+    """Generic Cloudflare Workers AI API error."""
+
+    pass
+
+
+class InvalidResponseError(Exception):
+    """Exception raised when Cloudflare returns an invalid response payload."""
+
+    pass
+
+
+def _get_cloudflare_credentials(
+    api_key: str | None = None,
+    account_id: str | None = None,
+) -> tuple[str, str]:
+    """Retrieve and validate Cloudflare API Token and Account ID."""
+    token = api_key or os.environ.get("CLOUDFLARE_API_TOKEN") or os.environ.get("CLOUDFLARE_API_KEY")
+    acc_id = account_id or os.environ.get("CLOUDFLARE_ACCOUNT_ID")
+
+    if not token:
+        raise ValueError(
+            "Cloudflare API token is required. Pass api_key or set CLOUDFLARE_API_TOKEN environment variable."
+        )
+    if not acc_id:
+        raise ValueError(
+            "Cloudflare Account ID is required. Pass account_id or set CLOUDFLARE_ACCOUNT_ID environment variable."
+        )
+    return token, acc_id
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    reraise=True,
+    retry=retry_if_exception_type(
+        (
+            httpx.HTTPStatusError,
+            httpx.RequestError,
+            httpx.TimeoutException,
+            InvalidResponseError,
+        )
+    ),
+)
+async def cloudflare_complete_if_cache(
+    model: str = "@cf/meta/llama-3.3-70b-instruct",
+    prompt: Union[str, list[dict[str, str]]] = "",
+    system_prompt: str | None = None,
+    history_messages: list[dict[str, Any]] | None = None,
+    enable_cot: bool = False,
+    api_key: str | None = None,
+    account_id: str | None = None,
+    base_url: str | None = None,
+    **kwargs: Any,
+) -> Union[str, AsyncIterator[str]]:
+    """Call Cloudflare Workers AI text generation endpoint with LightRAG interface.
+
+    Args:
+        model: Cloudflare model identifier (e.g. '@cf/meta/llama-3.3-70b-instruct').
+        prompt: User query string or message history.
+        system_prompt: Optional system prompt to instruct the model.
+        history_messages: Optional prior conversation history.
+        enable_cot: Whether to include reasoning trace if present.
+        api_key: Cloudflare API token.
+        account_id: Cloudflare account identifier.
+        base_url: Optional custom base URL.
+        **kwargs: Additional generation parameters (e.g. temperature, max_tokens, stream).
+
+    Returns:
+        Generated text string, or an async iterator of text chunks if stream=True.
+    """
+    token, acc_id = _get_cloudflare_credentials(api_key, account_id)
+    endpoint = base_url or f"https://api.cloudflare.com/client/v4/accounts/{acc_id}/ai/run"
+    url = f"{endpoint.rstrip('/')}/{model.lstrip('/')}"
+
+    # Prepare messages
+    messages: list[dict[str, str]] = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    if history_messages:
+        messages.extend(history_messages)
+
+    if isinstance(prompt, str):
+        if prompt:
+            messages.append({"role": "user", "content": prompt})
+    elif isinstance(prompt, list):
+        messages.extend(prompt)
+
+    # Clean kwargs and assemble payload
+    kwargs.pop("hashing_kv", None)
+    kwargs.pop("keyword_extraction", None)
+    kwargs.pop("entity_extraction", None)
+    stream = kwargs.pop("stream", False)
+
+    payload: dict[str, Any] = {
+        "messages": messages,
+        "stream": stream,
+    }
+    for key in ("max_tokens", "temperature", "top_p", "top_k", "seed", "repetition_penalty"):
+        if key in kwargs and kwargs[key] is not None:
+            payload[key] = kwargs[key]
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "User-Agent": f"LightRAG/{__api_version__}",
+    }
+
+    timeout = httpx.Timeout(60.0, connect=10.0)
+
+    logger.debug(f"===== Query Input to Cloudflare Workers AI ({model}) =====")
+    verbose_debug(f"Payload: {payload}")
+
+    if stream:
+        async def inner_stream() -> AsyncIterator[str]:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                async with client.stream("POST", url, headers=headers, json=payload) as response:
+                    if response.status_code != 200:
+                        content = await response.aread()
+                        raise httpx.HTTPStatusError(
+                            f"Cloudflare stream error {response.status_code}: {content.decode('utf-8', errors='replace')}",
+                            request=response.request,
+                            response=response,
+                        )
+                    async for line in response.aiter_lines():
+                        if not line:
+                            continue
+                        if line.startswith("data:"):
+                            data_str = line[len("data:"):].strip()
+                            if data_str == "[DONE]":
+                                break
+                            try:
+                                data = json.loads(data_str)
+                                chunk = data.get("response", "")
+                                if chunk:
+                                    if r"\u" in chunk:
+                                        chunk = safe_unicode_decode(chunk.encode("utf-8"))
+                                    yield chunk
+                            except json.JSONDecodeError:
+                                continue
+
+        return inner_stream()
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(url, headers=headers, json=payload)
+        if response.status_code != 200:
+            raise httpx.HTTPStatusError(
+                f"Cloudflare API error {response.status_code}: {response.text}",
+                request=response.request,
+                response=response,
+            )
+
+        resp_json = response.json()
+        if not resp_json.get("success", False) and "result" not in resp_json:
+            errors = resp_json.get("errors", [])
+            raise CloudflareAPIError(f"Cloudflare API returned error: {errors}")
+
+        result = resp_json.get("result", {})
+        content = result.get("response", "")
+        if not content and isinstance(result, str):
+            content = result
+
+        if not content:
+            raise InvalidResponseError(f"Empty response from Cloudflare model {model}")
+
+        if r"\u" in content:
+            content = safe_unicode_decode(content.encode("utf-8"))
+
+        return content
+
+
+@wrap_embedding_func_with_attrs(
+    embedding_dim=1024,
+    max_token_size=8192,
+    supports_asymmetric=False,
+    model_name="@cf/baai/bge-m3",
+)
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    reraise=True,
+    retry=retry_if_exception_type(
+        (
+            httpx.HTTPStatusError,
+            httpx.RequestError,
+            httpx.TimeoutException,
+            InvalidResponseError,
+        )
+    ),
+)
+async def cloudflare_embed(
+    texts: list[str],
+    model: str = "@cf/baai/bge-m3",
+    api_key: str | None = None,
+    account_id: str | None = None,
+    base_url: str | None = None,
+    **kwargs: Any,
+) -> np.ndarray:
+    """Generate embeddings for a list of texts using Cloudflare Workers AI.
+
+    Args:
+        texts: List of text strings to embed.
+        model: Cloudflare embedding model identifier (default: '@cf/baai/bge-m3').
+        api_key: Cloudflare API token.
+        account_id: Cloudflare account identifier.
+        base_url: Optional custom base URL.
+        **kwargs: Additional parameters.
+
+    Returns:
+        numpy.ndarray: 2D array of shape (len(texts), embedding_dim).
+    """
+    if not texts:
+        return np.empty((0, 1024), dtype=np.float32)
+
+    token, acc_id = _get_cloudflare_credentials(api_key, account_id)
+    endpoint = base_url or f"https://api.cloudflare.com/client/v4/accounts/{acc_id}/ai/run"
+    url = f"{endpoint.rstrip('/')}/{model.lstrip('/')}"
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "User-Agent": f"LightRAG/{__api_version__}",
+    }
+
+    payload = {"text": texts}
+    timeout = httpx.Timeout(60.0, connect=10.0)
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(url, headers=headers, json=payload)
+        if response.status_code != 200:
+            raise httpx.HTTPStatusError(
+                f"Cloudflare embedding error {response.status_code}: {response.text}",
+                request=response.request,
+                response=response,
+            )
+
+        resp_json = response.json()
+        if not resp_json.get("success", False) and "result" not in resp_json:
+            errors = resp_json.get("errors", [])
+            raise CloudflareAPIError(f"Cloudflare embedding API returned error: {errors}")
+
+        result = resp_json.get("result", {})
+        data = result.get("data")
+        if data is None:
+            raise InvalidResponseError(f"Cloudflare embedding response missing 'data' field: {resp_json}")
+
+        return np.array(data, dtype=np.float32)

--- a/tests/llm/cloudflare_impl/test_cloudflare.py
+++ b/tests/llm/cloudflare_impl/test_cloudflare.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+import httpx
+import numpy as np
+import pytest
+
+from lightrag.llm.cloudflare import (
+    cloudflare_complete_if_cache,
+    cloudflare_embed,
+    CloudflareAPIError,
+    InvalidResponseError,
+)
+from lightrag.llm.binding_options import (
+    CloudflareLLMOptions,
+    CloudflareEmbeddingOptions,
+)
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_complete_non_stream():
+    fake_response = {
+        "success": True,
+        "result": {
+            "response": "Hello from Cloudflare Workers AI!"
+        },
+        "errors": [],
+        "messages": [],
+    }
+
+    async def fake_post(url, **kwargs):
+        assert "accounts/fake-account-id/ai/run/@cf/meta/llama-3.3-70b-instruct" in url
+        assert kwargs["headers"]["Authorization"] == "Bearer fake-token"
+        req_json = kwargs["json"]
+        assert req_json["messages"][-1]["content"] == "Hello"
+        assert req_json["stream"] is False
+        assert req_json["temperature"] == 0.7
+        resp = httpx.Response(
+            status_code=200,
+            json=fake_response,
+            request=httpx.Request("POST", url),
+        )
+        return resp
+
+    with patch("httpx.AsyncClient.post", side_effect=fake_post):
+        result = await cloudflare_complete_if_cache(
+            model="@cf/meta/llama-3.3-70b-instruct",
+            prompt="Hello",
+            system_prompt="You are a helpful assistant",
+            api_key="fake-token",
+            account_id="fake-account-id",
+            temperature=0.7,
+        )
+        assert result == "Hello from Cloudflare Workers AI!"
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_complete_stream():
+    stream_lines = [
+        b'data: {"response": "Hello "}\n\n',
+        b'data: {"response": "world!"}\n\n',
+        b'data: [DONE]\n\n',
+    ]
+
+    class FakeStreamResponse:
+        status_code = 200
+        request = httpx.Request("POST", "https://fake.url")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+        async def aiter_lines(self):
+            for line in stream_lines:
+                yield line.decode("utf-8")
+
+    def fake_stream(method, url, **kwargs):
+        return FakeStreamResponse()
+
+    with patch("httpx.AsyncClient.stream", side_effect=fake_stream):
+        stream_gen = await cloudflare_complete_if_cache(
+            model="@cf/meta/llama-3.3-70b-instruct",
+            prompt="Hi",
+            api_key="fake-token",
+            account_id="fake-account-id",
+            stream=True,
+        )
+        chunks = []
+        async for chunk in stream_gen:
+            chunks.append(chunk)
+        assert "".join(chunks) == "Hello world!"
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_missing_credentials(monkeypatch):
+    monkeypatch.delenv("CLOUDFLARE_API_TOKEN", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_API_KEY", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_ACCOUNT_ID", raising=False)
+
+    with pytest.raises(ValueError, match="Cloudflare API token is required"):
+        await cloudflare_complete_if_cache(prompt="Hi")
+
+    with pytest.raises(ValueError, match="Cloudflare Account ID is required"):
+        await cloudflare_complete_if_cache(prompt="Hi", api_key="test-token")
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_embed():
+    fake_data = [
+        [0.1, 0.2, 0.3, 0.4],
+        [0.5, 0.6, 0.7, 0.8],
+    ]
+    fake_response = {
+        "success": True,
+        "result": {
+            "shape": [2, 4],
+            "data": fake_data,
+        },
+        "errors": [],
+    }
+
+    async def fake_post(url, **kwargs):
+        assert kwargs["json"]["text"] == ["doc1", "doc2"]
+        return httpx.Response(
+            status_code=200,
+            json=fake_response,
+            request=httpx.Request("POST", url),
+        )
+
+    with patch("httpx.AsyncClient.post", side_effect=fake_post):
+        embeddings = await cloudflare_embed.func(
+            texts=["doc1", "doc2"],
+            model="@cf/baai/bge-m3",
+            api_key="fake-token",
+            account_id="fake-account-id",
+        )
+        assert isinstance(embeddings, np.ndarray)
+        assert embeddings.shape == (2, 4)
+        assert np.allclose(embeddings[0], [0.1, 0.2, 0.3, 0.4])
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_embed_empty():
+    res = await cloudflare_embed.func(texts=[])
+    assert isinstance(res, np.ndarray)
+    assert res.shape == (0, 1024)
+
+
+def test_cloudflare_binding_options():
+    opt = CloudflareLLMOptions(
+        temperature=0.5,
+        max_tokens=1000,
+        top_p=0.9,
+    )
+    d = opt.asdict()
+    assert d["temperature"] == 0.5
+    assert d["max_tokens"] == 1000
+    assert d["top_p"] == 0.9
+
+    emb_opt = CloudflareEmbeddingOptions()
+    assert emb_opt._binding_name == "cloudflare_embedding"
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_api_error_response():
+    fake_error_response = {
+        "success": False,
+        "errors": [{"code": 1000, "message": "Model not found"}],
+    }
+
+    async def fake_post(url, **kwargs):
+        return httpx.Response(
+            status_code=200,
+            json=fake_error_response,
+            request=httpx.Request("POST", url),
+        )
+
+    with patch("httpx.AsyncClient.post", side_effect=fake_post):
+        with pytest.raises(CloudflareAPIError, match="Model not found"):
+            await cloudflare_complete_if_cache(
+                prompt="Hi",
+                api_key="fake-token",
+                account_id="fake-account-id",
+            )
+
+
+@pytest.mark.asyncio
+async def test_cloudflare_invalid_response():
+    fake_empty_response = {
+        "success": True,
+        "result": {},
+        "errors": [],
+    }
+
+    async def fake_post(url, **kwargs):
+        return httpx.Response(
+            status_code=200,
+            json=fake_empty_response,
+            request=httpx.Request("POST", url),
+        )
+
+    with patch("httpx.AsyncClient.post", side_effect=fake_post):
+        with pytest.raises(InvalidResponseError, match="Empty response"):
+            await cloudflare_complete_if_cache(
+                prompt="Hi",
+                api_key="fake-token",
+                account_id="fake-account-id",
+            )
+


### PR DESCRIPTION
## Description

Adds native provider support for Cloudflare Workers AI text generation (LLM) and text embeddings in LightRAG.

## Related Issues

Fixes #3305

## Changes Made

- **Native Provider ()**:
  - Implemented `cloudflare_complete_if_cache` supporting prompt, system prompt, conversation history, and real-time SSE streaming.
  - Implemented `cloudflare_embed` wrapped with `@wrap_embedding_func_with_attrs` (defaulting to `@cf/baai/bge-m3`).
  - Added credential resolution for `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_API_KEY` and `CLOUDFLARE_ACCOUNT_ID`.
  - Configured robust retry mechanisms via tenacity (`reraise=True`) for transient network errors and rate limits.
- **Binding Options ()**:
  - Added `CloudflareLLMOptions` and `CloudflareEmbeddingOptions`.
- **Unit Tests ()**:
  - Added offline unit tests covering non-streaming completions, SSE streaming, embeddings, credential validation, binding options, and error handling.
- **Examples ()**:
  - Added complete, clean demo script demonstrating indexing and hybrid/naive querying with Cloudflare Workers AI.

## Checklist

- [x] Changes tested locally with unit tests (all 8 tests passing)
- [x] Code style verified with ruff check
- [x] Unit tests added
- [x] Example demo provided