### PR TITLE
fix(faiss): materialize an overwrite in one atomic rebuild

### DIFF
--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -754,6 +754,12 @@ class FaissVectorDBStorage(BaseVectorStorage):
         ``self._id_to_meta`` flip together. Because ``IndexFlatIP`` has no
         in-place removal API, we collect the kept vectors and rebuild.
 
+        That "flip together" holds on the failure path too: the replacement
+        index is built locally and swapped in only once its ``add`` has
+        succeeded, so a raise leaves both structures exactly as they were
+        and the caller's own recovery (retry, or a reload) has consistent
+        state to work from.
+
         Callers that mutate via this helper are responsible for setting
         ``self._index_dirty = True`` themselves (skipped here so a no-op
         call — empty intersection between ``fid_list`` and current ids —
@@ -784,10 +790,16 @@ class FaissVectorDBStorage(BaseVectorStorage):
             vectors_to_keep.append(vec)
             new_id_to_meta[new_fid] = vec_meta
 
-        self._index = faiss.IndexFlatIP(self._dim)
+        # Build the replacement fully before it becomes visible. Assigning
+        # self._index first and then adding to it means a failing add leaves
+        # an empty index behind a full _id_to_meta — a skew that reads as
+        # "every row is unbacked" and, once persisted, drops all of them on
+        # the next load.
+        new_index = faiss.IndexFlatIP(self._dim)
         if vectors_to_keep:
             arr = np.array(vectors_to_keep, dtype=np.float32)
-            self._index.add(arr)
+            new_index.add(arr)
+        self._index = new_index
         self._id_to_meta = new_id_to_meta
 
     @staticmethod

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -744,37 +744,46 @@ class FaissVectorDBStorage(BaseVectorStorage):
             if meta.get("__id__") == custom_id
         ]
 
-    def _remove_faiss_ids_locked(self, fid_list) -> None:
-        """Remove a list of internal Faiss IDs by rebuilding the index.
+    def _rebuild_index_locked(
+        self, drop_fids, add_records: list[dict[str, Any]] = ()
+    ) -> None:
+        """Rebuild the index without ``drop_fids`` and with ``add_records``.
 
         Precondition: the caller must already hold ``_storage_lock``. This
         is synchronous (no ``await``) because every step — dict scan,
         ``IndexFlatIP`` re-init, ``index.add`` — is synchronous, and the
         single critical section guarantees ``self._index`` and
         ``self._id_to_meta`` flip together. Because ``IndexFlatIP`` has no
-        in-place removal API, we collect the kept vectors and rebuild.
+        in-place update API, a change to any existing row means rebuilding.
 
