### PR TITLE
fix(llm): close OpenAI stream on GeneratorExit during error-path COT close

### DIFF
--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -624,6 +624,17 @@ async def openai_complete_if_cache(
                     try:
                         yield "</think>"
                         cot_active = False
+                    except GeneratorExit:
+                        # Consumer disconnect while closing COT on the error
+                        # path. GeneratorExit is a BaseException, so neither
+                        # the handler below nor the co-sibling ``except
+                        # GeneratorExit`` above sees it. Without this clause
+                        # the finally block yields into a closing generator,
+                        # aclose() raises "async generator ignored
+                        # GeneratorExit", and the frame is abandoned before
+                        # the stream and the client are ever closed.
+                        closing_via_generator_exit = True
+                        raise
                     except Exception as close_error:
                         logger.warning(
                             f"Failed to close COT tag during exception handling: {close_error}"

--- a/tests/llm/openai_impl/test_openai_stream_generatorexit_cot_cleanup.py
+++ b/tests/llm/openai_impl/test_openai_stream_generatorexit_cot_cleanup.py
@@ -123,3 +123,63 @@ async def test_stream_closed_after_full_consumption_with_cot():
     assert chunks == ["<think>", "thinking", "</think>", "answer"]
     stream.aclose.assert_awaited()
     fake_client.close.assert_awaited()
+
+
+class _FailingOpenAIStream(_FakeOpenAIStream):
+    """Fake stream that raises after yielding its chunks, like an upstream 5xx."""
+
+    def __init__(self, chunks, error):
+        super().__init__(chunks)
+        self._error = error
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise self._error
+        return self._chunks.pop(0)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_stream_closed_on_disconnect_during_error_path_cot_close():
+    """A disconnect at the ERROR path's COT close must not abort cleanup.
+
+    ``inner()`` closes an open ``<think>`` tag from three places. Only the two
+    inside the outer ``try`` were guarded: a ``GeneratorExit`` raised there is
+    caught by ``except GeneratorExit`` and tells the ``finally`` to skip its
+    own yield. The third close lives in the ``except Exception`` handler, and
+    ``GeneratorExit`` is a ``BaseException`` -- neither the handler's own
+    ``except Exception as close_error`` nor the co-sibling ``except
+    GeneratorExit`` can catch it. Left unguarded, the ``finally`` then yields
+    while the generator is closing, ``aclose()`` raises "async generator
+    ignored GeneratorExit", and the frame is abandoned before
+    ``response.aclose()`` and ``openai_async_client.close()`` -- leaking both.
+
+    Named as out of scope by #3635, which fixed the consumer-disconnect
+    variant.
+    """
+    stream = _FailingOpenAIStream(
+        [_make_chunk(reasoning_content="thinking...")],
+        RuntimeError("upstream 500 mid-reasoning"),
+    )
+    fake_client = _make_stream_client(stream)
+
+    yielded = []
+    with patch(
+        "lightrag.llm.openai.create_openai_async_client", return_value=fake_client
+    ):
+        gen = await openai_complete_if_cache.__wrapped__(
+            model="deepseek-reasoner",
+            prompt="hello",
+            enable_cot=True,
+            stream=True,
+            api_key="test-key",
+        )
+        async for piece in gen:
+            yielded.append(piece)
+            if piece == "</think>":
+                break  # consumer goes away right after the error path closes COT
+        await gen.aclose()
+
+    assert yielded == ["<think>", "thinking...", "</think>"]
+    stream.aclose.assert_awaited()
+    fake_client.close.assert_awaited()


### PR DESCRIPTION
## Description

`openai_complete_if_cache`'s streaming `inner()` closes an open `<think>` tag from three suspension points. #3635 guarded the consumer-disconnect case and named this one as the remaining variant in its own Additional Notes:

> Not verified: `GeneratorExit` arriving while the generator is suspended inside the `except Exception` handler's own COT-close `yield` (a real API error, then a disconnect before exception-path cleanup finishes) is a narrower variant of the same class of bug and is left out of scope here.

The `except Exception as e:` handler's COT close is guarded only by `except Exception as close_error`. `GeneratorExit` is a `BaseException`, so that clause does not catch it, and the co-sibling `except GeneratorExit:` above cannot catch an exception raised inside another handler's body. `closing_via_generator_exit` stays `False` and `cot_active` stays `True`, so the `finally` takes its `yield "</think>"` branch while the generator is closing: `aclose()` raises `RuntimeError: async generator ignored GeneratorExit` and the frame is abandoned at that yield, before `response.aclose()` (`openai.py:672` on `main`) and `openai_async_client.close()` (`openai.py:687`). The handler's own `aclose`/`close` calls are skipped as well, since `GeneratorExit` propagated out of the handler before reaching them. Both the stream and the `AsyncOpenAI` client leak.

Trigger: a streaming API error while a `<think>` block is open, then a disconnect right after the handler emits `</think>` — a FastAPI `StreamingResponse` client going away just after an upstream 5xx in the reasoning phase.

Fixes #3712

## Changes Made

- Added an `except GeneratorExit` clause to the error handler's COT-close block, mirroring the one #3635 added for the main-loop site: it records the unwind reason in `closing_via_generator_exit` and re-raises. Placed before `except Exception as close_error` so the ordinary close-failure path is unchanged.
- No other change is needed: the `finally` already falls through unconditionally to `response.aclose()` / `openai_async_client.close()` once its own yield is skipped.
- Extended `tests/llm/openai_impl/test_openai_stream_generatorexit_cot_cleanup.py` (the file #3635 added) with a `_FailingOpenAIStream` and one test driving the real `openai_complete_if_cache` through an API error mid-COT followed by a disconnect.

## Verification

- The new test **fails on unmodified `main`** with the exact `RuntimeError: async generator ignored GeneratorExit`, `stream.aclose` and `client.close` both never awaited, and passes on this branch with both awaited. Confirmed both ways in the same working tree by reverting only `lightrag/llm/openai.py` and re-running: `1 failed, 2 passed` → restored → `3 passed`. #3635's two existing tests pass in both states, so the change does not alter the already-covered paths.
- Full offline suite (`pytest tests/ -m offline`), Python 3.13.5: **5880 passed, 48 skipped, 1304 deselected, 0 failed** — no failures, and the same count as unmodified `main` plus this PR's one new test (`main` baseline: 5879 passed, 48 skipped, 0 failed).
- `pytest tests/llm/openai_impl/` : 19 passed.
- `pre-commit run --files lightrag/llm/openai.py tests/llm/openai_impl/test_openai_stream_generatorexit_cot_cleanup.py` (trailing-whitespace, end-of-file-fixer, ruff-format, ruff): clean.

Not verified: behavior against a live OpenAI endpoint. The fix and its test exercise only the generator's own unwind path; the network boundary is mocked throughout, as in #3635's tests. The skipped tests in the run above are the pre-existing spaCy-model skips (`en_core_web_sm` / `zh_core_web_sm` not installed), unrelated to this change and identical on `main`.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not necessary — no behavior change to any documented interface)
- [x] Unit tests added

## Additional Notes

The three COT-close sites are now uniformly guarded. The post-loop close inside the outer `try` needs no clause of its own: a `GeneratorExit` there is caught by the existing `except GeneratorExit:` at `openai.py:615`.
