### PR TITLE
fix(opensearch): rank the wildcard graph view from a complete candidate set

### DIFF
--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -907,14 +907,17 @@ class BaseGraphStorage(StorageNameSpace, ABC):
         its graph view at the same cutoff. Every other backend orders its ``*``
         ranking on the label; do not copy the deviation into a new one.
 
-        **Known approximation -- OpenSearchGraphStorage** applies the rule, but
-        only to the candidates its degree aggregations surfaced, and that set is
-        approximate: the two endpoint aggregations are each capped at
-        ``max_nodes``, so an entity whose in- and out-degree both fall outside
-        their respective top-N never reaches the ranking however high its
-        undirected degree is, and terms aggregations are count-approximate
-        across shards. Tracked in issue #3613; it needs a storage-shape change,
-        not an ordering one.
+        **OpenSearchGraphStorage** ranks from a single terms aggregation over
+        an ``endpoints`` field carrying both ids of each edge document, so one
+        bucket per entity holds its true undirected degree and the candidate
+        set is the global top by degree. This replaced a union of two
+        per-field aggregations, each separately capped, which omitted any
+        entity whose in- and out-degree both fell outside their respective
+        top-N however high its total degree was (issue #3613). An index
+        predating the ``endpoints`` backfill keeps the old union until startup
+        completes it, and on a multi-shard index the merged bucket counts stay
+        subject to the usual terms-aggregation error, which that backend logs
+        when the reported bound is non-zero.
 
         This constrains WHICH nodes survive truncation, not the order of
         :class:`KnowledgeGraph.nodes` in the response — implementations

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -3662,6 +3662,40 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             )
             raise
 
+    @staticmethod
+    def _edge_missing_endpoints_query() -> dict[str, Any]:
+        """Edge docs the degree aggregation should see but cannot.
+
+        Only docs the ranking could ever use: one missing an endpoint id
+        cannot be given an ``endpoints`` value and must not hold the readiness
+        flag back forever.
+        """
+        return {
+            "bool": {
+                "must": [
+                    {"exists": {"field": "source_node_id"}},
+                    {"exists": {"field": "target_node_id"}},
+                ],
+                "must_not": [{"exists": {"field": _EDGE_ENDPOINTS_FIELD}}],
+            }
+        }
+
+    async def _edges_missing_endpoints_exist(self) -> bool:
+        """Whether any rankable edge doc still lacks ``endpoints``.
+
+        ``terminate_after`` bounds the documents collected, not the shards
+        consulted, so this is cheaper than the backfill's count only when the
+        answer is yes. That is the right way round: a clean index pays one
+        zero-hit query, and an index with a backlog stops at the first hit
+        instead of sizing a backlog it is about to refill anyway.
+        """
+        probe = await self.client.count(
+            index=self._edges_index,
+            body={"query": self._edge_missing_endpoints_query()},
+            terminate_after=1,
+        )
+        return bool(probe["count"])
+
     async def _ensure_edge_endpoints_ready(self) -> None:
         """Land the ``endpoints`` mapping and backfill it on legacy edge docs.
 
@@ -3678,8 +3712,25 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         error, a huge index mid-reindex) keeps serving the approximate ranking
         rather than refusing to start. Every subsequent ``initialize`` retries.
 
-        Idempotent via an index ``_meta`` flag, so a completed backfill costs
-        one mapping read per startup rather than a rescan.
+        **The ``_meta`` flag records that a backfill completed, not that the
+        field is still universal.** It cannot be the latter: nothing fences
+        writes against an old-version process, so during a rolling deploy a
+        worker running the previous release can index an edge without
+        ``endpoints`` after this one has stamped the flag. Trusting the flag
+        alone would leave that edge outside the aggregation permanently -- the
+        degree ranking would silently lose it, with no operation short of
+        clearing the flag by hand to bring it back. So every startup that finds
+        an existing index revalidates coverage, and a dirty one re-runs the
+        backfill; the flag saves the ``update_by_query`` and the ``_meta``
+        write on the clean path, not the query that asks. A startup that
+        *creates* the index is exempt, and safely: it holds the data-init lock
+        and the index it stamps is empty.
+
+        Revalidation closes the window rather than eliminating it: an edge
+        written by an old-version worker after the last startup stays uncovered
+        until the next one. That is as far as this can go without a write
+        fence, and it costs ranking quality alone -- never a wrong edge, only
+        an entity ranked from a degree short of its real one.
         """
         if self._edge_endpoints_ready:
             return
@@ -3692,9 +3743,33 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             mapping = await self.client.indices.get_mapping(index=self._edges_index)
             index_mapping = mapping.get(self._edges_index, {}).get("mappings", {})
             meta = index_mapping.get("_meta", {})
-            if meta.get(_EDGE_ENDPOINTS_META_FLAG):
-                self._edge_endpoints_ready = True
-                return
+            flagged = bool(meta.get(_EDGE_ENDPOINTS_META_FLAG))
+            if flagged:
+                try:
+                    dirty = await self._edges_missing_endpoints_exist()
+                except OpenSearchException as e:
+                    # Revalidation is a guard on top of a promise the flag
+                    # already made. Failing it must fall back to that promise,
+                    # not below it: the alternative downgrades a healthy index
+                    # to the approximate ranking for the life of the process,
+                    # which would make this check the likeliest cause of the
+                    # degradation it exists to prevent.
+                    logger.warning(
+                        f"[{self.workspace}] Could not revalidate "
+                        f"{_EDGE_ENDPOINTS_FIELD} coverage on "
+                        f"{self._edges_index}: {e}; trusting the readiness flag"
+                    )
+                    self._edge_endpoints_ready = True
+                    return
+                if not dirty:
+                    self._edge_endpoints_ready = True
+                    return
+                logger.warning(
+                    f"[{self.workspace}] Edge docs without {_EDGE_ENDPOINTS_FIELD} "
+                    f"found in {self._edges_index} after the readiness flag was "
+                    f"set; an old-version writer during a rolling deploy is the "
+                    f"usual cause. Re-running the backfill"
+                )
 
             if _EDGE_ENDPOINTS_FIELD not in index_mapping.get("properties", {}):
                 # Explicit keyword mapping: the index is `dynamic: true`, and a
@@ -3710,18 +3785,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     f"{self._edges_index}"
                 )
 
-            # Only docs the ranking could ever use: one missing an endpoint id
-            # cannot be given an `endpoints` value and must not hold the flag
-            # back forever.
-            missing_query = {
-                "bool": {
-                    "must": [
-                        {"exists": {"field": "source_node_id"}},
-                        {"exists": {"field": "target_node_id"}},
-                    ],
-                    "must_not": [{"exists": {"field": _EDGE_ENDPOINTS_FIELD}}],
-                }
-            }
+            missing_query = self._edge_missing_endpoints_query()
             remaining = (
                 await self.client.count(
                     index=self._edges_index, body={"query": missing_query}

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -3378,6 +3378,14 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                             "file_path": {"type": "keyword"},
                             "created_at": {"type": "long"},
                         },
+                        # Created from the current mapping and holding no
+                        # documents, so every edge it will ever have carries
+                        # `endpoints` from its first write. Stamped here rather
+                        # than left to _ensure_edge_endpoints_ready so the
+                        # promise is durable from the moment the index exists,
+                        # and no later startup rescans an index that cannot
+                        # hold a document without the field.
+                        "_meta": {_EDGE_ENDPOINTS_META_FLAG: True},
                     },
                     "settings": {
                         "index": {
@@ -3387,9 +3395,6 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     },
                 }
                 await self.client.indices.create(index=self._edges_index, body=body)
-                # Created from the current mapping and holding no documents, so
-                # every edge it will ever have carries `endpoints` from its
-                # first write: exact degree ranking with no backfill.
                 self._edge_endpoints_ready = True
                 logger.info(
                     f"[{self.workspace}] Created edges index: {self._edges_index}"
@@ -4987,6 +4992,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     "_id",
                     "source_node_id",
                     "target_node_id",
+                    _EDGE_ENDPOINTS_FIELD,
                     "relationship",
                     "source_ids",
                 )

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -326,6 +326,36 @@ _EDGE_ID_CANONICAL_META_FLAG = "edge_id_canonical_v1"
 # watching a large-index reindex see liveness and an X/total denominator.
 _EDGE_MIGRATION_PROGRESS_INTERVAL = 50_000
 
