### PR TITLE
fix(tokenizer): bisect the prefix bracket instead of clamping to one char

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -3099,12 +3099,15 @@ class Tokenizer:
         return TokenSpan(start, start + 1, first_cp_tokens)
 
     def truncate_by_token_limit(self, content: str, max_tokens: int) -> TokenSpan:
-        """Return the longest safe prefix of ``content`` that fits ``max_tokens``.
+        """Return a verified safe prefix of ``content`` that fits ``max_tokens``.
 
         The result always starts at character offset 0. If the whole string
-        already fits, the returned span covers it entirely. Raises
-        ``ValueError`` for a non-positive budget, and ``TokenBudgetError`` if
-        not even the first complete Unicode code point fits.
+        already fits, the returned span covers it entirely. Otherwise the
+        bracketed search aims to use the available budget efficiently, but a
+        non-monotonic tokenizer may have a longer fitting prefix that was not
+        sampled. Raises ``ValueError`` for a non-positive budget, and
+        ``TokenBudgetError`` if not even the first complete Unicode code point
+        fits.
         """
         if max_tokens <= 0:
             raise ValueError(f"max_tokens must be positive, got {max_tokens}")
@@ -3214,7 +3217,7 @@ class TiktokenTokenizer(Tokenizer):
             import tiktoken
         except ImportError:
             raise ImportError(
-                "tiktoken is not installed. Please install it with `pip install tiktoken` or define custom `tokenizer_func`."
+                "tiktoken is not installed. Please install it with `pip install tiktoken` or pass a custom `tokenizer`."
             )
 
         try:

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -3005,12 +3005,19 @@ class Tokenizer:
     # the cost of a handful of extra ``encode()`` calls per span compared to
     # the tiktoken fast path.
     #
-    # BPE token count is not monotonic in character-prefix length, so this is
-    # a bounded, STRICTLY ONE-DIRECTIONAL retreat: candidate length only ever
-    # decreases (by exponential character steps: 1, 2, 4, 8, ...), never
-    # re-expands. That rules out oscillation and bounds the number of
-    # re-encodes to O(log max_tokens) regardless of how good the initial
-    # char/token ratio estimate turns out to be for a given region of text.
+    # BPE token count is not monotonic in character-prefix length, so no
+    # candidate is ever trusted without encoding it. The search brackets the
+    # answer between a length verified to fit and one verified to overflow --
+    # reached by doubling or halving from the ratio estimate -- and then
+    # bisects that bracket. The bracket only ever narrows, which rules out
+    # oscillation, and both phases are logarithmic in the remaining character
+    # count, so the number of re-encodes stays bounded however wrong the
+    # initial char/token ratio estimate is for a given region of text.
+    #
+    # Bracketing is an assumption about the sampled lengths, not a proof about
+    # every length between them: the span returned is always verified to fit,
+    # but under a sufficiently non-monotonic tokenizer a longer one may exist
+    # that the bisection never sampled.
     #
     # No cross-call state: nothing here is written back onto ``self``. An
     # injected tokenizer must remain safe under concurrent calls from
@@ -3026,19 +3033,62 @@ class Tokenizer:
         whole-content encode) used only to pick a starting candidate length;
         the result is always independently verified by encoding the exact
         candidate substring.
+
+        That estimate is a whole-content average, so wherever token density
+        varies it is wrong in one of two directions at ``start``: a region
+        sparser than the average makes the seed too short, a denser one makes
+        it too long. Accepting the first candidate that happens to fit leaves
+        most of the budget unspent in the first case; stepping down from an
+        over-long seed by exponentially growing amounts overshoots the whole
+        remainder in the second, which is why that step-down had to clamp at
+        one character. Both are avoided by bracketing the answer between a
+        length verified to fit and one verified to overflow, then bisecting.
         """
         remaining_len = len(content) - start
