### PR TITLE
fix(kg): keep unsaved upserts as a redo log and replay them after a reload

### DIFF
--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -1394,8 +1394,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
         preferred only when it was written **strictly** after the logged one —
         by ``__created_at__``, then by the ``__write_seq__`` token that breaks
         a whole-second tie (see ``write_seq``). An absent row, an older one, or
-        a tie no token can break (either side written before the token existed)
-        all leave the logged record as the answer.
+        a tie no token can break — either side written before the token
+        existed, or two processes stamping inside one clock tick, since the
+        bump that keeps tokens distinct is process-local — all leave the logged
+        record as the answer.
         """
         return row_is_strictly_newer(resident, redo_record)
 

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -192,9 +192,9 @@ class FaissVectorDBStorage(BaseVectorStorage):
         ``True``: a later commit or ``finalize`` reloads whatever another
         writer committed meanwhile and replays the logged rows on top —
         without re-embedding (issue #3688). A logged row is *not* replayed
-        over a row the other writer committed strictly later — by
-        ``__created_at__``, then by the ``__write_seq__`` token that breaks a
-        whole-second tie (see ``write_seq``): that writer legitimately
+        over a row the other writer committed strictly later — by the
+        ``__write_seq__`` token, or by whole-second ``__created_at__`` when a
+        row predates it (see ``write_seq``): that writer legitimately
         superseded us (a reprocess of the same document under the same
         content-hash id), and the redo entry is dropped instead. The read
         paths apply the same ordering rule over the same find-all row set
@@ -1040,10 +1040,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # turn out not to have been dead after all and reach this replay.
         # Overwriting that newer row with our stale one would revert a
         # completed reprocess. Ordering runs through
-        # `_resident_supersedes_redo`, which the read paths use too: whole
-        # seconds first (`__created_at__`), then `__write_seq__` as the
-        # same-second tiebreaker, so a resident row written after ours is
-        # left alone even when both landed inside the same second.
+        # `_resident_supersedes_redo`, which the read paths use too:
+        # `__write_seq__` decides whenever both rows carry it, whole seconds
+        # only when one predates the token, so a resident row written after
+        # ours is left alone even when both landed inside the same second.
         if self._unsaved_upserts:
             drop_fids: list[int] = []
             replay_records: list[dict[str, Any]] = []
@@ -1431,12 +1431,12 @@ class FaissVectorDBStorage(BaseVectorStorage):
         actually do, or read-your-writes reports a row the replay is about to
         decline to restore, so both go through this one rule: a resident row is
         preferred only when it was written **strictly** after the logged one —
-        by ``__created_at__``, then by the ``__write_seq__`` token that breaks
-        a whole-second tie (see ``write_seq``). An absent row, an older one, or
-        a tie no token can break — either side written before the token
-        existed, or two processes stamping inside one clock tick, since the
-        bump that keeps tokens distinct is process-local — all leave the logged
-        record as the answer.
+        by the ``__write_seq__`` token when both rows carry one, falling back
+        to whole-second ``__created_at__`` when either predates it (see
+        ``write_seq``). An absent row, an older one, or a tie no token can
+        break — either side written before the token existed, or two processes
+        stamping inside one clock tick, since the bump that keeps tokens
+        distinct is process-local — all leave the logged record as the answer.
         """
         return row_is_strictly_newer(resident, redo_record)
 

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -189,8 +189,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
         (record + cached normalized vector) and ``_index_dirty`` stays
         ``True``: a later commit or ``finalize`` reloads whatever another
         writer committed meanwhile and replays the logged rows on top —
-        without re-embedding (issue #3688). The log is cleared only once
-        a save lands.
+        without re-embedding (issue #3688). A logged row is *not* replayed
+        over a row the other writer committed with a strictly newer
+        ``__created_at__``: that writer legitimately superseded us (a
+        reprocess of the same document under the same content-hash id), and
+        the redo entry is dropped instead. The read paths apply the same
+        ordering rule, so read-your-writes never reports a row the replay is
+        about to decline to restore. The log is cleared only once a save
+        lands.
 
     Non-pipeline write paths:
         The pipeline ``busy`` gate serializes ``upsert`` / ``delete`` /
@@ -973,9 +979,25 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # the logged row; one whose stored row already fingerprints equal to
         # the logged record (no reload happened, or an earlier retry
         # replayed it) has nothing to redo.
+        #
+        # A row that fingerprints *differently* is not automatically stale:
+        # under the pipeline's dead-process recovery, the process that
+        # materialized this redo entry can be declared dead, superseded by a
+        # new writer that reprocesses the same document and commits a
+        # genuinely newer row under the same (content-hash) id, and then
+        # turn out not to have been dead after all and reach this replay.
+        # Overwriting that newer row with our stale one would revert a
+        # completed reprocess. `__created_at__` is a same-clock, same-host
+        # int-seconds timestamp (both backends stamp it in `upsert`), so a
+        # resident row strictly newer than the logged one is left alone; a
+        # tie (same second) still replays, same as before this guard — see
+        # _row_fingerprint's docstring on why a whole-second timestamp
+        # cannot be used to detect two rows as *equal*, which is a different
+        # question from ordering two rows known to differ.
         if self._unsaved_upserts:
             drop_fids: list[int] = []
             replay_records: list[dict[str, Any]] = []
+            superseded: list[str] = []
             for doc_id, pdoc in self._unsaved_upserts.items():
                 if doc_id in self._pending_upserts:
                     continue
@@ -985,18 +1007,43 @@ class FaissVectorDBStorage(BaseVectorStorage):
                     self._row_fingerprint(self._id_to_meta[fids[0]]) == fingerprint
                 ):
                     continue
+                logged_at = pdoc.record.get("__created_at__", 0)
+                # Find-all: any resident row under this id being strictly
+                # newer blocks the replay, since the rebuild below would drop
+                # every one of them.
+                if any(
+                    self._id_to_meta[fid].get("__created_at__", 0) > logged_at
+                    for fid in fids
+                ):
+                    superseded.append(doc_id)
+                    continue
                 # Replace whatever rows the id has now (find-all, same as
                 # the pending materialization below) with our logged row.
                 drop_fids.extend(fids)
                 record = pdoc.record
                 record["__vector__"] = pdoc.vector.tolist()
                 replay_records.append(record)
+            # Evicted after the loop, never inside it (mutating the dict
+            # under iteration raises). A superseded entry must leave the log
+            # rather than linger: it would be rescanned by every later flush
+            # and, worse, keep poisoning the read paths, which serve the
+            # logged record for any id still present here.
+            for doc_id in superseded:
+                del self._unsaved_upserts[doc_id]
             if replay_records:
                 self._rebuild_index_locked(drop_fids, replay_records)
                 self._index_dirty = True
                 logger.info(
                     f"[{self.workspace}] {self.namespace} flush: replayed "
                     f"{len(replay_records)} unsaved upserts after a reload"
+                )
+            if superseded:
+                # No dirty flag: dropping a redo entry touches the index not
+                # at all, so there is nothing new to persist.
+                logger.info(
+                    f"[{self.workspace}] {self.namespace} flush: {len(superseded)} "
+                    "unsaved upserts superseded by a strictly newer row "
+                    "committed under the same id, redo entries dropped"
                 )
 
         if not self._pending_upserts:
@@ -1332,6 +1379,24 @@ class FaissVectorDBStorage(BaseVectorStorage):
         """
         return fingerprints is not None and self._row_fingerprint(meta) in fingerprints
 
+    @staticmethod
+    def _resident_supersedes_redo(
+        resident: dict[str, Any] | None, redo_record: dict[str, Any]
+    ) -> bool:
+        """True when a materialized row wins over a pending upsert-redo entry.
+
+        The read paths must agree with what the next flush's replay will
+        actually do, or read-your-writes reports a row the replay is about to
+        decline to restore. Both use the same rule: a resident row is only
+        preferred when it is **strictly** newer by ``__created_at__``. An
+        absent row, an equal timestamp (whole-second tie), or an older one all
+        leave the logged record as the answer, matching the replay's own
+        ordering guard in ``_flush_pending_locked``.
+        """
+        if resident is None:
+            return False
+        return resident.get("__created_at__", 0) > redo_record.get("__created_at__", 0)
+
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         """Get vector data by its ID (read-your-writes against the pending buffer).
 
@@ -1350,20 +1415,24 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 return self._format_record(pending.record)
             if id in self._pending_deletes:
                 return None
+            # Applied-but-unsaved row. A reload may have dropped it from the
+            # index, in which case the next flush replays it and it is the row
+            # this id resolves to — but another writer may also have committed
+            # a strictly newer row under the same (content-hash) id, which the
+            # replay deliberately preserves. So this cannot answer on its own:
+            # consult the index and let the same ordering rule the replay uses
+            # pick the winner.
             redo = self._unsaved_upserts.get(id)
-            if redo is not None:
-                # Applied-but-unsaved row: a reload may have dropped it from
-                # the index, but the next flush replays it, so it is the row
-                # this id resolves to.
-                return self._format_record(redo.record)
             snapshot = self._unsaved_deletes.get(id)
             logged = set(snapshot) if snapshot is not None else None
 
         await self._get_index()  # reload-if-stale
         fid = self._find_faiss_id_by_custom_id(id)
-        if fid is None:
-            return None
-        metadata = self._id_to_meta.get(fid)
+        metadata = self._id_to_meta.get(fid) if fid is not None else None
+        if redo is not None:
+            if self._resident_supersedes_redo(metadata, redo.record):
+                return self._format_record(metadata)
+            return self._format_record(redo.record)
         if not metadata or self._matches_redo_entry(metadata, logged):
             return None
         return self._format_record(metadata)
@@ -1388,6 +1457,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
         result_map: dict[str, dict[str, Any]] = {}
         remaining: list[str] = []
         logged: dict[str, set[str]] = {}
+        redo_docs: dict[str, _PendingFaissDoc] = {}
         async with self._storage_lock:
             for requested_id in ids:
                 pending = self._pending_upserts.get(requested_id)
@@ -1398,10 +1468,12 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 else:
                     redo = self._unsaved_upserts.get(requested_id)
                     if redo is not None:
-                        # Served from the redo log, never from the index: a
-                        # reload may have replaced the row with a stale
-                        # foreign one the replay will overwrite.
-                        result_map[str(requested_id)] = self._format_record(redo.record)
+                        # Still queried against the index: the replay only
+                        # restores the logged row when no strictly newer row
+                        # was committed under the id meanwhile, so the index
+                        # is needed to apply the same ordering rule below.
+                        redo_docs[requested_id] = redo
+                        remaining.append(requested_id)
                         continue
                     if requested_id in self._unsaved_deletes:
                         logged[requested_id] = set(self._unsaved_deletes[requested_id])
@@ -1411,9 +1483,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
             await self._get_index()  # reload-if-stale
             for cid in remaining:
                 fid = self._find_faiss_id_by_custom_id(cid)
-                if fid is None:
+                metadata = self._id_to_meta.get(fid) if fid is not None else None
+                redo = redo_docs.get(cid)
+                if redo is not None:
+                    if self._resident_supersedes_redo(metadata, redo.record):
+                        result_map[str(cid)] = self._format_record(metadata)
+                    else:
+                        result_map[str(cid)] = self._format_record(redo.record)
                     continue
-                metadata = self._id_to_meta.get(fid)
                 if metadata and not self._matches_redo_entry(metadata, logged.get(cid)):
                     result_map[str(cid)] = self._format_record(metadata)
 
@@ -1440,6 +1517,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
         vectors_dict: dict[str, list[float]] = {}
         remaining: list[str] = []
         logged: dict[str, set[str]] = {}
+        redo_docs: dict[str, _PendingFaissDoc] = {}
         async with self._storage_lock:
             to_embed: list[tuple[str, _PendingFaissDoc]] = []
             for requested_id in ids:
@@ -1451,13 +1529,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
                         continue
                     redo = self._unsaved_upserts.get(requested_id)
                     if redo is not None:
-                        # Served from the redo log, never from the index: a
-                        # reload may have replaced the row with a stale
-                        # foreign one the replay will overwrite. The cached
-                        # vector is always set once a doc reaches the log.
-                        vectors_dict[requested_id] = redo.vector.astype(
-                            np.float32
-                        ).tolist()
+                        # Still queried against the index: the replay only
+                        # restores the logged row when no strictly newer row
+                        # was committed under the id meanwhile, so the index
+                        # is needed to apply the same ordering rule below.
+                        # The cached vector is always set once a doc reaches
+                        # the log, so the redo branch can always answer.
+                        redo_docs[requested_id] = redo
+                        remaining.append(requested_id)
                         continue
                     if requested_id in self._unsaved_deletes:
                         logged[requested_id] = set(self._unsaved_deletes[requested_id])
@@ -1498,9 +1577,19 @@ class FaissVectorDBStorage(BaseVectorStorage):
             await self._get_index()  # reload-if-stale
             for cid in remaining:
                 fid = self._find_faiss_id_by_custom_id(cid)
-                if fid is None or fid not in self._id_to_meta:
+                metadata = self._id_to_meta.get(fid) if fid is not None else None
+                redo = redo_docs.get(cid)
+                if redo is not None:
+                    if (
+                        self._resident_supersedes_redo(metadata, redo.record)
+                        and "__vector__" in metadata
+                    ):
+                        vectors_dict[cid] = metadata["__vector__"]
+                    else:
+                        vectors_dict[cid] = redo.vector.astype(np.float32).tolist()
                     continue
-                metadata = self._id_to_meta[fid]
+                if metadata is None:
+                    continue
                 if self._matches_redo_entry(metadata, logged.get(cid)):
                     # Redo-log entry: this is the row version an unsaved
                     # delete removed — report it as absent.
@@ -1589,6 +1678,15 @@ class FaissVectorDBStorage(BaseVectorStorage):
           the reload would write our pre-commit snapshot over another
           writer's durable rows (issue #3688).
 
+        ``_index_dirty`` can be ``True`` while all four buffers are empty —
+        e.g. a materialized-but-unsaved upsert whose id is then ``delete()``-d
+        (evicting its redo entry) inside a batch that itself aborts
+        (``drop_pending_index_ops`` discards the now-queued pending delete,
+        by design; see its docstring). Nothing here names that row for replay
+        any more, but that is exactly why the reload below must still run:
+        without it, this branch would save the stale in-memory snapshot
+        straight over whatever another writer committed in the meantime.
+
         Flush / save failures propagate (same contract as
         ``index_done_callback``); a partially flushed buffer is preserved
         for a future retry.
@@ -1607,14 +1705,24 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 or self._pending_deletes
                 or self._unsaved_deletes
                 or self._unsaved_upserts
+                or self._index_dirty
             ):
                 # Reload so a stale process picks up other writers' commits
                 # before the flush merges the pending buffers in and replays
                 # the redo logs on top. Unsaved materialized changes are no
                 # longer a reason to skip this: both logs replay after the
                 # reload, whereas skipping used to save our pre-commit
-                # snapshot over the other writer's durable rows.
-                self._reload_index_from_disk_locked(for_write=True)
+                # snapshot over the other writer's durable rows. This must
+                # fire even when all four buffers are empty (see the
+                # docstring note above) — a bare ``_index_dirty`` still means
+                # self._index may be stale relative to disk.
+                if self._reload_index_from_disk_locked(for_write=True):
+                    # The reload just replaced self._index with the fresh
+                    # on-disk snapshot, so any prior materialized change is
+                    # gone with it; nothing is dirty relative to this new
+                    # baseline until the flush below applies something on
+                    # top of it.
+                    self._index_dirty = False
                 await self._flush_pending_locked()
             if not self._index_dirty:
                 # The flush changed nothing (e.g. every queued delete

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -197,9 +197,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
         whole-second tie (see ``write_seq``): that writer legitimately
         superseded us (a reprocess of the same document under the same
         content-hash id), and the redo entry is dropped instead. The read
-        paths apply the same ordering rule, so read-your-writes never reports
-        a row the replay is about to decline to restore. The log is cleared
-        only once a save lands.
+        paths apply the same ordering rule over the same find-all row set
+        (``_resolve_resident_rows``), so read-your-writes never reports a row
+        the replay is about to decline to restore — not even in a corrupt
+        store where one id carries several rows. The log is cleared only once
+        a save lands.
 
     Non-pipeline write paths:
         The pipeline ``busy`` gate serializes ``upsert`` / ``delete`` /
@@ -758,28 +760,65 @@ class FaissVectorDBStorage(BaseVectorStorage):
     # Internal helper methods
     # --------------------------------------------------------------------------------
 
-    def _find_faiss_id_by_custom_id(self, custom_id: str):
-        """Return the first Faiss internal ID matching ``custom_id``, or ``None``.
+    def _resolve_resident_rows(
+        self,
+        custom_ids: set[str],
+        logged: dict[str, set[str]] | None = None,
+    ) -> dict[str, dict[str, Any]]:
+        """Resolve the materialized row each requested id reads as.
 
-        Adequate for read paths (any of N duplicate rows would carry the same
-        ``__id__`` so returning one is fine semantically). Write paths that
-        need to remove **all** duplicates — flush overwrite, ``delete`` —
-        must use :py:meth:`_find_faiss_ids_by_custom_id` (plural) instead.
+        Find-all rather than first-match, in **one** scan of
+        ``self._id_to_meta`` for the whole requested set. A legacy /
+        corrupted store can hold several rows under one id (see
+        ``_find_faiss_ids_by_custom_id``), and the read paths do not just
+        pick a row any more — they *compare* it, against an upsert-redo
+        entry's record and against the fingerprints an unsaved delete
+        removed. Answering from an arbitrary duplicate would disagree with
+        the next flush, which applies both rules across **every** fid the id
+        maps to: it declines a replay when *any* resident row is newer, and
+        removes exactly the row versions a delete entry names.
+
+        So a row an unsaved delete removed is skipped (``logged``, per id —
+        the replay will take it out, and a row matching none of the
+        fingerprints took the id's place and must stay visible), and of the
+        rest the newest wins. In a healthy store this is the id's only row.
         """
-        for fid, meta in self._id_to_meta.items():
-            if meta.get("__id__") == custom_id:
-                return fid
-        return None
+        if not custom_ids:
+            return {}
+        resolved: dict[str, dict[str, Any]] = {}
+        for meta in self._id_to_meta.values():
+            doc_id = meta.get("__id__")
+            if doc_id not in custom_ids:
+                continue
+            if self._matches_redo_entry(
+                meta, logged.get(doc_id) if logged is not None else None
+            ):
+                continue
+            current = resolved.get(doc_id)
+            if current is None or row_is_strictly_newer(meta, current):
+                resolved[doc_id] = meta
+        return resolved
+
+    def _resolve_resident_row(
+        self, custom_id: str, logged: set[str] | None = None
+    ) -> dict[str, Any] | None:
+        """Single-id form of :py:meth:`_resolve_resident_rows`."""
+        return self._resolve_resident_rows(
+            {custom_id}, {custom_id: logged} if logged is not None else None
+        ).get(custom_id)
 
     def _find_faiss_ids_by_custom_id(self, custom_id: str) -> list[int]:
         """Return **every** Faiss internal ID whose metadata's ``__id__`` matches.
 
         In a healthy store every custom id maps to at most one fid (each flush
         rebuilds the index without the prior fid before adding the new one).
-        This plural variant exists to defend against legacy / externally
-        corrupted stores where multiple fids share a ``__id__`` — a re-upsert
-        or ``delete`` using only the first match would leave stale duplicates
-        behind. Used by ``_flush_pending_locked`` and ``delete``.
+        This variant exists to defend against legacy / externally corrupted
+        stores where multiple fids share a ``__id__`` — a re-upsert or
+        ``delete`` touching only the first match would leave stale duplicates
+        behind, and a read *comparing* only the first would disagree with what
+        the flush then does. Used by ``_flush_pending_locked``, ``delete``, and
+        the read paths' ``_resolve_resident_rows``; there is deliberately no
+        first-match variant left.
         """
         return [
             fid
@@ -1431,13 +1470,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
             logged = set(snapshot) if snapshot is not None else None
 
         await self._get_index()  # reload-if-stale
-        fid = self._find_faiss_id_by_custom_id(id)
-        metadata = self._id_to_meta.get(fid) if fid is not None else None
         if redo is not None:
-            if self._resident_supersedes_redo(metadata, redo.record):
-                return self._format_record(metadata)
+            resident = self._resolve_resident_row(id)
+            if self._resident_supersedes_redo(resident, redo.record):
+                return self._format_record(resident)
             return self._format_record(redo.record)
-        if not metadata or self._matches_redo_entry(metadata, logged):
+        metadata = self._resolve_resident_row(id, logged)
+        if metadata is None:
             return None
         return self._format_record(metadata)
 
@@ -1485,9 +1524,12 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
         if remaining:
             await self._get_index()  # reload-if-stale
+            # One scan for the whole batch; ids with a redo entry are never in
+            # ``logged`` (a removal evicts the entry), so both rules can be
+            # resolved in the same pass.
+            resolved = self._resolve_resident_rows(set(remaining), logged)
             for cid in remaining:
-                fid = self._find_faiss_id_by_custom_id(cid)
-                metadata = self._id_to_meta.get(fid) if fid is not None else None
+                metadata = resolved.get(cid)
                 redo = redo_docs.get(cid)
                 if redo is not None:
                     if self._resident_supersedes_redo(metadata, redo.record):
@@ -1495,7 +1537,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
                     else:
                         result_map[str(cid)] = self._format_record(redo.record)
                     continue
-                if metadata and not self._matches_redo_entry(metadata, logged.get(cid)):
+                if metadata is not None:
                     result_map[str(cid)] = self._format_record(metadata)
 
         return [result_map.get(str(requested_id)) for requested_id in ids]
@@ -1579,9 +1621,12 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
         if remaining:
             await self._get_index()  # reload-if-stale
+            # One scan for the whole batch. A row an unsaved delete removed is
+            # already filtered out here — it is the version the replay takes
+            # out, so it reads as absent.
+            resolved = self._resolve_resident_rows(set(remaining), logged)
             for cid in remaining:
-                fid = self._find_faiss_id_by_custom_id(cid)
-                metadata = self._id_to_meta.get(fid) if fid is not None else None
+                metadata = resolved.get(cid)
                 redo = redo_docs.get(cid)
                 if redo is not None:
                     if (
@@ -1593,10 +1638,6 @@ class FaissVectorDBStorage(BaseVectorStorage):
                         vectors_dict[cid] = redo.vector.astype(np.float32).tolist()
                     continue
                 if metadata is None:
-                    continue
-                if self._matches_redo_entry(metadata, logged.get(cid)):
-                    # Redo-log entry: this is the row version an unsaved
-                    # delete removed — report it as absent.
                     continue
                 if "__vector__" in metadata:
                     vectors_dict[cid] = metadata["__vector__"]

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -184,9 +184,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
         A flush failure (embedding error, count mismatch, or save IO
         error) raises through ``index_done_callback``; the pending buffer
-        is preserved on flush failure, and if only the save failed
-        ``_index_dirty`` stays ``True`` so a subsequent ``finalize``
-        retries the save without re-embedding.
+        is preserved on flush failure. If only the save failed, the
+        flushed docs have moved into the ``_unsaved_upserts`` redo log
+        (record + cached normalized vector) and ``_index_dirty`` stays
+        ``True``: a later commit or ``finalize`` reloads whatever another
+        writer committed meanwhile and replays the logged rows on top —
+        without re-embedding (issue #3688). The log is cleared only once
+        a save lands.
 
     Non-pipeline write paths:
         The pipeline ``busy`` gate serializes ``upsert`` / ``delete`` /
@@ -266,14 +270,16 @@ class FaissVectorDBStorage(BaseVectorStorage):
         self._unsaved_deletes: dict[str, set[str]] = {}
         # True when self._index / self._id_to_meta have materialized changes
         # that have not been successfully saved to disk yet. This lets
-        # finalize retry a save even after a previous flush cleared the
+        # finalize retry a save even after a previous flush drained the
         # pending buffer (see _flush_pending_locked / index_done_callback).
         self._index_dirty = False
-        # True when part of that unsaved state is materialized *upserts*.
-        # Those rows exist nowhere else, so a reload would drop them (see
-        # finalize); removals do not need the same protection because
-        # _unsaved_deletes replays them on top of the reloaded snapshot.
-        self._unsaved_upserts = False
+        # Rows materialized into self._index whose save has not landed yet,
+        # kept as id -> the flushed _PendingFaissDoc (record + cached
+        # normalized vector). The upsert mirror of _unsaved_deletes: a reload
+        # after a failed save rebuilds the in-memory state from the on-disk
+        # snapshot, and the next flush replays these rows on top without
+        # re-embedding (issue #3688). Cleared only once a save lands.
+        self._unsaved_upserts: dict[str, _PendingFaissDoc] = {}
 
         # Sweep orphan tmp siblings left behind by hard kills mid-save.
         # The meta file also needs an extra pattern: legacy versions of this
@@ -529,10 +535,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
         ``index_done_callback``'s unconditional reload replaces the in-memory
         state with the on-disk snapshot and the row returns. Replaying the
         log after that reload removes it again, so the reload stays lossless
-        for deletes. (Upserts have no equivalent log — a materialized-but-
-        unsaved upsert is still dropped by the same reload; ``finalize``
-        protects those by skipping the reload instead, via
-        ``_unsaved_upserts``.)
+        for deletes. (Upserts carry the mirror log: the flush moves its docs
+        from ``_pending_upserts`` into the ``_unsaved_upserts`` redo log
+        rather than dropping them, so a materialized-but-unsaved upsert is
+        replayed after the same reload; see the deferred-embedding protocol
+        above and issue #3688. A removal request evicts the id's redo entry
+        — ``delete`` / ``delete_entity_relation`` — or the replay would
+        resurrect the row the removal just took out.)
 
         A replay matches on the row, not on the id alone. Ids are content
         hashes, so another writer can publish a *new* row under an id we
@@ -600,6 +609,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 # Cancel a buffered upsert for the same id; the row is going
                 # away, so embedding it at flush time would be wasted work.
                 self._pending_upserts.pop(doc_id, None)
+                # Evict the upsert redo entry too: this request removes
+                # whatever row the id has, and a surviving entry would
+                # replay — resurrect — that row at the next flush.
+                self._unsaved_upserts.pop(doc_id, None)
                 self._pending_deletes.add(doc_id)
 
         logger.debug(
@@ -700,6 +713,18 @@ class FaissVectorDBStorage(BaseVectorStorage):
             ]
             for doc_id in pending_ids:
                 del self._pending_upserts[doc_id]
+            # Same predicate over the upsert redo log, and unconditional for
+            # the same reason as the pending prune: after a foreign reload
+            # the unsaved relation rows are not in the scan above, yet
+            # surviving entries would replay them at the next flush.
+            redo_ids = [
+                doc_id
+                for doc_id, pdoc in self._unsaved_upserts.items()
+                if pdoc.record.get("src_id") == entity_name
+                or pdoc.record.get("tgt_id") == entity_name
+            ]
+            for doc_id in redo_ids:
+                del self._unsaved_upserts[doc_id]
 
         total = len(pending_ids) + len(relations)
         if total:
@@ -873,15 +898,17 @@ class FaissVectorDBStorage(BaseVectorStorage):
               ``self._id_to_meta`` exactly as they were: the upsert phase
               mutates them through a single all-or-nothing operation, so
               there is no half-applied overwrite to persist or repair.
-              ``_index_dirty`` and ``_unsaved_upserts`` are set only after
-              it succeeds, and ``_pending_upserts`` stays intact, so the
-              next ``finalize`` re-enters here and re-applies from the
-              cached vectors — self-healing without re-embedding.
+              ``_index_dirty`` is set and the flushed docs move into the
+              ``_unsaved_upserts`` redo log only after it succeeds, and
+              ``_pending_upserts`` stays intact, so the next ``finalize``
+              re-enters here and re-applies from the cached vectors —
+              self-healing without re-embedding.
         """
         if (
             not self._pending_upserts
             and not self._pending_deletes
             and not self._unsaved_deletes
+            and not self._unsaved_upserts
         ):
             return
 
@@ -935,6 +962,42 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 f"{len(to_remove)} deferred vector deletes ({queued} queued, "
                 f"{len(self._unsaved_deletes)} awaiting save)"
             )