+# Multi-valued keyword field on the edge document holding BOTH endpoint ids, so
+# one terms aggregation yields true undirected degree in a single bucket per
+# entity. See _edge_endpoints and issue #3613.
+_EDGE_ENDPOINTS_FIELD = "endpoints"
+
+# Index _meta flag marking that every edge doc carries _EDGE_ENDPOINTS_FIELD.
+# Until it is set, degree ranking falls back to the legacy endpoint-pair
+# aggregations, whose candidate set is approximate.
+_EDGE_ENDPOINTS_META_FLAG = "edge_endpoints_v1"
+
+# Painless backfill for legacy edge docs written before `endpoints` existed.
+# Mirrors _edge_endpoints: both ids, deduplicated for a self-loop. A doc with
+# no endpoint ids is left untouched -- there is nothing to derive the value
+# from, and it is unreachable from the ranking either way.
+_EDGE_ENDPOINTS_BACKFILL_SCRIPT = (
+    "def s = ctx._source.source_node_id; "
+    "def t = ctx._source.target_node_id; "
+    "if (s == null || t == null) { ctx.op = 'noop'; return; } "
+    "ctx._source.endpoints = s.equals(t) ? [s] : [s, t];"
+)
+
+# Multiplier applied to a terms aggregation's `size` to derive `shard_size`.
+# A terms agg asks each shard for its own top `shard_size` buckets and merges
+# them, so a bucket outside a shard's local top-N contributes nothing and the
+# merged doc_count can be short. Over-fetching per shard shrinks that error;
+# the response's doc_count_error_upper_bound reports what is left. Irrelevant
+# at the single-shard default (OPENSEARCH_NUMBER_OF_SHARDS=1), where a terms
+# agg is exact.
+_DEGREE_AGG_SHARD_SIZE_FACTOR = 4
+
 # Ceiling on how many same-depth candidates get a degree lookup before the
 # max_nodes cap. node_degrees_batch puts the whole list in four `terms` clauses
 # (two in the query, two in the aggregation filters) and asks for one bucket per