-        candidate_len = min(remaining_len, max(1, int(max_tokens * chars_per_token)))
-        step = 1
-        while True:
-            candidate = content[start : start + candidate_len]
-            count = len(self.encode(candidate))
-            if count <= max_tokens:
-                return TokenSpan(start, start + candidate_len, count)
-            if candidate_len <= 1:
-                break
-            candidate_len = max(1, candidate_len - step)
-            step *= 2
+        seed = min(remaining_len, max(1, int(max_tokens * chars_per_token)))
+
+        # ``good`` is the longest length verified to fit, ``bad`` the shortest
+        # verified not to; ``bad`` starts one past the end as a sentinel for
+        # "nothing has overflowed yet".
+        good, good_count = 0, 0
+        bad = remaining_len + 1
+
+        count = len(self.encode(content[start : start + seed]))
+        if count <= max_tokens:
+            good, good_count = seed, count
+            if seed == remaining_len:
+                return TokenSpan(start, start + good, good_count)
+            candidate = seed
+            while True:  # double until a candidate overflows
+                candidate = min(remaining_len, candidate * 2)
+                probe_count = len(self.encode(content[start : start + candidate]))
+                if probe_count > max_tokens:
+                    bad = candidate
+                    break
+                good, good_count = candidate, probe_count
+                if candidate == remaining_len:
+                    return TokenSpan(start, start + good, good_count)
+        else:
+            bad = seed
+            candidate = seed
+            while candidate > 1:  # halve until a candidate fits
+                candidate //= 2
+                probe_count = len(self.encode(content[start : start + candidate]))
+                if probe_count <= max_tokens:
+                    good, good_count = candidate, probe_count
+                    break
+                bad = candidate
+
+        while bad - good > 1:  # bisect the bracket
+            midpoint = (good + bad) // 2
+            probe_count = len(self.encode(content[start : start + midpoint]))
+            if probe_count <= max_tokens:
+                good, good_count = midpoint, probe_count
+            else:
+                bad = midpoint
+
+        if good > 0:
+            return TokenSpan(start, start + good, good_count)
 
         first_cp = content[start : start + 1]
         first_cp_tokens = len(self.encode(first_cp))

--- a/tests/llm/test_tokenizer_split_truncate_contract.py
+++ b/tests/llm/test_tokenizer_split_truncate_contract.py
@@ -12,7 +12,7 @@ truncation helpers scattered across the codebase. The contract:
   verified to overflow, then bisects that bracket -- it only ever narrows
   (never oscillates) and stays logarithmic in the remaining length;
 * a third-party ``Tokenizer`` subclass implementing only ``encode``/``decode``
-  gets correct (if slower) behavior "for free" via the generic base-class
+  gets contract-safe (if slower) behavior "for free" via the generic base-class
   implementation, with no new abstract methods to fill in.
 """
 
@@ -45,15 +45,11 @@ class _CharTokenizer(TokenizerInterface):
 
 
 class _WordCountingTokenizer(TokenizerInterface):
-    """A BPE-like tokenizer where a shorter prefix can cost MORE tokens.
+    """A BPE-like tokenizer that recognizes each ``ab`` pair as one token.
 
-    "ab" is a single recognized "word" token (cost 1); any other content
-    costs one token per character. Truncating "ab" down to just "a" therefore
-    goes from 1 token to 1 token (no change), but truncating "abc" down to
-    "ab" goes from 3 (a, b, c) to 1 -- and, the counter-example this contract
-    must survive, extending "a" (1 token) to "ab" (1 token) then over to "abx"
-    jumps to 3. The property under test: re-encoding the actual candidate
-    (not assuming monotonicity) is what makes truncate/split safe here.
+    This models cross-character merges used by the list reserialization tests.
+    The separate ``_NonMonotonicPrefixTokenizer`` below supplies the explicit
+    counterexample where extending a prefix reduces its token count.
     """
 
     def encode(self, content: str) -> list[int]:
@@ -70,6 +66,24 @@ class _WordCountingTokenizer(TokenizerInterface):
 
     def decode(self, tokens: list[int]) -> str:
         return "".join("ab" if t == -1 else chr(t) for t in tokens)
