### PR TITLE
fix(openai): encode embedding input with disallowed_special=()

### DIFF
--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -1055,7 +1055,16 @@ async def openai_embed(
                 truncated_texts.append(text)
                 continue
 
-            tokens = encoding.encode(text)
+            # disallowed_special=() is required, not an optimization: tiktoken
+            # defaults to disallowed_special=ALL and raises ValueError as soon as
+            # the text merely CONTAINS a literal special-token string such as
+            # "<|endoftext|>". Since this encode runs for every non-empty text
+            # once truncation is enabled, one chunk of user content quoting that
+            # marker -- common in documentation, notes, or captured model output
+            # -- failed the whole embedding batch regardless of its length. The
+            # markers must be encoded as ordinary text, exactly as
+            # Tokenizer.encode does for every other tokenizing path.
+            tokens = encoding.encode(text, disallowed_special=())
             if len(tokens) > max_token_size:
                 truncated_tokens = tokens[:max_token_size]
                 truncated_texts.append(encoding.decode(truncated_tokens))

--- a/tests/llm/openai_impl/test_openai_embed_special_token.py
+++ b/tests/llm/openai_impl/test_openai_embed_special_token.py
@@ -1,0 +1,179 @@
+"""``openai_embed`` must not fail a batch over a literal special-token string.
+
+``tiktoken``'s ``Encoding.encode`` defaults to ``disallowed_special=ALL``, so it
+raises ``ValueError`` as soon as the text merely *contains* a marker such as
+``"<|endoftext|>"``. ``openai_embed``'s truncation block ran that encode for
+every non-empty text, so a single chunk of user content quoting the marker --
+documentation, notes, captured model output -- failed the whole embedding batch
+regardless of length. Fixed by encoding the markers as ordinary text, which is
+what every other tokenizing path in the codebase already does via
+``lightrag.utils.Tokenizer.encode``.
+
+Scope: the truncation block only runs where ``max_token_size`` actually arrives,
+i.e. direct library use (``LightRAG(embedding_func=openai_embed)``), because
+``EmbeddingFunc.__call__`` injects it only when the wrapped function's own
+signature declares the parameter. The API server wraps the binding in an
+``optimized_embedding_function`` whose signature does not, and
+``azure_openai_embed`` never forwards it either -- separate gaps, not covered
+here.
+
+The truncation itself (slice the token list, decode it back) is deliberately
+left as it was: it fills the budget exactly, which no character-prefix scheme
+can do, and its only artefact is at most one trailing U+FFFD when the cut lands
+inside a multi-byte code point -- pinned below, and negligible for an embedding
+vector.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from lightrag.llm.openai import _get_tiktoken_encoding_for_model, openai_embed
+
+pytestmark = pytest.mark.offline
+
+MODEL = "text-embedding-3-small"
+MARKER = "<|endoftext|>"
+REPLACEMENT = "�"
+
+
+class _FakeEmbeddingClient:
+    """Captures the ``input`` list that actually reaches the embeddings API."""
+
+    def __init__(self, captured):
+        self._captured = captured
+        self.embeddings = SimpleNamespace(create=self._create)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def _create(self, **params):
+        self._captured.append(params)
+        return SimpleNamespace(
+            data=[SimpleNamespace(embedding=[0.0, 1.0]) for _ in params["input"]]
+        )
+
+
+async def _embed(monkeypatch, texts, *, max_token_size, **kwargs):
+    """Drive the real ``openai_embed`` body; return the texts sent to the API.
+
+    ``.func`` unwraps ``@wrap_embedding_func_with_attrs`` so the fake client's
+    2-element vectors do not trip the wrapper's dimension check.
+    """
+    captured = []
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client",
+        lambda **_: _FakeEmbeddingClient(captured),
+    )
+    await openai_embed.func(
+        texts, model=MODEL, api_key="test-key", max_token_size=max_token_size, **kwargs
+    )
+    assert len(captured) == 1
+    return captured[0]["input"]
+
+
+def _token_count(text):
+    encoding = _get_tiktoken_encoding_for_model(MODEL)
+    # disallowed_special=() so this measurement is of the budget, never of
+    # tiktoken's special-token guard.
+    return len(encoding.encode(text, disallowed_special=()))
+
+
+# ---------------------------------------------------------------------------
+# Fix proof: each of these raises ValueError before the fix.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_text_containing_a_special_token_is_embedded(monkeypatch):
+    """A short text quoting the marker embeds unchanged, like any other text."""
+    text = f"an example of the {MARKER} marker in prose"
+
+    assert await _embed(monkeypatch, [text], max_token_size=8192) == [text]
+
+
+@pytest.mark.asyncio
+async def test_one_offending_text_does_not_fail_its_batch_siblings(monkeypatch):
+    """The old failure took down the whole batch, not just the offending item."""
+    texts = ["a perfectly ordinary chunk", f"another chunk mentioning {MARKER}"]
+
+    assert await _embed(monkeypatch, texts, max_token_size=8192) == texts
+
+
+@pytest.mark.asyncio
+async def test_oversized_text_containing_a_special_token(monkeypatch):
+    """Truncation and the marker in one input: encode, then cut to budget."""
+    text = f"filler words here {MARKER} more filler " * 40
+    budget = 24
+
+    (sent,) = await _embed(monkeypatch, [text], max_token_size=budget)
+
+    assert sent != text
+    assert _token_count(sent) <= budget
+
+
+# ---------------------------------------------------------------------------
+# Stability: these pass before and after the fix, and pin the properties that
+# the one-line change deliberately preserves.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_truncation_still_fills_the_budget(monkeypatch):
+    """No under-fill: the cut is at a token boundary, so the budget is used up.
+
+    This is why the token-slice truncation is kept rather than replaced by a
+    character-prefix scheme, which can only ever land at or below the budget.
+    """
+    text = "hello world " * 100
+    budget = 24
+
+    (sent,) = await _embed(monkeypatch, [text], max_token_size=budget)
+
+    assert _token_count(sent) == budget
+
+
+@pytest.mark.asyncio
+async def test_a_cut_inside_a_code_point_costs_one_trailing_replacement(monkeypatch):
+    """The accepted artefact, bounded: at most one U+FFFD, only at the end.
+
+    Every token before the cut decodes to complete characters; only the code
+    point whose remaining bytes lived in the next token is lost. The result
+    still fits the budget, which is what the API cares about.
+    """
+    text = "hello world " * 10 + "\U0001f44d" * 5
+    budget = 24
+
+    (sent,) = await _embed(monkeypatch, [text], max_token_size=budget)
+
+    assert sent.count(REPLACEMENT) <= 1
+    assert REPLACEMENT not in sent[:-1]
+    assert _token_count(sent) <= budget
+
+
+@pytest.mark.asyncio
+async def test_text_within_budget_and_empty_text_are_passed_through(monkeypatch):
+    sent = await _embed(monkeypatch, ["", "a short sentence"], max_token_size=8192)
+
+    assert sent == ["", "a short sentence"]
+
+
+@pytest.mark.asyncio
+async def test_prefix_is_applied_before_truncation(monkeypatch):
+    """The budget covers the prefix, so the prefix cannot push the input over."""
+    prefix = "search_document: "
+    budget = 12
+
+    (sent,) = await _embed(
+        monkeypatch,
+        ["hello world " * 10],
+        max_token_size=budget,
+        context="document",
+        document_prefix=prefix,
+    )
+
+    assert sent.startswith(prefix)
+    assert _token_count(sent) <= budget


### PR DESCRIPTION
## Description

`openai_embed`'s truncation block encodes every non-empty text with `tiktoken`'s default `disallowed_special=ALL`, so it raises `ValueError` as soon as a text merely *contains* a literal special-token string such as `<|endoftext|>`:

```python
tokens = encoding.encode(text)   # ValueError on any text quoting the marker
```

Because that encode runs for **every** text in the batch once truncation is enabled, one chunk of user content quoting the marker — documentation, notes, captured model output — failed the whole embedding batch, regardless of its length. Every other tokenizing path in the codebase already avoids this through `lightrag.utils.Tokenizer.encode`, whose comment names exactly this failure (*"This crashes document indexing on any user content that happens to contain those strings"*); this one site never reached it.

One line fixes it: encode the markers as ordinary text.

### Scope

The block only runs where `max_token_size` actually arrives. `EmbeddingFunc.__call__` injects it only when the wrapped function's own signature declares the parameter (`lightrag/utils.py:697-701`), so:

| Path | Truncation block runs? |
|---|---|
| Direct library use — `LightRAG(embedding_func=openai_embed)`, as in `examples/lightrag_openai_demo.py` | **yes** (8192 from the decorator) |
| API server — wraps the binding in `optimized_embedding_function(texts, embedding_dim=None, context="document")` | no |
| `azure_openai_embed` — signature omits the parameter | no |

The last two mean the server currently performs no local embedding-input truncation at all. That is a separate gap and is not addressed here.

## Related Issues

Fixes #3714. Supersedes #3715, which fixed the same defect by routing this site through `Tokenizer.truncate_by_token_limit`; see *Additional Notes* for the measurements that ruled that approach out.

## Changes Made

- `lightrag/llm/openai.py`: `encoding.encode(text, disallowed_special=())`, with a comment explaining why the argument is required rather than an optimization.
- `tests/llm/openai_impl/test_openai_embed_special_token.py`: 7 tests driving the real `openai_embed` with only `create_openai_async_client` mocked, asserting on the exact `input` list that reaches the embeddings API.

The truncation itself is deliberately unchanged. Slicing the token list and decoding it back **fills the budget exactly**, which no character-prefix scheme can do, and its only artefact is at most one trailing U+FFFD when the cut lands inside a multi-byte code point — every token before the cut decodes to complete characters, so the loss is bounded to the single code point whose remaining bytes lived in the next token. That is negligible for an embedding vector, and both properties are pinned by tests so a future change cannot silently trade them away.

## Verification

**Three-state check**, same working tree, reverting only `lightrag/llm/openai.py`:

| State | Result |
|---|---|
| impl + tests | `25 passed` across `tests/llm/openai_impl/` |
| revert impl only | `3 failed, 4 passed` — the three fix-proof tests fail with the real `ValueError`; the four stability tests pass on both revisions, as intended |
| restored | `427 passed` across `tests/llm/` |

`pre-commit run --files lightrag/llm/openai.py tests/llm/openai_impl/test_openai_embed_special_token.py`: clean.

**Re-encode safety of the unchanged truncation** — the one property a token-slice cut does not prove by construction is that `encode(decode(tokens[:n]))` still fits `n` (BPE token count is not monotonic in text length). Measured on `cl100k_base`:

| Fuzz | Trials | Over budget |
|---|---|---|
| random ASCII / CJK / emoji / combining-mark / literal-special-token / mixed text, random budgets | 7097 | **0** |
| targeted: every cut point over CJK / emoji / ZWJ / mixed text, 1103 of which produce a U+FFFD | ~2400 | **0** |

Worst deviation `+0` tokens; on emoji/ZWJ inputs some cuts come out a few tokens *under* budget. So the cut never exceeds the budget it was given.

Not verified: behavior against a live embeddings endpoint — the network boundary is mocked throughout.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not necessary — no documented interface changes)
- [x] Unit tests added

## Additional Notes

**Why not route this site through `Tokenizer.truncate_by_token_limit`** (the approach in #3715). That looks like the consistent choice, but measured end to end through `openai_embed` on a 192 000-character input (16 000-char contiguous CJK head + English tail) at the decorator's 8192 budget:

| | Sent to the API | Wall time |
|---|---|---|
| this PR | 8192 tokens | 0.99 s |
| #3715 (base `Tokenizer`) | **1 character** (`'语'`) | **13.1 s** |

Two independent causes, both in the generic `Tokenizer` implementation:

- `_bounded_prefix_span` seeds its candidate from one whole-text `chars_per_token` average and then retreats **strictly one-directionally**, never re-expanding. A head sparser than the document average is therefore accepted immediately at whatever length the average suggested — measured 4411/8192 tokens (≈45 % of the budget dropped) for an English head with a CJK body. A head much *denser* than the average overshoots instead, and `max(1, candidate_len - step)` clamps the last exponential step straight to 1 character. Its docstring promises "the **longest** safe prefix"; the generic implementation does not deliver that.
- The retreat re-encodes candidates that all still contain the same expensive CJK head. `tiktoken` is superlinear in the length of a single regex pretoken, and contiguous CJK has no whitespace to split on: 16 000 CJK chars cost 783 ms to encode, 32 000 cost 3106 ms, while the same characters with a space every 20 cost 2.9 ms. The 13.1 s is 16 × 0.78 s — one full encode plus 15 retreat candidates — of blocking CPU on the event loop.

Neither shows up on the homogeneous-density inputs used to validate that approach, and neither is a problem this site needs solved: the truncated string is sent over HTTP and discarded, so there is no consumer that needs character offsets into the original.

Unconditional `disallowed_special=()` is also strictly better than `Tokenizer.encode` on the special-token axis itself: that wrapper retries *after* catching the `ValueError`, paying a second full encode on affected texts (two 0.78 s encodes on CJK content), and its fallback is gated on the substring match `"special token" in str(e)`, which a `tiktoken` message change would silently break.

Known remaining, deliberately out of scope: neither the API server's `optimized_embedding_function` nor `azure_openai_embed` declares `max_token_size`, so no local truncation happens on those paths at all. Happy to open a separate issue.