@@ -350,6 +380,23 @@ def _canonical_edge_id(source_node_id: str, target_node_id: str) -> str:
     """
     lo, hi = sorted((source_node_id, target_node_id))
     return compute_mdhash_id(f"{lo}-{hi}", prefix="edge-")
+
+
+def _edge_endpoints(source_node_id: str, target_node_id: str) -> list[str]:
+    """Both endpoint ids of an edge, deduplicated, for ``endpoints``.
+
+    A terms aggregation over this field buckets by VALUE and counts DOCUMENTS,
+    so each edge contributes exactly one to each distinct endpoint's bucket:
+    one aggregation, one bucket per entity, holding true undirected degree.
+    That is what makes the wildcard ranking's candidate set complete — the
+    legacy pair of per-field aggregations each returned only its own top-N, so
+    an entity outside both never reached the sort (#3613).
+
+    A self-loop stores a single value, matching :meth:`node_degree`, which
+    counts the loop's one document once. (The legacy pair of aggregations
+    counted it twice, on both the source and the target side.)
+    """
+    return list(dict.fromkeys((source_node_id, target_node_id)))
 
 
 def _edge_source_id_list(doc: dict[str, Any]) -> list[str]:
@@ -3158,6 +3205,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
     _nodes_dirty: bool = field(default=False, init=False)
     _edges_dirty: bool = field(default=False, init=False)
     _ppl_graphlookup_available: bool = field(default=False, init=False)
+    _edge_endpoints_ready: bool = field(default=False, init=False)
 
     def __init__(self, namespace, global_config, embedding_func, workspace=None):
         super().__init__(
@@ -3188,6 +3236,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 self.client = await ClientManager.get_client()
             await self._create_indices_if_not_exist()
             await self._migrate_edges_to_canonical_id_if_needed()
+            await self._ensure_edge_endpoints_ready()
             self._indices_ready = True
             self._nodes_dirty = False
             self._edges_dirty = False
@@ -3319,6 +3368,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                         "properties": {
                             "source_node_id": {"type": "keyword"},
                             "target_node_id": {"type": "keyword"},
+                            _EDGE_ENDPOINTS_FIELD: {"type": "keyword"},
                             "relationship": {"type": "keyword"},
                             "description": {"type": "text"},
                             "weight": {"type": "float"},
@@ -3337,6 +3387,10 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                     },
                 }
                 await self.client.indices.create(index=self._edges_index, body=body)
+                # Created from the current mapping and holding no documents, so
+                # every edge it will ever have carries `endpoints` from its
+                # first write: exact degree ranking with no backfill.
+                self._edge_endpoints_ready = True
                 logger.info(
                     f"[{self.workspace}] Created edges index: {self._edges_index}"
                 )
@@ -3602,6 +3656,185 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 f"{self._edges_index}: {e}; aborting startup"
             )
             raise
+
+    async def _ensure_edge_endpoints_ready(self) -> None:
+        """Land the ``endpoints`` mapping and backfill it on legacy edge docs.
+
+        Degree ranking reads a single terms aggregation over ``endpoints``
+        (see :func:`_edge_endpoints`), which only works once every edge
+        document carries the field. Sets :attr:`_edge_endpoints_ready` when
+        that is true for the whole index; until then the ranking paths keep
+        using the legacy endpoint-pair aggregations.
+
+        **Degrades, does not fail startup.** Unlike the canonical-edge-id
+        migration next door, which has no correct fallback, this one does: the
+        legacy aggregations are exactly the behaviour that shipped before, so a
+        cluster that cannot complete the backfill (permissions, a transport
+        error, a huge index mid-reindex) keeps serving the approximate ranking
+        rather than refusing to start. Every subsequent ``initialize`` retries.
+
+        Idempotent via an index ``_meta`` flag, so a completed backfill costs
+        one mapping read per startup rather than a rescan.
+        """
+        if self._edge_endpoints_ready:
+            return
+        try:
+            if not await self.client.indices.exists(index=self._edges_index):
+                # No index yet: _create_indices_if_not_exist will build it from
+                # the current mapping and flag it ready.
+                return
+
+            mapping = await self.client.indices.get_mapping(index=self._edges_index)
+            index_mapping = mapping.get(self._edges_index, {}).get("mappings", {})
+            meta = index_mapping.get("_meta", {})
+            if meta.get(_EDGE_ENDPOINTS_META_FLAG):
+                self._edge_endpoints_ready = True
+                return
+
+            if _EDGE_ENDPOINTS_FIELD not in index_mapping.get("properties", {}):
+                # Explicit keyword mapping: the index is `dynamic: true`, and a
+                # dynamically mapped string array becomes `text` with a
+                # `.keyword` subfield, which cannot be aggregated under the
+                # bare field name.
+                await self.client.indices.put_mapping(
+                    index=self._edges_index,
+                    body={"properties": {_EDGE_ENDPOINTS_FIELD: {"type": "keyword"}}},
+                )
+                logger.info(
+                    f"[{self.workspace}] Added {_EDGE_ENDPOINTS_FIELD} mapping to "
+                    f"{self._edges_index}"
+                )
+
+            # Only docs the ranking could ever use: one missing an endpoint id
+            # cannot be given an `endpoints` value and must not hold the flag
+            # back forever.
+            missing_query = {
+                "bool": {
+                    "must": [
+                        {"exists": {"field": "source_node_id"}},
+                        {"exists": {"field": "target_node_id"}},
+                    ],
+                    "must_not": [{"exists": {"field": _EDGE_ENDPOINTS_FIELD}}],
+                }
+            }
+            remaining = (
+                await self.client.count(
+                    index=self._edges_index, body={"query": missing_query}
+                )
+            )["count"]
+            if remaining:
+                logger.info(
+                    f"[{self.workspace}] Backfilling {_EDGE_ENDPOINTS_FIELD} on "
+                    f"{remaining} edge docs in {self._edges_index}"
+                )
+                # conflicts=proceed: a concurrent writer's version bump is not a
+                # failure here, because that writer's own doc already carries
+                # `endpoints`. The recount below is what decides completeness.
+                await self.client.update_by_query(
+                    index=self._edges_index,
+                    body={
+                        "query": missing_query,
+                        "script": {
+                            "lang": "painless",
+                            "source": _EDGE_ENDPOINTS_BACKFILL_SCRIPT,
+                        },
+                    },
+                    conflicts="proceed",
+                    refresh=True,
+                    wait_for_completion=True,
+                )
+                remaining = (
+                    await self.client.count(
+                        index=self._edges_index, body={"query": missing_query}
+                    )
+                )["count"]
+                if remaining:
+                    logger.warning(
+                        f"[{self.workspace}] {remaining} edge docs in "
+                        f"{self._edges_index} still lack {_EDGE_ENDPOINTS_FIELD}; "
+                        f"degree ranking stays on the legacy approximate "
+                        f"aggregations and the backfill retries on next startup"
+                    )
+                    return
+
+            await self.client.indices.put_mapping(
+                index=self._edges_index,
+                body={"_meta": {**meta, _EDGE_ENDPOINTS_META_FLAG: True}},
+            )
+            self._edge_endpoints_ready = True
+            logger.info(
+                f"[{self.workspace}] {_EDGE_ENDPOINTS_FIELD} ready on "
+                f"{self._edges_index}; degree ranking is exact"
+            )
+        except OpenSearchException as e:
+            logger.warning(
+                f"[{self.workspace}] Could not prepare {_EDGE_ENDPOINTS_FIELD} on "
+                f"{self._edges_index}: {e}; degree ranking stays on the legacy "
+                f"approximate aggregations"
+            )
+
+    async def _degree_map_from_edge_index(self, size: int) -> dict[str, int]:
+        """Undirected degree per entity, for the top ``size`` candidates.
+
+        With ``endpoints`` backfilled this is one terms aggregation returning
+        one bucket per entity, so the candidate set is the true global top
+        ``size`` by undirected degree.
+
+        Without it, it falls back to the legacy union of two per-field
+        aggregations. That union is approximate in the way issue #3613
+        describes: each side returns only its own top-N, so an entity whose
+        in- and out-degree both fall outside their respective lists is absent
+        from the map however high its total degree is. Callers get the same
+        shape either way; only the completeness of the candidate set differs.
+
+        ``size`` is the candidate budget. The single aggregation spends it
+        exactly — one bucket per entity — while the fallback asks each side for
+        ``size``, so the pool it unions is never smaller than the one that
+        shipped for either caller.
+        """
+        if self._edge_endpoints_ready:
+            body = {
+                "size": 0,
+                "aggs": {
+                    "degrees": {
+                        "terms": {
+                            "field": _EDGE_ENDPOINTS_FIELD,
+                            "size": size,
+                            "shard_size": size * _DEGREE_AGG_SHARD_SIZE_FACTOR,
+                        }
+                    }
+                },
+            }
+            response = await self.client.search(index=self._edges_index, body=body)
+            agg = response["aggregations"]["degrees"]
+            error_bound = agg.get("doc_count_error_upper_bound") or 0
+            if error_bound:
+                # Non-zero only on a multi-shard index whose per-shard top-N
+                # over-fetch still was not enough. Surfaced rather than hidden:
+                # the ranking is usable, the degrees are just not exact.
+                logger.warning(
+                    f"[{self.workspace}] Degree aggregation on "
+                    f"{self._edges_index} is approximate "
+                    f"(doc_count_error_upper_bound={error_bound}); consider "
+                    f"fewer shards for an exact ranking"
+                )
+            return {bucket["key"]: bucket["doc_count"] for bucket in agg["buckets"]}
+
+        body = {
+            "size": 0,
+            "aggs": {
+                "src": {"terms": {"field": "source_node_id", "size": size}},
+                "tgt": {"terms": {"field": "target_node_id", "size": size}},
+            },
+        }
+        response = await self.client.search(index=self._edges_index, body=body)
+        degree_map: dict[str, int] = {}
+        for agg_name in ("src", "tgt"):
+            for bucket in response["aggregations"][agg_name]["buckets"]:
+                degree_map[bucket["key"]] = (
+                    degree_map.get(bucket["key"], 0) + bucket["doc_count"]
+                )
+        return degree_map
 
     async def _merge_into_canonical_edge(
         self, canonical_id: str, reverse_docs: list[tuple[str, dict[str, Any]]]
@@ -4145,6 +4378,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             doc = {k: v for k, v in edge_data.items() if k != "_id"}
             doc["source_node_id"] = source_node_id
             doc["target_node_id"] = target_node_id
+            doc[_EDGE_ENDPOINTS_FIELD] = _edge_endpoints(source_node_id, target_node_id)
             if edge_data.get("source_id", ""):
                 doc["source_ids"] = edge_data["source_id"].split(GRAPH_FIELD_SEP)
 
@@ -4321,6 +4555,7 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 doc = {k: v for k, v in edge_data.items() if k != "_id"}
                 doc["source_node_id"] = src
                 doc["target_node_id"] = tgt
+                doc[_EDGE_ENDPOINTS_FIELD] = _edge_endpoints(src, tgt)
                 if edge_data.get("source_id", ""):
                     doc["source_ids"] = edge_data["source_id"].split(GRAPH_FIELD_SEP)
                 edge_id = _canonical_edge_id(src, tgt)
@@ -4810,34 +5045,11 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             result.is_truncated = total > max_nodes
 
             if result.is_truncated:
-                # Get top nodes by degree
-                body = {
-                    "size": 0,
-                    "aggs": {
-                        "src": {
-                            "terms": {
-                                "field": "source_node_id",
-                                "size": max_nodes,
-                            }
-                        },
-                        "tgt": {
-                            "terms": {
-                                "field": "target_node_id",
-                                "size": max_nodes,
-                            }
-                        },
-                    },
-                }
-                resp = await self.client.search(index=self._edges_index, body=body)
-                degree_map = {}
-                for bucket in resp["aggregations"]["src"]["buckets"]:
-                    degree_map[bucket["key"]] = (
-                        degree_map.get(bucket["key"], 0) + bucket["doc_count"]
-                    )
-                for bucket in resp["aggregations"]["tgt"]["buckets"]:
-                    degree_map[bucket["key"]] = (
-                        degree_map.get(bucket["key"], 0) + bucket["doc_count"]
-                    )
+                # Twice max_nodes candidates, the same headroom the legacy union
+                # of two per-field aggregations happened to give: the cutoff is
+                # applied below only AFTER dangling endpoints are dropped, and
+                # the refill pass needs ranked ids past the cutoff to draw from.
+                degree_map = await self._degree_map_from_edge_index(max_nodes * 2)
                 # Degree descending, then label ascending — the BaseGraphStorage
                 # tie-break, and the same ordering get_popular_labels uses.
                 # Sorting on the degree alone is stable, so the equal-degree
@@ -4845,14 +5057,12 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 # order: which entities the caller saw depended on how the
                 # buckets happened to come back.
                 #
-                # Exact WITHIN degree_map, which is itself approximate, so the
-                # ranking on this backend is too (#3613). Each aggregation above
-                # returns only its own top max_nodes buckets, so an entity whose
-                # in- and out-degree each fall outside their respective top-N
-                # never reaches this sort however high its undirected degree is;
-                # and terms aggregations are count-approximate across shards, so
-                # the degrees themselves can be off. Neither is fixable here --
-                # the data the sort would need never reaches the client.
+                # Exact once `endpoints` is backfilled: one bucket per entity
+                # holding true undirected degree, so the candidate set is the
+                # global top by degree rather than a union of two separately
+                # truncated top-N lists (#3613). On an index still awaiting the
+                # backfill, _degree_map_from_edge_index falls back to that union
+                # and the ranking stays approximate in the documented way.
                 ranked_ids = sorted(
                     degree_map, key=lambda label: (-degree_map[label], label)
                 )
@@ -5371,30 +5581,16 @@ class OpenSearchGraphStorage(BaseGraphStorage):
             return []
         try:
             await self._refresh_graph_indices_if_dirty(refresh_edges=True)
-            body = {
-                "size": 0,
-                "aggs": {
-                    "src": {"terms": {"field": "source_node_id", "size": limit * 2}},
-                    "tgt": {"terms": {"field": "target_node_id", "size": limit * 2}},
-                },
-            }
-            response = await self.client.search(index=self._edges_index, body=body)
             # Keyed on edge ENDPOINTS, so an id with edge documents but no node
             # document (a dangling endpoint, only reachable as a data-quality
             # defect — the write path materializes both endpoints) also surfaces
             # here. Left in deliberately: confirming every ranked id against the
             # node index costs a round trip on every call, and the worst case is
             # a picker entry whose entity lookup comes back empty, which the
-            # client reports rather than crashes on.
-            degree_map = {}
-            for bucket in response["aggregations"]["src"]["buckets"]:
-                degree_map[bucket["key"]] = (
-                    degree_map.get(bucket["key"], 0) + bucket["doc_count"]
-                )
-            for bucket in response["aggregations"]["tgt"]["buckets"]:
-                degree_map[bucket["key"]] = (
-                    degree_map.get(bucket["key"], 0) + bucket["doc_count"]
-                )
+            # client reports rather than crashes on. Keeping the legacy union's
+            # `limit * 2` headroom covers the dangling ids the slice below then
+            # spends slots on.
+            degree_map = await self._degree_map_from_edge_index(limit * 2)
             # Ties break on the label, ascending — the ordering the SQL and
             # Cypher backends use, rather than aggregation bucket order.
             sorted_labels = sorted(

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -3731,6 +3731,13 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         until the next one. That is as far as this can go without a write
         fence, and it costs ranking quality alone -- never a wrong edge, only
         an entity ranked from a degree short of its real one.
+
+        A revalidation probe that itself fails (a transport error, a rejected
+        search) is not treated as a clean bill of health -- that would trade
+        away the guarantee above on exactly the index the probe exists to
+        watch. It falls through to the backfill path instead, which either
+        confirms and re-stamps a clean index or degrades to the legacy
+        ranking, same as any other failure here.
         """
         if self._edge_endpoints_ready:
             return