+
+
+class _NonMonotonicPrefixTokenizer(TokenizerInterface):
+    """A tokenizer whose prefix counts are explicitly non-monotonic.
+
+    For ``abcd`` the four prefix counts are 1, 2, 1, and 4: extending ``ab``
+    to ``abc`` creates one recognized token and makes the longer prefix
+    cheaper. This pins the generic contract's safety guarantee without
+    pretending that a logarithmic sampled search can prove the longest fit.
+    """
+
+    def encode(self, content: str) -> list[int]:
+        if content == "abc":
+            return [-1]
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join("abc" if token == -1 else chr(token) for token in tokens)
 
 
 def _char_tok() -> Tokenizer:
@@ -138,15 +152,13 @@ def test_truncate_raises_token_budget_error_when_even_one_code_point_does_not_fi
 
 
 def test_truncate_survives_the_bpe_non_monotonic_counter_example():
-    """A shorter candidate is not guaranteed to cost fewer tokens.
+    """A longer candidate is not guaranteed to cost more tokens.
 
-    "ab" costs 1 token; "abx" costs 3 (the word-token breaks). If truncate
-    ever assumed "shorter == fewer or equal tokens" without re-encoding, it
-    could accept a growing candidate incorrectly. Pin that every returned
-    span is independently safe regardless of this non-monotonicity.
+    ``ab`` costs 2 tokens while ``abc`` costs 1. Pin that every returned span
+    is independently safe regardless of this non-monotonicity.
     """
-    tok = Tokenizer("word", _WordCountingTokenizer())
-    text = "ab" + "x" * 20
+    tok = Tokenizer("non-monotonic", _NonMonotonicPrefixTokenizer())
+    text = "abc" + "x" * 20
     for budget in (1, 2, 3, 5, 10):
         span = tok.truncate_by_token_limit(text, budget)
         sub = text[span.start : span.end]
@@ -273,20 +285,19 @@ def test_split_rejects_a_non_progressing_window_shape():
 
 
 def test_split_survives_the_bpe_non_monotonic_counter_example():
-    tok = Tokenizer("word", _WordCountingTokenizer())
-    text = ("ab" + "x" * 8) * 6
+    tok = Tokenizer("non-monotonic", _NonMonotonicPrefixTokenizer())
+    text = ("abc" + "x" * 8) * 6
     spans = tok.split_by_token_limit(text, 4)
     _assert_split_invariants(tok, text, spans, 4)
 
 
 # --------------------------------------------------------------------------- #
-# Exponential (not halving) retreat
+# Bounded generic bracket search
 # --------------------------------------------------------------------------- #
 
 
-def test_generic_retreat_is_strictly_decreasing_and_bounded():
-    """The char-offset retreat in the generic implementation must never grow
-    and must terminate in O(log max_tokens) probes, not O(max_tokens)."""
+def test_generic_bracket_search_is_logarithmically_bounded():
+    """The generic search must take O(log length), not O(length), probes."""
 
     class _CountingTokenizer(TokenizerInterface):
         def __init__(self):
@@ -305,7 +316,7 @@ def test_generic_retreat_is_strictly_decreasing_and_bounded():
     span = tok.truncate_by_token_limit(text, 37)
     assert span.token_count <= 37
     # log2(5000) ~= 13; a handful of probes on top for the ratio estimate and
-    # floor check is still far below a 5000-step linear retreat.
+    # floor check is still far below a 5000-step linear search.
     assert underlying.encode_calls < 40
 
 
@@ -667,8 +678,8 @@ def test_probe_count_stays_logarithmic_on_heterogeneous_input(
     overflowing bound stays pinned while the fitting one advances a few
     characters per probe, and every one of those probes re-encodes a slice
     nearly as long as the document. That costs O(length) encodes rather than
-    O(length), which is worse than the defect being fixed. Bisection has no
-    such mode, and this bound is what pins it.
+    O(log length), which is worse than the defect being fixed. Bisection has
+    no such mode, and this bound is what pins it.
 
     The steeper tokenizer is the one that matters: a stalling rule stays
     within budget on a 16:1 ratio and only blows up as the cliff sharpens.
@@ -689,21 +700,29 @@ def test_probe_count_stays_logarithmic_on_heterogeneous_input(
 def test_bracket_survives_a_non_monotonic_tokenizer():
     """Bracketing samples lengths; it cannot assume what lies between them.
 