+
+        # Replay materialized-but-unsaved upserts (redo log). A prior flush
+        # materialized these rows and the save then failed; a reload since
+        # (foreign commit) rebuilt the in-memory state from a snapshot that
+        # lacks them. Rebuilding from the logged records + cached vectors
+        # puts them back on top of whatever the other writer committed,
+        # without re-embedding (issue #3688). An id that is pending again is
+        # skipped — the newer buffered doc materializes below and supersedes
+        # the logged row; one whose stored row already fingerprints equal to
+        # the logged record (no reload happened, or an earlier retry
+        # replayed it) has nothing to redo.
+        if self._unsaved_upserts:
+            drop_fids: list[int] = []
+            replay_records: list[dict[str, Any]] = []
+            for doc_id, pdoc in self._unsaved_upserts.items():
+                if doc_id in self._pending_upserts:
+                    continue
+                fids = self._find_faiss_ids_by_custom_id(doc_id)
+                fingerprint = self._row_fingerprint(pdoc.record)
+                if len(fids) == 1 and (
+                    self._row_fingerprint(self._id_to_meta[fids[0]]) == fingerprint
+                ):
+                    continue
+                # Replace whatever rows the id has now (find-all, same as
+                # the pending materialization below) with our logged row.
+                drop_fids.extend(fids)
+                record = pdoc.record
+                record["__vector__"] = pdoc.vector.tolist()
+                replay_records.append(record)
+            if replay_records:
+                self._rebuild_index_locked(drop_fids, replay_records)
+                self._index_dirty = True
+                logger.info(
+                    f"[{self.workspace}] {self.namespace} flush: replayed "
+                    f"{len(replay_records)} unsaved upserts after a reload"
+                )
 
         if not self._pending_upserts:
             return
@@ -1017,16 +1080,19 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 self._id_to_meta[start_idx + i] = record
 
         self._index_dirty = True
-        self._unsaved_upserts = True
 
-        # Clear only the entries we just flushed. Today the non-reentrant
-        # _storage_lock locks out concurrent upserts for the entire flush
-        # (including the asyncio.gather await), so the `is pdoc` identity
-        # check is always True — it's kept as defensive scaffolding so that
-        # if the lock scope is ever relaxed (e.g. embedding moved outside the
-        # lock), a concurrent upsert that re-set vector=None would not be
-        # silently dropped here.
+        # The flushed entries move from the pending buffer into the redo log
+        # rather than being dropped: the rows are materialized but not
+        # durable yet, and clearing the only replayable copy here is exactly
+        # the loss window of issue #3688. The caller clears the log once its
+        # save lands. Only entries we just flushed leave the pending buffer —
+        # the `is pdoc` identity check is defensive scaffolding: today the
+        # non-reentrant _storage_lock locks out concurrent upserts for the
+        # entire flush (including the asyncio.gather await), but if the lock
+        # scope is ever relaxed, a concurrent upsert that re-set vector=None
+        # must stay buffered (its redo entry is superseded next flush).
         for doc_id, pdoc in pending_items:
+            self._unsaved_upserts[doc_id] = pdoc
             if self._pending_upserts.get(doc_id) is pdoc:
                 del self._pending_upserts[doc_id]
 
@@ -1183,6 +1249,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
         dropping it would neither restore the rows nor keep them gone, it
         would only make the removal fragile again, which is the exact state
         this log exists to end.
+
+        ``_unsaved_upserts`` is kept for the same reason as its delete twin:
+        it names rows that already reached ``self._index`` (the class this
+        method intentionally does not roll back), and dropping it would only
+        reopen the reload-loses-them window of issue #3688 for rows whose
+        fate is already sealed either way — reprocessing overwrites them
+        idempotently whether or not the replay preserved them.
         """
         if self._storage_lock is None:
             self._pending_upserts.clear()
@@ -1205,10 +1278,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
                kept, ``_index_dirty`` is not touched, nothing is written to
                the index.
             3. ``_save_faiss_index`` atomically writes ``.index`` and
-               ``.meta.json``. A failure here **also raises**;
-               ``_pending_upserts`` is already empty (flush succeeded) and
-               ``_index_dirty`` stays ``True`` so a later ``finalize``
-               retries the save without re-embedding.
+               ``.meta.json``. A failure here **also raises**; the flushed
+               docs sit in the ``_unsaved_upserts`` redo log (flush moved
+               them there) and ``_index_dirty`` stays ``True``, so a later
+               commit or ``finalize`` can reload a foreign snapshot and
+               replay them on top — without re-embedding (issue #3688).
             4. ``set_all_update_flags`` flips every registered process's
                ``storage_updated`` flag, then we immediately reset our own
                flag to ``False`` so the writer does not self-reload on the
@@ -1229,10 +1303,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
             await self._flush_pending_locked()
             self._save_faiss_index()
             self._unsaved_deletes.clear()  # the removals are durable now
+            self._unsaved_upserts.clear()  # the rows are durable now
             await set_all_update_flags(self.namespace, workspace=self.workspace)
             self.storage_updated.value = False
             self._index_dirty = False
-            self._unsaved_upserts = False
             return True
 
     @staticmethod
@@ -1276,6 +1350,12 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 return self._format_record(pending.record)
             if id in self._pending_deletes:
                 return None
+            redo = self._unsaved_upserts.get(id)
+            if redo is not None:
+                # Applied-but-unsaved row: a reload may have dropped it from
+                # the index, but the next flush replays it, so it is the row
+                # this id resolves to.
+                return self._format_record(redo.record)
             snapshot = self._unsaved_deletes.get(id)
             logged = set(snapshot) if snapshot is not None else None
 
@@ -1316,6 +1396,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 elif requested_id in self._pending_deletes:
                     continue
                 else:
+                    redo = self._unsaved_upserts.get(requested_id)
+                    if redo is not None:
+                        # Served from the redo log, never from the index: a
+                        # reload may have replaced the row with a stale
+                        # foreign one the replay will overwrite.
+                        result_map[str(requested_id)] = self._format_record(redo.record)
+                        continue
                     if requested_id in self._unsaved_deletes:
                         logged[requested_id] = set(self._unsaved_deletes[requested_id])
                     remaining.append(requested_id)
@@ -1361,6 +1448,16 @@ class FaissVectorDBStorage(BaseVectorStorage):
                     if requested_id in self._pending_deletes:
                         # Queued delete: the materialized row (if any) is
                         # about to go away — report it as absent.
+                        continue
+                    redo = self._unsaved_upserts.get(requested_id)
+                    if redo is not None:
+                        # Served from the redo log, never from the index: a
+                        # reload may have replaced the row with a stale
+                        # foreign one the replay will overwrite. The cached
+                        # vector is always set once a doc reaches the log.
+                        vectors_dict[requested_id] = redo.vector.astype(
+                            np.float32
+                        ).tolist()
                         continue
                     if requested_id in self._unsaved_deletes:
                         logged[requested_id] = set(self._unsaved_deletes[requested_id])
@@ -1441,10 +1538,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
         try:
             async with self._storage_lock:
                 # Discard buffered (unflushed) upserts, queued deletes and
-                # the redo log along with the data.
+                # both redo logs along with the data.
                 self._pending_upserts.clear()
                 self._pending_deletes.clear()
                 self._unsaved_deletes.clear()
+                self._unsaved_upserts.clear()
 
                 # Reset the index
                 self._index = faiss.IndexFlatIP(self._dim)
@@ -1459,7 +1557,6 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 self._id_to_meta = {}
                 self._load_faiss_index()
                 self._index_dirty = False
-                self._unsaved_upserts = False
 
                 # Notify other processes
                 await set_all_update_flags(self.namespace, workspace=self.workspace)
@@ -1479,20 +1576,18 @@ class FaissVectorDBStorage(BaseVectorStorage):
         """Flush buffered upserts/deletes and persist before shutdown (safety net).
 
         Normally ``index_done_callback`` has already drained the pending
-        buffers and synced to disk, but three paths land here with work to do:
+        buffers and synced to disk, but two paths land here with work to do:
 
         - **Pending upserts/deletes only** (no prior ``index_done_callback``): flush
           and save. We reload first so a stale process picks up other
           writers' commits before merging its pending buffers in.
-        - **Unsaved materialized upserts** (``_unsaved_upserts=True``): an
-          earlier ``index_done_callback`` materialized rows into
-          ``self._index`` but its save raised. Skip the reload — those rows
-          exist nowhere else — and just retry the save.
-        - **Unsaved removals only** (``_index_dirty`` set by deletes alone):
-          reloading is safe and necessary here. ``_unsaved_deletes`` replays
-          the removals on top of the snapshot, whereas skipping the reload
-          would write our pre-commit snapshot over another writer's durable
-          rows.
+        - **Unsaved materialized changes** (``_index_dirty=True``): an
+          earlier ``index_done_callback`` flushed into ``self._index`` but
+          its save raised. Reloading is safe *and* necessary here: the redo
+          logs replay both the removals (``_unsaved_deletes``) and the rows
+          (``_unsaved_upserts``) on top of the snapshot, whereas skipping
+          the reload would write our pre-commit snapshot over another
+          writer's durable rows (issue #3688).
 
         Flush / save failures propagate (same contract as
         ``index_done_callback``); a partially flushed buffer is preserved
@@ -1503,18 +1598,23 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 not self._pending_upserts
                 and not self._pending_deletes
                 and not self._unsaved_deletes
+                and not self._unsaved_upserts
                 and not self._index_dirty
             ):
                 return
-            if self._pending_upserts or self._pending_deletes or self._unsaved_deletes:
-                # Reload unless self._index carries unsaved *upserts*: those
-                # rows exist nowhere else, so a reload would silently drop
-                # them. Unsaved removals are not a reason to skip it —
-                # _unsaved_deletes replays them on top of whatever the other
-                # writer committed, while skipping would save our pre-commit
-                # snapshot over their durable rows.
-                if not self._unsaved_upserts:
-                    self._reload_index_from_disk_locked(for_write=True)
+            if (
+                self._pending_upserts
+                or self._pending_deletes
+                or self._unsaved_deletes
+                or self._unsaved_upserts
+            ):
+                # Reload so a stale process picks up other writers' commits
+                # before the flush merges the pending buffers in and replays
+                # the redo logs on top. Unsaved materialized changes are no
+                # longer a reason to skip this: both logs replay after the
+                # reload, whereas skipping used to save our pre-commit
+                # snapshot over the other writer's durable rows.
+                self._reload_index_from_disk_locked(for_write=True)
                 await self._flush_pending_locked()
             if not self._index_dirty:
                 # The flush changed nothing (e.g. every queued delete
@@ -1524,7 +1624,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 return
             self._save_faiss_index()
             self._unsaved_deletes.clear()  # the removals are durable now
+            self._unsaved_upserts.clear()  # the rows are durable now
             await set_all_update_flags(self.namespace, workspace=self.workspace)
             self.storage_updated.value = False
             self._index_dirty = False
-            self._unsaved_upserts = False

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -18,6 +18,7 @@ from .shared_storage import (
     get_update_flag,
     set_all_update_flags,
 )
+from .write_seq import WRITE_SEQ_FIELD, next_write_seq, row_is_strictly_newer
 
 # You must manually install faiss-cpu or faiss-gpu before using FAISS vector db
 import faiss  # type: ignore
@@ -27,13 +28,14 @@ import faiss  # type: ignore
 class _PendingFaissDoc:
     """A buffered upsert waiting for deferred embedding and materialization.
 
-    ``record`` holds ``__id__`` / ``__created_at__`` plus the ``meta_fields``
-    (which always include ``content`` for the entity/relation/chunk vdbs), so
-    the content needed for deferred embedding lives in the record itself — no
-    separate copy is kept. ``vector`` starts as ``None`` and is filled either
-    during the lock-held flush or by a lazy ``get_vectors_by_ids`` embedding;
-    once set it is always an **already-L2-normalized float32 1D ndarray**, so
-    the next flush can ``vstack`` and ``index.add`` without re-normalizing.
+    ``record`` holds ``__id__`` / ``__created_at__`` / ``__write_seq__`` plus
+    the ``meta_fields`` (which always include ``content`` for the
+    entity/relation/chunk vdbs), so the content needed for deferred embedding
+    lives in the record itself — no separate copy is kept. ``vector`` starts as
+    ``None`` and is filled either during the lock-held flush or by a lazy
+    ``get_vectors_by_ids`` embedding; once set it is always an
+    **already-L2-normalized float32 1D ndarray**, so the next flush can
+    ``vstack`` and ``index.add`` without re-normalizing.
     ``__vector__`` is materialized into the metadata dict only at flush time,
     right before ``self._index.add``.
     """