@@ -3748,28 +3755,37 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 try:
                     dirty = await self._edges_missing_endpoints_exist()
                 except OpenSearchException as e:
-                    # Revalidation is a guard on top of a promise the flag
-                    # already made. Failing it must fall back to that promise,
-                    # not below it: the alternative downgrades a healthy index
-                    # to the approximate ranking for the life of the process,
-                    # which would make this check the likeliest cause of the
-                    # degradation it exists to prevent.
+                    # "Cannot verify" is not "verified clean". Trusting the
+                    # flag here risks exactly the silent-wrong-ranking window
+                    # the revalidation exists to close, and on precisely the
+                    # index most likely to actually be dirty (one old enough
+                    # to have lived through a rolling deploy). Falling
+                    # through to the backfill path below costs one recount:
+                    # if the failure was transient and the index is clean,
+                    # that recount is zero-hit and the flag is re-stamped
+                    # immediately; if the index is genuinely dirty, the same
+                    # recount finds it and backfills within this startup
+                    # instead of waiting for the next one; if the store is
+                    # still unreachable, the recount fails the same way and
+                    # the outer handler below degrades to the legacy ranking
+                    # -- the same safe default every other failure in this
+                    # method already falls back to.
                     logger.warning(
                         f"[{self.workspace}] Could not revalidate "
                         f"{_EDGE_ENDPOINTS_FIELD} coverage on "
-                        f"{self._edges_index}: {e}; trusting the readiness flag"
+                        f"{self._edges_index}: {e}; re-running the backfill "
+                        f"check rather than trusting the flag"
                     )
-                    self._edge_endpoints_ready = True
-                    return
-                if not dirty:
-                    self._edge_endpoints_ready = True
-                    return
-                logger.warning(
-                    f"[{self.workspace}] Edge docs without {_EDGE_ENDPOINTS_FIELD} "
-                    f"found in {self._edges_index} after the readiness flag was "
-                    f"set; an old-version writer during a rolling deploy is the "
-                    f"usual cause. Re-running the backfill"
-                )
+                else:
+                    if not dirty:
+                        self._edge_endpoints_ready = True
+                        return
+                    logger.warning(
+                        f"[{self.workspace}] Edge docs without {_EDGE_ENDPOINTS_FIELD} "
+                        f"found in {self._edges_index} after the readiness flag was "
+                        f"set; an old-version writer during a rolling deploy is the "
+                        f"usual cause. Re-running the backfill"
+                    )
 
             if _EDGE_ENDPOINTS_FIELD not in index_mapping.get("properties", {}):
                 # Explicit keyword mapping: the index is `dynamic: true`, and a