-    ``_WordCountingTokenizer`` makes a longer prefix cost fewer tokens, so the
-    fitting and overflowing bounds do not partition the range cleanly. The
-    span must still be verified to fit -- that is the guarantee -- even though
-    a longer fitting prefix may exist that bisection never sampled.
+    The prefix counts for ``abcd`` are 1, 2, 1, and 4. With a budget of 1,
+    bisection can return ``a`` after sampling overflowing ``ab`` even though
+    the longer ``abc`` also fits. The returned span must still be verified to
+    fit -- that is the guarantee -- without claiming it is the longest fit.
     """
-    tokenizer = Tokenizer(model_name="words", tokenizer=_WordCountingTokenizer())
-    content = "abababab" + "xyz" * 300 + "abababab"
+    tokenizer = Tokenizer(
+        model_name="non-monotonic", tokenizer=_NonMonotonicPrefixTokenizer()
+    )
+    content = "abcd"
+    budget = 1
 
-    for budget in (1, 2, 3, 5, 8, 13, 40):
-        span = tokenizer.truncate_by_token_limit(content, budget)
-        assert span.start == 0
-        assert span.end >= 1
-        assert content.startswith(content[: span.end])
-        assert len(tokenizer.encode(content[: span.end])) == span.token_count
-        assert span.token_count <= budget
+    assert [len(tokenizer.encode(content[:end])) for end in range(1, 5)] == [
+        1,
+        2,
+        1,
+        4,
+    ]
+    span = tokenizer.truncate_by_token_limit(content, budget)
+
+    assert span == TokenSpan(0, 1, 1)
+    assert len(tokenizer.encode(content[: span.end])) == span.token_count
+    assert span.token_count <= budget
+    assert len(tokenizer.encode(content[:3])) <= budget  # a longer fit exists
 
 
 def test_budget_below_one_code_point_still_raises():
@@ -717,9 +736,10 @@ def test_budget_below_one_code_point_still_raises():
 def test_real_tokenizer_dense_head_keeps_the_budget():
     """End to end on tiktoken, through the generic path.
 
