### PR TITLE
fix(openai): use safe token truncation for embedding input

### DIFF
--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -31,6 +31,8 @@ from lightrag.utils import (
     empty_length_truncated_hint,
     logger,
     TruncatedResponse,
+    Tokenizer,
+    TokenBudgetError,
 )
 
 from lightrag.api import __api_version__
@@ -1046,22 +1048,45 @@ async def openai_embed(
         texts = [document_prefix + text for text in texts]
     # Apply text truncation if max_token_size is provided
     if max_token_size is not None and max_token_size > 0:
-        encoding = _get_tiktoken_encoding_for_model(model)
+        # Wrap the resolved encoding in LightRAG's verified tokenizer instead of
+        # slicing the raw token list: Tokenizer.encode treats special-token
+        # strings such as "<|endoftext|>" as ordinary text, and
+        # truncate_by_token_limit returns a character-boundary prefix whose token
+        # count is independently re-verified. The base class is used rather than
+        # TiktokenTokenizer because the latter resolves the encoding from the
+        # model name itself and raises ValueError for the deployment / gateway
+        # names this binding accepts; its decode_with_offsets fast path only pays
+        # off across the many windows of a split, not a single truncate. The BPE
+        # table is already memoized by _get_tiktoken_encoding_for_model.
+        tokenizer = Tokenizer(
+            model_name=model, tokenizer=_get_tiktoken_encoding_for_model(model)
+        )
         truncated_texts = []
         truncation_count = 0
 
-        for text in texts:
+        for index, text in enumerate(texts):
             if not text:
                 truncated_texts.append(text)
                 continue
 
-            tokens = encoding.encode(text)
-            if len(tokens) > max_token_size:
-                truncated_tokens = tokens[:max_token_size]
-                truncated_texts.append(encoding.decode(truncated_tokens))
+            try:
+                span = tokenizer.truncate_by_token_limit(text, max_token_size)
+            except TokenBudgetError as e:
+                # Only reachable when a single Unicode code point does not fit
+                # the budget -- surfaced rather than swallowed, matching
+                # _truncate_vdb_content.
+                logger.error(
+                    f"Embedding input {index + 1}/{len(texts)} cannot fit "
+                    f"token limit {max_token_size}: {e}"
+                )
+                raise
+
+            if span.end < len(text):
+                truncated_texts.append(text[span.start : span.end])
                 truncation_count += 1
                 logger.debug(
-                    f"Text truncated from {len(tokens)} to {max_token_size} tokens"
+                    f"Text truncated to {span.token_count} tokens "
+                    f"(limit {max_token_size}, {len(text) - span.end} chars dropped)"
                 )
             else:
                 truncated_texts.append(text)

--- a/tests/llm/openai_impl/test_openai_embed_safe_truncation.py
+++ b/tests/llm/openai_impl/test_openai_embed_safe_truncation.py
@@ -1,0 +1,211 @@
+"""``openai_embed``'s own truncation must honour the safe-tokenizer contract.
+
+#3565 introduced ``lightrag.utils.Tokenizer``'s verified split/truncate
+contract and migrated the paths it covered, listing this one under "Known
+remaining paths": ``openai_embed`` sliced the raw tiktoken token list and
+``decode()``d it back, bypassing ``Tokenizer`` entirely with no
+re-verification. Two consequences, both live wherever the truncation block runs at all. That is
+direct library use -- ``LightRAG(embedding_func=openai_embed)``, as in
+``examples/lightrag_openai_demo.py`` -- where ``EmbeddingFunc`` injects the
+decorator's ``max_token_size=8192`` because ``openai_embed``'s own signature
+declares the parameter. (The API server wraps the binding in an
+``optimized_embedding_function`` whose signature does not, so nothing is
+injected there and the block is skipped entirely; ``azure_openai_embed``
+likewise never forwards the parameter. Both are separate gaps, out of scope
+here.)
+
+1. ``Encoding.encode`` defaults to ``disallowed_special=ALL``, so a chunk whose
+   text merely *contains* the literal ``"<|endoftext|>"`` raised ``ValueError``
+   and failed the whole embedding batch -- regardless of its length, since the
+   encode ran for every non-empty text once the block was entered.
+   ``Tokenizer.encode`` exists precisely to treat those strings as ordinary
+   text.
+2. ``decode(tokens[:n])`` decodes with ``errors="replace"``, so a budget landing
+   inside a multi-token code point yielded a string ending in U+FFFD. What was
+   embedded was then not a prefix of the input at all.
+
+Nothing re-encoded the result either, which the contract requires because BPE
+token count is not monotonic in text length.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from lightrag.llm.openai import (
+    _get_tiktoken_encoding_for_model,
+    openai_embed,
+)
+from lightrag.utils import TokenBudgetError
+
+
+pytestmark = pytest.mark.offline
+
+MODEL = "text-embedding-3-small"
+
+
+class _FakeEmbeddingClient:
+    """Captures the ``input`` list that actually reaches the embeddings API."""
+
+    def __init__(self, captured):
+        self._captured = captured
+        self.embeddings = SimpleNamespace(create=self._create)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def _create(self, **params):
+        self._captured.append(params)
+        return SimpleNamespace(
+            data=[SimpleNamespace(embedding=[0.0, 1.0]) for _ in params["input"]]
+        )
+
+
+async def _embed(monkeypatch, texts, *, max_token_size, model=MODEL, **kwargs):
+    """Drive the real ``openai_embed`` body; return the texts sent to the API."""
+    captured = []
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client",
+        lambda **_: _FakeEmbeddingClient(captured),
+    )
+    # ``.func`` unwraps @wrap_embedding_func_with_attrs, ``__wrapped__`` the
+    # tenacity retry, so a raised error surfaces once instead of three times.
+    await openai_embed.func.__wrapped__(
+        texts, model=model, api_key="test-key", max_token_size=max_token_size, **kwargs
+    )
+    assert len(captured) == 1
+    return captured[0]["input"]
+
+
+@pytest.mark.asyncio
+async def test_literal_special_token_does_not_fail_the_batch(monkeypatch):
+    """A chunk containing "<|endoftext|>" must embed like any other text."""
+    text = "an example of the <|endoftext|> marker in prose"
+
+    sent = await _embed(monkeypatch, [text], max_token_size=8192)
+
+    assert sent == [text]
+
+
+@pytest.mark.asyncio
+async def test_truncation_lands_on_a_code_point_boundary(monkeypatch):
+    """The truncated text is a real prefix of the input, never U+FFFD-tailed."""
+    text = "hello world " * 10 + "\U0001f44d" * 5
+
+    (sent,) = await _embed(monkeypatch, [text], max_token_size=24)
+
+    assert "�" not in sent
+    assert text.startswith(sent)
+    assert sent != text
+
+
+@pytest.mark.asyncio
+async def test_truncated_text_is_re_verified_against_the_budget(monkeypatch):
+    """Re-encoding the result actually fits -- BPE count is not monotonic."""
+    text = "hello world " * 10 + "\U0001f44d" * 5
+    budget = 24
+
+    (sent,) = await _embed(monkeypatch, [text], max_token_size=budget)
+
+    # Count with disallowed_special=() so this assertion measures the budget,
+    # not tiktoken's special-token guard.
+    encoding = _get_tiktoken_encoding_for_model(MODEL)
+    assert len(encoding.encode(sent, disallowed_special=())) <= budget
+
+
+@pytest.mark.asyncio
+async def test_text_within_budget_is_sent_unchanged(monkeypatch):
+    text = "a short sentence"
+
+    sent = await _embed(monkeypatch, [text], max_token_size=8192)
+
+    assert sent == [text]
+
+
+@pytest.mark.asyncio
+async def test_empty_text_is_passed_through(monkeypatch):
+    sent = await _embed(monkeypatch, ["", "kept"], max_token_size=8192)
+
+    assert sent == ["", "kept"]
+
+
+@pytest.mark.asyncio
+async def test_prefix_is_applied_before_truncation(monkeypatch):
+    """Prefix-then-truncate order is unchanged, so the budget covers the prefix."""
+    prefix = "search_document: "
+    text = "hello world " * 10
+
+    (sent,) = await _embed(
+        monkeypatch,
+        [text],
+        max_token_size=12,
+        context="document",
+        document_prefix=prefix,
+    )
+
+    assert sent.startswith(prefix)
+    assert (prefix + text).startswith(sent)
+    # The two assertions above both survive a prefix-after-truncate swap; this
+    # one does not -- swapping puts the payload prefix_tokens over budget.
+    encoding = _get_tiktoken_encoding_for_model(MODEL)
+    assert len(encoding.encode(sent, disallowed_special=())) <= 12
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_name_still_truncates(monkeypatch):
+    """Deployment / gateway names tiktoken cannot resolve fall back, not raise.
+
+    ``TiktokenTokenizer(model_name=...)`` raises ``ValueError`` for these; the
+    binding must keep ``_get_tiktoken_encoding_for_model``'s cl100k_base
+    fallback.
+    """
+    text = "hello world " * 10
+
+    (sent,) = await _embed(
+        monkeypatch, [text], max_token_size=12, model="my-azure-deployment-xyz"
+    )
+
+    assert text.startswith(sent)
+    assert sent != text
+
+
+@pytest.mark.asyncio
+async def test_budget_smaller_than_one_code_point_is_surfaced(monkeypatch):
+    """A budget no single code point can fit is an error, not a silent U+FFFD.
+
+    The ERROR line is asserted too, so deleting the binding's own
+    ``except TokenBudgetError`` handler is caught -- a bare ``pytest.raises``
+    would still pass on the tokenizer's own exception alone. Matches
+    ``_truncate_vdb_content``'s handling of the same condition, and the
+    position tells the operator which input in the batch was at fault.
+    """
+    with patch("lightrag.llm.openai.logger") as mock_logger:
+        with pytest.raises(TokenBudgetError):
+            await _embed(monkeypatch, ["ok", "\U0001f44d" * 10], max_token_size=1)
+
+    logged = " ".join(str(call) for call in mock_logger.error.call_args_list)
+    assert "Embedding input 2/2 cannot fit token limit 1" in logged
+
+
+@pytest.mark.asyncio
+async def test_oversized_text_containing_a_special_token(monkeypatch):
+    """The composite case: both defects meet in one input.
+
+    Over budget AND carrying a literal special token, so the result must come
+    from encoding the marker as ordinary text and then cutting on a code-point
+    boundary -- neither half of the fix alone produces it.
+    """
+    text = "filler words here <|endoftext|> more filler " * 40
+    budget = 24
+
+    (sent,) = await _embed(monkeypatch, [text], max_token_size=budget)
+
+    assert text.startswith(sent)
+    assert sent != text
+    assert "\ufffd" not in sent
+    encoding = _get_tiktoken_encoding_for_model(MODEL)
+    assert len(encoding.encode(sent, disallowed_special=())) <= budget


### PR DESCRIPTION
## Description

`openai_embed`'s own truncation slices the raw tiktoken token list and decodes it back, bypassing `lightrag.utils.Tokenizer`. #3565 established the verified split/truncate contract, migrated the paths it covered, and listed this one under "Known remaining paths (not migrated this round)" with the approach to take:

> **`openai_embed`**'s local truncation (`lightrag/llm/openai.py`): `tokens[:max_token_size]` + `decode()`, bypasses `lightrag.utils.Tokenizer` entirely, no re-verification. This **is** a live embedding call path and should be the next follow-up; suggested fix: apply `document_prefix`/`query_prefix` first (unchanged order), use the already-resolved embedding-model tiktoken encoding, call a safe truncate on the full prefixed input, and independently re-verify the result.

Two defects:

- **A literal special-token string fails the whole batch.** `Encoding.encode` defaults to `disallowed_special=ALL`, so text merely containing the literal `<|endoftext|>` raises `ValueError`. Once the block is entered the `encode` runs for every non-empty text, so length is irrelevant. `Tokenizer.encode` exists precisely to encode those as ordinary text — its comment reads *"This crashes document indexing on any user content that happens to contain those strings"* — and this path never reached it.
- **Truncation can cut inside a code point.** `decode(tokens[:n])` decodes with `errors="replace"`, so a budget landing mid-character yields a trailing U+FFFD; what gets embedded is then not a prefix of the input. Nothing re-encoded the result to confirm it fits, which the contract requires because BPE token count is not monotonic in text length.

**Scope.** The block only runs where `max_token_size` actually arrives: direct library use (`LightRAG(embedding_func=openai_embed)`, as in `examples/lightrag_openai_demo.py`), where `EmbeddingFunc` injects the decorator's 8192 because `openai_embed`'s signature declares the parameter. The API server's `optimized_embedding_function(texts, embedding_dim=None, context="document")` does not declare it, so `EmbeddingFunc.__call__`'s `inspect.signature` check (`utils.py:697-701`) skips the injection and the block never runs there; `azure_openai_embed` does not forward the parameter either. Both look like separate gaps — happy to open an issue for them, but they are not touched here.

Fixes #3714

## Changes Made

- The truncation loop now builds a `Tokenizer` over the encoding `_get_tiktoken_encoding_for_model` already resolves, and takes `truncate_by_token_limit(text, max_token_size)`, slicing the original string. The result is a verbatim character-boundary prefix whose token count is independently re-verified. Prefix application order is untouched, as prescribed.
- The **base** `Tokenizer` is used rather than `TiktokenTokenizer`, for two reasons stated in the code comment: `TiktokenTokenizer` resolves the encoding from the model name itself and raises `ValueError` for the deployment / gateway names this binding accepts (which is why `_get_tiktoken_encoding_for_model` has a `cl100k_base` fallback at all), and its `decode_with_offsets` fast path is aimed at the many windows of a `split`, not a single `truncate` — see the measurements below.
- `TokenBudgetError` is logged with the offending input's batch position and re-raised rather than swallowed, matching `_truncate_vdb_content` (`lightrag/operate.py:318-330`), the sibling call site #3565 migrated. It is only reachable when a single code point cannot fit the budget.
- The debug line keeps a magnitude signal (`chars dropped`) so operators can still see how much was cut.

## Verification

New `tests/llm/openai_impl/test_openai_embed_safe_truncation.py` (9 tests) drives the real `openai_embed`, mocking only `create_openai_async_client`, and asserts on the exact `input` list that reaches the embeddings API.

**Three-state check**, same working tree, reverting only `lightrag/llm/openai.py`:

| State | Result |
|---|---|
| impl + tests | `9 passed` |
| revert impl only | `4 failed, 5 passed` — genuine assertion failures, not an `ImportError` (the module imports only symbols present in both revisions) |
| restored | `27 passed` across `tests/llm/openai_impl/` |

**Mutation check** — each mutation applied to the implementation, suite re-run, then reverted:

| Mutation | Caught |
|---|---|
| prefixes applied *after* truncation instead of before | `1 failed` |
| `except TokenBudgetError` handler deleted | `1 failed` |
| tokenizer built from a hardcoded model name | `9 failed` |

- Full offline suite (`pytest tests/ -m offline`), Python 3.13.5: **5888 passed, 48 skipped, 1304 deselected, 0 failed** — the `main` baseline (5879 passed, 0 failed) plus this PR's 9 new tests.
- `pre-commit run --files lightrag/llm/openai.py tests/llm/openai_impl/test_openai_embed_safe_truncation.py`: clean.

**Performance**, measured on this machine (`text-embedding-3-small` / `cl100k_base`, best of 3):

| Case | old slice+decode | base `Tokenizer` | `TiktokenTokenizer` fast path |
|---|---|---|---|
| 40 texts under budget (the common case) | — | 9.8 ms | 9.6 ms |
| 20 texts at ~12 000 tokens, budget 8192 | — | **51.7 ms** | 124.9 ms |
| tokens kept at budget 8192 | 8192 | 8192 | 8192 |

A 3000-case fuzz over ASCII / CJK / ZWJ-emoji / combining-mark / literal-special-token inputs at budgets 1–128 found zero contract violations for either tokenizer and identical `TokenBudgetError` behaviour; the fast path keeps 0–14 more tokens on 35% of *small* budgets and exactly the same amount at 8192. So the base class is the right choice here: same output at realistic budgets, 2.4× faster on the branch that does work.

Not verified: behavior against a live embeddings endpoint. The change and its tests exercise only the local text→text truncation; the network boundary is mocked throughout. The skipped tests are the pre-existing spaCy-model skips, identical on `main`.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not necessary — no documented interface changes)
- [x] Unit tests added

## Additional Notes

Deliberately **not** in this PR, flagged rather than silently left:

- **The loop is still synchronous CPU work inside an `async def`.** #3565 submits its analogous work through `run_in_tokenizer_executor`. That is a real improvement, but the blocking is pre-existing (the old slice+decode ran on the event loop too) and moving this loop into the tokenizer executor changes the concurrency of every embedding batch — a bigger, separately-reviewable change. With the base `Tokenizer` the added block on the truncation branch is ~1.3× the old cost, not the ~3× the fast path would have cost; texts already within budget are unchanged.
- **`_truncate_section_context`** (`operate.py`), the other path #3565 listed as remaining — an internal display string rather than a live embedding path, which that PR itself ranked lower priority.