--- a/tests/kg/opensearch_impl/test_opensearch_degree_ranking.py
+++ b/tests/kg/opensearch_impl/test_opensearch_degree_ranking.py
@@ -29,6 +29,7 @@ pytest.importorskip(
 from lightrag.kg.opensearch_impl import (  # noqa: E402
     _EDGE_ENDPOINTS_FIELD,
     _EDGE_ENDPOINTS_META_FLAG,
+    _EDGE_ID_CANONICAL_META_FLAG,
     OpenSearchGraphStorage,
     _edge_endpoints,
 )
@@ -361,16 +362,50 @@ def test_graph_edge_properties_omit_the_endpoints_field():
 # -- backfill --------------------------------------------------------------
 
 
-def _migration_storage():
+def _counter(*, probe_missing=0, backfill_counts=()):
+    """Answer both count shapes from one stub.
+
+    The coverage probe and the backfill's own count run the same query against
+    the same client; `terminate_after` is what tells them apart, and it is
+    capped at 1 because the probe only ever asks a boolean.
+    """
+    remaining = list(backfill_counts)
+
+    async def count(*, index=None, body=None, **kwargs):
+        if kwargs.get("terminate_after"):
+            return {"count": min(probe_missing, 1)}
+        return {"count": remaining.pop(0)}
+
+    return AsyncMock(side_effect=count)
+
+
+def _migration_storage(*, flagged=False, missing_after_flag=0, backfill_counts=()):
     storage = OpenSearchGraphStorage.__new__(OpenSearchGraphStorage)
     storage.workspace = "test"
     storage._edges_index = "test-edges"
     storage._edge_endpoints_ready = False
     storage.client = AsyncMock()
     storage.client.indices.exists = AsyncMock(return_value=True)
-    storage.client.indices.get_mapping = AsyncMock(
-        return_value={"test-edges": {"mappings": {"properties": {}, "_meta": {}}}}
+    properties = {_EDGE_ENDPOINTS_FIELD: {"type": "keyword"}} if flagged else {}
+    # A real flagged index also carries the canonical-edge-id flag, so the
+    # re-stamp on the dirty path has something to preserve.
+    meta = (
+        {
+            _EDGE_ENDPOINTS_META_FLAG: True,
+            _EDGE_ID_CANONICAL_META_FLAG: True,
+        }
+        if flagged
+        else {}
     )
+    storage.client.indices.get_mapping = AsyncMock(
+        return_value={
+            "test-edges": {"mappings": {"properties": properties, "_meta": meta}}
+        }
+    )
+    if flagged:
+        storage.client.count = _counter(
+            probe_missing=missing_after_flag, backfill_counts=backfill_counts
+        )
     return storage
 
 
@@ -412,23 +447,85 @@ async def test_backfill_leaves_flag_unset_when_docs_remain():
 
 @pytest.mark.asyncio
 async def test_completed_backfill_skips_the_rescan():
-    storage = _migration_storage()
-    storage.client.indices.get_mapping = AsyncMock(
-        return_value={
-            "test-edges": {
-                "mappings": {
-                    "properties": {_EDGE_ENDPOINTS_FIELD: {"type": "keyword"}},
-                    "_meta": {_EDGE_ENDPOINTS_META_FLAG: True},
-                }
-            }
-        }
+    storage = _migration_storage(flagged=True)
+
+    await storage._ensure_edge_endpoints_ready()
+
+    assert storage._edge_endpoints_ready is True
+    # The flag's remaining job: the coverage probe still runs, the backfill and
+    # the _meta write it guards do not.
+    storage.client.count.assert_awaited_once()
+    storage.client.update_by_query.assert_not_awaited()
+    storage.client.indices.put_mapping.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_coverage_probe_is_bounded_to_a_single_hit():
+    """The question is a boolean, so the probe must not pay for counting a
+    whole backlog on an index the backfill has not reached yet."""
+    storage = _migration_storage(flagged=True)
+
+    await storage._ensure_edge_endpoints_ready()
+
+    call = storage.client.count.await_args
+    assert call.kwargs["terminate_after"] == 1
+    assert call.kwargs["body"]["query"] == storage._edge_missing_endpoints_query()
+
+
+@pytest.mark.asyncio
+async def test_flagged_index_with_missing_docs_is_backfilled_again():
+    """Nothing fences writes against an old-version process, so a rolling
+    deploy can index an edge without `endpoints` after the flag is stamped.
+    Trusting the flag alone would leave that edge outside the aggregation
+    permanently."""
+    storage = _migration_storage(
+        flagged=True, missing_after_flag=1, backfill_counts=(1, 0)
     )
+
+    await storage._ensure_edge_endpoints_ready()
+
+    storage.client.update_by_query.assert_awaited_once()
+    assert storage._edge_endpoints_ready is True
+    # The re-stamp must not clobber the canonical-edge-id flag sharing _meta;
+    # losing it would re-trigger that whole migration on every startup.
+    restamped = [
+        call.kwargs["body"]["_meta"]
+        for call in storage.client.indices.put_mapping.await_args_list
+        if "_meta" in call.kwargs["body"]
+    ]
+    assert restamped == [
+        {_EDGE_ENDPOINTS_META_FLAG: True, _EDGE_ID_CANONICAL_META_FLAG: True}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_flagged_index_that_cannot_be_repaired_keeps_the_legacy_ranking():
+    """A backfill that does not finish must not leave the ranking claiming an
+    exactness the field no longer has."""
+    storage = _migration_storage(
+        flagged=True, missing_after_flag=1, backfill_counts=(5, 2)
+    )
+
+    await storage._ensure_edge_endpoints_ready()
+
+    assert storage._edge_endpoints_ready is False
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_falls_back_to_the_flag_rather_than_below_it():
+    """Revalidation guards a promise the flag already made. A search rejection
+    or a transport error must not downgrade a healthy migrated index to the
+    approximate ranking for the life of the process, which would make the
+    guard the likeliest cause of the degradation it prevents."""
+    from opensearchpy.exceptions import OpenSearchException
+
+    storage = _migration_storage(flagged=True)
+    storage.client.count = AsyncMock(side_effect=OpenSearchException("rejected"))
 
     await storage._ensure_edge_endpoints_ready()
 
     assert storage._edge_endpoints_ready is True
     storage.client.update_by_query.assert_not_awaited()
-    storage.client.indices.put_mapping.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/kg/opensearch_impl/test_opensearch_degree_ranking.py
+++ b/tests/kg/opensearch_impl/test_opensearch_degree_ranking.py
@@ -299,13 +299,63 @@ async def test_upsert_edge_deduplicates_a_self_loop():
     assert doc[_EDGE_ENDPOINTS_FIELD] == ["A"]
 
 
-def test_edges_index_mapping_declares_endpoints_as_keyword():
-    """A `dynamic: true` index would map the array as text with a `.keyword`
-    subfield, which cannot be aggregated under the bare field name."""
-    import inspect
+@pytest.mark.asyncio
+async def test_created_edges_index_maps_endpoints_and_stamps_the_flag():
+    """Pinned on the request the storage sends, not on its source text.
 
-    source = inspect.getsource(OpenSearchGraphStorage._create_indices_if_not_exist)
-    assert '_EDGE_ENDPOINTS_FIELD: {"type": "keyword"}' in source
+    Two properties of a freshly created edges index, both of which a later
+    reformatting of the literal must not be able to break:
+
+    `endpoints` is mapped `keyword` explicitly, because the index is
+    `dynamic: true` and a dynamically mapped string array becomes `text` with a
+    `.keyword` subfield, which cannot be aggregated under the bare field name.
+
+    The readiness flag is in the mapping `_meta`, so an index that can never
+    hold a document without the field says so durably instead of leaving the
+    next startup to recount.
+    """
+    storage = OpenSearchGraphStorage.__new__(OpenSearchGraphStorage)
+    storage.workspace = "test"
+    storage._nodes_index = "test-nodes"
+    storage._edges_index = "test-edges"
+    storage._edge_endpoints_ready = False
+    storage.client = AsyncMock()
+    storage.client.indices.exists = AsyncMock(return_value=False)
+
+    await storage._create_indices_if_not_exist()
+
+    bodies = {
+        call.kwargs["index"]: call.kwargs["body"]
+        for call in storage.client.indices.create.await_args_list
+    }
+    mappings = bodies["test-edges"]["mappings"]
+
+    assert mappings["properties"][_EDGE_ENDPOINTS_FIELD] == {"type": "keyword"}
+    assert mappings["_meta"][_EDGE_ENDPOINTS_META_FLAG] is True
+    assert storage._edge_endpoints_ready is True
+
+
+def test_graph_edge_properties_omit_the_endpoints_field():
+    """`endpoints` is storage-internal and duplicates the top-level
+    source/target, so it must not reach the API or the WebUI edge panel."""
+    storage = OpenSearchGraphStorage.__new__(OpenSearchGraphStorage)
+
+    edge = storage._construct_graph_edge(
+        "edge-1",
+        {
+            "source_node_id": "A",
+            "target_node_id": "B",
+            _EDGE_ENDPOINTS_FIELD: _edge_endpoints("A", "B"),
+            "relationship": "r",
+            "weight": 1.0,
+            "description": "d",
+            "source_ids": ["c1"],
+        },
+    )
+
+    assert edge.source == "A"
+    assert edge.target == "B"
+    assert edge.properties == {"weight": 1.0, "description": "d"}
 
 
 # -- backfill --------------------------------------------------------------

--- a/tests/kg/opensearch_impl/test_opensearch_degree_ranking.py
+++ b/tests/kg/opensearch_impl/test_opensearch_degree_ranking.py
@@ -1,0 +1,396 @@
+"""``get_knowledge_graph('*')`` must rank the whole graph, not two top-N lists.
+
+Degree came from two ``terms`` aggregations on the edge index, one per endpoint
+field, each capped at its own ``size``. An entity whose in-degree and out-degree
+both fell outside their respective top-N was therefore absent from the ranking
+entirely, however high its undirected degree was -- an ordinary shape for a
+large graph, since the cutoff normally lands in the degree-1/degree-2 band.
+
+Edge documents now carry ``endpoints``, a multi-valued keyword holding both
+ids, so one aggregation yields one bucket per entity holding true undirected
+degree. The aggregation stub below implements faithful ``terms`` semantics
+(buckets ordered by ``doc_count``, only the top ``size`` returned) for BOTH
+shapes from the same edge list, which is what lets these tests show the old
+candidate set losing an entity the new one keeps.
+
+See issue #3613.
+"""
+
+from collections import Counter
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip(
+    "opensearchpy",
+    reason="opensearch-py is required for OpenSearch storage tests",
+)
+
+from lightrag.kg.opensearch_impl import (  # noqa: E402
+    _EDGE_ENDPOINTS_FIELD,
+    _EDGE_ENDPOINTS_META_FLAG,
+    OpenSearchGraphStorage,
+    _edge_endpoints,
+)
+
+
+pytestmark = pytest.mark.offline
+
+
+# The issue's minimal case. Every entity has undirected degree 2, so the label
+# decides the single slot and "A" must win it. "A" is the one entity that holds
+# neither a top-1 out-degree (that is Z, with 2) nor a top-1 in-degree (that is
+# Y, with 2), so a union of two size-1 aggregations cannot see it at all.
+_EDGES = [
+    {"source_node_id": "Z", "target_node_id": "P"},
+    {"source_node_id": "Z", "target_node_id": "Q"},
+    {"source_node_id": "R", "target_node_id": "Y"},
+    {"source_node_id": "S", "target_node_id": "Y"},
+    {"source_node_id": "A", "target_node_id": "T"},
+    {"source_node_id": "U", "target_node_id": "A"},
+]
+
+
+def _edge_search_side_effect(edges):
+    """Answer the degree aggregation and the both-endpoints edge fetch.
+
+    `terms` returns only the top `size` buckets, ordered by doc_count
+    descending and then by key ascending, so a key that falls off the end is
+    indistinguishable from one with no edges at all -- modelling that
+    truncation faithfully is the whole point here.
+    """
+
+    def _top(counts, size):
+        ranked = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[:size]
+        return [{"key": key, "doc_count": count} for key, count in ranked]
+
+    async def _search(index=None, body=None, **kwargs):
+        aggs = (body or {}).get("aggs")
+        if aggs:
+            if "degrees" in aggs:
+                spec = aggs["degrees"]["terms"]
+                assert spec["field"] == _EDGE_ENDPOINTS_FIELD
+                counts = Counter()
+                for edge in edges:
+                    for endpoint in _edge_endpoints(
+                        edge["source_node_id"], edge["target_node_id"]
+                    ):
+                        counts[endpoint] += 1
+                buckets = _top(counts, spec["size"])
+                return {
+                    "hits": {"hits": []},
+                    "aggregations": {
+                        "degrees": {
+                            "buckets": buckets,
+                            "doc_count_error_upper_bound": 0,
+                        }
+                    },
+                }
+
+            def _terms(name, field):
+                counts = Counter(edge[field] for edge in edges)
+                return {"buckets": _top(counts, aggs[name]["terms"]["size"])}
+
+            return {
+                "hits": {"hits": []},
+                "aggregations": {
+                    "src": _terms("src", "source_node_id"),
+                    "tgt": _terms("tgt", "target_node_id"),
+                },
+            }
+
+        must = body["query"]["bool"]["must"]
+        sources = set(must[0]["terms"]["source_node_id"])
+        targets = set(must[1]["terms"]["target_node_id"])
+        return {
+            "hits": {
+                "hits": [
+                    {"_source": edge, "sort": [i]}
+                    for i, edge in enumerate(edges)
+                    if edge["source_node_id"] in sources
+                    and edge["target_node_id"] in targets
+                ]
+            }
+        }
+
+    return _search
+
+
+def _mget_side_effect(real_ids):
+    async def _mget(index=None, body=None, **kwargs):
+        return {
+            "docs": [
+                {"_id": nid, "found": True, "_source": {"entity_type": "person"}}
+                if nid in real_ids
+                else {"_id": nid, "found": False}
+                for nid in body["ids"]
+            ]
+        }
+
+    return _mget
+
+
+def _make_storage(*, endpoints_ready, edges=_EDGES, node_count=99):
+    storage = OpenSearchGraphStorage.__new__(OpenSearchGraphStorage)
+    storage.workspace = "test"
+    storage.global_config = {"max_graph_nodes": 1000}
+    storage._nodes_index = "test-nodes"
+    storage._edges_index = "test-edges"
+    storage._indices_ready = True
+    storage._ppl_graphlookup_available = False
+    storage._edge_endpoints_ready = endpoints_ready
+    storage._refresh_graph_indices_if_dirty = AsyncMock(return_value=None)
+    storage.client = AsyncMock()
+    storage.client.search = AsyncMock(side_effect=_edge_search_side_effect(edges))
+    # node_count > max_nodes so the wildcard view reports truncation and takes
+    # the ranked path rather than collecting every node.
+    storage.client.count = AsyncMock(return_value={"count": node_count})
+    storage.client.mget = AsyncMock(
+        side_effect=_mget_side_effect(
+            {e["source_node_id"] for e in edges} | {e["target_node_id"] for e in edges}
+        )
+    )
+    storage.client.create_pit = AsyncMock(return_value={"pit_id": "pit"})
+    storage.client.delete_pit = AsyncMock()
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_wildcard_ranking_sees_an_entity_outside_both_top_n():
+    """One slot, three entities tied at undirected degree 2, "A" sorts first.
+
+    "A" reaches the sort only because a single aggregation over `endpoints`
+    buckets it once with its true degree.
+    """
+    storage = _make_storage(endpoints_ready=True)
+
+    result = await storage.get_knowledge_graph("*", max_depth=1, max_nodes=1)
+
+    assert [node.id for node in result.nodes] == ["A"]
+    assert result.is_truncated is True
+
+
+@pytest.mark.asyncio
+async def test_legacy_union_omits_what_the_endpoints_aggregation_ranks():
+    """The defect itself, at the candidate budget the issue describes.
+
+    Asking for one candidate, the union of two size-1 aggregations returns the
+    top out-degree and the top in-degree and never sees "A"; one aggregation
+    over `endpoints` returns "A" with its true undirected degree. Pinning both
+    keeps the fallback from being mistaken for the fix.
+    """
+    legacy = _make_storage(endpoints_ready=False)
+    modern = _make_storage(endpoints_ready=True)
+
+    legacy_degrees = await legacy._degree_map_from_edge_index(1)
+    modern_degrees = await modern._degree_map_from_edge_index(1)
+
+    assert "A" not in legacy_degrees
+    assert modern_degrees == {"A": 2}
+
+
+@pytest.mark.asyncio
+async def test_wildcard_ranking_uses_one_aggregation():
+    storage = _make_storage(endpoints_ready=True)
+
+    await storage.get_knowledge_graph("*", max_depth=1, max_nodes=1)
+
+    agg_bodies = [
+        call.kwargs["body"]
+        for call in storage.client.search.await_args_list
+        if "aggs" in (call.kwargs.get("body") or {})
+    ]
+    assert len(agg_bodies) == 1
+    assert list(agg_bodies[0]["aggs"]) == ["degrees"]
+
+
+@pytest.mark.asyncio
+async def test_popular_labels_ranks_from_undirected_degree():
+    """`get_popular_labels` ranked from the same two truncated aggregations and
+    gets the same complete candidate set."""
+    storage = _make_storage(endpoints_ready=True)
+    storage._collect_isolated_labels = AsyncMock(return_value=[])
+
+    labels = await storage.get_popular_labels(limit=3)
+
+    # Every entity ties at degree 2 except the leaves, so the label orders them.
+    assert labels == ["A", "Y", "Z"]
+
+
+@pytest.mark.asyncio
+async def test_degree_aggregation_over_fetches_per_shard():
+    """`shard_size` above `size` is what keeps the merged counts honest on a
+    multi-shard index; without it each shard reports only its own top `size`."""
+    storage = _make_storage(endpoints_ready=True)
+
+    await storage.get_knowledge_graph("*", max_depth=1, max_nodes=4)
+
+    terms = next(
+        call.kwargs["body"]["aggs"]["degrees"]["terms"]
+        for call in storage.client.search.await_args_list
+        if "degrees" in (call.kwargs.get("body") or {}).get("aggs", {})
+    )
+    assert terms["shard_size"] > terms["size"]
+
+
+@pytest.mark.asyncio
+async def test_residual_shard_error_is_reported():
+    """A non-zero error bound means the degrees themselves are still
+    approximate. Usable, but the operator is told rather than left guessing."""
+    storage = _make_storage(endpoints_ready=True)
+
+    async def _search(index=None, body=None, **kwargs):
+        return {
+            "hits": {"hits": []},
+            "aggregations": {
+                "degrees": {
+                    "buckets": [{"key": "A", "doc_count": 2}],
+                    "doc_count_error_upper_bound": 7,
+                }
+            },
+        }
+
+    storage.client.search = AsyncMock(side_effect=_search)
+
+    # lightrag's logger does not propagate to the root logger caplog listens on.
+    with patch("lightrag.kg.opensearch_impl.logger") as mock_logger:
+        await storage._degree_map_from_edge_index(10)
+
+    warning = mock_logger.warning.call_args[0][0]
+    assert "doc_count_error_upper_bound=7" in warning
+
+
+# -- write path ------------------------------------------------------------
+
+
+def _upsert_storage():
+    storage = OpenSearchGraphStorage.__new__(OpenSearchGraphStorage)
+    storage.workspace = "test"
+    storage.global_config = {}
+    storage._nodes_index = "test-nodes"
+    storage._edges_index = "test-edges"
+    storage._indices_ready = True
+    storage._edge_endpoints_ready = True
+    storage._ensure_indices_ready = AsyncMock(return_value=None)
+    storage.has_nodes_batch = AsyncMock(side_effect=lambda ids: set(ids))
+    storage.client = AsyncMock()
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_writes_both_endpoints():
+    storage = _upsert_storage()
+
+    await storage.upsert_edge("A", "B", {"weight": 1.0})
+
+    doc = storage.client.index.await_args.kwargs["body"]
+    assert doc[_EDGE_ENDPOINTS_FIELD] == ["A", "B"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_deduplicates_a_self_loop():
+    """`node_degree` counts the loop's single document once; two values would
+    make the aggregation disagree with it."""
+    storage = _upsert_storage()
+
+    await storage.upsert_edge("A", "A", {"weight": 1.0})
+
+    doc = storage.client.index.await_args.kwargs["body"]
+    assert doc[_EDGE_ENDPOINTS_FIELD] == ["A"]
+
+
+def test_edges_index_mapping_declares_endpoints_as_keyword():
+    """A `dynamic: true` index would map the array as text with a `.keyword`
+    subfield, which cannot be aggregated under the bare field name."""
+    import inspect
+
+    source = inspect.getsource(OpenSearchGraphStorage._create_indices_if_not_exist)
+    assert '_EDGE_ENDPOINTS_FIELD: {"type": "keyword"}' in source
+
+
+# -- backfill --------------------------------------------------------------
+
+
+def _migration_storage():
+    storage = OpenSearchGraphStorage.__new__(OpenSearchGraphStorage)
+    storage.workspace = "test"
+    storage._edges_index = "test-edges"
+    storage._edge_endpoints_ready = False
+    storage.client = AsyncMock()
+    storage.client.indices.exists = AsyncMock(return_value=True)
+    storage.client.indices.get_mapping = AsyncMock(
+        return_value={"test-edges": {"mappings": {"properties": {}, "_meta": {}}}}
+    )
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_backfill_lands_mapping_values_and_flag():
+    storage = _migration_storage()
+    storage.client.count = AsyncMock(
+        side_effect=[{"count": 12}, {"count": 0}]  # before, after
+    )
+
+    await storage._ensure_edge_endpoints_ready()
+
+    put_bodies = [
+        call.kwargs["body"]
+        for call in storage.client.indices.put_mapping.await_args_list
+    ]
+    assert {"properties": {_EDGE_ENDPOINTS_FIELD: {"type": "keyword"}}} in put_bodies
+    assert {"_meta": {_EDGE_ENDPOINTS_META_FLAG: True}} in put_bodies
+    storage.client.update_by_query.assert_awaited_once()
+    assert storage._edge_endpoints_ready is True
+
+
+@pytest.mark.asyncio
+async def test_backfill_leaves_flag_unset_when_docs_remain():
+    """The flag is the promise the aggregation relies on. A partial backfill
+    must keep the legacy path rather than rank from an incomplete field."""
+    storage = _migration_storage()
+    storage.client.count = AsyncMock(side_effect=[{"count": 12}, {"count": 3}])
+
+    await storage._ensure_edge_endpoints_ready()
+
+    assert storage._edge_endpoints_ready is False
+    put_bodies = [
+        call.kwargs["body"]
+        for call in storage.client.indices.put_mapping.await_args_list
+    ]
+    assert {"_meta": {_EDGE_ENDPOINTS_META_FLAG: True}} not in put_bodies
+
+
+@pytest.mark.asyncio
+async def test_completed_backfill_skips_the_rescan():
+    storage = _migration_storage()
+    storage.client.indices.get_mapping = AsyncMock(
+        return_value={
+            "test-edges": {
+                "mappings": {
+                    "properties": {_EDGE_ENDPOINTS_FIELD: {"type": "keyword"}},
+                    "_meta": {_EDGE_ENDPOINTS_META_FLAG: True},
+                }
+            }
+        }
+    )
+
+    await storage._ensure_edge_endpoints_ready()
+
+    assert storage._edge_endpoints_ready is True
+    storage.client.update_by_query.assert_not_awaited()
+    storage.client.indices.put_mapping.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backfill_failure_degrades_instead_of_failing_startup():
+    """The legacy aggregations are exactly what shipped before, so a cluster
+    that cannot complete the backfill keeps serving them rather than refusing
+    to start."""
+    from opensearchpy.exceptions import OpenSearchException
+
+    storage = _migration_storage()
+    storage.client.count = AsyncMock(side_effect=OpenSearchException("boom"))
+
+    await storage._ensure_edge_endpoints_ready()
+
+    assert storage._edge_endpoints_ready is False

--- a/tests/kg/opensearch_impl/test_opensearch_degree_ranking.py
+++ b/tests/kg/opensearch_impl/test_opensearch_degree_ranking.py
@@ -512,11 +512,14 @@ async def test_flagged_index_that_cannot_be_repaired_keeps_the_legacy_ranking():
 
 
 @pytest.mark.asyncio
-async def test_probe_failure_falls_back_to_the_flag_rather_than_below_it():
-    """Revalidation guards a promise the flag already made. A search rejection
-    or a transport error must not downgrade a healthy migrated index to the
-    approximate ranking for the life of the process, which would make the
-    guard the likeliest cause of the degradation it prevents."""
+async def test_probe_failure_never_trusts_the_flag_unverified():
+    """ "Cannot verify" must not be treated as "verified clean". A search
+    rejection or transport error on the revalidation probe must not mark a
+    flagged index ready outright -- that would silently accept whatever a
+    rolling-deploy writer left behind on precisely the index the probe
+    exists to catch. It must fall through to the backfill path and, if that
+    path also cannot reach the store, degrade to the legacy ranking like
+    every other failure in this method."""
     from opensearchpy.exceptions import OpenSearchException
 
     storage = _migration_storage(flagged=True)
@@ -524,8 +527,61 @@ async def test_probe_failure_falls_back_to_the_flag_rather_than_below_it():
 
     await storage._ensure_edge_endpoints_ready()
 
+    assert storage._edge_endpoints_ready is False
+    storage.client.update_by_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_self_heals_when_the_index_is_actually_clean():
+    """A transient probe failure on a genuinely clean index must not cost
+    more than one extra recount: falling through to the backfill path finds
+    zero missing docs and re-stamps the flag within the same startup,
+    rather than waiting for the next one."""
+    from opensearchpy.exceptions import OpenSearchException
+
+    storage = _migration_storage(flagged=True)
+    calls = {"n": 0}
+
+    async def count(*, index=None, body=None, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            assert kwargs.get("terminate_after") == 1  # this is the probe
+            raise OpenSearchException("transient")
+        return {"count": 0}  # the backfill recount: genuinely clean
+
+    storage.client.count = AsyncMock(side_effect=count)
+
+    await storage._ensure_edge_endpoints_ready()
+
     assert storage._edge_endpoints_ready is True
     storage.client.update_by_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_finds_and_repairs_a_dirty_index_same_startup():
+    """A transient probe failure on an index a rolling deploy actually
+    dirtied must not wait for the next startup: falling through to the
+    backfill path finds the missing docs and repairs them immediately."""
+    from opensearchpy.exceptions import OpenSearchException
+
+    storage = _migration_storage(flagged=True)
+    calls = {"n": 0}
+
+    async def count(*, index=None, body=None, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            assert kwargs.get("terminate_after") == 1  # this is the probe
+            raise OpenSearchException("transient")
+        # First recount (post-fallthrough) finds the backlog the probe
+        # couldn't confirm; the post-backfill recount confirms it is gone.
+        return {"count": 1} if calls["n"] == 2 else {"count": 0}
+
+    storage.client.count = AsyncMock(side_effect=count)
+
+    await storage._ensure_edge_endpoints_ready()
+
+    storage.client.update_by_query.assert_awaited_once()
+    assert storage._edge_endpoints_ready is True
 
 
 @pytest.mark.asyncio

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -231,6 +231,7 @@ def _make_client():
                 "status_counts": {"buckets": []},
                 "src": {"buckets": []},
                 "tgt": {"buckets": []},
+                "degrees": {"buckets": []},
                 "source_degrees": {"ids": {"buckets": []}},
                 "target_degrees": {"ids": {"buckets": []}},
             },
@@ -240,6 +241,20 @@ def _make_client():
     client.create_pit = AsyncMock(return_value={"pit_id": "mock_pit_id_123"})
     client.delete_pit = AsyncMock()
     return client
+
+
+def _degree_buckets(src_buckets, tgt_buckets):
+    """The `endpoints` aggregation's answer for the graph a stub describes as
+    separate source/target buckets: one bucket per entity holding undirected
+    degree, count descending. Lets a stub state the edges once and answer
+    either aggregation shape (see issue #3613)."""
+    merged: dict[str, int] = {}
+    for bucket in [*src_buckets, *tgt_buckets]:
+        merged[bucket["key"]] = merged.get(bucket["key"], 0) + bucket["doc_count"]
+    return [
+        {"key": key, "doc_count": count}
+        for key, count in sorted(merged.items(), key=lambda kv: (-kv[1], kv[0]))
+    ]
 
 
 def _mget_by_ids_side_effect(node_sources: dict[str, dict]):
@@ -2292,6 +2307,7 @@ class TestGraphStorage:
                     "status_counts": {"buckets": []},
                     "src": {"buckets": []},
                     "tgt": {"buckets": []},
+                    "degrees": {"buckets": []},
                 },
             }
         )
@@ -3197,6 +3213,15 @@ class TestGraphStorage:
                         ]
                     },
                     "tgt": {"buckets": [{"key": "A", "doc_count": 3}]},
+                    "degrees": {
+                        "buckets": _degree_buckets(
+                            [
+                                {"key": "A", "doc_count": 5},
+                                {"key": "B", "doc_count": 2},
+                            ],
+                            [{"key": "A", "doc_count": 3}],
+                        )
+                    },
                     "status_counts": {"buckets": []},
                 },
             }