-    A ``tokenizer_func`` injection reaches the base class -- ``TiktokenTokenizer``
-    overrides split/truncate with its ``decode_with_offsets`` fast path and does
-    not -- so the base class is wrapped around the same encoding directly.
+    A custom ``Tokenizer`` injection reaches the base class --
+    ``TiktokenTokenizer`` overrides split/truncate with its
+    ``decode_with_offsets`` fast path and does not -- so the base class is
+    wrapped around the same encoding directly.
     """
     tiktoken = pytest.importorskip("tiktoken")
     tokenizer = Tokenizer(

--- a/tests/llm/test_tokenizer_split_truncate_contract.py
+++ b/tests/llm/test_tokenizer_split_truncate_contract.py
@@ -8,7 +8,9 @@ truncation helpers scattered across the codebase. The contract:
   ``max_tokens`` (BPE token count is not monotonic in text length, so nothing
   short of re-encoding the actual candidate can be trusted);
 * ``split`` fully covers the input with no gaps and real forward progress;
-* retreat is bounded and strictly one-directional (never oscillates);
+* the search brackets each span between a length verified to fit and one
+  verified to overflow, then bisects that bracket -- it only ever narrows
+  (never oscillates) and stays logarithmic in the remaining length;
 * a third-party ``Tokenizer`` subclass implementing only ``encode``/``decode``
   gets correct (if slower) behavior "for free" via the generic base-class
   implementation, with no new abstract methods to fill in.
@@ -495,3 +497,244 @@ def test_split_overlap_clamped_to_previous_window_size_minus_one():
     # window transition.
     spans = tok.split_by_token_limit(text, max_tokens=10, overlap_tokens=5000)
     _assert_split_invariants(tok, text, spans, 10)
+
+
+class _DensityVaryingTokenizer(TokenizerInterface):
+    """A tokenizer whose token density differs sharply between two regions.
+
+    ``D`` costs 4 tokens per character; every other character costs 1 token
+    per 4 characters. A document mixing the two has a whole-content
+    chars-per-token average that is wrong for *both* regions, which is
+    exactly the estimate ``_bounded_prefix_span`` seeds from. Real corpora do
+    this whenever contiguous CJK meets Latin text.
+
+    ``decode`` asserts rather than answering: the generic split/truncate
+    implementation is contractually encode-only, and a call here would mean
+    that promise was broken.
+    """
+
+    def encode(self, content: str) -> list[int]:
+        tokens: list[int] = []
+        index = 0
+        while index < len(content):
+            if content[index] == "D":
+                tokens.extend([1, 1, 1, 1])
+                index += 1
+            else:
+                run = 0
+                while index < len(content) and content[index] != "D":
+                    run += 1
+                    index += 1
+                tokens.extend([2] * ((run + 3) // 4))
+        return tokens
+
+    def decode(self, tokens: list[int]) -> str:  # pragma: no cover - see docstring
+        raise AssertionError("the generic contract must never call decode()")
+
+
+class _DensityCliffTokenizer(TokenizerInterface):
+    """A density ratio steep enough to expose a stalling convergence rule.
+
+    ``D`` costs 10 tokens per character, everything else 1 token per 1000 --
+    a 10 000:1 cliff, which real tokenizers do reach (in ``cl100k`` a run of
+    ``.`` is ~63 chars/token while Tifinagh is ~0.33, a 190:1 ratio, and
+    whitespace runs push it further). The gentler ratio in
+    ``_DensityVaryingTokenizer`` is enough to expose a wrong ANSWER but not a
+    wrong probe COUNT, which is what this one is for.
+    """
+
+    def encode(self, content: str) -> list[int]:
+        tokens: list[int] = []
+        index = 0
+        while index < len(content):
+            if content[index] == "D":
+                tokens.extend([1] * 10)
+                index += 1
+            else:
+                run = 0
+                while index < len(content) and content[index] != "D":
+                    run += 1
+                    index += 1
+                tokens.extend([2] * ((run + 999) // 1000))
+        return tokens
+
+    def decode(self, tokens: list[int]) -> str:  # pragma: no cover
+        raise AssertionError("the generic contract must never call decode()")
+
+
+class _CountingTokenizer(TokenizerInterface):
+    """Wraps another tokenizer and counts ``encode`` calls."""
+
+    def __init__(self, inner: TokenizerInterface):
+        self.inner = inner
+        self.encode_calls = 0
+
+    def encode(self, content: str) -> list[int]:
+        self.encode_calls += 1
+        return self.inner.encode(content)
+
+    def decode(self, tokens: list[int]) -> str:
+        return self.inner.decode(tokens)
+
+
+def _density_tokenizer() -> Tokenizer:
+    return Tokenizer(model_name="density", tokenizer=_DensityVaryingTokenizer())
+
+
+def test_dense_head_is_not_truncated_to_a_single_character():
+    """A head denser than the document average must not collapse the span.
+
+    The seed length comes from the whole-content average. When the head is
+    denser than that average the seed overflows, and stepping down by
+    exponentially growing amounts used to overshoot the whole remainder in a
+    few iterations -- ``max(1, candidate_len - step)`` then clamped straight
+    to one character, so a 5000-character budget returned one character.
+    """
+    content = "D" * 400 + "s" * 40000  # dense head, very sparse tail
+    tokenizer = _density_tokenizer()
+
+    span = tokenizer.truncate_by_token_limit(content, 500)
+
+    assert span.start == 0
+    assert span.end > 1, "the dense head collapsed the span to a single character"
+    assert span.token_count <= 500
+    assert len(tokenizer.encode(content[: span.end])) == span.token_count
+    # 500 tokens buys 125 dense chars; anything near that beats the clamp.
+    assert span.end >= 100
+
+
+def test_sparse_head_does_not_silently_drop_budget():
+    """A head sparser than the average must not stop at the first fit.
+
+    The old implementation returned the first candidate whose count fit, so a
+    seed shortened by a dense document average spent only a fraction of the
+    budget and reported success.
+    """
+    content = "s" * 40000 + "D" * 400  # sparse head, dense tail
+    tokenizer = _density_tokenizer()
+
+    span = tokenizer.truncate_by_token_limit(content, 500)
+
+    assert span.token_count == 500, "budget was left unspent on a sparse head"
+    assert len(tokenizer.encode(content[: span.end])) == span.token_count
+
+
+def test_split_does_not_emit_single_character_spans():
+    """The same clamp reached ``split_by_token_limit`` one window at a time.
+
+    Every window whose start landed in a dense region returned one character,
+    so a density-heterogeneous document was split into per-character chunks --
+    each one separately embedded downstream.
+    """
+    content = ("D" * 200 + "s" * 8000) * 3
+    tokenizer = _density_tokenizer()
+
+    spans = tokenizer.split_by_token_limit(content, 256)
+
+    assert spans, "split returned nothing"
+    assert min(span.end - span.start for span in spans) > 1
+    # Full coverage, no gaps, real forward progress -- the existing contract.
+    assert spans[0].start == 0
+    assert spans[-1].end == len(content)
+    for previous, current in zip(spans, spans[1:]):
+        assert current.start <= previous.end
+        assert current.end > previous.end
+    # A 256-token budget over this document needs tens of spans, not thousands.
+    assert len(spans) < 100
+
+
+@pytest.mark.parametrize(
+    "tokenizer_factory",
+    [_DensityVaryingTokenizer, _DensityCliffTokenizer],
+    ids=["ratio_16", "ratio_10000"],
+)
+@pytest.mark.parametrize(
+    "content,budget",
+    [
+        ("s" * 60000 + "D" * 4000, 4096),  # sparse head, dense tail
+        ("D" * 4000 + "s" * 60000, 4096),  # dense head, sparse tail
+        (("D" * 200 + "s" * 8000) * 8, 2048),  # alternating blocks
+        ("s" * 100000 + "D" * 5000, 8192),  # long, and sparse for most of it
+    ],
+)
+def test_probe_count_stays_logarithmic_on_heterogeneous_input(
+    content, budget, tokenizer_factory
+):
+    """Closing the bracket must halve it, not creep towards it.
+
+    Any closing rule that merely avoids the two endpoints -- interpolating
+    between the measurements, for instance -- can stall on one side: the
+    overflowing bound stays pinned while the fitting one advances a few
+    characters per probe, and every one of those probes re-encodes a slice
+    nearly as long as the document. That costs O(length) encodes rather than
+    O(length), which is worse than the defect being fixed. Bisection has no
+    such mode, and this bound is what pins it.
+
+    The steeper tokenizer is the one that matters: a stalling rule stays
+    within budget on a 16:1 ratio and only blows up as the cliff sharpens.
+    Measured here, bisection needs 13-23 probes across every case; the
+    interpolating rule this replaced needs 47-71 on the 10 000:1 cases.
+    """
+    inner = _CountingTokenizer(tokenizer_factory())
+    tokenizer = Tokenizer(model_name="density", tokenizer=inner)
+
+    inner.encode_calls = 0
+    span = tokenizer.truncate_by_token_limit(content, budget)
+
+    assert span.token_count <= budget
+    assert len(tokenizer.encode(content[: span.end])) == span.token_count
+    assert inner.encode_calls <= 40
+
+
+def test_bracket_survives_a_non_monotonic_tokenizer():
+    """Bracketing samples lengths; it cannot assume what lies between them.
+
+    ``_WordCountingTokenizer`` makes a longer prefix cost fewer tokens, so the
+    fitting and overflowing bounds do not partition the range cleanly. The
+    span must still be verified to fit -- that is the guarantee -- even though
+    a longer fitting prefix may exist that bisection never sampled.
+    """
+    tokenizer = Tokenizer(model_name="words", tokenizer=_WordCountingTokenizer())
+    content = "abababab" + "xyz" * 300 + "abababab"
+
+    for budget in (1, 2, 3, 5, 8, 13, 40):
+        span = tokenizer.truncate_by_token_limit(content, budget)
+        assert span.start == 0
+        assert span.end >= 1
+        assert content.startswith(content[: span.end])
+        assert len(tokenizer.encode(content[: span.end])) == span.token_count
+        assert span.token_count <= budget
+
+
+def test_budget_below_one_code_point_still_raises():
+    """The bracket must not paper over a genuinely impossible budget."""
+    tokenizer = _density_tokenizer()
+
+    with pytest.raises(TokenBudgetError):
+        tokenizer.truncate_by_token_limit("D" + "s" * 100, 3)
+
+
+def test_real_tokenizer_dense_head_keeps_the_budget():
+    """End to end on tiktoken, through the generic path.
+
+    A ``tokenizer_func`` injection reaches the base class -- ``TiktokenTokenizer``
+    overrides split/truncate with its ``decode_with_offsets`` fast path and does
+    not -- so the base class is wrapped around the same encoding directly.
+    """
+    tiktoken = pytest.importorskip("tiktoken")
+    tokenizer = Tokenizer(
+        model_name="gpt-4o-mini",
+        tokenizer=tiktoken.encoding_for_model("gpt-4o-mini"),
+    )
+    content = (
+        "\u8bed\u8a00\u6a21\u578b\u7684\u77e5\u8bc6\u56fe\u8c31" * 200
+        + "the quick brown fox jumps over the lazy dog " * 400
+    )
+
+    span = tokenizer.truncate_by_token_limit(content, 512)
+
+    assert span.start == 0
+    assert span.end > 1
+    assert span.token_count <= 512
+    assert len(tokenizer.encode(content[: span.end])) == span.token_count
+    assert span.token_count >= 500, "budget largely unspent on a dense head"


### PR DESCRIPTION
## Description

`_bounded_prefix_span` seeds a candidate length from a whole-content `chars_per_token` average, returns the first candidate that fits, and steps down from an over-long one by exponentially growing amounts — a step-down that overshoots the whole remainder within a few iterations, where `max(1, candidate_len - step)` clamps it to a single character.

Wherever token density varies, that average is wrong at `start` in one of two directions, and each breaks differently: a denser-than-average head collapses the span to one character; a sparser-than-average head fits on the first try and returns with most of the budget unspent. The docstring promises the *longest* safe prefix, so both are contract violations.

This is the follow-up @danielaskdd named when closing #3715:

> a bisect between the last-known-good and last-known-bad candidate instead of the exponential clamp

Fixes #3721

## Changes Made

- `_bounded_prefix_span` now brackets the answer between a length verified to fit (`good`) and one verified to overflow (`bad`) — reached by doubling up from the seed or halving down from it — and bisects that bracket. Plain bisection, no interpolation: the bracket halves every iteration, so the probe count is logarithmic in the remaining length and cannot stall.
- Updated the class-level "Safe split/truncate contract" comment block, whose three claims (strictly one-directional retreat, exponential character steps 1-2-4-8, `O(log max_tokens)`) all described the removed algorithm.
- The docstring now states the limit honestly: bracketing is an assumption about the *sampled* lengths, not a proof about every length between them, so under a sufficiently non-monotonic tokenizer a longer fitting prefix may exist that bisection never sampled. The span returned is always verified to fit — that part is unconditional.

## Verification

**Effect** (base `Tokenizer` over the `text-embedding-3-small` encoding — a `tokenizer_func` injection; `TiktokenTokenizer` overrides both methods and is untouched):

| `truncate_by_token_limit`, budget 8192 | before | after |
|---|---|---|
| 192 000 chars, CJK head + Latin tail | 1 char / **0.0 %** of budget / 5.56 s | 6 963 chars / **100 %** / 1.15 s |
| 119 600 chars, Latin head + CJK body | 7 926 chars / **19.8 %** / 14.69 s | 21 502 chars / **100 %** / 14.98 s |
| homogeneous Latin | 100 % / 0.01 s | 100 % / 0.01 s |
| homogeneous CJK | 100 % / 14.84 s | 100 % / 14.84 s |

| `split_by_token_limit`, 58 920 chars alternating CJK/Latin, budget 512 | before | after |
|---|---|---|
| spans | 4 633 | **36** |
| median span length | **1 character** | 2 070 chars |
| spans of ≤ 4 chars | 4 596 (99.2 %) | **0** |
| wall time | 41.1 s | **0.06 s** |

**Three-state**, same working tree, reverting only `lightrag/utils.py`:

| State | Result |
|---|---|
| impl + tests | `60 passed` |
| revert impl only | **`4 failed, 56 passed`** — genuine assertion failures |
| restored | `60 passed` |

**Mutations** — each applied to the implementation, suite re-run, then reverted:

| Mutation | Caught by |
|---|---|
| close the bracket by interpolating between the measurements | `test_probe_count_stays_logarithmic_on_heterogeneous_input` |
| return the seed as soon as it fits (no upward search) | `test_sparse_head_does_not_silently_drop_budget` |
| restore the exponential step-down and its clamp-to-1 | `test_dense_head_…`, `test_split_does_not_emit_single_character_spans`, `test_real_tokenizer_…` |

The first of those is worth spelling out, because I tried it first and it is wrong: interpolating converges in fewer probes on gentle density gradients, but a guard that only excludes the bracket endpoints lets a guess of `good + 1` be accepted forever — the overflowing bound stays pinned while the fitting one creeps, each probe re-encoding a near-document-length slice. On a 10 000:1 density cliff that costs **145 encodes where bisection costs 15**. `_DensityCliffTokenizer` in the new tests exists specifically to pin that; the gentler `_DensityVaryingTokenizer` (16:1) is enough to expose a wrong *answer* but not a wrong *probe count*.

- Full offline suite (`pytest tests/ -m offline`), Python 3.13.5: **5903 passed, 48 skipped, 1304 deselected, 0 failed** — the `main` baseline (5889 passed, 0 failed) plus this PR's 14 new tests.
- `pre-commit run --files lightrag/utils.py tests/llm/test_tokenizer_split_truncate_contract.py`: clean.

**Cost.** Bisection replaces "first candidate that fits" with a real search, so on homogeneous documents — where the average estimate was already right — a span costs ~13-17 encodes instead of 1-2. That is the price of the fix: the old single probe was cheap precisely because it was not looking for the longest prefix. Absolute cost stays small on Latin text (0.01 s for a 264 000-character document) and is dominated by tiktoken's own superlinear cost on contiguous CJK, which is unchanged. On the heterogeneous inputs this PR is about, it is strictly faster (5.56 s → 1.15 s; 41.1 s → 0.06 s) because it stops re-encoding the same over-long candidate.

Not verified: real third-party tokenizers other than tiktoken. Non-monotonicity is modelled with the existing `_WordCountingTokenizer` (a longer prefix costing fewer tokens) rather than measured on HuggingFace or sentencepiece.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (the contract comment block and the affected docstrings)
- [x] Unit tests added

## Additional Notes

The two `max_token_size`-forwarding gaps flagged in #3715 (`optimized_embedding_function` and `azure_openai_embed` not declaring the parameter, so `EMBEDDING_TOKEN_LIMIT` never reaches the binding) are filed separately as #3720.