-        That "flip together" holds on the failure path too: the replacement
-        index is built locally and swapped in only once its ``add`` has
-        succeeded, so a raise leaves both structures exactly as they were
-        and the caller's own recovery (retry, or a reload) has consistent
-        state to work from.
+        Both halves in one call, deliberately. An overwrite is "drop the row
+        the id had, write the row it has now", and doing that as two index
+        operations means a failure between them lands one half without the
+        other: remove-then-add can leave the id with no row at all, and
+        add-then-remove can leave it with two rows of different vintages,
+        where the read paths return the stale one. Neither state is
+        reachable through ``NanoVectorDBStorage``, whose client updates an
+        existing id in place, and neither should be reachable here.
+
+        So the replacement is assembled locally and swapped in only once its
+        ``add`` has succeeded: either the whole change lands or nothing does,
+        leaving both structures exactly as they were for the caller's retry
+        or reload. ``add_records`` must already carry ``__vector__``.
 
         Callers that mutate via this helper are responsible for setting
         ``self._index_dirty = True`` themselves (skipped here so a no-op
-        call — empty intersection between ``fid_list`` and current ids —
-        does not falsely mark the storage dirty).
+        call does not falsely mark the storage dirty).
         """
-        if not fid_list:
+        if not drop_fids and not add_records:
             return
 
-        fid_set = set(fid_list)
-        keep_fids = [fid for fid in self._id_to_meta if fid not in fid_set]
+        drop_set = set(drop_fids)
+        vectors: list[list[float]] = []
+        new_id_to_meta: dict[int, dict[str, Any]] = {}
 
-        vectors_to_keep = []
-        new_id_to_meta = {}
-        for old_fid in keep_fids:
-            vec_meta = self._id_to_meta[old_fid]
+        for old_fid, vec_meta in self._id_to_meta.items():
+            if old_fid in drop_set:
+                continue
             if "__vector__" in vec_meta:
                 vec = vec_meta["__vector__"]
             elif old_fid < self._index.ntotal:
@@ -786,21 +795,31 @@ class FaissVectorDBStorage(BaseVectorStorage):
                     f"no vector and fid exceeds index size ({self._index.ntotal})"
                 )
                 continue
-            new_fid = len(vectors_to_keep)
-            vectors_to_keep.append(vec)
-            new_id_to_meta[new_fid] = vec_meta
+            new_id_to_meta[len(vectors)] = vec_meta
+            vectors.append(vec)
 
-        # Build the replacement fully before it becomes visible. Assigning
-        # self._index first and then adding to it means a failing add leaves
-        # an empty index behind a full _id_to_meta — a skew that reads as
-        # "every row is unbacked" and, once persisted, drops all of them on
-        # the next load.
+        # Appended after the survivors, which is where a plain index.add
+        # would have put them — so fid ordering is unchanged.
+        for record in add_records:
+            new_id_to_meta[len(vectors)] = record
+            vectors.append(record["__vector__"])
+
         new_index = faiss.IndexFlatIP(self._dim)
-        if vectors_to_keep:
-            arr = np.array(vectors_to_keep, dtype=np.float32)
-            new_index.add(arr)
+        if vectors:
+            new_index.add(np.array(vectors, dtype=np.float32))
         self._index = new_index
         self._id_to_meta = new_id_to_meta
+
+    def _remove_faiss_ids_locked(self, fid_list) -> None:
+        """Remove a list of internal Faiss IDs by rebuilding the index.
+
+        Thin wrapper over :py:meth:`_rebuild_index_locked` for the delete
+        paths, which drop rows without writing any. Same preconditions and
+        the same all-or-nothing guarantee.
+        """
+        if not fid_list:
+            return
+        self._rebuild_index_locked(fid_list)
 
     @staticmethod
     def _row_fingerprint(meta: dict[str, Any]) -> str:
@@ -849,20 +868,15 @@ class FaissVectorDBStorage(BaseVectorStorage):
             * Embedding error / count mismatch → raises before any mutation
               to ``self._index`` / ``self._id_to_meta``; ``_pending_upserts``
               is left intact and ``self._index_dirty`` is not touched.
-            * ``index.add`` failure → raises before anything is removed
-              (see the add-before-remove ordering below), so the index is
-              exactly as it was. ``_index_dirty`` is not set and
-              ``_pending_upserts`` stays intact, so the next ``finalize``
-              re-enters here and re-adds from the cached vectors —
-              self-healing without re-embedding.
-            * ``_remove_faiss_ids_locked`` failure (the superseded-row
-              cleanup, which runs last) → raises with the new rows already
-              added, leaving duplicate ``__id__`` rows. That state is safe
-              to persist: duplicates are a tolerated shape here (the
-              find-all read and delete helpers exist for exactly it) and
-              the next re-upsert of the id collapses them. ``_index_dirty``
-              is already ``True`` and the rows are real, so the save must
-              go ahead.
+            * Materialization failure (``index.add``, or the rebuild an
+              overwrite goes through) → raises with ``self._index`` and
+              ``self._id_to_meta`` exactly as they were: the upsert phase
+              mutates them through a single all-or-nothing operation, so
+              there is no half-applied overwrite to persist or repair.
+              ``_index_dirty`` and ``_unsaved_upserts`` are set only after
+              it succeeds, and ``_pending_upserts`` stays intact, so the
+              next ``finalize`` re-enters here and re-applies from the
+              cached vectors — self-healing without re-embedding.
         """
         if (
             not self._pending_upserts
@@ -971,37 +985,39 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # All pending vectors are now non-None and already-normalized float32.
         # Note which existing fids the re-upserted ids occupy (find-all so
         # duplicate __id__ rows from a legacy / corrupt store still get fully
-        # cleaned). This has to happen BEFORE the add, or the rows we are
-        # about to write would match their own ids and be removed again.
+        # cleaned).
         existing_fids: list[int] = []
         for doc_id, _ in pending_items:
             existing_fids.extend(self._find_faiss_ids_by_custom_id(doc_id))
 
-        # Add first, drop the superseded rows after. The reverse order — the
-        # one this used to use — is not crash-equivalent: a failure between
-        # the removal and the add left the old row gone and the new one never
-        # written, and since an aborting batch discards _pending_upserts, the
-        # vector it was the only remaining copy of was lost for good once
-        # anything persisted the index (the delete half of a mixed flush is
-        # enough to mark it dirty). Adding first means a failure can only
-        # leave a duplicate, never a hole.
         matrix = np.vstack([pdoc.vector for _, pdoc in pending_items]).astype(
             np.float32
         )
-        start_idx = self._index.ntotal
-        self._index.add(matrix)
+        records = []
         for i, (_, pdoc) in enumerate(pending_items):
-            fid = start_idx + i
-            record = pdoc.record
-            record["__vector__"] = matrix[i].tolist()
-            self._id_to_meta[fid] = record
+            pdoc.record["__vector__"] = matrix[i].tolist()
+            records.append(pdoc.record)
+
+        if existing_fids:
+            # An overwrite: drop the rows those ids had and write the ones
+            # they have now, in a single rebuild. Splitting it into an add
+            # and a removal would let a failure land one half — a missing
+            # row one way round, two rows of different vintages the other —
+            # and neither is reachable through the Nano backend, whose
+            # client updates an existing id in place. This is also one pass
+            # cheaper than adding and then rebuilding to clean up.
+            self._rebuild_index_locked(existing_fids, records)
+        else:
+            # Nothing is being superseded, so appending cannot leave a
+            # half-applied overwrite behind — and it avoids an O(rows)
+            # rebuild on the path that does not need one.
+            start_idx = self._index.ntotal
+            self._index.add(matrix)
+            for i, record in enumerate(records):
+                self._id_to_meta[start_idx + i] = record
 
         self._index_dirty = True
         self._unsaved_upserts = True
-
-        # Superseded rows last. The rebuild keeps every fid not named here,
-        # so the rows just added (all >= start_idx) survive it.
-        self._remove_faiss_ids_locked(existing_fids)
 
         # Clear only the entries we just flushed. Today the non-reentrant
         # _storage_lock locks out concurrent upserts for the entire flush

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -692,17 +692,20 @@ class FaissVectorDBStorage(BaseVectorStorage):
             * Embedding error / count mismatch → raises before any mutation
               to ``self._index`` / ``self._id_to_meta``; ``_pending_upserts``
               is left intact and ``self._index_dirty`` is not touched.
-            * Rebuild / ``index.add`` failure → raises mid-write. The
-              materialized state may already be partially mutated (e.g.
-              ``_remove_faiss_ids_locked`` ran and dropped the prior fids
-              for re-upserted ids), but ``_index_dirty`` is **not** set
-              because we deliberately treat ``_pending_upserts`` as the
-              source of truth on this path: pending stays intact, and the
-              next ``finalize`` call re-enters ``_flush_pending_locked``,
-              which will rebuild the affected rows from the cached vectors
-              and re-add them — self-healing without re-embedding. The
-              dirty flag is reserved for "materialized but unsaved",
-              which is only true after ``index.add`` completes.
+            * ``index.add`` failure → raises before anything is removed
+              (see the add-before-remove ordering below), so the index is
+              exactly as it was. ``_index_dirty`` is not set and
+              ``_pending_upserts`` stays intact, so the next ``finalize``
+              re-enters here and re-adds from the cached vectors —
+              self-healing without re-embedding.
+            * ``_remove_faiss_ids_locked`` failure (the superseded-row
+              cleanup, which runs last) → raises with the new rows already
+              added, leaving duplicate ``__id__`` rows. That state is safe
+              to persist: duplicates are a tolerated shape here (the
+              find-all read and delete helpers exist for exactly it) and
+              the next re-upsert of the id collapses them. ``_index_dirty``
+              is already ``True`` and the rows are real, so the save must
+              go ahead.
         """
         if not self._pending_upserts:
             return
@@ -751,15 +754,22 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 pdoc.vector = arr[i].copy()
 
         # All pending vectors are now non-None and already-normalized float32.
-        # Remove every existing fid in self._id_to_meta whose custom id is
-        # being re-upserted (find-all so duplicate __id__ rows from a legacy /
-        # corrupt store still get fully cleaned), then add the new vectors in
-        # a single batch.
+        # Note which existing fids the re-upserted ids occupy (find-all so
+        # duplicate __id__ rows from a legacy / corrupt store still get fully
+        # cleaned). This has to happen BEFORE the add, or the rows we are
+        # about to write would match their own ids and be removed again.
         existing_fids: list[int] = []
         for doc_id, _ in pending_items:
             existing_fids.extend(self._find_faiss_ids_by_custom_id(doc_id))
-        self._remove_faiss_ids_locked(existing_fids)
 
+        # Add first, drop the superseded rows after. The reverse order — the
+        # one this used to use — is not crash-equivalent: a failure between
+        # the removal and the add left the old row gone and the new one never
+        # written, and since an aborting batch discards _pending_upserts, the
+        # vector it was the only remaining copy of was lost for good once
+        # anything persisted the index (the delete half of a mixed flush is
+        # enough to mark it dirty). Adding first means a failure can only
+        # leave a duplicate, never a hole.
         matrix = np.vstack([pdoc.vector for _, pdoc in pending_items]).astype(
             np.float32
         )
@@ -772,6 +782,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
             self._id_to_meta[fid] = record
 
         self._index_dirty = True
+
+        # Superseded rows last. The rebuild keeps every fid not named here,
+        # so the rows just added (all >= start_idx) survive it.
+        self._remove_faiss_ids_locked(existing_fids)
 
         # Clear only the entries we just flushed. Today the non-reentrant
         # _storage_lock locks out concurrent upserts for the entire flush

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -931,3 +931,64 @@ async def test_flush_cleanup_failure_leaves_a_duplicate_not_a_hole(
     record = await storage.get_by_id("keep")
     assert record is not None and record["content"] == "v3"
     _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_rebuild_failure_leaves_index_and_meta_untouched(tmp_path, monkeypatch):
+    """``_remove_faiss_ids_locked`` promises that ``_index`` and
+    ``_id_to_meta`` flip together; this pins that the promise survives the
+    failure path, where the two are actually assigned.
+
+    Building the replacement index in place — assigning ``self._index`` and
+    only then adding to it — left an empty index behind a full
+    ``_id_to_meta`` when the add raised. Every row then reads as unbacked,
+    and because the cleanup runs after the flush has marked the index dirty
+    with unsaved upserts, ``finalize`` skips the reload and persists it: the
+    whole namespace is dropped on the next load.
+    """
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+    await storage.upsert({f"row{i}": {"content": f"c{i}"} for i in range(4)})
+    assert await storage.index_done_callback() is True
+    _assert_consistent(storage)
+
+    # Overwrite one row, so the flush runs its superseded-row cleanup.
+    await storage.upsert({"row0": {"content": "new"}})
+
+    # Fail the add of the index the cleanup builds — not the helper itself,
+    # which is where the damage actually happened. During a flush the only
+    # IndexFlatIP constructed is the cleanup's, so the first one is it.
+    real_cls = faiss.IndexFlatIP
+    built = {"n": 0}
+
+    def failing_factory(dim):
+        index = real_cls(dim)
+        built["n"] += 1
+        if built["n"] == 1:
+
+            def boom(_arr):
+                raise RuntimeError("cleanup rebuild add boom")
+
+            index.add = boom
+        return index
+
+    monkeypatch.setattr(faiss, "IndexFlatIP", failing_factory)
+    with pytest.raises(RuntimeError, match="cleanup rebuild add boom"):
+        await storage.index_done_callback()
+    monkeypatch.undo()
+
+    _assert_consistent(storage)
+
+    # The batch aborts and a later save commits whatever the index holds.
+    await storage.drop_pending_index_ops()
+    await storage.finalize()
+
+    reloaded = _make_storage(tmp_path, _CountingEmbed())
+    await reloaded.initialize()
+    for i in range(4):
+        assert await reloaded.get_by_id(f"row{i}") is not None, (
+            f"row{i} must survive a failed cleanup rebuild"
+        )
+    _assert_consistent(reloaded)

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -822,3 +822,92 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     assert storage._index.ntotal == 1, "materialized id1 NOT rolled back"
     assert storage._index_dirty is True, "still dirty for a later save retry"
     _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_flush_add_failure_leaves_the_superseded_row_intact(
+    tmp_path, monkeypatch
+):
+    """The flush materializes an overwrite by adding the new row and only
+    then dropping the row it supersedes. The reverse order was not
+    crash-equivalent: a failure in between left the old row gone and the new
+    one never written, and since an aborting batch discards
+    ``_pending_upserts`` — the only remaining copy of that vector — anything
+    that later persisted the index made the loss permanent.
+
+    The batch has to carry a delete as well as the overwrite: that is what
+    marks the index dirty, and a dirty index is what makes the later save go
+    ahead and commit the hole.
+    """
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+    await storage.upsert({"doomed": {"content": "x"}, "keep": {"content": "v1"}})
+    assert await storage.index_done_callback() is True
+    _assert_consistent(storage)
+
+    # A mixed batch: one delete, one overwrite of an existing row.
+    await storage.delete(["doomed"])
+    await storage.upsert({"keep": {"content": "v2"}})
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("faiss add boom")
+
+    monkeypatch.setattr(np, "vstack", boom)
+    with pytest.raises(RuntimeError, match="faiss add boom"):
+        await storage.index_done_callback()
+    monkeypatch.undo()
+    _assert_consistent(storage)
+
+    # The pipeline aborts the batch, discarding the buffered replacement —
+    # the only remaining copy of that vector — and a later save persists
+    # whatever the index holds.
+    await storage.drop_pending_index_ops()
+    await storage.finalize()
+
+    reloaded = _make_storage(tmp_path, _CountingEmbed())
+    await reloaded.initialize()
+    survivor = await reloaded.get_by_id("keep")
+    assert survivor is not None, "an aborted overwrite must not delete the row"
+    assert survivor["content"] == "v1"
+    assert await reloaded.get_by_id("doomed") is None, "the delete still applies"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_flush_cleanup_failure_leaves_a_duplicate_not_a_hole(
+    tmp_path, monkeypatch
+):
+    """If the superseded-row cleanup itself fails, the new row is already in
+    the index, so the worst case is a duplicate ``__id__`` — a shape this
+    storage tolerates and collapses on the next re-upsert — never a missing
+    vector."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+    await storage.upsert({"keep": {"content": "v1"}})
+    assert await storage.index_done_callback() is True
+
+    await storage.upsert({"keep": {"content": "v2"}})
+
+    def boom(_fids):
+        raise RuntimeError("faiss rebuild boom")
+
+    monkeypatch.setattr(storage, "_remove_faiss_ids_locked", boom)
+    with pytest.raises(RuntimeError, match="faiss rebuild boom"):
+        await storage.index_done_callback()
+    monkeypatch.undo()
+
+    fids = storage._find_faiss_ids_by_custom_id("keep")
+    assert len(fids) == 2, "both the old and the new row are present"
+    assert storage._index_dirty is True, "the new row is real and must be saved"
+    _assert_consistent(storage)
+
+    # The next successful flush collapses the duplicates.
+    await storage.upsert({"keep": {"content": "v3"}})
+    assert await storage.index_done_callback() is True
+    assert len(storage._find_faiss_ids_by_custom_id("keep")) == 1
+    record = await storage.get_by_id("keep")
+    assert record is not None and record["content"] == "v3"
+    _assert_consistent(storage)

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -849,12 +849,13 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
 async def test_flush_add_failure_leaves_the_superseded_row_intact(
     tmp_path, monkeypatch
 ):
-    """The flush materializes an overwrite by adding the new row and only
-    then dropping the row it supersedes. The reverse order was not
-    crash-equivalent: a failure in between left the old row gone and the new
-    one never written, and since an aborting batch discards
-    ``_pending_upserts`` — the only remaining copy of that vector — anything
-    that later persisted the index made the loss permanent.
+    """A failure while preparing the overwrite must leave the row the id
+    already had.
+
+    The flush used to drop that row first and add the replacement after, so a
+    failure in between left the id with nothing. An aborting batch then
+    discards ``_pending_upserts``, which held the only remaining copy of the
+    vector, and the next save committed the hole.
 
     The batch has to carry a delete as well as the overwrite: that is what
     marks the index dirty, and a dirty index is what makes the later save go
@@ -896,36 +897,62 @@ async def test_flush_add_failure_leaves_the_superseded_row_intact(
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_flush_cleanup_failure_leaves_a_duplicate_not_a_hole(
-    tmp_path, monkeypatch
-):
-    """If the superseded-row cleanup itself fails, the new row is already in
-    the index, so the worst case is a duplicate ``__id__`` — a shape this
-    storage tolerates and collapses on the next re-upsert — never a missing
-    vector."""
+async def test_overwrite_is_one_rebuild_and_all_or_nothing(tmp_path, monkeypatch):
+    """An overwrite goes through a single rebuild that both drops the row the
+    id had and writes the row it has now.
+
+    Two properties, and they are the same property. It is *one* operation, so
+    a failure cannot land one half — no missing row, no two rows of different
+    vintages — and it is one *rebuild*, not an append followed by a cleanup
+    rebuild, so it does not cost an extra O(rows) pass either.
+    """
     embed = _CountingEmbed()
     storage = _make_storage(tmp_path, embed)
     await storage.initialize()
-    await storage.upsert({"keep": {"content": "v1"}})
+    await storage.upsert({"keep": {"content": "v1"}, "other": {"content": "o"}})
     assert await storage.index_done_callback() is True
 
-    await storage.upsert({"keep": {"content": "v2"}})
+    rebuilds = []
+    original = storage._rebuild_index_locked
 
-    def boom(_fids):
+    def counting(drop_fids, add_records=()):
+        rebuilds.append((list(drop_fids), len(add_records)))
+        return original(drop_fids, add_records)
+
+    monkeypatch.setattr(storage, "_rebuild_index_locked", counting)
+    await storage.upsert({"keep": {"content": "v2"}})
+    assert await storage.index_done_callback() is True
+    monkeypatch.undo()
+
+    assert len(rebuilds) == 1, "an overwrite is a single rebuild"
+    assert rebuilds[0][1] == 1, "the new row is written by that same rebuild"
+    assert len(storage._find_faiss_ids_by_custom_id("keep")) == 1
+    record = await storage.get_by_id("keep")
+    assert record is not None and record["content"] == "v2"
+    _assert_consistent(storage)
+
+    # Now fail that rebuild: neither half may land.
+    await storage.upsert({"keep": {"content": "v3"}})
+
+    def boom(_drop_fids, _add_records=()):
         raise RuntimeError("faiss rebuild boom")
 
-    monkeypatch.setattr(storage, "_remove_faiss_ids_locked", boom)
+    monkeypatch.setattr(storage, "_rebuild_index_locked", boom)
     with pytest.raises(RuntimeError, match="faiss rebuild boom"):
         await storage.index_done_callback()
     monkeypatch.undo()
 
     fids = storage._find_faiss_ids_by_custom_id("keep")
-    assert len(fids) == 2, "both the old and the new row are present"
-    assert storage._index_dirty is True, "the new row is real and must be saved"
+    assert len(fids) == 1, "a failed overwrite must not leave a second row"
+    assert storage._id_to_meta[fids[0]]["content"] == "v2", (
+        "the row the id had must be intact"
+    )
+    assert storage._index_dirty is False, "nothing landed, so nothing to save"
     _assert_consistent(storage)
 
-    # The next successful flush collapses the duplicates.
-    await storage.upsert({"keep": {"content": "v3"}})
+    # The read paths still show the buffered v3 — the retry is pending, not
+    # lost — and a successful retry applies it exactly once.
+    assert "keep" in storage._pending_upserts
     assert await storage.index_done_callback() is True
     assert len(storage._find_faiss_ids_by_custom_id("keep")) == 1
     record = await storage.get_by_id("keep")
@@ -935,17 +962,46 @@ async def test_flush_cleanup_failure_leaves_a_duplicate_not_a_hole(
 
 @pytest.mark.offline
 @pytest.mark.asyncio
+async def test_insert_only_flush_does_not_rebuild(tmp_path, monkeypatch):
+    """Nothing is superseded when every id is new, so the flush appends
+    instead of rebuilding — the O(rows) pass belongs to overwrites only."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+    await storage.upsert({f"row{i}": {"content": f"c{i}"} for i in range(3)})
+    assert await storage.index_done_callback() is True
+
+    rebuilds = []
+    original = storage._rebuild_index_locked
+
+    def counting(drop_fids, add_records=()):
+        rebuilds.append(list(drop_fids))
+        return original(drop_fids, add_records)
+
+    monkeypatch.setattr(storage, "_rebuild_index_locked", counting)
+    await storage.upsert({"fresh": {"content": "brand new"}})
+    assert await storage.index_done_callback() is True
+    monkeypatch.undo()
+
+    assert rebuilds == [], "an insert-only flush must not rebuild the index"
+    assert storage._index.ntotal == 4
+    record = await storage.get_by_id("fresh")
+    assert record is not None and record["content"] == "brand new"
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
 async def test_rebuild_failure_leaves_index_and_meta_untouched(tmp_path, monkeypatch):
-    """``_remove_faiss_ids_locked`` promises that ``_index`` and
-    ``_id_to_meta`` flip together; this pins that the promise survives the
-    failure path, where the two are actually assigned.
+    """``_rebuild_index_locked`` promises that ``_index`` and ``_id_to_meta``
+    flip together; this pins that the promise survives the failure path,
+    where the two are actually assigned.
 
     Building the replacement index in place — assigning ``self._index`` and
     only then adding to it — left an empty index behind a full
     ``_id_to_meta`` when the add raised. Every row then reads as unbacked,
-    and because the cleanup runs after the flush has marked the index dirty
-    with unsaved upserts, ``finalize`` skips the reload and persists it: the
-    whole namespace is dropped on the next load.
+    and once anything persisted that state the whole namespace was dropped
+    on the next load.
     """
     embed = _CountingEmbed()
     storage = _make_storage(tmp_path, embed)
@@ -954,12 +1010,12 @@ async def test_rebuild_failure_leaves_index_and_meta_untouched(tmp_path, monkeyp
     assert await storage.index_done_callback() is True
     _assert_consistent(storage)
 
-    # Overwrite one row, so the flush runs its superseded-row cleanup.
+    # Overwrite one row, so the flush goes through a rebuild.
     await storage.upsert({"row0": {"content": "new"}})
 
-    # Fail the add of the index the cleanup builds — not the helper itself,
-    # which is where the damage actually happened. During a flush the only
-    # IndexFlatIP constructed is the cleanup's, so the first one is it.
+    # Fail the add of the index the rebuild constructs — not the helper
+    # itself, since inside it is where the damage happened. During a flush
+    # the only IndexFlatIP built is the rebuild's, so the first one is it.
     real_cls = faiss.IndexFlatIP
     built = {"n": 0}
 
@@ -969,17 +1025,21 @@ async def test_rebuild_failure_leaves_index_and_meta_untouched(tmp_path, monkeyp
         if built["n"] == 1:
 
             def boom(_arr):
-                raise RuntimeError("cleanup rebuild add boom")
+                raise RuntimeError("rebuild add boom")
 
             index.add = boom
         return index
 
     monkeypatch.setattr(faiss, "IndexFlatIP", failing_factory)
-    with pytest.raises(RuntimeError, match="cleanup rebuild add boom"):
+    with pytest.raises(RuntimeError, match="rebuild add boom"):
         await storage.index_done_callback()
     monkeypatch.undo()
 
     _assert_consistent(storage)
+    assert len(storage._find_faiss_ids_by_custom_id("row0")) == 1, (
+        "a failed overwrite leaves the id one row — the one it already had, "
+        "not that row plus the replacement"
+    )
 
     # The batch aborts and a later save commits whatever the index holds.
     await storage.drop_pending_index_ops()
@@ -989,6 +1049,6 @@ async def test_rebuild_failure_leaves_index_and_meta_untouched(tmp_path, monkeyp
     await reloaded.initialize()
     for i in range(4):
         assert await reloaded.get_by_id(f"row{i}") is not None, (
-            f"row{i} must survive a failed cleanup rebuild"
+            f"row{i} must survive a failed rebuild"
         )
     _assert_consistent(reloaded)


### PR DESCRIPTION
## Summary

`FaissVectorDBStorage._flush_pending_locked` materializes an overwrite as two index operations — drop the row the id had, write the row it has now — so a failure between them lands one half without the other. Which half depends on the order, and **both orders are wrong**:

| ordering | what a failure leaves | symptom |
|---|---|---|
| remove-then-add (`main`) | the id has no row | the vector is gone; the aborting batch has already discarded the only remaining copy |
| add-then-remove | the id has two rows, different vintages | `_find_faiss_id_by_custom_id` returns the **older** one and a query returns both |

This does both halves in a single rebuild instead, so either the whole overwrite lands or none of it does.

## Why this is the right shape

Neither state is reachable through `NanoVectorDBStorage`, and that is not an accident of its failure handling — its client has no two-step to fail between. `nano_vectordb.dbs.NanoVectorDB.upsert` updates an id it already holds **in place**:

```python
for i, already_data in enumerate(self.__storage["data"]):
    if already_data[f_ID] in _index_datas:
        update_d = _index_datas.pop(already_data[f_ID])
        self.__storage["matrix"][i] = update_d[f_VECTOR].astype(Float)
        self.__storage["data"][i] = update_d
# only genuinely new ids fall through to the vstack append
```

So on Nano an id is always either its old version or its new one — never both, never absent. The two-step in FAISS is an artifact of `IndexFlatIP` having no in-place update API, not a difference in storage semantics, and it should not leak into what a failure can leave behind.

## What changed

- **`_rebuild_index_locked(drop_fids, add_records)`** — the atomic primitive. It assembles the replacement index locally and swaps it into `self._index` / `self._id_to_meta` only once its `add` has succeeded, so a raise leaves both structures exactly as they were. Previously the rebuild assigned `self._index` a fresh `IndexFlatIP` and *then* added to it, which on a failing add left an empty index behind a full `_id_to_meta` — every row reads as unbacked, and persisting that drops all of them on the next load.
- **`_remove_faiss_ids_locked`** is now the delete paths' wrapper over it (they drop rows without writing any), unchanged for its callers.
- **The flush** routes an overwrite through the unified rebuild, and keeps the plain append when nothing is superseded — that path cannot leave an overwrite half-applied, and it should not pay an O(rows) rebuild.
- `_index_dirty` / `_unsaved_upserts` are set only after materialization succeeds.

## Side effect analysis

- **Performance**: a pass cheaper, not dearer. Overwriting used to append *and then* rebuild to clean up; it now rebuilds once. An insert-only flush still does not rebuild at all. `test_insert_only_flush_does_not_rebuild` pins that, so the quadratic-ingestion work in #3693 is not eroded.
- **Success path**: unchanged, including fid numbering — the rebuild appends the new rows after the survivors, which is where the append had put them.
- **Backward compatibility**: no API or storage-format change; `_rebuild_index_locked` is private.
- **Delete paths**: strictly better. They already went through the rebuild, which is now all-or-nothing for them too.

## Validation

Reachable failure states for a batch that carries a delete (the delete marks the index dirty, so the state does reach disk), same script throughout:

```
remove-then-add   persisted []                 row lost
add-then-remove   persisted [old, new]         stale read
one rebuild       persisted [old]              overwrite retried
```

**Tests** in `tests/kg/faiss_impl/test_faiss_deferred_embedding.py`:

- `test_overwrite_is_one_rebuild_and_all_or_nothing` — one rebuild per overwrite, and a failing one leaves neither half.
- `test_insert_only_flush_does_not_rebuild` — the O(rows) pass stays on the overwrite path.
- `test_flush_add_failure_leaves_the_superseded_row_intact` — the row the id had survives, asserted through a reload from disk.
- `test_rebuild_failure_leaves_index_and_meta_untouched` — the two structures still agree after a failed rebuild, and the id has one row rather than two (`assert 2 == 1` on the add-then-remove commit).

`pytest tests/kg` — 2051 passed, 184 skipped. `pre-commit run --files ...` clean (ruff + ruff-format at the pinned version).

## Related

Found while reviewing #3693; the defect predates it and reproduces the same way on `main`. Two rounds of Codex review on this PR drove the shape: the first caught the in-place rebuild, the second that versioned duplicates are not the harmless state the add-then-remove commit claimed. Both are addressed by removing the two-step rather than by choosing between its orderings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)