@@ -3219,6 +3244,12 @@ class TestGraphStorage:
                     "aggregations": {
                         "src": {"buckets": [{"key": "A", "doc_count": 1}]},
                         "tgt": {"buckets": [{"key": "B", "doc_count": 1}]},
+                        "degrees": {
+                            "buckets": _degree_buckets(
+                                [{"key": "A", "doc_count": 1}],
+                                [{"key": "B", "doc_count": 1}],
+                            )
+                        },
                         "status_counts": {"buckets": []},
                     },
                 },
@@ -3589,6 +3620,7 @@ class TestGraphPPLDetection:
                     "status_counts": {"buckets": []},
                     "src": {"buckets": []},
                     "tgt": {"buckets": []},
+                    "degrees": {"buckets": []},
                 },
             }
         )
@@ -3948,6 +3980,7 @@ class TestVectorStorage:
                     "status_counts": {"buckets": []},
                     "src": {"buckets": []},
                     "tgt": {"buckets": []},
+                    "degrees": {"buckets": []},
                 },
             }
         )
@@ -3980,6 +4013,7 @@ class TestVectorStorage:
                     "status_counts": {"buckets": []},
                     "src": {"buckets": []},
                     "tgt": {"buckets": []},
+                    "degrees": {"buckets": []},
                 },
             }
         )
