### PR TITLE
fix(embeddings): keep provider API keys request-local

### DIFF
--- a/lightrag/llm/jina.py
+++ b/lightrag/llm/jina.py
@@ -116,16 +116,14 @@ async def jina_embed(
         aiohttp.ClientError: If there is a connection error with the Jina API.
         aiohttp.ClientResponseError: If the Jina API returns an error response.
     """
-    if api_key:
-        os.environ["JINA_API_KEY"] = api_key
-
-    if "JINA_API_KEY" not in os.environ:
+    effective_api_key = api_key or os.getenv("JINA_API_KEY")
+    if not effective_api_key:
         raise ValueError("JINA_API_KEY environment variable is required")
 
     url = base_url or "https://api.jina.ai/v1/embeddings"
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {os.environ['JINA_API_KEY']}",
+        "Authorization": f"Bearer {effective_api_key}",
     }
 
     # Determine task based on context if not explicitly provided

--- a/lightrag/llm/nvidia_openai.py
+++ b/lightrag/llm/nvidia_openai.py
@@ -1,5 +1,4 @@
 import sys
-import os
 
 if sys.version_info < (3, 9):
     pass
@@ -53,12 +52,13 @@ async def nvidia_openai_embed(
     trunc: str = "NONE",  # NONE or START or END
     encode: str = "float",  # float or base64
 ) -> np.ndarray:
+    client_kwargs = {}
+    if base_url is not None:
+        client_kwargs["base_url"] = base_url
     if api_key:
-        os.environ["OPENAI_API_KEY"] = api_key
+        client_kwargs["api_key"] = api_key
 
-    openai_async_client = (
-        AsyncOpenAI() if base_url is None else AsyncOpenAI(base_url=base_url)
-    )
+    openai_async_client = AsyncOpenAI(**client_kwargs)
     # Hold the client in an async-with so its httpx connection pool is
     # released on every exit path (success, error, and each @retry attempt),
     # instead of leaking one pool per call until GC. Mirrors ``openai_embed``.

--- a/tests/llm/jina_impl/test_jina_api_key_isolation.py
+++ b/tests/llm/jina_impl/test_jina_api_key_isolation.py
@@ -1,0 +1,32 @@
+"""Regression tests for request-local Jina API credentials."""
+
+import base64
+import os
+from unittest.mock import AsyncMock, patch
+
+import numpy as np
+import pytest
+
+from lightrag.llm.jina import jina_embed
+
+
+def _encoded_embedding(values=(0.1, 0.2, 0.3)) -> str:
+    return base64.b64encode(np.asarray(values, dtype=np.float32).tobytes()).decode()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_explicit_api_key_is_request_local(monkeypatch):
+    """An explicit Jina key must not replace the process-wide default key."""
+    monkeypatch.setenv("JINA_API_KEY", "shared-jina-key")
+    fetch = AsyncMock(return_value=[{"embedding": _encoded_embedding()}])
+
+    with patch("lightrag.llm.jina.fetch_data", fetch):
+        result = await jina_embed.func.__wrapped__(
+            texts=["hello"], api_key="request-jina-key", embedding_dim=3
+        )
+
+    _, headers, _ = fetch.await_args.args
+    assert headers["Authorization"] == "Bearer request-jina-key"
+    assert os.environ["JINA_API_KEY"] == "shared-jina-key"
+    np.testing.assert_allclose(result, [[0.1, 0.2, 0.3]])

--- a/tests/llm/nvidia_impl/test_nvidia_client_cleanup.py
+++ b/tests/llm/nvidia_impl/test_nvidia_client_cleanup.py
@@ -11,6 +11,7 @@ via ``.func.__wrapped__`` to bypass the ``EmbeddingFunc`` and tenacity
 ``@retry`` wrappers.
 """
 
+import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -67,3 +68,24 @@ async def test_client_closed_on_error():
 
     fake.embeddings.create.assert_awaited_once()
     fake.close.assert_awaited()
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_explicit_api_key_is_request_local(monkeypatch):
+    """An explicit NVIDIA key must not replace the process-wide OpenAI key."""
+    monkeypatch.setenv("OPENAI_API_KEY", "shared-openai-key")
+    fake = _FakeAsyncOpenAI(create=AsyncMock(return_value=_make_response()))
+
+    with patch(
+        "lightrag.llm.nvidia_openai.AsyncOpenAI", return_value=fake
+    ) as client_cls:
+        await nvidia_openai_embed.func.__wrapped__(
+            texts=["hello"], api_key="request-nvidia-key"
+        )
+
+    client_cls.assert_called_once_with(
+        base_url="https://integrate.api.nvidia.com/v1",
+        api_key="request-nvidia-key",
+    )
+    assert os.environ["OPENAI_API_KEY"] == "shared-openai-key"


### PR DESCRIPTION
## Description

Keep explicit Jina and NVIDIA embedding API keys local to the current call instead of writing them into process-wide environment variables.

Previously, calling either embedding function with `api_key=...` permanently replaced `JINA_API_KEY` or `OPENAI_API_KEY`. A later call that relied on the process default could therefore inherit credentials from an unrelated earlier request. This is especially surprising for library users that construct provider functions with different credentials in the same process.

## Related Issues

No linked issue. This was found while auditing provider credential and client-lifecycle behavior.

## Changes Made

- Resolve the Jina request key from the explicit argument first, then the existing environment fallback, without mutating `os.environ`.
- Pass an explicit NVIDIA key directly to `AsyncOpenAI`, preserving SDK environment fallback when no key is supplied.
- Add offline regression coverage proving that explicit keys reach each provider while the process-wide defaults remain unchanged.
- Preserve the existing client cleanup, retry, base URL, and missing-key behavior.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not necessary; public configuration behavior is unchanged)
- [x] Unit tests added

## Additional Notes

Validation:

- `python -m pytest tests/llm/jina_impl tests/llm/nvidia_impl -q -p no:cacheprovider` (4 passed)
- LightRAG pre-commit hooks on all four changed files (all passed)
- `git diff --check` (passed)

Boundary: this PR does not change environment variable names, API server configuration, credential storage, retry policy, or any other provider.