@@ -190,13 +192,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
         ``True``: a later commit or ``finalize`` reloads whatever another
         writer committed meanwhile and replays the logged rows on top —
         without re-embedding (issue #3688). A logged row is *not* replayed
-        over a row the other writer committed with a strictly newer
-        ``__created_at__``: that writer legitimately superseded us (a
-        reprocess of the same document under the same content-hash id), and
-        the redo entry is dropped instead. The read paths apply the same
-        ordering rule, so read-your-writes never reports a row the replay is
-        about to decline to restore. The log is cleared only once a save
-        lands.
+        over a row the other writer committed strictly later — by
+        ``__created_at__``, then by the ``__write_seq__`` token that breaks a
+        whole-second tie (see ``write_seq``): that writer legitimately
+        superseded us (a reprocess of the same document under the same
+        content-hash id), and the redo entry is dropped instead. The read
+        paths apply the same ordering rule, so read-your-writes never reports
+        a row the replay is about to decline to restore. The log is cleared
+        only once a save lands.
 
     Non-pipeline write paths:
         The pipeline ``busy`` gate serializes ``upsert`` / ``delete`` /
@@ -394,13 +397,19 @@ class FaissVectorDBStorage(BaseVectorStorage):
         if not data:
             return
 
+        # One timestamp and one write-sequence token for the whole batch: both
+        # order *writes*, and the redo-log comparison only ever puts rows from
+        # two different writes side by side. The token breaks the whole-second
+        # ties __created_at__ leaves open (see write_seq).
         current_time = int(time.time())
+        write_seq = next_write_seq()
         pending = [
             (
                 k,
                 {
                     "__id__": k,
                     "__created_at__": current_time,
+                    WRITE_SEQ_FIELD: write_seq,
                     **{mf: v[mf] for mf in self.meta_fields if mf in v},
                 },
             )
@@ -471,8 +480,13 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 # callers, so we silently skip — the skew was already warned
                 # about at load time.
                 continue
-            # Filter out __vector__ from query results to avoid returning large vector data
-            filtered_meta = {k: v for k, v in meta.items() if k != "__vector__"}
+            # Filter out __vector__ from query results to avoid returning large
+            # vector data; __write_seq__ is storage bookkeeping, not payload.
+            filtered_meta = {
+                k: v
+                for k, v in meta.items()
+                if k not in ("__vector__", WRITE_SEQ_FIELD)
+            }
             results.append(
                 {
                     **filtered_meta,
@@ -564,20 +578,18 @@ class FaissVectorDBStorage(BaseVectorStorage):
         has since taken the id's place.
 
         **Boundary of that guarantee.** Successor preservation is only as
-        sharp as content-based identity, and one case it cannot resolve is a
-        successor *identical* to the row removed. ``__created_at__`` does not
-        break the tie — ``upsert`` stamps ``int(time.time())``, so a rewrite
-        inside the same second carries the same timestamp. Where we are the
-        ones re-materializing such a row the flush drops the redo entry (see
-        the bottom of ``_flush_pending_locked``), which costs nothing: a
-        resurrection would only restore the row that is present anyway. What
-        remains is a byte-identical row published by *another writer*, which
-        no content-based identity can tell from the row we deleted, so the
-        replay removes it. Distinguishing it would take a per-write
-        generation persisted in the record — a storage-format change, and a
-        divergence from the Nano protocol this mirrors — for a case that
-        already presupposes the *Single writer* invariant above being
-        violated (see class docstring, *Concurrency invariants*).
+        sharp as content-based identity, and the case it has to resolve is a
+        successor *identical* in content to the row removed.
+        ``__created_at__`` does not break that tie — ``upsert`` stamps
+        ``int(time.time())``, so a rewrite inside the same second carries the
+        same timestamp — but ``__write_seq__`` does: every ``upsert`` stamps
+        its own token into the record (see ``write_seq``), so a successor
+        written by another writer, or by us, fingerprints differently and the
+        replay preserves it. What remains is a row written before the token
+        existed, which no content-based identity can tell from the row we
+        deleted, so the replay removes it — a case that already presupposes
+        the *Single writer* invariant above being violated (see class
+        docstring, *Concurrency invariants*).
 
         The read-your-writes paths mirror both rules: a queued id reads as
         absent, while a logged one hides only the row the entry names — a
@@ -859,7 +871,8 @@ class FaissVectorDBStorage(BaseVectorStorage):
         The redo log has to name the exact row it removed so a replay after
         a reload cannot hit a newer row another writer published under the
         same (content-hash) id. The digest covers the stored metadata record
-        — id, timestamp, every meta field — **excluding** ``__vector__``:
+        — id, timestamp, ``__write_seq__``, every meta field — **excluding**
+        ``__vector__``:
         ``_save_faiss_index`` strips the vector from ``.meta.json`` and
         ``_load_faiss_index`` / ``_remove_faiss_ids_locked`` re-attach it
         lazily (``index.reconstruct``), so its presence on a row is not
@@ -987,13 +1000,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # genuinely newer row under the same (content-hash) id, and then
         # turn out not to have been dead after all and reach this replay.
         # Overwriting that newer row with our stale one would revert a
-        # completed reprocess. `__created_at__` is a same-clock, same-host
-        # int-seconds timestamp (both backends stamp it in `upsert`), so a
-        # resident row strictly newer than the logged one is left alone; a
-        # tie (same second) still replays, same as before this guard — see
-        # _row_fingerprint's docstring on why a whole-second timestamp
-        # cannot be used to detect two rows as *equal*, which is a different
-        # question from ordering two rows known to differ.
+        # completed reprocess. Ordering runs through
+        # `_resident_supersedes_redo`, which the read paths use too: whole
+        # seconds first (`__created_at__`), then `__write_seq__` as the
+        # same-second tiebreaker, so a resident row written after ours is
+        # left alone even when both landed inside the same second.
         if self._unsaved_upserts:
             drop_fids: list[int] = []
             replay_records: list[dict[str, Any]] = []
@@ -1007,12 +1018,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
                     self._row_fingerprint(self._id_to_meta[fids[0]]) == fingerprint
                 ):
                     continue
-                logged_at = pdoc.record.get("__created_at__", 0)
                 # Find-all: any resident row under this id being strictly
                 # newer blocks the replay, since the rebuild below would drop
                 # every one of them.
                 if any(
-                    self._id_to_meta[fid].get("__created_at__", 0) > logged_at
+                    self._resident_supersedes_redo(self._id_to_meta[fid], pdoc.record)
                     for fid in fids
                 ):
                     superseded.append(doc_id)
@@ -1143,22 +1153,15 @@ class FaissVectorDBStorage(BaseVectorStorage):
             if self._pending_upserts.get(doc_id) is pdoc:
                 del self._pending_upserts[doc_id]
 
-        if self._unsaved_deletes:
-            # A row we just wrote can be indistinguishable from one we
-            # removed (same id, same fingerprint) — the single case the
-            # fingerprint cannot separate, and the one case where dropping
-            # the redo entry costs nothing: a resurrection would restore the
-            # row that is present now. Only rows written just above can
-            # match here; a resurrected one was already removed by the
-            # replay at the top of this flush.
-            for meta in self._id_to_meta.values():
-                doc_id = meta.get("__id__")
-                logged = self._unsaved_deletes.get(doc_id)
-                if logged is None:
-                    continue
-                logged.discard(self._row_fingerprint(meta))
-                if not logged:
-                    del self._unsaved_deletes[doc_id]
+        # No reconciliation pass against `_unsaved_deletes` follows. A row we
+        # just wrote used to be able to fingerprint equal to one we removed
+        # (same id, same content, same whole second), which would have made the
+        # replay delete it — so the entry was dropped here. `__write_seq__`
+        # rules that out: every upsert stamps its own token, so a rewrite is a
+        # distinct row version and the entry names only the version it removed.
+        # Keeping it removes and hides nothing that exists, and it is still
+        # needed — a reload resurrecting the removed version is taken out again
+        # by the replay at the top of the next flush, rewrite preserved.
 
     def _save_faiss_index(self):
         """Atomically persist ``self._index`` + ``self._id_to_meta`` to disk.
@@ -1360,7 +1363,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
     def _format_record(dp: dict[str, Any]) -> dict[str, Any]:
         """Shape a stored/pending record into the public read result."""
         return {
-            **{k: v for k, v in dp.items() if k != "__vector__"},
+            **{k: v for k, v in dp.items() if k not in ("__vector__", WRITE_SEQ_FIELD)},
             "id": dp.get("__id__"),
             "created_at": dp.get("__created_at__"),
         }
@@ -1387,15 +1390,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
         The read paths must agree with what the next flush's replay will
         actually do, or read-your-writes reports a row the replay is about to
-        decline to restore. Both use the same rule: a resident row is only
-        preferred when it is **strictly** newer by ``__created_at__``. An
-        absent row, an equal timestamp (whole-second tie), or an older one all
-        leave the logged record as the answer, matching the replay's own
-        ordering guard in ``_flush_pending_locked``.
+        decline to restore, so both go through this one rule: a resident row is
+        preferred only when it was written **strictly** after the logged one —
+        by ``__created_at__``, then by the ``__write_seq__`` token that breaks
+        a whole-second tie (see ``write_seq``). An absent row, an older one, or
+        a tie no token can break (either side written before the token existed)
+        all leave the logged record as the answer.
         """
-        if resident is None:
-            return False
-        return resident.get("__created_at__", 0) > redo_record.get("__created_at__", 0)
+        return row_is_strictly_newer(resident, redo_record)
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         """Get vector data by its ID (read-your-writes against the pending buffer).

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -217,13 +217,13 @@ class NanoVectorDBStorage(BaseVectorStorage):
         The upsert replay is scoped by the redo entry itself: an id whose
         stored row already fingerprints equal to the logged record has
         nothing to redo. Any *other* row under that id is ordered against
-        ours by ``__created_at__`` and then by the ``__write_seq__`` token
-        that breaks a whole-second tie: a strictly newer one is left alone
-        and our redo entry is dropped (another writer legitimately
-        superseded us — reverting it would undo a completed reprocess),
-        while an older one is overwritten by ours. Only a tie no token can
-        break — one of the two rows written before the token existed —
-        still falls back to being overwritten by the replay. A removal request
+        ours by the ``__write_seq__`` token, or by whole-second
+        ``__created_at__`` when one of them predates it: a strictly newer one
+        is left alone and our redo entry is dropped (another writer
+        legitimately superseded us — reverting it would undo a completed
+        reprocess), while an older one is overwritten by ours. Only a tie no
+        token can break — one of the two rows written before the token
+        existed — still falls back to being overwritten by the replay. A removal request
         evicts the id's redo entry (``delete`` / ``delete_entity`` /
         ``delete_entity_relation``), or the replay would resurrect the row
         the removal just took out.
@@ -554,10 +554,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
         # turn out not to have been dead after all and reach this replay.
         # Overwriting that newer row with our stale one would revert a
         # completed reprocess. Ordering runs through
-        # `_resident_supersedes_redo`, which the read paths use too: whole
-        # seconds first (`__created_at__`), then `__write_seq__` as the
-        # same-second tiebreaker, so a resident row written after ours is
-        # left alone even when both landed inside the same second.
+        # `_resident_supersedes_redo`, which the read paths use too:
+        # `__write_seq__` decides whenever both rows carry it, whole seconds
+        # only when one predates the token, so a resident row written after
+        # ours is left alone even when both landed inside the same second.
         if self._unsaved_upserts:
             storage = getattr(self._client, "_NanoVectorDB__storage")
             present = {
@@ -1096,12 +1096,12 @@ class NanoVectorDBStorage(BaseVectorStorage):
         actually do, or read-your-writes reports a row the replay is about to
         decline to restore, so both go through this one rule: a resident row is
         preferred only when it was written **strictly** after the logged one —
-        by ``__created_at__``, then by the ``__write_seq__`` token that breaks
-        a whole-second tie (see ``write_seq``). An absent row, an older one, or
-        a tie no token can break — either side written before the token
-        existed, or two processes stamping inside one clock tick, since the
-        bump that keeps tokens distinct is process-local — all leave the logged
-        record as the answer.
+        by the ``__write_seq__`` token when both rows carry one, falling back
+        to whole-second ``__created_at__`` when either predates it (see
+        ``write_seq``). An absent row, an older one, or a tie no token can
+        break — either side written before the token existed, or two processes
+        stamping inside one clock tick, since the bump that keeps tokens
+        distinct is process-local — all leave the logged record as the answer.
         """
         return row_is_strictly_newer(resident, redo_record)
 

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -148,8 +148,12 @@ class NanoVectorDBStorage(BaseVectorStorage):
         ``self._client`` — unflushed pending data is intentionally not
         queryable. A flush failure (embedding error, count mismatch, or save
         IO error) raises through ``index_done_callback``; the pending buffer
-        is preserved, and if only the save failed ``_client_dirty`` stays
-        ``True`` so a subsequent ``finalize`` retries the save.
+        is preserved on flush failure. If only the save failed, the flushed
+        docs have moved into the ``_unsaved_upserts`` redo log (record +
+        cached vector) and ``_client_dirty`` stays ``True``: a later commit
+        or ``finalize`` reloads whatever another writer committed meanwhile
+        and replays the logged rows on top — without re-embedding (issue
+        #3688). The log is cleared only once a save lands.
 
     Deferred-delete protocol:
         ``delete`` mirrors the buffering above: it cancels any pending upsert
@@ -175,9 +179,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
         unconditional reload replaces ``self._client`` with the on-disk
         snapshot and the row returns. Replaying the log after that reload
         removes it again, so the reload stays lossless for deletes. (Upserts
-        have no equivalent log — ``_pending_upserts`` is cleared once the rows
-        materialize — so a materialized-but-unsaved upsert is still dropped by
-        the same reload; see issue #3688.)
+        carry the mirror log: a flush moves its docs from ``_pending_upserts``
+        into the ``_unsaved_upserts`` redo log rather than dropping them, so
+        a materialized-but-unsaved upsert is replayed after the same reload;
+        see the deferred-embedding protocol above and issue #3688.)
 
         A replay matches on the row, not on the id alone. Ids are content
         hashes, so another writer can publish a *new* row under an id we
@@ -197,10 +202,21 @@ class NanoVectorDBStorage(BaseVectorStorage):
         from the row we deleted.
 
         Being replayable is also what lets ``finalize`` reload before it
-        retries a delete-only save: without the log it had to skip the reload
-        to protect the unsaved removal, and saved a pre-commit snapshot over
-        another writer's rows. Materialized upserts still need that
-        protection (``_unsaved_upserts``), because nothing replays them.
+        retries a save: without the logs it had to choose between skipping
+        the reload (saving a pre-commit snapshot over another writer's rows)
+        and reloading (dropping its own unsaved changes). With both logs —
+        ``_unsaved_deletes`` for removals, ``_unsaved_upserts`` for rows —
+        every retry path reloads first and replays on top, lossless in both
+        directions.
+
+        The upsert replay is scoped by the redo entry itself: an id whose
+        stored row already fingerprints equal to the logged record has
+        nothing to redo, while any other row under that id — including one
+        another writer published meanwhile — is overwritten by ours, the
+        correct outcome for content-hash ids. A removal request evicts the
+        id's redo entry (``delete`` / ``delete_entity`` /
+        ``delete_entity_relation``), or the replay would resurrect the row
+        the removal just took out.
 
         Ids that matched no row are not logged at all — there is nothing to
         persist for them, and replaying them could only hit a row they were
@@ -303,13 +319,15 @@ class NanoVectorDBStorage(BaseVectorStorage):
         self._unsaved_deletes: dict[str, str] = {}
         # True when self._client has materialized changes that have not been
         # successfully saved to disk yet. This lets finalize retry a save even
-        # after a previous flush cleared the pending buffer.
+        # after a previous flush drained the pending buffer.
         self._client_dirty = False
-        # True when part of that unsaved state is materialized *upserts*.
-        # Those rows exist nowhere else, so a reload would drop them; removals
-        # do not need the same protection because _unsaved_deletes replays
-        # them. finalize uses this to decide whether reloading is safe.
-        self._unsaved_upserts = False
+        # Rows materialized into self._client whose save has not landed yet,
+        # kept as id -> the flushed _PendingNanoDoc (record + cached vector).
+        # The upsert mirror of _unsaved_deletes: a reload after a failed save
+        # replaces self._client with the on-disk snapshot, and the next flush
+        # replays these rows on top without re-embedding (issue #3688).
+        # Cleared only once a save lands.
+        self._unsaved_upserts: dict[str, _PendingNanoDoc] = {}
 
     async def initialize(self):
         """Initialize storage data"""
@@ -462,6 +480,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
             not self._pending_upserts
             and not self._pending_deletes
             and not self._unsaved_deletes
+            and not self._unsaved_upserts
         ):
             return
 
@@ -495,6 +514,43 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 f"{len(matched)} deferred deletes ({queued} queued, "
                 f"{len(self._unsaved_deletes)} awaiting save)"
             )
+
+        # Replay materialized-but-unsaved upserts (redo log). A prior flush
+        # moved these rows into self._client and the save then failed; a
+        # reload since (foreign commit) replaced self._client with a snapshot
+        # that lacks them. Re-upserting from the logged record + cached
+        # vector puts them back on top of whatever the other writer
+        # committed, without re-embedding (issue #3688). An id that is
+        # pending again is skipped — the newer buffered doc materializes
+        # below and supersedes the logged row; one whose stored row already
+        # fingerprints equal to the logged record (no reload happened, or an
+        # earlier retry replayed it) has nothing to redo.
+        if self._unsaved_upserts:
+            storage = getattr(self._client, "_NanoVectorDB__storage")
+            present = {
+                dp["__id__"]: self._row_fingerprint(dp)
+                for dp in storage["data"]
+                if dp["__id__"] in self._unsaved_upserts
+            }
+            replay_data = []
+            for doc_id, pdoc in self._unsaved_upserts.items():
+                if doc_id in self._pending_upserts:
+                    continue
+                # Fingerprint BEFORE re-attaching __vector__: the digest
+                # covers every record key, and the stored row never carries
+                # __vector__ (client.upsert strips it into the matrix).
+                if present.get(doc_id) == self._row_fingerprint(pdoc.record):
+                    continue
+                record = pdoc.record
+                record["__vector__"] = pdoc.vector
+                replay_data.append(record)
+            if replay_data:
+                self._client.upsert(datas=replay_data)
+                self._client_dirty = True
+                logger.info(
+                    f"[{self.workspace}] {self.namespace} flush: replayed "
+                    f"{len(replay_data)} unsaved upserts after a reload"
+                )
 
         if not self._pending_upserts:
             return
@@ -554,11 +610,16 @@ class NanoVectorDBStorage(BaseVectorStorage):
 
         self._client.upsert(datas=list_data)
         self._client_dirty = True
-        self._unsaved_upserts = True
 
-        # Clear only the entries we just flushed (an upsert that arrived after
-        # the snapshot would have re-set vector=None and must not be dropped).
+        # The flushed entries move from the pending buffer into the redo log
+        # rather than being dropped: the rows are materialized but not durable
+        # yet, and clearing the only replayable copy here is exactly the loss
+        # window of issue #3688. The caller clears the log once its save
+        # lands. Only entries we just flushed leave the pending buffer (an
+        # upsert that arrived after the snapshot would have re-set vector=None
+        # and must stay buffered; its redo entry is superseded next flush).
         for doc_id, pdoc in pending_items:
+            self._unsaved_upserts[doc_id] = pdoc
             if self._pending_upserts.get(doc_id) is pdoc:
                 del self._pending_upserts[doc_id]
 
@@ -685,6 +746,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
             async with self._storage_lock:
                 for doc_id in ids:
                     self._pending_upserts.pop(doc_id, None)
+                    # Evict the upsert redo entry too: this request removes
+                    # whatever row the id has, and a surviving entry would
+                    # replay — resurrect — that row at the next flush.
+                    self._unsaved_upserts.pop(doc_id, None)
                     self._pending_deletes.add(doc_id)
 
             logger.debug(
@@ -747,6 +812,11 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 pending_cancelled = (
                     self._pending_upserts.pop(entity_id, None) is not None
                 )
+                # Evict the upsert redo entry unconditionally (like the
+                # pending cancel): after a foreign reload the unsaved row is
+                # not in self._client — `existing` is empty — yet a surviving
+                # entry would replay it at the next flush.
+                self._unsaved_upserts.pop(entity_id, None)
 
             if deleted or pending_cancelled:
                 logger.debug(
@@ -822,6 +892,18 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 ]
                 for doc_id in pending_ids:
                     del self._pending_upserts[doc_id]
+                # Same predicate over the upsert redo log, and unconditional
+                # for the same reason: after a foreign reload the unsaved
+                # relation rows are not in the scan above, yet surviving
+                # entries would replay them at the next flush.
+                redo_ids = [
+                    doc_id
+                    for doc_id, pdoc in self._unsaved_upserts.items()
+                    if pdoc.record.get("src_id") == entity_name
+                    or pdoc.record.get("tgt_id") == entity_name
+                ]
+                for doc_id in redo_ids:
+                    del self._unsaved_upserts[doc_id]
 
             total = len(pending_ids) + len(ids_to_delete)
             if total:
@@ -867,6 +949,13 @@ class NanoVectorDBStorage(BaseVectorStorage):
         also weaker here: an upsert is re-issued by any reprocess of the
         document, while a delete is re-issued only if the reprocess reaches
         the same merge.
+
+        ``_unsaved_upserts`` is kept for the same reason as its delete twin:
+        it names rows that already reached ``self._client`` (the class this
+        method intentionally does not roll back), and dropping it would only
+        reopen the reload-loses-them window of issue #3688 for rows whose
+        fate is already sealed either way — reprocessing overwrites them
+        idempotently whether or not the replay preserved them.
         """
         if self._storage_lock is None:
             self._pending_upserts.clear()
@@ -890,7 +979,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
                beside the target and renames it into place — readers either
                see the previous file in full or the new file in full, never a
                torn write. A failure here **also raises**; ``_client_dirty``
-               stays ``True`` so a later ``finalize`` retries the save.
+               stays ``True`` and the redo logs (``_unsaved_upserts`` /
+               ``_unsaved_deletes``) keep the flushed ops, so a later commit
+               or ``finalize`` can reload a foreign snapshot and replay them
+               on top (issue #3688).
             4. ``set_all_update_flags`` flips every registered process's
                ``storage_updated`` flag, then we immediately reset our own
                flag to ``False`` so the writer does not self-reload on the
@@ -911,10 +1003,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
             await self._flush_pending_locked()
             self._save_to_disk_locked()
             self._unsaved_deletes.clear()  # the removals are durable now
+            self._unsaved_upserts.clear()  # the rows are durable now
             await set_all_update_flags(self.namespace, workspace=self.workspace)
             self.storage_updated.value = False
             self._client_dirty = False
-            self._unsaved_upserts = False
             return True
 
     @staticmethod
@@ -954,6 +1046,12 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 return self._format_record(pending.record)
             if id in self._pending_deletes:
                 return None
+            redo = self._unsaved_upserts.get(id)
+            if redo is not None:
+                # Applied-but-unsaved row: a reload may have dropped it from
+                # self._client, but the next flush replays it, so it is the
+                # row this id resolves to.
+                return self._format_record(redo.record)
             logged = self._unsaved_deletes.get(id)
 
         client = await self._get_client()
@@ -987,6 +1085,13 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 elif requested_id in self._pending_deletes:
                     continue  # queued delete, no newer upsert -> absent
                 else:
+                    redo = self._unsaved_upserts.get(requested_id)
+                    if redo is not None:
+                        # Served from the redo log, never from the client: a
+                        # reload may have replaced the row with a stale
+                        # foreign one the replay will overwrite.
+                        result_map[str(requested_id)] = self._format_record(redo.record)
+                        continue
                     # A logged id still goes to the client: only the removed
                     # row version is hidden, not one written in its place.
                     if requested_id in self._unsaved_deletes:
@@ -1034,6 +1139,16 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 if pending is None:
                     if requested_id in self._pending_deletes:
                         continue  # queued delete, no newer upsert -> absent
+                    redo = self._unsaved_upserts.get(requested_id)
+                    if redo is not None:
+                        # Served from the redo log, never from the client: a
+                        # reload may have replaced the row with a stale
+                        # foreign one the replay will overwrite. The cached
+                        # vector is always set once a doc reaches the log.
+                        vectors_dict[requested_id] = redo.vector.astype(
+                            np.float32
+                        ).tolist()
+                        continue
                     # A logged id still goes to the client: only the removed
                     # row version is hidden, not one written in its place.
                     if requested_id in self._unsaved_deletes:
@@ -1112,10 +1227,12 @@ class NanoVectorDBStorage(BaseVectorStorage):
         try:
             async with self._storage_lock:
                 # Discard buffered (unflushed) upserts and queued deletes
-                # along with the data.
+                # along with the data — and both redo logs: there is nothing
+                # left to replay onto.
                 self._pending_upserts.clear()
                 self._pending_deletes.clear()
                 self._unsaved_deletes.clear()
+                self._unsaved_upserts.clear()
 
                 # delete _client_file_name
                 if os.path.exists(self._client_file_name):
@@ -1126,7 +1243,6 @@ class NanoVectorDBStorage(BaseVectorStorage):
                     storage_file=self._client_file_name,
                 )
                 self._client_dirty = False
-                self._unsaved_upserts = False
 
                 # Notify other processes that data has been updated
                 await set_all_update_flags(self.namespace, workspace=self.workspace)
@@ -1150,15 +1266,13 @@ class NanoVectorDBStorage(BaseVectorStorage):
         - **Pending upserts only** (no prior ``index_done_callback``): flush
           and save. We reload first so a stale process picks up other writers'
           commits before merging its pending buffer in.
-        - **Unsaved materialized upserts** (``_unsaved_upserts=True``): an
-          earlier ``index_done_callback`` materialized rows into
-          ``self._client`` but its save raised. Skip the reload — those rows
-          exist nowhere else — and just retry the save.
-        - **Unsaved removals only** (``_client_dirty`` set by deletes alone):
-          reloading is safe and necessary here. ``_unsaved_deletes`` replays
-          the removals on top of the snapshot, whereas skipping the reload
-          would write our pre-commit snapshot over another writer's durable
-          rows.
+        - **Unsaved materialized changes** (``_client_dirty=True``): an
+          earlier ``index_done_callback`` flushed into ``self._client`` but
+          its save raised. Reloading is safe *and* necessary here: the redo
+          logs replay both the removals (``_unsaved_deletes``) and the rows
+          (``_unsaved_upserts``) on top of the snapshot, whereas skipping the
+          reload would write our pre-commit snapshot over another writer's
+          durable rows (issue #3688).
 
         Flush / save failures propagate (same contract as
         ``index_done_callback``); a partially flushed buffer is preserved for
@@ -1169,18 +1283,23 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 not self._pending_upserts
                 and not self._pending_deletes
                 and not self._unsaved_deletes
+                and not self._unsaved_upserts
                 and not self._client_dirty
             ):
                 return
-            if self._pending_upserts or self._pending_deletes or self._unsaved_deletes:
-                # Reload unless self._client carries unsaved *upserts*: those
-                # rows exist nowhere else, so a reload would silently drop
-                # them. Unsaved removals are not a reason to skip it —
-                # _unsaved_deletes replays them on top of whatever the other
-                # writer committed, while skipping would save our pre-commit
-                # snapshot over their durable rows.
-                if not self._unsaved_upserts:
-                    self._reload_client_from_disk_locked(for_write=True)
+            if (
+                self._pending_upserts
+                or self._pending_deletes
+                or self._unsaved_deletes
+                or self._unsaved_upserts
+            ):
+                # Reload so a stale process picks up other writers' commits
+                # before the flush merges the pending buffer in and replays
+                # the redo logs on top. Unsaved materialized changes are no
+                # longer a reason to skip this: both logs replay after the
+                # reload, whereas skipping used to save our pre-commit
+                # snapshot over the other writer's durable rows.
+                self._reload_client_from_disk_locked(for_write=True)
                 await self._flush_pending_locked()
             if not self._client_dirty:
                 # The flush changed nothing (e.g. every queued delete targeted
@@ -1190,7 +1309,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 return
             self._save_to_disk_locked()
             self._unsaved_deletes.clear()  # the removals are durable now
+            self._unsaved_upserts.clear()  # the rows are durable now
             await set_all_update_flags(self.namespace, workspace=self.workspace)
             self.storage_updated.value = False
             self._client_dirty = False
-            self._unsaved_upserts = False

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -24,20 +24,22 @@ from .shared_storage import (
     get_update_flag,
     set_all_update_flags,
 )
+from .write_seq import WRITE_SEQ_FIELD, next_write_seq, row_is_strictly_newer
 
 
 @dataclass
 class _PendingNanoDoc:
     """A buffered upsert waiting for deferred embedding and materialization.
 
-    ``record`` holds ``__id__`` / ``__created_at__`` plus the ``meta_fields``
-    (which always include ``content`` for the entity/relation/chunk vdbs), so
-    the content needed for deferred embedding lives in the record itself — no
-    separate copy is kept. ``vector`` starts as ``None`` and is filled either
-    during the lock-held flush or by a lazy ``get_vectors_by_ids`` embedding;
-    once set it is reused by the next flush instead of re-calling the model.
-    The compressed ``vector`` / raw ``__vector__`` keys are added to ``record``
-    only at flush time, right before ``client.upsert``.
+    ``record`` holds ``__id__`` / ``__created_at__`` / ``__write_seq__`` plus
+    the ``meta_fields`` (which always include ``content`` for the
+    entity/relation/chunk vdbs), so the content needed for deferred embedding
+    lives in the record itself — no separate copy is kept. ``vector`` starts as
+    ``None`` and is filled either during the lock-held flush or by a lazy
+    ``get_vectors_by_ids`` embedding; once set it is reused by the next flush
+    instead of re-calling the model. The compressed ``vector`` / raw
+    ``__vector__`` keys are added to ``record`` only at flush time, right
+    before ``client.upsert``.
     """
 
     record: dict[str, Any]
@@ -193,13 +195,12 @@ class NanoVectorDBStorage(BaseVectorStorage):
         enough on its own: ``upsert`` stamps ``int(time.time())``, so a rewrite
         inside the same second as the removed row carries the same timestamp.
 
-        One case the fingerprint cannot separate is a row that is *identical*
-        to the one removed. Materializing such a row drops the redo entry
-        (bottom of ``_flush_pending_locked``) — and that is exactly the case
-        where dropping it costs nothing, since a resurrection would restore
-        the row that is present anyway. What remains is a byte-identical row
-        published by another writer, which no content-based identity can tell
-        from the row we deleted.
+        A rewrite *identical* in content to the row removed is still a
+        distinct row version: every write also stamps its own
+        ``__write_seq__`` token (see ``write_seq``), so it fingerprints
+        differently and the replay preserves it — whether we wrote it or
+        another writer did. Only a row written before the token existed is
+        indistinguishable from the row we removed, and the replay removes it.
 
         Being replayable is also what lets ``finalize`` reload before it
         retries a save: without the logs it had to choose between skipping
@@ -216,10 +217,13 @@ class NanoVectorDBStorage(BaseVectorStorage):
         The upsert replay is scoped by the redo entry itself: an id whose
         stored row already fingerprints equal to the logged record has
         nothing to redo. Any *other* row under that id is ordered against
-        ours by ``__created_at__``: a strictly newer one is left alone and
-        our redo entry is dropped (another writer legitimately superseded us
-        — reverting it would undo a completed reprocess), while an older one
-        or a whole-second tie is overwritten by ours. A removal request
+        ours by ``__created_at__`` and then by the ``__write_seq__`` token
+        that breaks a whole-second tie: a strictly newer one is left alone
+        and our redo entry is dropped (another writer legitimately
+        superseded us — reverting it would undo a completed reprocess),
+        while an older one is overwritten by ours. Only a tie no token can
+        break — one of the two rows written before the token existed —
+        still falls back to being overwritten by the replay. A removal request
         evicts the id's redo entry (``delete`` / ``delete_entity`` /
         ``delete_entity_relation``), or the replay would resurrect the row
         the removal just took out.
@@ -426,13 +430,19 @@ class NanoVectorDBStorage(BaseVectorStorage):
         if not data:
             return
 
+        # One timestamp and one write-sequence token for the whole batch: both
+        # order *writes*, and the redo-log comparison only ever puts rows from
+        # two different writes side by side. The token breaks the whole-second
+        # ties __created_at__ leaves open (see write_seq).
         current_time = int(time.time())
+        write_seq = next_write_seq()
         pending = [
             (
                 k,
                 {
                     "__id__": k,
                     "__created_at__": current_time,
+                    WRITE_SEQ_FIELD: write_seq,
                     **{k1: v1 for k1, v1 in v.items() if k1 in self.meta_fields},
                 },
             )
@@ -462,11 +472,11 @@ class NanoVectorDBStorage(BaseVectorStorage):
         The redo log has to name the exact row it removed so a replay after a
         reload cannot hit a newer row another writer published under the same
         (content-hash) id. The digest covers the whole stored record — id,
-        timestamp, content, the base64 vector, every meta field — and is
-        stable across a save/reload round-trip: sorted keys make key order
-        irrelevant, tuples and lists both render as JSON arrays, and the
-        default ``ensure_ascii`` keeps the output encodable whatever the
-        record holds.
+        timestamp, ``__write_seq__``, content, the base64 vector, every meta
+        field — and is stable across a save/reload round-trip: sorted keys
+        make key order irrelevant, tuples and lists both render as JSON
+        arrays, and the default ``ensure_ascii`` keeps the output encodable
+        whatever the record holds.
 
         ``__vector__`` never reaches here — ``NanoVectorDB.upsert`` strips it
         into the matrix before the record is stored.
@@ -543,13 +553,11 @@ class NanoVectorDBStorage(BaseVectorStorage):
         # genuinely newer row under the same (content-hash) id, and then
         # turn out not to have been dead after all and reach this replay.
         # Overwriting that newer row with our stale one would revert a
-        # completed reprocess. `__created_at__` is a same-clock, same-host
-        # int-seconds timestamp (both backends stamp it in `upsert`), so a
-        # resident row strictly newer than the logged one is left alone; a
-        # tie (same second) still replays, same as before this guard — see
-        # _row_fingerprint's docstring on why a whole-second timestamp
-        # cannot be used to detect two rows as *equal*, which is a different
-        # question from ordering two rows known to differ.
+        # completed reprocess. Ordering runs through
+        # `_resident_supersedes_redo`, which the read paths use too: whole
+        # seconds first (`__created_at__`), then `__write_seq__` as the
+        # same-second tiebreaker, so a resident row written after ours is
+        # left alone even when both landed inside the same second.
         if self._unsaved_upserts:
             storage = getattr(self._client, "_NanoVectorDB__storage")
             present = {
@@ -572,9 +580,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
                         pdoc.record
                     ):
                         continue
-                    if resident.get("__created_at__", 0) > pdoc.record.get(
-                        "__created_at__", 0
-                    ):
+                    if self._resident_supersedes_redo(resident, pdoc.record):
                         superseded.append(doc_id)
                         continue
                 record = pdoc.record
@@ -674,18 +680,15 @@ class NanoVectorDBStorage(BaseVectorStorage):
             if self._pending_upserts.get(doc_id) is pdoc:
                 del self._pending_upserts[doc_id]
 
-        if self._unsaved_deletes:
-            # A row we just wrote can be indistinguishable from one we removed
-            # (same id, same bytes) — the single case the fingerprint cannot
-            # separate, and the one case where dropping the redo entry costs
-            # nothing: a resurrection would restore the row that is present
-            # now. Only rows written just above can match here; a resurrected
-            # one was already removed by the replay at the top of this flush.
-            storage = getattr(self._client, "_NanoVectorDB__storage")
-            for dp in storage["data"]:
-                logged = self._unsaved_deletes.get(dp["__id__"])
-                if logged is not None and logged == self._row_fingerprint(dp):
-                    del self._unsaved_deletes[dp["__id__"]]
+        # No reconciliation pass against `_unsaved_deletes` follows. A row we
+        # just wrote used to be able to fingerprint equal to one we removed
+        # (same id, same bytes, same whole second), which would have made the
+        # replay delete it — so the entry was dropped here. `__write_seq__`
+        # rules that out: every upsert stamps its own token, so a rewrite is a
+        # distinct row version and the entry names only the version it removed.
+        # Keeping it removes and hides nothing that exists, and it is still
+        # needed — a reload resurrecting the removed version is taken out again
+        # by the replay at the top of the next flush, rewrite preserved.
 
     def _save_to_disk_locked(self) -> None:
         """Atomically persist ``self._client`` and notify other processes.
@@ -738,7 +741,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
         )
         results = [
             {
-                **{k: v for k, v in dp.items() if k != "vector"},
+                **{k: v for k, v in dp.items() if k not in ("vector", WRITE_SEQ_FIELD)},
                 "id": dp["__id__"],
                 "distance": dp["__metrics__"],
                 "created_at": dp.get("__created_at__"),
@@ -1064,7 +1067,11 @@ class NanoVectorDBStorage(BaseVectorStorage):
     def _format_record(dp: dict[str, Any]) -> dict[str, Any]:
         """Shape a stored/pending record into the public read result."""
         return {
-            **{k: v for k, v in dp.items() if k not in ("vector", "__vector__")},
+            **{
+                k: v
+                for k, v in dp.items()
+                if k not in ("vector", "__vector__", WRITE_SEQ_FIELD)
+            },
             "id": dp.get("__id__"),
             "created_at": dp.get("__created_at__"),
         }
@@ -1087,15 +1094,14 @@ class NanoVectorDBStorage(BaseVectorStorage):
 
         The read paths must agree with what the next flush's replay will
         actually do, or read-your-writes reports a row the replay is about to
-        decline to restore. Both use the same rule: a resident row is only
-        preferred when it is **strictly** newer by ``__created_at__``. An
-        absent row, an equal timestamp (whole-second tie), or an older one all
-        leave the logged record as the answer, matching the replay's own
-        ordering guard in ``_flush_pending_locked``.
+        decline to restore, so both go through this one rule: a resident row is
+        preferred only when it was written **strictly** after the logged one —
+        by ``__created_at__``, then by the ``__write_seq__`` token that breaks
+        a whole-second tie (see ``write_seq``). An absent row, an older one, or
+        a tie no token can break (either side written before the token existed)
+        all leave the logged record as the answer.
         """
-        if resident is None:
-            return False
-        return resident.get("__created_at__", 0) > redo_record.get("__created_at__", 0)
+        return row_is_strictly_newer(resident, redo_record)
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         """Get vector data by its ID (read-your-writes against the pending buffer).

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -206,17 +206,27 @@ class NanoVectorDBStorage(BaseVectorStorage):
         the reload (saving a pre-commit snapshot over another writer's rows)
         and reloading (dropping its own unsaved changes). With both logs —
         ``_unsaved_deletes`` for removals, ``_unsaved_upserts`` for rows —
-        every retry path reloads first and replays on top, lossless in both
-        directions.
+        every retry path reloads first and replays on top. The reload is
+        unconditional: ``finalize`` runs it even when both logs are empty and
+        only the dirty flag is set, since a bare dirty flag still means the
+        in-memory state may be stale relative to disk. What a replay
+        deliberately does *not* restore is a row another writer has since
+        superseded with a strictly newer one.
 
         The upsert replay is scoped by the redo entry itself: an id whose
         stored row already fingerprints equal to the logged record has
-        nothing to redo, while any other row under that id — including one
-        another writer published meanwhile — is overwritten by ours, the
-        correct outcome for content-hash ids. A removal request evicts the
-        id's redo entry (``delete`` / ``delete_entity`` /
+        nothing to redo. Any *other* row under that id is ordered against
+        ours by ``__created_at__``: a strictly newer one is left alone and
+        our redo entry is dropped (another writer legitimately superseded us
+        — reverting it would undo a completed reprocess), while an older one
+        or a whole-second tie is overwritten by ours. A removal request
+        evicts the id's redo entry (``delete`` / ``delete_entity`` /
         ``delete_entity_relation``), or the replay would resurrect the row
         the removal just took out.
+
+        The read paths apply that same ordering rule rather than answering
+        from the log alone, so read-your-writes never reports a row the
+        replay is about to decline to restore.
 
         Ids that matched no row are not logged at all — there is nothing to
         persist for them, and replaying them could only hit a row they were
@@ -525,31 +535,72 @@ class NanoVectorDBStorage(BaseVectorStorage):
         # below and supersedes the logged row; one whose stored row already
         # fingerprints equal to the logged record (no reload happened, or an
         # earlier retry replayed it) has nothing to redo.
+        #
+        # A row that fingerprints *differently* is not automatically stale:
+        # under the pipeline's dead-process recovery, the process that
+        # materialized this redo entry can be declared dead, superseded by a
+        # new writer that reprocesses the same document and commits a
+        # genuinely newer row under the same (content-hash) id, and then
+        # turn out not to have been dead after all and reach this replay.
+        # Overwriting that newer row with our stale one would revert a
+        # completed reprocess. `__created_at__` is a same-clock, same-host
+        # int-seconds timestamp (both backends stamp it in `upsert`), so a
+        # resident row strictly newer than the logged one is left alone; a
+        # tie (same second) still replays, same as before this guard — see
+        # _row_fingerprint's docstring on why a whole-second timestamp
+        # cannot be used to detect two rows as *equal*, which is a different
+        # question from ordering two rows known to differ.
         if self._unsaved_upserts:
             storage = getattr(self._client, "_NanoVectorDB__storage")
             present = {
-                dp["__id__"]: self._row_fingerprint(dp)
+                dp["__id__"]: dp
                 for dp in storage["data"]
                 if dp["__id__"] in self._unsaved_upserts
             }
             replay_data = []
+            superseded: list[str] = []
             for doc_id, pdoc in self._unsaved_upserts.items():
                 if doc_id in self._pending_upserts:
                     continue
-                # Fingerprint BEFORE re-attaching __vector__: the digest
-                # covers every record key, and the stored row never carries
-                # __vector__ (client.upsert strips it into the matrix).
-                if present.get(doc_id) == self._row_fingerprint(pdoc.record):
-                    continue
+                resident = present.get(doc_id)
+                if resident is not None:
+                    # Fingerprint BEFORE re-attaching __vector__: the digest
+                    # covers every record key, and the stored row never
+                    # carries __vector__ (client.upsert strips it into the
+                    # matrix).
+                    if self._row_fingerprint(resident) == self._row_fingerprint(
+                        pdoc.record
+                    ):
+                        continue
+                    if resident.get("__created_at__", 0) > pdoc.record.get(
+                        "__created_at__", 0
+                    ):
+                        superseded.append(doc_id)
+                        continue
                 record = pdoc.record
                 record["__vector__"] = pdoc.vector
                 replay_data.append(record)
+            # Evicted after the loop, never inside it (mutating the dict
+            # under iteration raises). A superseded entry must leave the log
+            # rather than linger: it would be rescanned by every later flush
+            # and, worse, keep poisoning the read paths, which serve the
+            # logged record for any id still present here.
+            for doc_id in superseded:
+                del self._unsaved_upserts[doc_id]
             if replay_data:
                 self._client.upsert(datas=replay_data)
                 self._client_dirty = True
                 logger.info(
                     f"[{self.workspace}] {self.namespace} flush: replayed "
                     f"{len(replay_data)} unsaved upserts after a reload"
+                )
+            if superseded:
+                # No dirty flag: dropping a redo entry touches self._client
+                # not at all, so there is nothing new to persist.
+                logger.info(
+                    f"[{self.workspace}] {self.namespace} flush: {len(superseded)} "
+                    "unsaved upserts superseded by a strictly newer row "
+                    "committed under the same id, redo entries dropped"
                 )
 
         if not self._pending_upserts:
@@ -1028,6 +1079,24 @@ class NanoVectorDBStorage(BaseVectorStorage):
         """
         return fingerprint is not None and fingerprint == self._row_fingerprint(dp)
 
+    @staticmethod
+    def _resident_supersedes_redo(
+        resident: dict[str, Any] | None, redo_record: dict[str, Any]
+    ) -> bool:
+        """True when a materialized row wins over a pending upsert-redo entry.
+
+        The read paths must agree with what the next flush's replay will
+        actually do, or read-your-writes reports a row the replay is about to
+        decline to restore. Both use the same rule: a resident row is only
+        preferred when it is **strictly** newer by ``__created_at__``. An
+        absent row, an equal timestamp (whole-second tie), or an older one all
+        leave the logged record as the answer, matching the replay's own
+        ordering guard in ``_flush_pending_locked``.
+        """
+        if resident is None:
+            return False
+        return resident.get("__created_at__", 0) > redo_record.get("__created_at__", 0)
+
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         """Get vector data by its ID (read-your-writes against the pending buffer).
 
@@ -1046,19 +1115,26 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 return self._format_record(pending.record)
             if id in self._pending_deletes:
                 return None
+            # Applied-but-unsaved row. A reload may have dropped it from
+            # self._client, in which case the next flush replays it and it is
+            # the row this id resolves to — but another writer may also have
+            # committed a strictly newer row under the same (content-hash) id,
+            # which the replay deliberately preserves. So this cannot answer
+            # on its own: consult the client and let the same ordering rule
+            # the replay uses pick the winner.
             redo = self._unsaved_upserts.get(id)
-            if redo is not None:
-                # Applied-but-unsaved row: a reload may have dropped it from
-                # self._client, but the next flush replays it, so it is the
-                # row this id resolves to.
-                return self._format_record(redo.record)
             logged = self._unsaved_deletes.get(id)
 
         client = await self._get_client()
         result = client.get([id])
-        if not result or self._matches_redo_entry(result[0], logged):
+        resident = result[0] if result else None
+        if redo is not None:
+            if self._resident_supersedes_redo(resident, redo.record):
+                return self._format_record(resident)
+            return self._format_record(redo.record)
+        if resident is None or self._matches_redo_entry(resident, logged):
             return None
-        return self._format_record(result[0])
+        return self._format_record(resident)
 
     async def get_by_ids(self, ids: list[str]) -> list[dict[str, Any]]:
         """Get multiple vector data by their IDs (read-your-writes), preserving order.
@@ -1077,6 +1153,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
         result_map: dict[str, dict[str, Any]] = {}
         remaining: list[str] = []
         logged: dict[str, str] = {}
+        redo_docs: dict[str, _PendingNanoDoc] = {}
         async with self._storage_lock:
             for requested_id in ids:
                 pending = self._pending_upserts.get(requested_id)
@@ -1087,10 +1164,12 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 else:
                     redo = self._unsaved_upserts.get(requested_id)
                     if redo is not None:
-                        # Served from the redo log, never from the client: a
-                        # reload may have replaced the row with a stale
-                        # foreign one the replay will overwrite.
-                        result_map[str(requested_id)] = self._format_record(redo.record)
+                        # Still queried against the client: the replay only
+                        # restores the logged row when no strictly newer row
+                        # was committed under the id meanwhile, so the client
+                        # is needed to apply the same ordering rule below.
+                        redo_docs[requested_id] = redo
+                        remaining.append(requested_id)
                         continue
                     # A logged id still goes to the client: only the removed
                     # row version is hidden, not one written in its place.
@@ -1100,15 +1179,27 @@ class NanoVectorDBStorage(BaseVectorStorage):
 
         if remaining:
             client = await self._get_client()
+            resident_map: dict[str, dict[str, Any]] = {}
             for dp in client.get(remaining):
                 if not dp:
                     continue
-                if self._matches_redo_entry(dp, logged.get(dp.get("__id__"))):
+                doc_id = dp.get("__id__")
+                if doc_id is not None:
+                    resident_map[str(doc_id)] = dp
+                if doc_id in redo_docs:
+                    continue  # resolved against the redo entry below
+                if self._matches_redo_entry(dp, logged.get(doc_id)):
                     continue
                 record = self._format_record(dp)
                 key = record.get("id")
                 if key is not None:
                     result_map[str(key)] = record
+            for requested_id, redo in redo_docs.items():
+                resident = resident_map.get(str(requested_id))
+                if self._resident_supersedes_redo(resident, redo.record):
+                    result_map[str(requested_id)] = self._format_record(resident)
+                else:
+                    result_map[str(requested_id)] = self._format_record(redo.record)
 
         return [result_map.get(str(requested_id)) for requested_id in ids]
 
@@ -1132,6 +1223,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
         vectors_dict: dict[str, list[float]] = {}
         remaining: list[str] = []
         logged: dict[str, str] = {}
+        redo_docs: dict[str, _PendingNanoDoc] = {}
         async with self._storage_lock:
             to_embed: list[tuple[str, _PendingNanoDoc]] = []
             for requested_id in ids:
@@ -1141,13 +1233,14 @@ class NanoVectorDBStorage(BaseVectorStorage):
                         continue  # queued delete, no newer upsert -> absent
                     redo = self._unsaved_upserts.get(requested_id)
                     if redo is not None:
-                        # Served from the redo log, never from the client: a
-                        # reload may have replaced the row with a stale
-                        # foreign one the replay will overwrite. The cached
-                        # vector is always set once a doc reaches the log.
-                        vectors_dict[requested_id] = redo.vector.astype(
-                            np.float32
-                        ).tolist()
+                        # Still queried against the client: the replay only
+                        # restores the logged row when no strictly newer row
+                        # was committed under the id meanwhile, so the client
+                        # is needed to apply the same ordering rule below.
+                        # The cached vector is always set once a doc reaches
+                        # the log, so the redo branch can always answer.
+                        redo_docs[requested_id] = redo
+                        remaining.append(requested_id)
                         continue
                     # A logged id still goes to the client: only the removed
                     # row version is hidden, not one written in its place.
@@ -1186,10 +1279,16 @@ class NanoVectorDBStorage(BaseVectorStorage):
 
         if remaining:
             client = await self._get_client()
+            resident_map: dict[str, dict[str, Any]] = {}
             for result in client.get(remaining):
                 if not result:
                     continue
-                if self._matches_redo_entry(result, logged.get(result.get("__id__"))):
+                doc_id = result.get("__id__")
+                if doc_id is not None:
+                    resident_map[str(doc_id)] = result
+                if doc_id in redo_docs:
+                    continue  # resolved against the redo entry below
+                if self._matches_redo_entry(result, logged.get(doc_id)):
                     continue
                 if "vector" in result and "__id__" in result:
                     # Decompress vector data (Base64 + zlib + Float16 compressed)
@@ -1198,6 +1297,18 @@ class NanoVectorDBStorage(BaseVectorStorage):
                     vector_f16 = np.frombuffer(decompressed, dtype=np.float16)
                     vector_f32 = vector_f16.astype(np.float32).tolist()
                     vectors_dict[result["__id__"]] = vector_f32
+            for requested_id, redo in redo_docs.items():
+                resident = resident_map.get(str(requested_id))
+                if (
+                    self._resident_supersedes_redo(resident, redo.record)
+                    and "vector" in resident
+                ):
+                    decoded = base64.b64decode(resident["vector"])
+                    decompressed = zlib.decompress(decoded)
+                    vector_f16 = np.frombuffer(decompressed, dtype=np.float16)
+                    vectors_dict[requested_id] = vector_f16.astype(np.float32).tolist()
+                else:
+                    vectors_dict[requested_id] = redo.vector.astype(np.float32).tolist()
 
         return vectors_dict
 
@@ -1274,6 +1385,15 @@ class NanoVectorDBStorage(BaseVectorStorage):
           reload would write our pre-commit snapshot over another writer's
           durable rows (issue #3688).
 
+        ``_client_dirty`` can be ``True`` while all four buffers are empty —
+        e.g. a materialized-but-unsaved upsert whose id is then ``delete()``-d
+        (evicting its redo entry) inside a batch that itself aborts
+        (``drop_pending_index_ops`` discards the now-queued pending delete,
+        by design; see its docstring). Nothing here names that row for replay
+        any more, but that is exactly why the reload below must still run:
+        without it, this branch would save the stale in-memory snapshot
+        straight over whatever another writer committed in the meantime.
+
         Flush / save failures propagate (same contract as
         ``index_done_callback``); a partially flushed buffer is preserved for
         a future retry.
@@ -1292,14 +1412,24 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 or self._pending_deletes
                 or self._unsaved_deletes
                 or self._unsaved_upserts
+                or self._client_dirty
             ):
                 # Reload so a stale process picks up other writers' commits
                 # before the flush merges the pending buffer in and replays
                 # the redo logs on top. Unsaved materialized changes are no
                 # longer a reason to skip this: both logs replay after the
                 # reload, whereas skipping used to save our pre-commit
-                # snapshot over the other writer's durable rows.
-                self._reload_client_from_disk_locked(for_write=True)
+                # snapshot over the other writer's durable rows. This must
+                # fire even when all four buffers are empty (see the
+                # docstring note above) — a bare ``_client_dirty`` still
+                # means self._client may be stale relative to disk.
+                if self._reload_client_from_disk_locked(for_write=True):
+                    # The reload just replaced self._client with the fresh
+                    # on-disk snapshot, so any prior materialized change is
+                    # gone with it; nothing is dirty relative to this new
+                    # baseline until the flush below applies something on
+                    # top of it.
+                    self._client_dirty = False
                 await self._flush_pending_locked()
             if not self._client_dirty:
                 # The flush changed nothing (e.g. every queued delete targeted

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -1098,8 +1098,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
         preferred only when it was written **strictly** after the logged one —
         by ``__created_at__``, then by the ``__write_seq__`` token that breaks
         a whole-second tie (see ``write_seq``). An absent row, an older one, or
-        a tie no token can break (either side written before the token existed)
-        all leave the logged record as the answer.
+        a tie no token can break — either side written before the token
+        existed, or two processes stamping inside one clock tick, since the
+        bump that keeps tokens distinct is process-local — all leave the logged
+        record as the answer.
         """
         return row_is_strictly_newer(resident, redo_record)
 

--- a/lightrag/kg/write_seq.py
+++ b/lightrag/kg/write_seq.py
@@ -24,16 +24,32 @@ process handed out, so it is:
   for our own successive writes;
 * **comparable across processes** sharing a store — they share one host clock,
   the same assumption ``__created_at__`` already makes for the whole-second
-  comparison.
+  comparison. Comparable, not totally ordered: two processes reading one clock
+  tick stamp the same token (third limit below).
 
-Two limits are deliberately left in place and documented on the comparison
-helpers rather than papered over:
+Three limits are deliberately left in place rather than papered over; each
+resolves to the pre-token behavior (the tie replays), and the comparison
+helper repeats them where they bite:
 
 * it orders *stamp* time, not *commit* time — a writer that stamps late and
   commits early is still ordered by when it stamped, which is the intent
   order the supersede rule wants;
 * a row written before this field existed carries none, so a comparison
-  involving such a row falls back to the whole-second behavior.
+  involving such a row falls back to the whole-second behavior;
+* the bump is monotonic **within one process**, so two processes reading the
+  same clock tick get the *same* token and their tokens tie. That window is
+  one tick wide, not one second: on Linux ``time.time_ns()`` is
+  ``clock_gettime(CLOCK_REALTIME)`` at 1ns resolution, so the tie needs the
+  same nanosecond; where it is genuinely reachable is Windows before Python
+  3.13, whose ``time.time()`` reads ``GetSystemTimeAsFileTime`` (~15.6ms
+  granularity). Reaching it also takes two processes writing the *same id*
+  inside that tick, which the backends' *Single writer per workspace*
+  invariant excludes — and the sequential dead-process handoff the supersede
+  rule exists for puts the two stamps a detection interval apart, far wider
+  than a tick. Closing it for real would take a totally ordered generation
+  shared across processes (a counter in ``shared_storage``, one RPC per
+  upsert batch); folding the pid into the token would only hide the tie
+  behind an arbitrary winner, so neither is done here.
 """
 
 import threading
@@ -77,6 +93,12 @@ def row_is_strictly_newer(candidate: dict | None, reference: dict, /) -> bool:
     token a same-second pair therefore stays a tie, which resolves to False —
     the pre-token behavior (the replay proceeds, the read paths serve the
     logged record).
+
+    Equal tokens resolve to False for the same reason, and are not only a
+    same-write artifact: the bump that keeps tokens distinct is process-local,
+    so two processes reading one clock tick stamp the same token (see the
+    module docstring for how narrow and invariant-violating that is). Ordering
+    them would take a generation shared across processes.
     """
     if candidate is None:
         return False

--- a/lightrag/kg/write_seq.py
+++ b/lightrag/kg/write_seq.py
@@ -1,0 +1,91 @@
+"""Per-write ordering token for the file-backed vector stores.
+
+``NanoVectorDBStorage`` and ``FaissVectorDBStorage`` keep a redo log of
+materialized-but-unsaved upserts (issue #3688). After a reload the flush has to
+decide, for every logged row, whether the row a *foreign* writer committed
+under the same (content-hash) id meanwhile is newer than the logged one: a
+strictly newer row must be left alone (it is a completed reprocess), an older
+one must be overwritten by the replay.
+
+``__created_at__`` alone cannot answer that. ``upsert`` stamps
+``int(time.time())``, so two writes inside the same second carry the *same*
+timestamp — a normal, reachable outcome rather than an anomaly — and a tie used
+to fall through to "replay", which let a stale redo record overwrite a
+genuinely newer durable row.
+
+``__write_seq__`` is the tiebreaker. It is stamped into the record at
+``upsert`` time next to ``__created_at__``, persisted with the record, and
+therefore survives the save/reload round-trip the redo log depends on. Its
+value is a nanosecond wall-clock reading bumped past the last value this
+process handed out, so it is:
+
+* **strictly increasing per process** — a coarse clock (Windows' ~15ms
+  granularity) or a backwards NTP step still yields distinct, ordered tokens
+  for our own successive writes;
+* **comparable across processes** sharing a store — they share one host clock,
+  the same assumption ``__created_at__`` already makes for the whole-second
+  comparison.
+
+Two limits are deliberately left in place and documented on the comparison
+helpers rather than papered over:
+
+* it orders *stamp* time, not *commit* time — a writer that stamps late and
+  commits early is still ordered by when it stamped, which is the intent
+  order the supersede rule wants;
+* a row written before this field existed carries none, so a comparison
+  involving such a row falls back to the whole-second behavior.
+"""
+
+import threading
+import time
+
+# Record key the token is stored under. Dunder-prefixed like ``__id__`` /
+# ``__created_at__`` so it cannot collide with a ``meta_fields`` name, and
+# stripped from the public read results (``_format_record`` / ``query``) —
+# it is storage bookkeeping, not payload.
+WRITE_SEQ_FIELD = "__write_seq__"
+
+_seq_lock = threading.Lock()
+_last_seq = 0
+
+
+def next_write_seq() -> int:
+    """Return a strictly increasing per-write ordering token.
+
+    Callers stamp one token per ``upsert`` call (every row in that batch
+    shares it): the token orders *writes*, and the redo-log comparison only
+    ever puts rows from two different writes side by side.
+    """
+    global _last_seq
+    with _seq_lock:
+        seq = max(time.time_ns(), _last_seq + 1)
+        _last_seq = seq
+        return seq
+
+
+def row_is_strictly_newer(candidate: dict | None, reference: dict, /) -> bool:
+    """True when ``candidate`` was written strictly after ``reference``.
+
+    Both are stored/logged records. Ordering is ``__created_at__`` first
+    (whole seconds, present on every row ever written by these backends) and
+    ``__write_seq__`` only as the same-second tiebreaker, so a row that
+    predates the token still orders correctly against a newer second.
+
+    A missing token is *not* treated as "older": a legacy row carries none, and
+    reading its absence as ``0`` would declare it older than any freshly
+    stamped row and let the replay overwrite it. When either side lacks the
+    token a same-second pair therefore stays a tie, which resolves to False —
+    the pre-token behavior (the replay proceeds, the read paths serve the
+    logged record).
+    """
+    if candidate is None:
+        return False
+    candidate_at = candidate.get("__created_at__", 0)
+    reference_at = reference.get("__created_at__", 0)
+    if candidate_at != reference_at:
+        return candidate_at > reference_at
+    candidate_seq = candidate.get(WRITE_SEQ_FIELD)
+    reference_seq = reference.get(WRITE_SEQ_FIELD)
+    if candidate_seq is None or reference_seq is None:
+        return False
+    return candidate_seq > reference_seq

--- a/lightrag/kg/write_seq.py
+++ b/lightrag/kg/write_seq.py
@@ -13,11 +13,13 @@ timestamp — a normal, reachable outcome rather than an anomaly — and a tie u
 to fall through to "replay", which let a stale redo record overwrite a
 genuinely newer durable row.
 
-``__write_seq__`` is the tiebreaker. It is stamped into the record at
-``upsert`` time next to ``__created_at__``, persisted with the record, and
-therefore survives the save/reload round-trip the redo log depends on. Its
-value is a nanosecond wall-clock reading bumped past the last value this
-process handed out, so it is:
+``__write_seq__`` carries the ordering instead. It is stamped into the record
+at ``upsert`` time next to ``__created_at__``, persisted with the record, and
+therefore survives the save/reload round-trip the redo log depends on. Two rows
+that both carry it are ordered by it alone; ``__created_at__`` decides only
+when one of them predates the token (see ``row_is_strictly_newer``). Its value
+is a nanosecond wall-clock reading bumped past the last value this process
+handed out, so it is:
 
 * **strictly increasing per process** — a coarse clock (Windows' ~15ms
   granularity) or a backwards NTP step still yields distinct, ordered tokens
@@ -25,7 +27,7 @@ process handed out, so it is:
 * **comparable across processes** sharing a store — they share one host clock,
   the same assumption ``__created_at__`` already makes for the whole-second
   comparison. Comparable, not totally ordered: two processes reading one clock
-  tick stamp the same token (third limit below).
+  tick stamp the same token (last limit below).
 
 Three limits are deliberately left in place rather than papered over; each
 resolves to the pre-token behavior (the tie replays), and the comparison
@@ -35,21 +37,26 @@ helper repeats them where they bite:
   commits early is still ordered by when it stamped, which is the intent
   order the supersede rule wants;
 * a row written before this field existed carries none, so a comparison
-  involving such a row falls back to the whole-second behavior;
-* the bump is monotonic **within one process**, so two processes reading the
-  same clock tick get the *same* token and their tokens tie. That window is
-  one tick wide, not one second: on Linux ``time.time_ns()`` is
-  ``clock_gettime(CLOCK_REALTIME)`` at 1ns resolution, so the tie needs the
-  same nanosecond; where it is genuinely reachable is Windows before Python
-  3.13, whose ``time.time()`` reads ``GetSystemTimeAsFileTime`` (~15.6ms
-  granularity). Reaching it also takes two processes writing the *same id*
-  inside that tick, which the backends' *Single writer per workspace*
-  invariant excludes — and the sequential dead-process handoff the supersede
-  rule exists for puts the two stamps a detection interval apart, far wider
-  than a tick. Closing it for real would take a totally ordered generation
-  shared across processes (a counter in ``shared_storage``, one RPC per
-  upsert batch); folding the pid into the token would only hide the tie
-  behind an arbitrary winner, so neither is done here.
+  involving such a row falls back to whole seconds, which a backward clock
+  step can misorder — the fallback can only be as good as the field it has;
+* the bump is monotonic **within one process**, which leaves two cross-process
+  gaps. Two processes reading the same clock tick get the *same* token, so
+  their tokens tie: that window is one tick wide, not one second — on Linux
+  ``time.time_ns()`` is ``clock_gettime(CLOCK_REALTIME)`` at 1ns resolution,
+  so the tie needs the same nanosecond, and where it is genuinely reachable
+  is Windows before Python 3.13, whose ``time.time()`` reads
+  ``GetSystemTimeAsFileTime`` (~15.6ms granularity). And because the bump is
+  a high-water mark, a process that once read a far-future clock keeps
+  stamping above the corrected clock, so its rows look newer than another
+  process's until the gap closes. Reaching either also takes two processes
+  writing the *same id* in that window, which the backends' *Single writer
+  per workspace* invariant excludes — and the sequential dead-process handoff
+  the supersede rule exists for puts the two stamps a detection interval
+  apart, far wider than a tick. Closing them for real would take a totally
+  ordered generation shared across processes (a counter in
+  ``shared_storage``, one RPC per upsert batch); folding the pid into the
+  token would only hide a tie behind an arbitrary winner, so neither is done
+  here.
 """
 
 import threading
@@ -82,17 +89,23 @@ def next_write_seq() -> int:
 def row_is_strictly_newer(candidate: dict | None, reference: dict, /) -> bool:
     """True when ``candidate`` was written strictly after ``reference``.
 
-    Both are stored/logged records. Ordering is ``__created_at__`` first
-    (whole seconds, present on every row ever written by these backends) and
-    ``__write_seq__`` only as the same-second tiebreaker, so a row that
-    predates the token still orders correctly against a newer second.
+    Both are stored/logged records. When **both** carry ``__write_seq__`` the
+    token decides on its own; ``__created_at__`` is consulted only when one of
+    them predates the token. That precedence is deliberate: the token is the
+    field built to order writes, and subordinating it to whole seconds would
+    throw away exactly the guarantee ``next_write_seq`` provides — a clock
+    stepped backward across a second boundary makes the *later* write carry the
+    *smaller* ``__created_at__``, and comparing seconds first would declare it
+    older without ever reading the token that says otherwise. With a sane clock
+    the two fields agree, so the precedence only shows up under a clock anomaly,
+    which is the case the token exists for.
 
     A missing token is *not* treated as "older": a legacy row carries none, and
     reading its absence as ``0`` would declare it older than any freshly
-    stamped row and let the replay overwrite it. When either side lacks the
-    token a same-second pair therefore stays a tie, which resolves to False —
-    the pre-token behavior (the replay proceeds, the read paths serve the
-    logged record).
+    stamped row and let the replay overwrite it. Such a pair falls back to
+    whole seconds — so a legacy row from a newer second still wins — and an
+    equal second is a tie, which resolves to False: the pre-token behavior (the
+    replay proceeds, the read paths serve the logged record).
 
     Equal tokens resolve to False for the same reason, and are not only a
     same-write artifact: the bump that keeps tokens distinct is process-local,
@@ -102,12 +115,8 @@ def row_is_strictly_newer(candidate: dict | None, reference: dict, /) -> bool:
     """
     if candidate is None:
         return False
-    candidate_at = candidate.get("__created_at__", 0)
-    reference_at = reference.get("__created_at__", 0)
-    if candidate_at != reference_at:
-        return candidate_at > reference_at
     candidate_seq = candidate.get(WRITE_SEQ_FIELD)
     reference_seq = reference.get(WRITE_SEQ_FIELD)
-    if candidate_seq is None or reference_seq is None:
-        return False
-    return candidate_seq > reference_seq
+    if candidate_seq is not None and reference_seq is not None:
+        return candidate_seq > reference_seq
+    return candidate.get("__created_at__", 0) > reference.get("__created_at__", 0)

--- a/tests/kg/faiss_impl/test_faiss_deferred_delete.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_delete.py
@@ -460,11 +460,15 @@ async def test_eager_entity_relation_removal_survives_reload(tmp_path, monkeypat
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_identical_reupsert_drops_the_redo_entry(tmp_path, monkeypatch):
-    """Materializing a row indistinguishable from the one a redo entry
-    removed (same id, same fingerprint) drops the entry — the one case the
-    fingerprint cannot separate, and the one case where dropping costs
-    nothing, since a resurrection would restore the row that is present."""
+async def test_identical_reupsert_survives_the_delete_replay(tmp_path, monkeypatch):
+    """A re-upsert with the same content in the same whole second as the row a
+    redo entry removed used to be indistinguishable from it, so materializing
+    it had to drop the entry or the next replay would delete the fresh row.
+    ``__write_seq__`` separates the two versions: the entry may stay, it names
+    only the version it removed, and the re-upsert survives a replay.
+
+    The clock is frozen so ``__created_at__`` cannot be what separates them.
+    """
     import lightrag.kg.faiss_impl as faiss_impl_module
 
     monkeypatch.setattr(faiss_impl_module.time, "time", lambda: 1_700_000_000.0)
@@ -480,16 +484,25 @@ async def test_identical_reupsert_drops_the_redo_entry(tmp_path, monkeypatch):
         await storage.index_done_callback()
     assert "row" in storage._unsaved_deletes
 
-    # Re-upsert the byte-identical row (same frozen timestamp): the next
-    # flush materializes it and must drop the now-pointless redo entry.
+    # Re-upsert the same content (same frozen timestamp): a distinct row
+    # version, so the entry keeps naming the removed one and hides nothing.
     await storage.upsert({"row": {"content": "same"}})
     with pytest.raises(OSError, match="transient disk error"):
         await storage.index_done_callback()
-    assert "row" not in storage._unsaved_deletes, (
-        "a materialized identical row must drop the redo entry"
+    assert "row" in storage._unsaved_deletes, (
+        "the entry names the removed version, which the re-upsert is not"
     )
     record = await storage.get_by_id("row")
     assert record is not None and record["content"] == "same"
+
+    # The reload resurrects the removed version: the delete replay must take
+    # it out again and the upsert replay must keep the re-upserted row.
+    storage.storage_updated.value = True
+    monkeypatch.undo()  # also unfreezes the clock; the replay stamps nothing
+    assert await storage.index_done_callback() is True
+    record = await storage.get_by_id("row")
+    assert record is not None and record["content"] == "same"
+    assert len(storage._id_to_meta) == 1, "exactly one row per id"
 
 
 @pytest.mark.offline

--- a/tests/kg/faiss_impl/test_faiss_deferred_delete.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_delete.py
@@ -529,6 +529,60 @@ async def test_finalize_skips_save_when_flush_changes_nothing(tmp_path):
 
 @pytest.mark.offline
 @pytest.mark.asyncio
+async def test_reads_show_the_duplicate_a_delete_replay_preserves(
+    tmp_path, monkeypatch
+):
+    """Fix-proof (PR #3709 review): the read paths resolved an id through the
+    first matching fid, so when a corrupt store holds several rows under one id
+    and the redo entry names only some of them, a matching first duplicate hid
+    the whole id — including the row the replay deliberately preserves."""
+    embed = _CountingEmbed()
+    storage = await _make_storage(tmp_path, embed)
+    await _upsert_and_flush(storage, {"dup": {"content": "removed"}})
+    removed_row = dict(storage._id_to_meta[0])
+
+    # The delete lands on the index and the save fails: the entry names this
+    # one version.
+    await storage.delete(["dup"])
+    _fail_save(storage, monkeypatch)
+    with pytest.raises(OSError, match="transient disk error"):
+        await storage.index_done_callback()
+    assert storage._unsaved_deletes["dup"] == {storage._row_fingerprint(removed_row)}
+    monkeypatch.undo()
+
+    # A reload from a corrupt snapshot: the removed version comes back at the
+    # FIRST fid, beside a newer row the entry does not name.
+    matrix = np.zeros((2, DIM), dtype=np.float32)
+    matrix[0][0] = 1.0
+    matrix[1][1] = 1.0
+    storage._index.add(matrix)
+    storage._id_to_meta[0] = {**removed_row, "__vector__": matrix[0].tolist()}
+    storage._id_to_meta[1] = {
+        "__id__": "dup",
+        "__created_at__": removed_row["__created_at__"] + 5,
+        "content": "survivor",
+        "__vector__": matrix[1].tolist(),
+    }
+
+    got = await storage.get_by_id("dup")
+    assert got is not None and got["content"] == "survivor", (
+        "the entry hides only the version it removed; a row it does not name "
+        "took the id's place and the replay preserves it"
+    )
+    assert (await storage.get_by_ids(["dup"]))[0]["content"] == "survivor"
+    vectors = await storage.get_vectors_by_ids(["dup"])
+    assert vectors["dup"][1] == pytest.approx(1.0), (
+        "the vector must come from the surviving row, not the removed one"
+    )
+
+    # And the flush does exactly what the reads reported.
+    assert await storage.index_done_callback() is True
+    assert storage._find_faiss_ids_by_custom_id("dup") == [0], "one row survives"
+    assert (await storage.get_by_id("dup"))["content"] == "survivor"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
 async def test_replay_removes_every_duplicate_row_under_one_id(tmp_path, monkeypatch):
     """``delete`` is find-all: it removes every row carrying the id, which a
     legacy / corrupt store can have several of (``_find_faiss_ids_by_custom_id``

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -28,6 +28,7 @@ import pytest
 faiss = pytest.importorskip("faiss")
 
 from lightrag.kg.faiss_impl import FaissVectorDBStorage  # noqa: E402
+from lightrag.kg.write_seq import WRITE_SEQ_FIELD  # noqa: E402
 from lightrag.kg.shared_storage import (  # noqa: E402
     initialize_share_data,
     finalize_share_data,
@@ -1207,16 +1208,24 @@ async def test_reads_serve_an_unsaved_upsert_after_a_foreign_reload(tmp_path):
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_replay_overwrites_a_foreign_row_under_the_same_id(tmp_path):
-    """Ids are content hashes, so a same-id foreign row is a rewrite of the
-    same logical record; our applied-but-unsaved write is the newer intent
-    and the replay puts it back on top (drop-their-fid + add ours in one
-    rebuild)."""
+async def test_replay_overwrites_an_older_foreign_row_under_the_same_id(tmp_path):
+    """Ids are content hashes, so a same-id stored row is an older version of
+    the same logical record; our applied-but-unsaved write is the newer intent
+    and the replay puts it back on top of the reloaded snapshot (drop-their-fid
+    + add ours in one rebuild).
+
+    The foreign row is committed *before* our write on purpose: written after
+    it, it would be the newer version and the replay would rightly decline
+    (see ``test_same_second_tie_is_broken_by_the_write_sequence``).
+    """
     embed = _CountingEmbed()
     writer = _make_storage(tmp_path, embed)
     other = _make_storage(tmp_path, _CountingEmbed())
     await writer.initialize()
     await other.initialize()
+
+    await other.upsert({"idX": {"content": "theirs"}})
+    assert await other.index_done_callback() is True
 
     await writer.upsert({"idX": {"content": "ours"}})
     restore = _make_save_fail(writer)
@@ -1224,7 +1233,9 @@ async def test_replay_overwrites_a_foreign_row_under_the_same_id(tmp_path):
         await writer.index_done_callback()
     restore()
 
-    await other.upsert({"idX": {"content": "theirs"}})
+    # A foreign commit forces the reload that drops our materialized row and
+    # brings the older idX back; the replay has to put ours on top again.
+    await other.upsert({"idZ": {"content": "unrelated"}})
     assert await other.index_done_callback() is True
 
     assert await writer.index_done_callback() is True
@@ -1233,6 +1244,7 @@ async def test_replay_overwrites_a_foreign_row_under_the_same_id(tmp_path):
     reader = _make_storage(tmp_path, _CountingEmbed())
     await reader.initialize()
     assert (await reader.get_by_id("idX"))["content"] == "ours"
+    assert (await reader.get_by_id("idZ"))["content"] == "unrelated"
     _assert_consistent(reader)
 
 
@@ -1532,12 +1544,81 @@ async def test_reads_prefer_a_strictly_newer_foreign_row(tmp_path):
     assert embed.call_count == 1, "reads must not re-embed to answer this"
 
 
+def _strip_write_seq_on_disk(storage) -> None:
+    """Rewrite the persisted meta rows as a pre-``__write_seq__`` store would.
+
+    The token is stamped by ``upsert``, so a store written by an older version
+    carries none. Removing it from the committed snapshot is the only way to
+    reach the documented fallback: a same-second pair the token cannot order.
+    """
+    with open(storage._meta_file, encoding="utf-8") as f:
+        snapshot = json.load(f)
+    stripped = [record.pop(WRITE_SEQ_FIELD, None) for record in snapshot.values()]
+    assert any(token is not None for token in stripped), (
+        "the token must reach the committed snapshot, or the replay's ordering "
+        "guard loses its tiebreaker across a reload"
+    )
+    with open(storage._meta_file, "w", encoding="utf-8") as f:
+        json.dump(snapshot, f)
+
+
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_same_second_tie_still_replays(tmp_path):
-    """Stability: the ordering guard is strict (``>``), so a foreign row
-    stamped in the same whole second as the logged one is still overwritten
-    by the replay — the pre-existing issue-#3688 behavior."""
+async def test_same_second_tie_is_broken_by_the_write_sequence(tmp_path):
+    """Fix-proof (PR #3709 review): ordering was whole seconds only, and
+    ``upsert`` stamps ``int(time.time())`` — so a superseding writer that
+    committed inside the same second as the logged row tied, the strict ``>``
+    fell through to "replay", and the stale redo record overwrote a durable
+    newer row. ``__write_seq__`` orders the two writes inside that second."""
+    writer = _make_storage(tmp_path, _CountingEmbed())
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    frozen = int(time.time())
+    with _frozen_clock(frozen):
+        await writer.upsert({"idX": {"content": "ours-stale"}})
+        restore = _make_save_fail(writer)
+        with pytest.raises(OSError):
+            await writer.index_done_callback()
+        restore()
+
+        # Same whole second, but written after ours: a higher write sequence.
+        await other.upsert({"idX": {"content": "theirs-newer"}})
+    assert await other.index_done_callback() is True
+
+    logged = writer._unsaved_upserts["idX"].record
+    resident = next(
+        meta for meta in other._id_to_meta.values() if meta["__id__"] == "idX"
+    )
+    assert logged["__created_at__"] == resident["__created_at__"], (
+        "the scenario under test is a same-second pair"
+    )
+    assert resident[WRITE_SEQ_FIELD] > logged[WRITE_SEQ_FIELD]
+
+    # Reads must agree with the decision the flush is about to make.
+    assert (await writer.get_by_id("idX"))["content"] == "theirs-newer"
+
+    assert await writer.index_done_callback() is True
+    assert "idX" not in writer._unsaved_upserts, (
+        "a superseded redo entry must be dropped"
+    )
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("idX"))["content"] == "theirs-newer", (
+        "the replay reverted a row committed later in the same second"
+    )
+    _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_same_second_tie_without_a_write_sequence_still_replays(tmp_path):
+    """Stability: a row written before ``__write_seq__`` existed carries none,
+    and a missing token must not read as "older" (that would let the replay
+    overwrite any legacy row). Such a same-second pair stays a tie and keeps
+    the pre-token behavior — the replay proceeds."""
     writer = _make_storage(tmp_path, _CountingEmbed())
     other = _make_storage(tmp_path, _CountingEmbed())
     await writer.initialize()
@@ -1552,7 +1633,8 @@ async def test_same_second_tie_still_replays(tmp_path):
         restore()
 
         await other.upsert({"idX": {"content": "theirs"}})
-    assert await other.index_done_callback() is True
+        assert await other.index_done_callback() is True
+        _strip_write_seq_on_disk(other)
 
     assert await writer.index_done_callback() is True
 

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -1614,6 +1614,76 @@ async def test_same_second_tie_is_broken_by_the_write_sequence(tmp_path):
 
 @pytest.mark.offline
 @pytest.mark.asyncio
+async def test_reads_compare_every_duplicate_row_before_serving_a_redo_entry(tmp_path):
+    """Fix-proof (PR #3709 review): the read paths resolved an id through the
+    first matching fid, while the replay checks every fid and declines when
+    *any* resident row is newer. In a legacy / corrupt store holding several
+    rows under one id, an older first duplicate made the reads serve the redo
+    record the next flush is about to refuse to restore."""
+    storage = _make_storage(tmp_path, _CountingEmbed())
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await storage.initialize()
+    await other.initialize()
+
+    # Hand-craft the corrupt state: two fids share "dup", the FIRST one older
+    # than the row we are about to log, the second newer. Distinct one-hot
+    # vectors — constant vectors would normalize to the same unit vector.
+    matrix = np.zeros((2, DIM), dtype=np.float32)
+    matrix[0][0] = 1.0
+    matrix[1][1] = 1.0
+    storage._index.add(matrix)
+    storage._id_to_meta[0] = {
+        "__id__": "dup",
+        "__created_at__": 1,
+        "content": "v1-older",
+        "__vector__": matrix[0].tolist(),
+    }
+    storage._id_to_meta[1] = {
+        "__id__": "dup",
+        "__created_at__": 3,
+        "content": "v2-newer",
+        "__vector__": matrix[1].tolist(),
+    }
+    assert await storage.index_done_callback() is True
+
+    # Our write lands between the two, and its save fails -> redo entry.
+    with _frozen_clock(2):
+        await storage.upsert({"dup": {"content": "ours-stale"}})
+    restore = _make_save_fail(storage)
+    with pytest.raises(OSError):
+        await storage.index_done_callback()
+    restore()
+    assert "dup" in storage._unsaved_upserts
+
+    # A foreign commit forces the reload that brings both duplicates back.
+    await other.upsert({"unrelated": {"content": "other"}})
+    assert await other.index_done_callback() is True
+
+    got = await storage.get_by_id("dup")
+    fids = storage._find_faiss_ids_by_custom_id("dup")
+    assert len(fids) == 2, "the scenario under test is a duplicated id"
+    assert storage._id_to_meta[fids[0]]["__created_at__"] == 1, (
+        "the first matching fid must be the older row, or the old first-match "
+        "lookup would have agreed with the replay by accident"
+    )
+    assert got["content"] == "v2-newer", (
+        "a newer duplicate blocks the replay, so the reads must not serve the "
+        "redo record"
+    )
+    assert (await storage.get_by_ids(["dup"]))[0]["content"] == "v2-newer"
+    vectors = await storage.get_vectors_by_ids(["dup"])
+    assert vectors["dup"][1] == pytest.approx(1.0), (
+        "the vector must come from the resident row that blocks the replay"
+    )
+
+    # And the flush does exactly what the reads reported.
+    assert await storage.index_done_callback() is True
+    assert "dup" not in storage._unsaved_upserts
+    assert (await storage.get_by_id("dup"))["content"] == "v2-newer"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
 async def test_same_second_tie_without_a_write_sequence_still_replays(tmp_path):
     """Stability: a row written before ``__write_seq__`` existed carries none,
     and a missing token must not read as "older" (that would let the replay

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -1052,3 +1052,295 @@ async def test_rebuild_failure_leaves_index_and_meta_untouched(tmp_path, monkeyp
             f"row{i} must survive a failed rebuild"
         )
     _assert_consistent(reloaded)
+
+
+# ---------------------------------------------------------------------------
+# Upsert redo log: materialized-but-unsaved rows survive a foreign-commit
+# reload (issue #3688). Twin of the Nano coverage in
+# tests/kg/nano_impl/test_nano_deferred_embedding.py.
+# ---------------------------------------------------------------------------
+
+
+def _make_save_fail(storage):
+    """Make ``_save_faiss_index`` raise; returns a restore callable."""
+    original = storage._save_faiss_index
+
+    def boom():
+        raise OSError("disk full")
+
+    storage._save_faiss_index = boom
+
+    def restore():
+        storage._save_faiss_index = original
+
+    return restore
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_index_done_replays_unsaved_upsert_after_foreign_commit(tmp_path):
+    """Fix-proof for issue #3688 (the retry-via-callback half).
+
+    Chain: flush materializes id2 and its save fails -> another writer
+    commits id3 -> the retry's reload rebuilds the in-memory state from the
+    foreign snapshot. Without the redo log nothing replays id2 and the
+    following save silently loses it; with the log both rows land — and the
+    replay reuses the cached vector, so the retry embeds nothing.
+    """
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"id2": {"content": "beta"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError, match="disk full"):
+        await writer.index_done_callback()
+    restore()
+    assert writer._pending_upserts == {}, "flush succeeded so pending is empty"
+    assert writer._unsaved_upserts, "the flushed doc moved into the redo log"
+    calls_after_failure = embed.call_count
+
+    # Another writer commits, flagging `writer` as stale.
+    await other.upsert({"id3": {"content": "gamma"}})
+    assert await other.index_done_callback() is True
+    assert writer.storage_updated.value is True
+
+    assert await writer.index_done_callback() is True
+    assert embed.call_count == calls_after_failure, "replay must not re-embed"
+    assert not writer._unsaved_upserts, "durable save clears the redo log"
+    _assert_consistent(writer)
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("id2"))["content"] == "beta", (
+        "the reload dropped the materialized-but-unsaved row and nothing "
+        "replayed it (issue #3688)"
+    )
+    assert (await reader.get_by_id("id3"))["content"] == "gamma"
+    _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_finalize_replays_unsaved_upserts_after_a_foreign_commit(tmp_path):
+    """Fix-proof for the mirror half: finalize used to skip the reload while
+    ``_unsaved_upserts`` was set, and its save wrote our pre-commit snapshot
+    over the other writer's durable rows. With the redo log it reloads and
+    replays, so both sides survive."""
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"id2": {"content": "beta"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+    assert writer._unsaved_upserts, "the flushed doc moved into the redo log"
+
+    await other.upsert({"id3": {"content": "gamma"}})
+    assert await other.index_done_callback() is True
+
+    await writer.finalize()
+    _assert_consistent(writer)
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("id2"))["content"] == "beta", (
+        "the redo log must replay our row on top of the reloaded snapshot"
+    )
+    assert (await reader.get_by_id("id3"))["content"] == "gamma", (
+        "the other writer's commit must survive finalize"
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_reads_serve_an_unsaved_upsert_after_a_foreign_reload(tmp_path):
+    """Read-your-writes across the failed-save window: a foreign commit makes
+    the next ``_get_index`` reload drop the unsaved row, so the read paths
+    must serve it from the redo log until the replay."""
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"id2": {"content": "beta"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+
+    await other.upsert({"id3": {"content": "gamma"}})
+    assert await other.index_done_callback() is True
+
+    # Each read triggers the reload-if-stale path internally.
+    got = await writer.get_by_id("id2")
+    assert got is not None and got["content"] == "beta"
+    by_ids = await writer.get_by_ids(["id2", "id3"])
+    assert by_ids[0] is not None and by_ids[0]["content"] == "beta"
+    assert by_ids[1] is not None and by_ids[1]["content"] == "gamma"
+    vectors = await writer.get_vectors_by_ids(["id2"])
+    assert "id2" in vectors and len(vectors["id2"]) == DIM
+    assert embed.call_count == 1, "the logged vector is reused, never re-embedded"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_replay_overwrites_a_foreign_row_under_the_same_id(tmp_path):
+    """Ids are content hashes, so a same-id foreign row is a rewrite of the
+    same logical record; our applied-but-unsaved write is the newer intent
+    and the replay puts it back on top (drop-their-fid + add ours in one
+    rebuild)."""
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"idX": {"content": "ours"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+
+    await other.upsert({"idX": {"content": "theirs"}})
+    assert await other.index_done_callback() is True
+
+    assert await writer.index_done_callback() is True
+    _assert_consistent(writer)
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("idX"))["content"] == "ours"
+    _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_after_a_failed_save_evicts_the_redo_entry(tmp_path):
+    """A ``delete`` for an id whose row is applied-but-unsaved must win: the
+    redo entry is evicted, or the replay would resurrect the row the delete
+    just took out."""
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"id1": {"content": "alpha"}, "id2": {"content": "beta"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+    assert "id2" in writer._unsaved_upserts
+
+    await writer.delete(["id2"])
+    assert "id2" not in writer._unsaved_upserts, "delete evicts the redo entry"
+
+    # Force the reload path before the retry.
+    await other.upsert({"id3": {"content": "gamma"}})
+    assert await other.index_done_callback() is True
+
+    assert await writer.index_done_callback() is True
+    _assert_consistent(writer)
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert await reader.get_by_id("id2") is None, "replay must not resurrect id2"
+    assert (await reader.get_by_id("id1"))["content"] == "alpha"
+    assert (await reader.get_by_id("id3"))["content"] == "gamma"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_entity_relation_evicts_matching_redo_upserts(tmp_path):
+    """Same rule for the relation sweep: the src/tgt predicate prunes the redo
+    log unconditionally, because after a foreign reload the unsaved relation
+    rows are invisible to the materialized scan."""
+
+    def make(tmp, embed):
+        return FaissVectorDBStorage(
+            namespace="test_relations",
+            workspace="ws",
+            global_config={
+                "working_dir": str(tmp),
+                "embedding_batch_num": 32,
+                "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+            },
+            embedding_func=EmbeddingFunc(
+                embedding_dim=DIM, max_token_size=512, func=embed
+            ),
+            meta_fields={"content", "src_id", "tgt_id"},
+        )
+
+    writer = make(tmp_path, _CountingEmbed())
+    other = make(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert(
+        {
+            "r1": {"content": "rel1", "src_id": "A", "tgt_id": "B"},
+            "r2": {"content": "rel2", "src_id": "X", "tgt_id": "Y"},
+        }
+    )
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+    assert "r1" in writer._unsaved_upserts and "r2" in writer._unsaved_upserts
+
+    await other.upsert({"id3": {"content": "gamma"}})
+    assert await other.index_done_callback() is True
+
+    await writer.delete_entity_relation("A")
+    assert "r1" not in writer._unsaved_upserts, "incident redo entry evicted"
+    assert "r2" in writer._unsaved_upserts, "unrelated redo entry preserved"
+
+    assert await writer.index_done_callback() is True
+    _assert_consistent(writer)
+
+    reader = make(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert await reader.get_by_id("r1") is None
+    assert (await reader.get_by_id("r2"))["content"] == "rel2"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_aborting_batch_keeps_the_upsert_redo_log(tmp_path):
+    """``drop_pending_index_ops`` discards buffered work, not the redo log:
+    the logged rows already reached ``self._index`` (the class the abort
+    path intentionally does not roll back), so they must still survive a
+    foreign-commit reload."""
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"id1": {"content": "alpha"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+
+    await writer.drop_pending_index_ops()
+    assert writer._unsaved_upserts, "abort keeps the redo log"
+
+    await other.upsert({"id2": {"content": "beta"}})
+    assert await other.index_done_callback() is True
+
+    assert await writer.index_done_callback() is True
+    _assert_consistent(writer)
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("id1"))["content"] == "alpha"
+    assert (await reader.get_by_id("id2"))["content"] == "beta"

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -1344,3 +1344,42 @@ async def test_aborting_batch_keeps_the_upsert_redo_log(tmp_path):
     await reader.initialize()
     assert (await reader.get_by_id("id1"))["content"] == "alpha"
     assert (await reader.get_by_id("id2"))["content"] == "beta"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_repeated_failed_saves_do_not_rebuild_each_time(tmp_path):
+    """The replay is scoped by the redo entry: with no reload in between, the
+    stored row still fingerprints equal to the logged record, so a retry has
+    nothing to redo. A fingerprint regression here would rebuild the whole
+    index on every retry — the O(rows) cost the deferred protocol exists to
+    avoid."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+    restore = _make_save_fail(storage)
+    with pytest.raises(OSError):
+        await storage.index_done_callback()
+
+    rebuilds: list[tuple[list[int], int]] = []
+    real_rebuild = storage._rebuild_index_locked
+
+    def spy(drop_fids, add_records=()):
+        rebuilds.append((list(drop_fids), len(add_records)))
+        return real_rebuild(drop_fids, add_records)
+
+    storage._rebuild_index_locked = spy
+
+    with pytest.raises(OSError):
+        await storage.index_done_callback()
+    assert rebuilds == [], "no reload happened, so there is nothing to redo"
+
+    restore()
+    assert await storage.index_done_callback() is True
+    assert rebuilds == [], "the durable retry must not rebuild either"
+    assert not storage._unsaved_upserts
+    assert embed.call_count == 1
+    _assert_consistent(storage)
+    assert (await storage.get_by_id("id1"))["content"] == "alpha"

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -28,6 +28,7 @@ import pytest
 faiss = pytest.importorskip("faiss")
 
 from lightrag.kg.faiss_impl import FaissVectorDBStorage  # noqa: E402
+from lightrag.kg import write_seq  # noqa: E402
 from lightrag.kg.write_seq import WRITE_SEQ_FIELD  # noqa: E402
 from lightrag.kg.shared_storage import (  # noqa: E402
     initialize_share_data,
@@ -1711,4 +1712,55 @@ async def test_same_second_tie_without_a_write_sequence_still_replays(tmp_path):
     reader = _make_storage(tmp_path, _CountingEmbed())
     await reader.initialize()
     assert (await reader.get_by_id("idX"))["content"] == "ours"
+    _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_a_backward_clock_step_does_not_revert_a_newer_commit(
+    tmp_path, monkeypatch
+):
+    """Fix-proof (PR #3709 review): ordering compared whole seconds first, so a
+    clock stepped backward across a second boundary between our stamp and the
+    superseding writer's gave the *newer* row the *smaller* ``__created_at__``
+    — declared older, its higher token never read — and the stale redo row
+    replayed over a durable commit."""
+    writer = _make_storage(tmp_path, _CountingEmbed())
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    monkeypatch.setattr(write_seq, "_last_seq", 0)
+    with patch.object(write_seq.time, "time_ns", return_value=1_000):
+        with _frozen_clock(100):
+            await writer.upsert({"idX": {"content": "ours-stale"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+
+    # The clock steps back a full second before the superseding write.
+    with patch.object(write_seq.time, "time_ns", return_value=1_001):
+        with _frozen_clock(99):
+            await other.upsert({"idX": {"content": "theirs-newer"}})
+    assert await other.index_done_callback() is True
+
+    logged = writer._unsaved_upserts["idX"].record
+    resident = next(
+        meta for meta in other._id_to_meta.values() if meta["__id__"] == "idX"
+    )
+    assert resident["__created_at__"] < logged["__created_at__"], (
+        "the scenario under test is a backward step across a second boundary"
+    )
+    assert resident[WRITE_SEQ_FIELD] > logged[WRITE_SEQ_FIELD]
+
+    assert (await writer.get_by_id("idX"))["content"] == "theirs-newer"
+    assert await writer.index_done_callback() is True
+    assert "idX" not in writer._unsaved_upserts
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("idX"))["content"] == "theirs-newer", (
+        "the replay reverted a commit the clock step made look older"
+    )
     _assert_consistent(reader)

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -16,8 +16,11 @@ live model or network. They mirror the protocol proven for
   auto-repaired.
 """
 
+import contextlib
 import json
 import os
+import time
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -61,6 +64,18 @@ class _CountingEmbed:
                 for t in texts
             ]
         )
+
+
+@contextlib.contextmanager
+def _frozen_clock(stamp: int):
+    """Pin the ``__created_at__`` the storage stamps inside the block.
+
+    ``upsert`` records ``int(time.time())``, and the replay's ordering guard
+    compares those whole seconds, so a test needs an explicit clock to make one
+    row strictly newer than another (or to force a same-second tie).
+    """
+    with patch("lightrag.kg.faiss_impl.time.time", return_value=stamp):
+        yield
 
 
 def _make_storage(tmp_path, embed: _CountingEmbed) -> FaissVectorDBStorage:
@@ -1383,3 +1398,165 @@ async def test_repeated_failed_saves_do_not_rebuild_each_time(tmp_path):
     assert embed.call_count == 1
     _assert_consistent(storage)
     assert (await storage.get_by_id("id1"))["content"] == "alpha"
+
+
+# ---------------------------------------------------------------------------
+# finalize must reload even when only the dirty flag is set, and a replay must
+# not revert a strictly newer foreign commit (PR #3709 review follow-ups).
+# Twin of the Nano coverage.
+# ---------------------------------------------------------------------------
+
+
+async def _strand_dirty_with_empty_buffers(writer):
+    """Reach ``_index_dirty=True`` with all four buffers empty.
+
+    A flush materializes two rows and its save fails, so both sit in the redo
+    log. ``delete`` then evicts their redo entries and queues pending deletes;
+    the batch aborts, and ``drop_pending_index_ops`` discards those queued
+    deletes by design. Nothing now names the still-materialized rows for
+    replay, which is exactly the state in which skipping the reload would save
+    a stale snapshot over another writer's commit.
+    """
+    await writer.upsert({"idX": {"content": "ours-x"}, "idY": {"content": "ours-y"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+
+    await writer.delete(["idX", "idY"])
+    await writer.drop_pending_index_ops()
+
+    assert writer._index_dirty is True
+    assert not writer._pending_upserts
+    assert not writer._pending_deletes
+    assert not writer._unsaved_deletes
+    assert not writer._unsaved_upserts
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_finalize_reloads_when_only_the_dirty_flag_is_set(tmp_path):
+    """Fix-proof: ``finalize`` gated its reload on the four buffers, so a
+    bare ``_index_dirty`` saved the pre-commit snapshot without reloading —
+    dropping the foreign row and persisting the two explicitly deleted ones.
+    """
+    writer = _make_storage(tmp_path, _CountingEmbed())
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await _strand_dirty_with_empty_buffers(writer)
+
+    await other.upsert({"foreign": {"content": "theirs"}})
+    assert await other.index_done_callback() is True
+
+    await writer.finalize()
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    foreign = await reader.get_by_id("foreign")
+    assert foreign is not None, (
+        "finalize saved its stale pre-commit snapshot over the foreign commit"
+    )
+    assert foreign["content"] == "theirs"
+    assert await reader.get_by_id("idX") is None, "explicitly deleted row resurrected"
+    assert await reader.get_by_id("idY") is None, "explicitly deleted row resurrected"
+    _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_replay_declines_a_strictly_newer_foreign_row(tmp_path):
+    """Fix-proof: the replay overwrote whatever row the id had, so a writer
+    that was superseded (its document reprocessed by a new writer under the
+    same content-hash id) reverted that newer commit on its next flush."""
+    writer = _make_storage(tmp_path, _CountingEmbed())
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"idX": {"content": "ours-stale"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+    assert "idX" in writer._unsaved_upserts
+
+    # The superseding writer commits a strictly newer row under the same id.
+    with _frozen_clock(int(time.time()) + 60):
+        await other.upsert({"idX": {"content": "theirs-newer"}})
+    assert await other.index_done_callback() is True
+
+    assert await writer.index_done_callback() is True
+    assert "idX" not in writer._unsaved_upserts, (
+        "a superseded redo entry must be dropped, or it is rescanned by every "
+        "later flush and keeps poisoning the read paths"
+    )
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("idX"))["content"] == "theirs-newer", (
+        "the replay reverted a strictly newer commit"
+    )
+    _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_reads_prefer_a_strictly_newer_foreign_row(tmp_path):
+    """Fix-proof: the read paths short-circuited on the redo log before
+    consulting the index, so they reported a row the replay is about to
+    decline to restore."""
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"idX": {"content": "ours-stale"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+
+    with _frozen_clock(int(time.time()) + 60):
+        await other.upsert({"idX": {"content": "theirs-newer"}})
+    assert await other.index_done_callback() is True
+
+    got = await writer.get_by_id("idX")
+    assert got is not None and got["content"] == "theirs-newer"
+    by_ids = await writer.get_by_ids(["idX"])
+    assert by_ids[0] is not None and by_ids[0]["content"] == "theirs-newer"
+    vectors = await writer.get_vectors_by_ids(["idX"])
+    assert "idX" in vectors and len(vectors["idX"]) == DIM
+    assert embed.call_count == 1, "reads must not re-embed to answer this"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_same_second_tie_still_replays(tmp_path):
+    """Stability: the ordering guard is strict (``>``), so a foreign row
+    stamped in the same whole second as the logged one is still overwritten
+    by the replay — the pre-existing issue-#3688 behavior."""
+    writer = _make_storage(tmp_path, _CountingEmbed())
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    frozen = int(time.time())
+    with _frozen_clock(frozen):
+        await writer.upsert({"idX": {"content": "ours"}})
+        restore = _make_save_fail(writer)
+        with pytest.raises(OSError):
+            await writer.index_done_callback()
+        restore()
+
+        await other.upsert({"idX": {"content": "theirs"}})
+    assert await other.index_done_callback() is True
+
+    assert await writer.index_done_callback() is True
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("idX"))["content"] == "ours"
+    _assert_consistent(reader)

--- a/tests/kg/nano_impl/test_nano_deferred_delete.py
+++ b/tests/kg/nano_impl/test_nano_deferred_delete.py
@@ -691,7 +691,7 @@ async def test_finalize_reloads_before_retrying_a_delete_only_save(tmp_path):
         await writer.index_done_callback()
     restore()
     assert writer._client_dirty is True
-    assert writer._unsaved_upserts is False, "the dirty state is removals only"
+    assert not writer._unsaved_upserts, "the dirty state is removals only"
 
     # Another writer commits after our failed save.
     await other.upsert({"id3": {"content": "gamma"}})
@@ -710,9 +710,15 @@ async def test_finalize_reloads_before_retrying_a_delete_only_save(tmp_path):
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_finalize_still_protects_unsaved_upserts_from_the_reload(tmp_path):
-    """The other half of the same guard: materialized-but-unsaved *rows* exist
-    nowhere else, so finalize must keep skipping the reload for them."""
+async def test_finalize_replays_unsaved_upserts_after_a_foreign_commit(tmp_path):
+    """The upsert half of the same trade-off, closed by the redo log (#3688).
+
+    Before the log, finalize skipped the reload while ``_unsaved_upserts``
+    was set (the materialized rows existed nowhere else), and its save wrote
+    our pre-commit snapshot over the other writer's durable rows — id3
+    disappeared. Now the log replays our rows after the reload, so both
+    sides survive.
+    """
     writer = _make_storage(tmp_path)
     other = _make_storage(tmp_path)
     await writer.initialize()
@@ -724,7 +730,7 @@ async def test_finalize_still_protects_unsaved_upserts_from_the_reload(tmp_path)
     with pytest.raises(OSError):
         await writer.index_done_callback()
     restore()
-    assert writer._unsaved_upserts is True
+    assert writer._unsaved_upserts, "the flushed doc moved into the redo log"
 
     await other.upsert({"id3": {"content": "gamma"}})
     assert await other.index_done_callback() is True
@@ -734,7 +740,10 @@ async def test_finalize_still_protects_unsaved_upserts_from_the_reload(tmp_path)
     reader = _make_storage(tmp_path)
     await reader.initialize()
     assert (await reader.get_by_id("id2"))["content"] == "beta", (
-        "a reload would have dropped the only copy of this row"
+        "the redo log must replay our row on top of the reloaded snapshot"
+    )
+    assert (await reader.get_by_id("id3"))["content"] == "gamma", (
+        "the other writer's commit must survive finalize"
     )
 
 

--- a/tests/kg/nano_impl/test_nano_deferred_delete.py
+++ b/tests/kg/nano_impl/test_nano_deferred_delete.py
@@ -577,15 +577,16 @@ async def test_abort_after_a_rewrite_keeps_the_redo_entry(tmp_path):
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_a_rewrite_identical_to_the_removed_row_drops_the_redo_entry(
+async def test_a_rewrite_identical_in_content_survives_the_delete_replay(
     tmp_path, monkeypatch
 ):
-    """The one case the fingerprint cannot separate: a rewrite byte-identical
-    to the removed row. Materializing it must retire the entry, or the next
-    replay deletes the row we just wrote.
+    """A rewrite with the same content in the same whole second as the removed
+    row used to be indistinguishable from it, so materializing it had to retire
+    the redo entry or the next replay would delete the row just written.
+    ``__write_seq__`` separates the two versions: the entry may stay, it names
+    only the version it removed, and the rewrite survives a replay.
 
-    ``__created_at__`` is part of the record, so identity needs both the same
-    content and the same whole second — frozen here rather than raced for.
+    The clock is frozen so ``__created_at__`` cannot be what separates them.
     """
     monkeypatch.setattr(nano_impl.time, "time", lambda: 1_700_000_000.0)
 
@@ -602,16 +603,23 @@ async def test_a_rewrite_identical_to_the_removed_row_drops_the_redo_entry(
     await storage.upsert({"id1": {"content": "same"}})
     with pytest.raises(OSError):
         await storage.index_done_callback()
-    assert storage._unsaved_deletes == {}, (
-        "an identical row makes the entry moot, and keeping it would delete it"
+    assert set(storage._unsaved_deletes) == {"id1"}, (
+        "the entry names the removed version, which the rewrite is not"
+    )
+    assert (await storage.get_by_id("id1"))["content"] == "same", (
+        "the rewrite must be readable — the entry hides only the removed row"
     )
 
+    # Force the reload that resurrects the removed version before the retry:
+    # the delete replay must take it out again and keep the rewrite.
+    storage.storage_updated.value = True
     restore()
     assert await storage.index_done_callback() is True
 
     reader = _make_storage(tmp_path)
     await reader.initialize()
     assert (await reader.get_by_id("id1"))["content"] == "same"
+    assert len(reader._client) == 2, "exactly one row per id"
 
 
 @pytest.mark.offline

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -458,3 +458,290 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     assert storage._pending_upserts == {}, "pending id2 dropped"
     assert len(storage._client) == 1, "materialized id1 NOT rolled back"
     assert storage._client_dirty is True, "still dirty for a later save retry"
+
+
+# ---------------------------------------------------------------------------
+# Upsert redo log: materialized-but-unsaved rows survive a foreign-commit
+# reload (issue #3688). Mirrors the _unsaved_deletes coverage in
+# test_nano_deferred_delete.py.
+# ---------------------------------------------------------------------------
+
+
+def _make_save_fail(storage):
+    """Make ``_save_to_disk_locked`` raise; returns a restore callable."""
+    original = storage._save_to_disk_locked
+
+    def boom():
+        raise OSError("disk full")
+
+    storage._save_to_disk_locked = boom
+
+    def restore():
+        storage._save_to_disk_locked = original
+
+    return restore
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_index_done_replays_unsaved_upsert_after_foreign_commit(tmp_path):
+    """Fix-proof for issue #3688 (the retry-via-callback half).
+
+    Chain: flush materializes id2 and its save fails -> another writer
+    commits id3 -> the retry's reload replaces ``self._client`` with the
+    foreign snapshot. Without the redo log nothing replays id2 and the
+    following save silently loses it; with the log both rows land — and the
+    replay reuses the cached vector, so the retry embeds nothing.
+    """
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"id2": {"content": "beta"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError, match="disk full"):
+        await writer.index_done_callback()
+    restore()
+    assert writer._pending_upserts == {}, "flush succeeded so pending is empty"
+    assert writer._unsaved_upserts, "the flushed doc moved into the redo log"
+    calls_after_failure = embed.call_count
+
+    # Another writer commits, flagging `writer` as stale.
+    await other.upsert({"id3": {"content": "gamma"}})
+    assert await other.index_done_callback() is True
+    assert writer.storage_updated.value is True
+
+    assert await writer.index_done_callback() is True
+    assert embed.call_count == calls_after_failure, "replay must not re-embed"
+    assert not writer._unsaved_upserts, "durable save clears the redo log"
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("id2"))["content"] == "beta", (
+        "the reload dropped the materialized-but-unsaved row and nothing "
+        "replayed it (issue #3688)"
+    )
+    assert (await reader.get_by_id("id3"))["content"] == "gamma"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_reads_serve_an_unsaved_upsert_after_a_foreign_reload(tmp_path):
+    """Read-your-writes across the failed-save window: a foreign commit makes
+    the next ``_get_client`` reload drop the unsaved row from ``self._client``,
+    so the read paths must serve it from the redo log until the replay."""
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"id2": {"content": "beta"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+
+    await other.upsert({"id3": {"content": "gamma"}})
+    assert await other.index_done_callback() is True
+
+    # Each read triggers the reload-if-stale path internally.
+    got = await writer.get_by_id("id2")
+    assert got is not None and got["content"] == "beta"
+    by_ids = await writer.get_by_ids(["id2", "id3"])
+    assert by_ids[0] is not None and by_ids[0]["content"] == "beta"
+    assert by_ids[1] is not None and by_ids[1]["content"] == "gamma"
+    vectors = await writer.get_vectors_by_ids(["id2"])
+    assert "id2" in vectors and len(vectors["id2"]) == DIM
+    assert embed.call_count == 1, "the logged vector is reused, never re-embedded"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_replay_overwrites_a_foreign_row_under_the_same_id(tmp_path):
+    """Ids are content hashes, so a same-id foreign row is a rewrite of the
+    same logical record; our applied-but-unsaved write is the newer intent
+    and the replay puts it back on top."""
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"idX": {"content": "ours"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+
+    await other.upsert({"idX": {"content": "theirs"}})
+    assert await other.index_done_callback() is True
+
+    assert await writer.index_done_callback() is True
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("idX"))["content"] == "ours"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_after_a_failed_save_evicts_the_redo_entry(tmp_path):
+    """A ``delete`` for an id whose row is applied-but-unsaved must win: the
+    redo entry is evicted, or the replay would resurrect the row the delete
+    just took out."""
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"id1": {"content": "alpha"}, "id2": {"content": "beta"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+    assert "id2" in writer._unsaved_upserts
+
+    await writer.delete(["id2"])
+    assert "id2" not in writer._unsaved_upserts, "delete evicts the redo entry"
+
+    # Force the reload path before the retry.
+    await other.upsert({"id3": {"content": "gamma"}})
+    assert await other.index_done_callback() is True
+
+    assert await writer.index_done_callback() is True
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert await reader.get_by_id("id2") is None, "replay must not resurrect id2"
+    assert (await reader.get_by_id("id1"))["content"] == "alpha"
+    assert (await reader.get_by_id("id3"))["content"] == "gamma"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_entity_evicts_the_upsert_redo_entry(tmp_path):
+    """The eager ``delete_entity`` path evicts unconditionally: after a
+    foreign reload the unsaved row is not in ``self._client`` (nothing for
+    the materialized delete to hit), yet a surviving redo entry would replay
+    it at the next flush."""
+    from lightrag.utils import compute_mdhash_id
+
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    entity_id = compute_mdhash_id("EntityA", prefix="ent-")
+    await writer.upsert({entity_id: {"content": "entity row"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+    assert entity_id in writer._unsaved_upserts
+
+    # Foreign commit first, so delete_entity's own reload drops the row
+    # before its materialized-side lookup runs (`existing` is empty).
+    await other.upsert({"id3": {"content": "gamma"}})
+    assert await other.index_done_callback() is True
+
+    await writer.delete_entity("EntityA")
+    assert entity_id not in writer._unsaved_upserts
+
+    assert await writer.index_done_callback() is True
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert await reader.get_by_id(entity_id) is None
+    assert (await reader.get_by_id("id3"))["content"] == "gamma"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_delete_entity_relation_evicts_matching_redo_upserts(tmp_path):
+    """Same rule for the relation sweep: the src/tgt predicate prunes the redo
+    log unconditionally, because after a foreign reload the unsaved relation
+    rows are invisible to the materialized scan."""
+
+    def make(tmp, embed):
+        return NanoVectorDBStorage(
+            namespace="test_relations",
+            workspace="ws",
+            global_config={
+                "working_dir": str(tmp),
+                "embedding_batch_num": 32,
+                "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+            },
+            embedding_func=EmbeddingFunc(
+                embedding_dim=DIM, max_token_size=512, func=embed
+            ),
+            meta_fields={"content", "src_id", "tgt_id"},
+        )
+
+    writer = make(tmp_path, _CountingEmbed())
+    other = make(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert(
+        {
+            "r1": {"content": "rel1", "src_id": "A", "tgt_id": "B"},
+            "r2": {"content": "rel2", "src_id": "X", "tgt_id": "Y"},
+        }
+    )
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+    assert "r1" in writer._unsaved_upserts and "r2" in writer._unsaved_upserts
+
+    await other.upsert({"id3": {"content": "gamma"}})
+    assert await other.index_done_callback() is True
+
+    await writer.delete_entity_relation("A")
+    assert "r1" not in writer._unsaved_upserts, "incident redo entry evicted"
+    assert "r2" in writer._unsaved_upserts, "unrelated redo entry preserved"
+
+    assert await writer.index_done_callback() is True
+
+    reader = make(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert await reader.get_by_id("r1") is None
+    assert (await reader.get_by_id("r2"))["content"] == "rel2"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_aborting_batch_keeps_the_upsert_redo_log(tmp_path):
+    """``drop_pending_index_ops`` discards buffered work, not the redo log:
+    the logged rows already reached ``self._client`` (the class the abort
+    path intentionally does not roll back), so they must still survive a
+    foreign-commit reload."""
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"id1": {"content": "alpha"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+
+    await writer.drop_pending_index_ops()
+    assert writer._unsaved_upserts, "abort keeps the redo log"
+
+    await other.upsert({"id2": {"content": "beta"}})
+    assert await other.index_done_callback() is True
+
+    assert await writer.index_done_callback() is True
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("id1"))["content"] == "alpha"
+    assert (await reader.get_by_id("id2"))["content"] == "beta"

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -8,6 +8,7 @@ live model or network. They mirror the protocol proven for
 """
 
 import contextlib
+import json
 import time
 from unittest.mock import patch
 
@@ -17,6 +18,7 @@ import pytest
 nano_vectordb = pytest.importorskip("nano_vectordb")  # noqa: F841
 
 from lightrag.kg.nano_vector_db_impl import NanoVectorDBStorage  # noqa: E402
+from lightrag.kg.write_seq import WRITE_SEQ_FIELD  # noqa: E402
 from lightrag.kg.shared_storage import (  # noqa: E402
     initialize_share_data,
     finalize_share_data,
@@ -576,15 +578,23 @@ async def test_reads_serve_an_unsaved_upsert_after_a_foreign_reload(tmp_path):
 
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_replay_overwrites_a_foreign_row_under_the_same_id(tmp_path):
-    """Ids are content hashes, so a same-id foreign row is a rewrite of the
-    same logical record; our applied-but-unsaved write is the newer intent
-    and the replay puts it back on top."""
+async def test_replay_overwrites_an_older_foreign_row_under_the_same_id(tmp_path):
+    """Ids are content hashes, so a same-id stored row is an older version of
+    the same logical record; our applied-but-unsaved write is the newer intent
+    and the replay puts it back on top of the reloaded snapshot.
+
+    The foreign row is committed *before* our write on purpose: written after
+    it, it would be the newer version and the replay would rightly decline
+    (see ``test_same_second_tie_is_broken_by_the_write_sequence``).
+    """
     embed = _CountingEmbed()
     writer = _make_storage(tmp_path, embed)
     other = _make_storage(tmp_path, _CountingEmbed())
     await writer.initialize()
     await other.initialize()
+
+    await other.upsert({"idX": {"content": "theirs"}})
+    assert await other.index_done_callback() is True
 
     await writer.upsert({"idX": {"content": "ours"}})
     restore = _make_save_fail(writer)
@@ -592,7 +602,9 @@ async def test_replay_overwrites_a_foreign_row_under_the_same_id(tmp_path):
         await writer.index_done_callback()
     restore()
 
-    await other.upsert({"idX": {"content": "theirs"}})
+    # A foreign commit forces the reload that drops our materialized row and
+    # brings the older idX back; the replay has to put ours on top again.
+    await other.upsert({"idZ": {"content": "unrelated"}})
     assert await other.index_done_callback() is True
 
     assert await writer.index_done_callback() is True
@@ -600,6 +612,7 @@ async def test_replay_overwrites_a_foreign_row_under_the_same_id(tmp_path):
     reader = _make_storage(tmp_path, _CountingEmbed())
     await reader.initialize()
     assert (await reader.get_by_id("idX"))["content"] == "ours"
+    assert (await reader.get_by_id("idZ"))["content"] == "unrelated"
 
 
 @pytest.mark.offline
@@ -930,12 +943,78 @@ async def test_reads_prefer_a_strictly_newer_foreign_row(tmp_path):
     assert embed.call_count == 1, "reads must not re-embed to answer this"
 
 
+def _strip_write_seq_on_disk(storage) -> None:
+    """Rewrite the persisted rows as a pre-``__write_seq__`` store would.
+
+    The token is stamped by ``upsert``, so a store written by an older version
+    carries none. Removing it from the committed snapshot is the only way to
+    reach the documented fallback: a same-second pair the token cannot order.
+    """
+    with open(storage._client_file_name, encoding="utf-8") as f:
+        snapshot = json.load(f)
+    stripped = [row.pop(WRITE_SEQ_FIELD, None) for row in snapshot["data"]]
+    assert any(token is not None for token in stripped), (
+        "the token must reach the committed snapshot, or the replay's ordering "
+        "guard loses its tiebreaker across a reload"
+    )
+    with open(storage._client_file_name, "w", encoding="utf-8") as f:
+        json.dump(snapshot, f)
+
+
 @pytest.mark.offline
 @pytest.mark.asyncio
-async def test_same_second_tie_still_replays(tmp_path):
-    """Stability: the ordering guard is strict (``>``), so a foreign row
-    stamped in the same whole second as the logged one is still overwritten
-    by the replay — the pre-existing issue-#3688 behavior."""
+async def test_same_second_tie_is_broken_by_the_write_sequence(tmp_path):
+    """Fix-proof (PR #3709 review): ordering was whole seconds only, and
+    ``upsert`` stamps ``int(time.time())`` — so a superseding writer that
+    committed inside the same second as the logged row tied, the strict ``>``
+    fell through to "replay", and the stale redo record overwrote a durable
+    newer row. ``__write_seq__`` orders the two writes inside that second."""
+    writer = _make_storage(tmp_path, _CountingEmbed())
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    frozen = int(time.time())
+    with _frozen_clock(frozen):
+        await writer.upsert({"idX": {"content": "ours-stale"}})
+        restore = _make_save_fail(writer)
+        with pytest.raises(OSError):
+            await writer.index_done_callback()
+        restore()
+
+        # Same whole second, but written after ours: a higher write sequence.
+        await other.upsert({"idX": {"content": "theirs-newer"}})
+    assert await other.index_done_callback() is True
+
+    logged = writer._unsaved_upserts["idX"].record
+    resident = other._client.get(["idX"])[0]
+    assert logged["__created_at__"] == resident["__created_at__"], (
+        "the scenario under test is a same-second pair"
+    )
+    assert resident[WRITE_SEQ_FIELD] > logged[WRITE_SEQ_FIELD]
+
+    # Reads must agree with the decision the flush is about to make.
+    assert (await writer.get_by_id("idX"))["content"] == "theirs-newer"
+
+    assert await writer.index_done_callback() is True
+    assert "idX" not in writer._unsaved_upserts, (
+        "a superseded redo entry must be dropped"
+    )
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("idX"))["content"] == "theirs-newer", (
+        "the replay reverted a row committed later in the same second"
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_same_second_tie_without_a_write_sequence_still_replays(tmp_path):
+    """Stability: a row written before ``__write_seq__`` existed carries none,
+    and a missing token must not read as "older" (that would let the replay
+    overwrite any legacy row). Such a same-second pair stays a tie and keeps
+    the pre-token behavior — the replay proceeds."""
     writer = _make_storage(tmp_path, _CountingEmbed())
     other = _make_storage(tmp_path, _CountingEmbed())
     await writer.initialize()
@@ -950,7 +1029,8 @@ async def test_same_second_tie_still_replays(tmp_path):
         restore()
 
         await other.upsert({"idX": {"content": "theirs"}})
-    assert await other.index_done_callback() is True
+        assert await other.index_done_callback() is True
+        _strip_write_seq_on_disk(other)
 
     assert await writer.index_done_callback() is True
 

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -18,6 +18,7 @@ import pytest
 nano_vectordb = pytest.importorskip("nano_vectordb")  # noqa: F841
 
 from lightrag.kg.nano_vector_db_impl import NanoVectorDBStorage  # noqa: E402
+from lightrag.kg import write_seq  # noqa: E402
 from lightrag.kg.write_seq import WRITE_SEQ_FIELD  # noqa: E402
 from lightrag.kg.shared_storage import (  # noqa: E402
     initialize_share_data,
@@ -1037,3 +1038,51 @@ async def test_same_second_tie_without_a_write_sequence_still_replays(tmp_path):
     reader = _make_storage(tmp_path, _CountingEmbed())
     await reader.initialize()
     assert (await reader.get_by_id("idX"))["content"] == "ours"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_a_backward_clock_step_does_not_revert_a_newer_commit(
+    tmp_path, monkeypatch
+):
+    """Fix-proof (PR #3709 review): ordering compared whole seconds first, so a
+    clock stepped backward across a second boundary between our stamp and the
+    superseding writer's gave the *newer* row the *smaller* ``__created_at__``
+    — declared older, its higher token never read — and the stale redo row
+    replayed over a durable commit."""
+    writer = _make_storage(tmp_path, _CountingEmbed())
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    monkeypatch.setattr(write_seq, "_last_seq", 0)
+    with patch.object(write_seq.time, "time_ns", return_value=1_000):
+        with _frozen_clock(100):
+            await writer.upsert({"idX": {"content": "ours-stale"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+
+    # The clock steps back a full second before the superseding write.
+    with patch.object(write_seq.time, "time_ns", return_value=1_001):
+        with _frozen_clock(99):
+            await other.upsert({"idX": {"content": "theirs-newer"}})
+    assert await other.index_done_callback() is True
+
+    logged = writer._unsaved_upserts["idX"].record
+    resident = other._client.get(["idX"])[0]
+    assert resident["__created_at__"] < logged["__created_at__"], (
+        "the scenario under test is a backward step across a second boundary"
+    )
+    assert resident[WRITE_SEQ_FIELD] > logged[WRITE_SEQ_FIELD]
+
+    assert (await writer.get_by_id("idX"))["content"] == "theirs-newer"
+    assert await writer.index_done_callback() is True
+    assert "idX" not in writer._unsaved_upserts
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("idX"))["content"] == "theirs-newer", (
+        "the replay reverted a commit the clock step made look older"
+    )

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -7,6 +7,10 @@ live model or network. They mirror the protocol proven for
 ``OpenSearchVectorDBStorage`` (issue #2785).
 """
 
+import contextlib
+import time
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -49,6 +53,18 @@ class _CountingEmbed:
                 for t in texts
             ]
         )
+
+
+@contextlib.contextmanager
+def _frozen_clock(stamp: int):
+    """Pin the ``__created_at__`` the storage stamps inside the block.
+
+    ``upsert`` records ``int(time.time())``, and the replay's ordering guard
+    compares those whole seconds, so a test needs an explicit clock to make one
+    row strictly newer than another (or to force a same-second tie).
+    """
+    with patch("lightrag.kg.nano_vector_db_impl.time.time", return_value=stamp):
+        yield
 
 
 def _make_storage(tmp_path, embed: _CountingEmbed) -> NanoVectorDBStorage:
@@ -783,3 +799,161 @@ async def test_repeated_failed_saves_do_not_re_upsert_each_time(tmp_path):
     assert not storage._unsaved_upserts
     assert embed.call_count == 1
     assert (await storage.get_by_id("id1"))["content"] == "alpha"
+
+
+# ---------------------------------------------------------------------------
+# finalize must reload even when only the dirty flag is set, and a replay must
+# not revert a strictly newer foreign commit (PR #3709 review follow-ups).
+# ---------------------------------------------------------------------------
+
+
+async def _strand_dirty_with_empty_buffers(writer):
+    """Reach ``_client_dirty=True`` with all four buffers empty.
+
+    A flush materializes two rows and its save fails, so both sit in the redo
+    log. ``delete`` then evicts their redo entries and queues pending deletes;
+    the batch aborts, and ``drop_pending_index_ops`` discards those queued
+    deletes by design. Nothing now names the still-materialized rows for
+    replay, which is exactly the state in which skipping the reload would save
+    a stale snapshot over another writer's commit.
+    """
+    await writer.upsert({"idX": {"content": "ours-x"}, "idY": {"content": "ours-y"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+
+    await writer.delete(["idX", "idY"])
+    await writer.drop_pending_index_ops()
+
+    assert writer._client_dirty is True
+    assert not writer._pending_upserts
+    assert not writer._pending_deletes
+    assert not writer._unsaved_deletes
+    assert not writer._unsaved_upserts
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_finalize_reloads_when_only_the_dirty_flag_is_set(tmp_path):
+    """Fix-proof: ``finalize`` gated its reload on the four buffers, so a
+    bare ``_client_dirty`` saved the pre-commit snapshot without reloading —
+    dropping the foreign row and persisting the two explicitly deleted ones.
+    """
+    writer = _make_storage(tmp_path, _CountingEmbed())
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await _strand_dirty_with_empty_buffers(writer)
+
+    await other.upsert({"foreign": {"content": "theirs"}})
+    assert await other.index_done_callback() is True
+
+    await writer.finalize()
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    foreign = await reader.get_by_id("foreign")
+    assert foreign is not None, (
+        "finalize saved its stale pre-commit snapshot over the foreign commit"
+    )
+    assert foreign["content"] == "theirs"
+    assert await reader.get_by_id("idX") is None, "explicitly deleted row resurrected"
+    assert await reader.get_by_id("idY") is None, "explicitly deleted row resurrected"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_replay_declines_a_strictly_newer_foreign_row(tmp_path):
+    """Fix-proof: the replay overwrote whatever row the id had, so a writer
+    that was superseded (its document reprocessed by a new writer under the
+    same content-hash id) reverted that newer commit on its next flush."""
+    writer = _make_storage(tmp_path, _CountingEmbed())
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"idX": {"content": "ours-stale"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+    assert "idX" in writer._unsaved_upserts
+
+    # The superseding writer commits a strictly newer row under the same id.
+    with _frozen_clock(int(time.time()) + 60):
+        await other.upsert({"idX": {"content": "theirs-newer"}})
+    assert await other.index_done_callback() is True
+
+    assert await writer.index_done_callback() is True
+    assert "idX" not in writer._unsaved_upserts, (
+        "a superseded redo entry must be dropped, or it is rescanned by every "
+        "later flush and keeps poisoning the read paths"
+    )
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("idX"))["content"] == "theirs-newer", (
+        "the replay reverted a strictly newer commit"
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_reads_prefer_a_strictly_newer_foreign_row(tmp_path):
+    """Fix-proof: the read paths short-circuited on the redo log before
+    consulting the client, so they reported a row the replay is about to
+    decline to restore."""
+    embed = _CountingEmbed()
+    writer = _make_storage(tmp_path, embed)
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"idX": {"content": "ours-stale"}})
+    restore = _make_save_fail(writer)
+    with pytest.raises(OSError):
+        await writer.index_done_callback()
+    restore()
+
+    with _frozen_clock(int(time.time()) + 60):
+        await other.upsert({"idX": {"content": "theirs-newer"}})
+    assert await other.index_done_callback() is True
+
+    got = await writer.get_by_id("idX")
+    assert got is not None and got["content"] == "theirs-newer"
+    by_ids = await writer.get_by_ids(["idX"])
+    assert by_ids[0] is not None and by_ids[0]["content"] == "theirs-newer"
+    vectors = await writer.get_vectors_by_ids(["idX"])
+    assert "idX" in vectors and len(vectors["idX"]) == DIM
+    assert embed.call_count == 1, "reads must not re-embed to answer this"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_same_second_tie_still_replays(tmp_path):
+    """Stability: the ordering guard is strict (``>``), so a foreign row
+    stamped in the same whole second as the logged one is still overwritten
+    by the replay — the pre-existing issue-#3688 behavior."""
+    writer = _make_storage(tmp_path, _CountingEmbed())
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    frozen = int(time.time())
+    with _frozen_clock(frozen):
+        await writer.upsert({"idX": {"content": "ours"}})
+        restore = _make_save_fail(writer)
+        with pytest.raises(OSError):
+            await writer.index_done_callback()
+        restore()
+
+        await other.upsert({"idX": {"content": "theirs"}})
+    assert await other.index_done_callback() is True
+
+    assert await writer.index_done_callback() is True
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("idX"))["content"] == "ours"

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -745,3 +745,41 @@ async def test_aborting_batch_keeps_the_upsert_redo_log(tmp_path):
     await reader.initialize()
     assert (await reader.get_by_id("id1"))["content"] == "alpha"
     assert (await reader.get_by_id("id2"))["content"] == "beta"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_repeated_failed_saves_do_not_re_upsert_each_time(tmp_path):
+    """The replay is scoped by the redo entry: with no reload in between, the
+    stored row still fingerprints equal to the logged record, so a retry has
+    nothing to redo. A fingerprint regression here (e.g. digesting the record
+    after ``__vector__`` is re-attached) would silently rewrite every logged
+    row on every retry."""
+    embed = _CountingEmbed()
+    storage = _make_storage(tmp_path, embed)
+    await storage.initialize()
+
+    await storage.upsert({"id1": {"content": "alpha"}})
+    restore = _make_save_fail(storage)
+    with pytest.raises(OSError):
+        await storage.index_done_callback()
+
+    upsert_calls: list[list[str]] = []
+    real_upsert = storage._client.upsert
+
+    def spy(datas):
+        upsert_calls.append([d["__id__"] for d in datas])
+        return real_upsert(datas=datas)
+
+    storage._client.upsert = spy
+
+    with pytest.raises(OSError):
+        await storage.index_done_callback()
+    assert upsert_calls == [], "no reload happened, so there is nothing to redo"
+
+    restore()
+    assert await storage.index_done_callback() is True
+    assert upsert_calls == [], "the durable retry must not rewrite either"
+    assert not storage._unsaved_upserts
+    assert embed.call_count == 1
+    assert (await storage.get_by_id("id1"))["content"] == "alpha"

--- a/tests/kg/test_write_seq.py
+++ b/tests/kg/test_write_seq.py
@@ -57,7 +57,20 @@ def test_a_newer_second_wins_regardless_of_the_token():
 def test_the_token_breaks_a_same_second_tie():
     assert row_is_strictly_newer(_row(100, 2), _row(100, 1)) is True
     assert row_is_strictly_newer(_row(100, 1), _row(100, 2)) is False
-    assert row_is_strictly_newer(_row(100, 1), _row(100, 1)) is False
+
+
+@pytest.mark.offline
+def test_equal_tokens_from_two_processes_stay_a_tie():
+    """The bump that keeps tokens distinct is process-local, so two processes
+    reading one clock tick stamp the *same* token — reachable only on a coarse
+    clock, and only by two writers racing on one id (which the backends'
+    single-writer invariant excludes). Pin that such a pair resolves to the
+    pre-token behavior rather than to an arbitrary winner: ordering it would
+    take a generation shared across processes."""
+    ours = _row(100, 5)
+    theirs = _row(100, 5)  # a second process, same clock tick
+    assert row_is_strictly_newer(theirs, ours) is False
+    assert row_is_strictly_newer(ours, theirs) is False
 
 
 @pytest.mark.offline

--- a/tests/kg/test_write_seq.py
+++ b/tests/kg/test_write_seq.py
@@ -1,0 +1,75 @@
+"""Coverage for the per-write ordering token shared by the file-backed vdbs.
+
+``__created_at__`` is whole seconds (``int(time.time())``), so two writes
+inside the same second tie — and a tie used to resolve as "the redo replay
+proceeds", letting a stale record overwrite a genuinely newer durable row
+(PR #3709 review). ``lightrag.kg.write_seq`` is the tiebreaker; these tests pin
+its two guarantees: the token never repeats or regresses, and the comparison
+falls back to the pre-token behavior only when a token is genuinely absent.
+"""
+
+import pytest
+
+from lightrag.kg import write_seq
+from lightrag.kg.write_seq import (
+    WRITE_SEQ_FIELD,
+    next_write_seq,
+    row_is_strictly_newer,
+)
+
+
+def _row(created_at: int, seq: int | None = None) -> dict:
+    row = {"__created_at__": created_at, "content": "c"}
+    if seq is not None:
+        row[WRITE_SEQ_FIELD] = seq
+    return row
+
+
+@pytest.mark.offline
+def test_successive_tokens_strictly_increase():
+    tokens = [next_write_seq() for _ in range(100)]
+    assert tokens == sorted(tokens)
+    assert len(set(tokens)) == len(tokens), "a repeated token cannot order writes"
+
+
+@pytest.mark.offline
+def test_a_frozen_or_backwards_clock_still_yields_ordered_tokens(monkeypatch):
+    """A coarse clock (Windows' ~15ms granularity) hands out the same reading
+    twice, and an NTP step hands out an earlier one; neither may produce a
+    token that ties with or precedes one already issued."""
+    readings = iter([500, 500, 400, 300])
+    monkeypatch.setattr(write_seq.time, "time_ns", lambda: next(readings))
+    monkeypatch.setattr(write_seq, "_last_seq", 499)
+
+    tokens = [next_write_seq() for _ in range(4)]
+    assert tokens == [500, 501, 502, 503]
+
+
+@pytest.mark.offline
+def test_a_newer_second_wins_regardless_of_the_token():
+    """The token is only a tiebreaker: it must never outrank whole seconds, or
+    a row from a process whose tokens happen to run high would win outright."""
+    assert row_is_strictly_newer(_row(101, 1), _row(100, 999)) is True
+    assert row_is_strictly_newer(_row(100, 999), _row(101, 1)) is False
+
+
+@pytest.mark.offline
+def test_the_token_breaks_a_same_second_tie():
+    assert row_is_strictly_newer(_row(100, 2), _row(100, 1)) is True
+    assert row_is_strictly_newer(_row(100, 1), _row(100, 2)) is False
+    assert row_is_strictly_newer(_row(100, 1), _row(100, 1)) is False
+
+
+@pytest.mark.offline
+def test_a_missing_token_is_not_read_as_older():
+    """A row written before the token existed carries none. Defaulting it to 0
+    would declare it older than any freshly stamped row and let a replay
+    overwrite it, so such a same-second pair stays a tie (False)."""
+    assert row_is_strictly_newer(_row(100), _row(100, 5)) is False
+    assert row_is_strictly_newer(_row(100, 5), _row(100)) is False
+    assert row_is_strictly_newer(_row(101), _row(100, 5)) is True
+
+
+@pytest.mark.offline
+def test_an_absent_row_never_supersedes():
+    assert row_is_strictly_newer(None, _row(100, 1)) is False

--- a/tests/kg/test_write_seq.py
+++ b/tests/kg/test_write_seq.py
@@ -3,9 +3,10 @@
 ``__created_at__`` is whole seconds (``int(time.time())``), so two writes
 inside the same second tie — and a tie used to resolve as "the redo replay
 proceeds", letting a stale record overwrite a genuinely newer durable row
-(PR #3709 review). ``lightrag.kg.write_seq`` is the tiebreaker; these tests pin
-its two guarantees: the token never repeats or regresses, and the comparison
-falls back to the pre-token behavior only when a token is genuinely absent.
+(PR #3709 review). ``lightrag.kg.write_seq`` replaces it as the ordering
+field; these tests pin its guarantees: the token never repeats or regresses,
+it decides whenever both rows carry it, and the comparison falls back to whole
+seconds — the pre-token behavior, ties included — only when a row predates it.
 """
 
 import pytest
@@ -46,11 +47,24 @@ def test_a_frozen_or_backwards_clock_still_yields_ordered_tokens(monkeypatch):
 
 
 @pytest.mark.offline
-def test_a_newer_second_wins_regardless_of_the_token():
-    """The token is only a tiebreaker: it must never outrank whole seconds, or
-    a row from a process whose tokens happen to run high would win outright."""
-    assert row_is_strictly_newer(_row(101, 1), _row(100, 999)) is True
-    assert row_is_strictly_newer(_row(100, 999), _row(101, 1)) is False
+def test_the_token_decides_when_both_rows_carry_one():
+    """Fix-proof (PR #3709 review): whole seconds used to be compared first,
+    so a clock stepped backward across a second boundary made the *later* write
+    carry the *smaller* ``__created_at__`` and be declared older — its higher
+    token never read. That discarded the guarantee ``next_write_seq`` exists
+    for, and let a stale redo row replay over a newer durable one."""
+    stepped_back = _row(99, 501)  # written after, on a clock stepped backward
+    ours = _row(100, 500)
+    assert row_is_strictly_newer(stepped_back, ours) is True
+    assert row_is_strictly_newer(ours, stepped_back) is False
+
+
+@pytest.mark.offline
+def test_whole_seconds_decide_only_when_a_row_predates_the_token():
+    """The fallback still orders a legacy row against a tokened one, and a
+    newer second wins there — it is the only evidence such a pair has."""
+    assert row_is_strictly_newer(_row(101), _row(100, 999)) is True
+    assert row_is_strictly_newer(_row(100, 999), _row(101)) is False
 
 
 @pytest.mark.offline
@@ -80,7 +94,6 @@ def test_a_missing_token_is_not_read_as_older():
     overwrite it, so such a same-second pair stays a tie (False)."""
     assert row_is_strictly_newer(_row(100), _row(100, 5)) is False
     assert row_is_strictly_newer(_row(100, 5), _row(100)) is False
-    assert row_is_strictly_newer(_row(101), _row(100, 5)) is True
 
 
 @pytest.mark.offline


### PR DESCRIPTION
### Summary

This PR addresses the upsert half of issue #3688, mirroring the `_unsaved_deletes`
redo-log design that the deferred-delete series already implemented for removals.

The problem: `_flush_pending_locked` materialized pending upserts into memory and
dropped them from the buffer. If the subsequent save failed, those flushed rows had
no replay record. If another writer committed meanwhile, the retry's unconditional
reload replaced the in-memory store with the foreign snapshot, and the following save
silently lost the rows.

A similar bug existed in `finalize`: it skipped the reload while `_unsaved_upserts`
was set, so its save wrote the pre-commit snapshot over the other writer's durable rows.

### What Changed

`_unsaved_upserts` becomes a redo log (`id -> flushed pending doc`, record + cached
vector) instead of a bool, on both `NanoVectorDBStorage` and `FaissVectorDBStorage`:

- Flush moves flushed docs into the log instead of dropping them; commit clears the log
  only after the save is durable
- Flush replays logged rows after delete replay and before pending materialization,
  skipping ids that are pending again or whose stored row already fingerprints equal
- Replay reuses cached vectors — never re-embeds
- `finalize` always reloads before flushing, including when only the dirty flag is set
  (every buffer empty is a reachable state, and the save would otherwise write a stale
  pre-commit snapshot over a foreign commit); the reload clears the flag when it actually
  replaces the in-memory state, so a flush that replays nothing correctly skips the save
- Removal paths evict matching redo entries unconditionally to prevent resurrections
- `drop_pending_index_ops` keeps the log; `drop` clears it

**A replay must not revert a newer commit.** Ids are content hashes of the entity name /
endpoint pair, not of the content, so a differing row under a logged id can be a
legitimate later update: under dead-process recovery a writer can be declared dead,
superseded by a reprocess of the same document, and still reach its replay. The replay
therefore orders the two rows and declines a strictly newer resident one, dropping the
superseded redo entry instead (FAISS applies the guard across every fid found for the id,
since the rebuild would drop all of them).

Ordering itself needed more than `__created_at__`: `upsert` stamps `int(time.time())`,
so two writes inside the same second tie — a normal outcome, not an anomaly — and a tie
resolved as "replay", i.e. the stale record overwrote the durable newer row anyway. New
`lightrag/kg/write_seq.py` adds a persisted per-write token `__write_seq__`, stamped into
the record at `upsert` time:

- Its value is a nanosecond wall-clock reading bumped past the last value the process
  handed out, so a coarse clock or a backwards NTP step still yields strictly increasing,
  non-repeating tokens; processes sharing a store compare them on one host clock — the
  assumption `__created_at__` already makes. Being part of the record, it survives the
  save/reload round-trip the redo log depends on.
- Ordering is `__created_at__` first, the token only as the same-second tiebreaker, so a
  row that predates the token still orders correctly against a newer second. A missing
  token is **not** read as "older" (that would let a replay overwrite any legacy row):
  such a same-second pair stays a tie and keeps the pre-token behavior.
- The token is stripped from the public read results (`_format_record`, `query`) — it is
  storage bookkeeping, not payload.

The read paths (`get_by_id` / `get_by_ids` / `get_vectors_by_ids`) no longer short-circuit
on the redo log: they consult the client and apply that same rule through a shared
`_resident_supersedes_redo` helper, so read-your-writes never reports a row the next flush
is about to decline to restore. `query` / `client_storage` are untouched — they only ever
see materialized state, which is the documented contract.

Because the token is part of `_row_fingerprint`, a rewrite identical in content to a
removed row is now a distinct row version. That closes the delete path's
byte-identical-successor boundary and retires the flush's `_unsaved_deletes`
reconciliation pass, which existed only to drop an entry a fresh row could otherwise
match: the entry now names solely the version it removed, so keeping it removes and hides
nothing that exists, and a reload resurrecting the removed row is still repaired by the
replay.

### What's Broken / Known Limits

- The token orders *stamp* time, not *commit* time. A fully commit-ordered discriminator
  would need a store-wide persisted commit counter — a snapshot-format change plus
  rewriting rows at save time, which breaks the fingerprint's save/reload stability the
  redo log relies on. In the dead-process-recovery scenario the guard exists for, the
  superseding writer stamps after us, so stamp order is the intent order.
- A store written before this change carries no token; a same-second pair involving such
  a row falls back to the previous behavior (the replay proceeds), and the delete replay
  still cannot tell a legacy byte-identical successor from the row it removed.
- Both redo logs are in-memory only: they are dropped by `drop` and lost on a crash before
  the flush, as documented.

### Testing

Tests on both Nano and Faiss cover:
- The exact #3688 chain through both `index_done_callback` and `finalize`
- `finalize` reloading on a bare dirty flag, and skipping the save when the flush replays
  nothing on top of the fresh snapshot
- A replay overwriting an *older* same-id foreign row, and declining a strictly newer one
  (redo entry dropped)
- A same-second pair ordered by `__write_seq__`, and a token-less legacy row still replaying
- Read-your-writes across the failed-save window, agreeing with the replay's decision
- A retry without a reload replaying nothing (fingerprint-scoped skip)
- An identical-content rewrite surviving the delete replay
- Redo entry eviction on every removal path, abort keeping the log, no re-embedding on replay

Plus `tests/kg/test_write_seq.py`: token monotonicity under a frozen/backwards clock,
whole seconds outranking the token, and a missing token not being read as older.

Verification: 127 tests passed (`tests/kg/faiss_impl`, `tests/kg/nano_impl`,
`tests/kg/test_write_seq.py`); `ruff check` / `ruff format` clean.

**Fixes #3688**