@@ -4005,6 +4039,7 @@ class TestVectorStorage:
                     "status_counts": {"buckets": []},
                     "src": {"buckets": []},
                     "tgt": {"buckets": []},
+                    "degrees": {"buckets": []},
                 },
             }
         )
@@ -5384,6 +5419,7 @@ class TestGraphReadContract:
             "aggregations": {
                 "src": {"buckets": src_buckets},
                 "tgt": {"buckets": tgt_buckets},
+                "degrees": {"buckets": _degree_buckets(src_buckets, tgt_buckets)},
                 "status_counts": {"buckets": []},
             },
         }


### PR DESCRIPTION
## Description

`OpenSearchGraphStorage` ranked the `*` graph view by degree read from two terms aggregations on the edge index, one per endpoint field, each capped at its own `size`. The union of two separately-truncated top-N lists is not the global top-N: an entity whose in-degree and out-degree both fall outside their respective lists never reaches the sort, however high its undirected degree is. The `max_nodes` cutoff normally lands in the degree-1/degree-2 band, so an entity with one in-edge and one out-edge outside both lists is an ordinary shape for a large graph, not a pathological one.

Edge documents now carry `endpoints`, a multi-valued keyword holding both ids, so a single terms aggregation returns one bucket per entity holding true undirected degree. The candidate set the ranking sorts is then the global top by degree.

Of the two storage shapes proposed in the issue, this takes the `endpoints` field rather than materializing per-node degree onto the node document. Materialized degree would have to be maintained on every edge write and delete, adding a hot-path cost and a correctness surface that the field approach does not need.

## Related Issues

Closes #3613. Follows #3593, which changed only how the existing ranking broke ties.

## Changes Made

- `endpoints` keyword field on the edges mapping, written by both `upsert_edge` and `upsert_edges_batch`. A self-loop stores a single value, which also makes the ranking agree with `node_degree`: that method counts the loop's one document once, while the pair of aggregations counted it on both the source and the target side.
- `_ensure_edge_endpoints_ready` lands the mapping and backfills existing indexes with a scripted `update_by_query`, guarded by an index `_meta` flag so a completed run costs one mapping read per startup rather than a rescan. The same `put_mapping` + value-backfill pattern as `_ensure_scheduling_tiebreaker_ready`.
- `_degree_map_from_edge_index` is the single ranking source for both `_get_knowledge_graph_all` and `get_popular_labels`, which ranked from the same two aggregations (checklist item 4 in the issue).
- The aggregation sets an explicit `shard_size` and logs when the response still reports a non-zero `doc_count_error_upper_bound`.
- `BaseGraphStorage.get_knowledge_graph` contract updated.

### The backfill degrades rather than failing startup

Worth a look during review, since it differs from the canonical-edge-id migration next door. That one is fail-fast because it has no correct fallback. This one does: the legacy aggregations are exactly the behaviour that shipped, so a cluster that cannot complete the backfill (permissions, a transport error, a large index mid-reindex) keeps serving the approximate ranking and retries on the next startup, rather than refusing to start over a ranking-quality issue. The `_meta` flag is set only after a recount confirms no documents still lack the field, so a partial backfill cannot be mistaken for a complete one.

### On the second approximation

Terms aggregations are count-approximate across shards independently of the truncation above. Degree is exact at the single-shard default (`OPENSEARCH_NUMBER_OF_SHARDS=1`). On a multi-shard index this sets an explicit `shard_size` to shrink the error and logs the residual bound when the cluster reports one, rather than hiding it. Removing it entirely would need a composite aggregation paging every term, which cannot order by count. The contract docstring says this rather than claiming the caveat is fully retired (checklist item 5).

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

New `tests/kg/opensearch_impl/test_opensearch_degree_ranking.py` uses a stub with faithful `terms` semantics (buckets ordered by `doc_count` descending then key ascending, only the top `size` returned) so one edge fixture drives both aggregation shapes. It pins the issue's minimal case in both directions: the legacy union omits `A`, the `endpoints` aggregation returns it with its true degree 2. Write-path, backfill-completion, partial-backfill and degradation-on-error cases are covered too.

Thirteen existing stubs in `test_opensearch_storage.py` hard-coded the two-aggregation response shape and were updated to answer either shape from the same described graph.

`tests/kg/opensearch_impl` passes (375) and `ruff check .` is clean. The wider `tests/kg` run shows 11 failures on my machine that are Windows-only and predate this branch (`module 'signal' has no attribute 'SIGKILL'` in the lock and reservation tests); none of those files touch OpenSearch.
