### PR TITLE
Allow Bedrock default credential providers

### DIFF
--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -248,13 +248,14 @@ def _is_set(value: str | None) -> bool:
 
 
 def validate_bedrock_auth_configuration(args: argparse.Namespace) -> None:
-    """Reject Bedrock configuration with no explicit supported auth source."""
-    bearer_token = os.getenv("AWS_BEARER_TOKEN_BEDROCK")
+    """Validate explicitly configured Bedrock credentials.
 
-    def has_valid_auth(prefix: str | None = None) -> bool:
-        if _is_set(bearer_token):
-            return True
+    When no explicit credentials or bearer token is provided, boto3 resolves
+    credentials through its default provider chain, including web identity
+    tokens used by Kubernetes IRSA.
+    """
 
+    def has_no_partial_explicit_credentials(prefix: str | None = None) -> bool:
         if prefix:
             role_access_key = getattr(args, f"{prefix}_aws_access_key_id", None)
             role_secret_key = getattr(args, f"{prefix}_aws_secret_access_key", None)
@@ -263,42 +264,46 @@ def validate_bedrock_auth_configuration(args: argparse.Namespace) -> None:
 
         access_key = getattr(args, "aws_access_key_id", None)
         secret_key = getattr(args, "aws_secret_access_key", None)
-        return _is_set(access_key) and _is_set(secret_key)
+        return not (_is_set(access_key) or _is_set(secret_key)) or (
+            _is_set(access_key) and _is_set(secret_key)
+        )
 
     if getattr(args, "llm_binding", None) == "bedrock":
-        if not has_valid_auth():
+        if not has_no_partial_explicit_credentials():
             raise ValueError(
-                "Bedrock LLM binding requires AWS_ACCESS_KEY_ID and "
-                "AWS_SECRET_ACCESS_KEY, or process-level AWS_BEARER_TOKEN_BEDROCK."
+                "Bedrock LLM binding requires both AWS_ACCESS_KEY_ID and "
+                "AWS_SECRET_ACCESS_KEY when either explicit credential is set."
             )
         if _is_set(getattr(args, "llm_binding_api_key", None)):
             logging.warning(
                 "LLM_BINDING_API_KEY is set but ignored for Bedrock LLM binding. "
-                "Use SigV4 AWS_* variables or process-level AWS_BEARER_TOKEN_BEDROCK instead."
+                "Use AWS credentials, the default AWS credential provider chain, or "
+                "process-level AWS_BEARER_TOKEN_BEDROCK instead."
             )
 
     if getattr(args, "embedding_binding", None) == "bedrock":
-        if not has_valid_auth():
+        if not has_no_partial_explicit_credentials():
             raise ValueError(
-                "Bedrock embedding binding requires AWS_ACCESS_KEY_ID and "
-                "AWS_SECRET_ACCESS_KEY, or process-level AWS_BEARER_TOKEN_BEDROCK."
+                "Bedrock embedding binding requires both AWS_ACCESS_KEY_ID and "
+                "AWS_SECRET_ACCESS_KEY when either explicit credential is set."
             )
         if _is_set(getattr(args, "embedding_binding_api_key", None)):
             logging.warning(
                 "EMBEDDING_BINDING_API_KEY is set but ignored for Bedrock embedding binding. "
-                "Use SigV4 AWS_* variables or process-level AWS_BEARER_TOKEN_BEDROCK instead."
+                "Use AWS credentials, the default AWS credential provider chain, or "
+                "process-level AWS_BEARER_TOKEN_BEDROCK instead."
             )
 
     for spec in ROLES:
         role = spec.name
         if getattr(
             args, f"{role}_llm_binding", None
-        ) == "bedrock" and not has_valid_auth(role):
+        ) == "bedrock" and not has_no_partial_explicit_credentials(role):
             raise ValueError(
-                f"Bedrock role '{role}' requires {spec.env_prefix}_AWS_ACCESS_KEY_ID "
-                f"and {spec.env_prefix}_AWS_SECRET_ACCESS_KEY, global "
-                "AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, or process-level "
-                "AWS_BEARER_TOKEN_BEDROCK."
+                f"Bedrock role '{role}' requires both "
+                f"{spec.env_prefix}_AWS_ACCESS_KEY_ID and "
+                f"{spec.env_prefix}_AWS_SECRET_ACCESS_KEY when either explicit "
+                "credential is set."
             )
 
 

--- a/tests/api/config/test_api_config_bedrock.py
+++ b/tests/api/config/test_api_config_bedrock.py
@@ -18,6 +18,8 @@ def _clear_bedrock_auth_env(monkeypatch):
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SESSION_TOKEN",
         "AWS_BEARER_TOKEN_BEDROCK",
+        "AWS_ROLE_ARN",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
         "QUERY_AWS_ACCESS_KEY_ID",
         "QUERY_AWS_SECRET_ACCESS_KEY",
     ):
@@ -84,14 +86,40 @@ def test_bedrock_role_api_key_is_rejected(monkeypatch):
         parse_args()
 
 
-def test_bedrock_binding_requires_sigv4_pair_or_bearer_token(monkeypatch):
+def test_bedrock_binding_accepts_default_aws_credential_provider_chain(monkeypatch):
     _clear_bedrock_auth_env(monkeypatch)
     monkeypatch.setattr(sys, "argv", ["lightrag-server"])
     monkeypatch.setenv("LLM_BINDING", "bedrock")
     monkeypatch.setenv("EMBEDDING_BINDING", "ollama")
+    monkeypatch.setenv(
+        "AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/lightrag-bedrock"
+    )
+    monkeypatch.setenv(
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "/var/run/secrets/eks.amazonaws.com/serviceaccount/token",
+    )
 
-    with pytest.raises(ValueError, match="Bedrock LLM binding requires"):
-        parse_args()
+    args = parse_args()
+
+    assert args.llm_binding == "bedrock"
+
+
+def test_bedrock_role_accepts_default_aws_credential_provider_chain(monkeypatch):
+    _clear_bedrock_auth_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.setenv("QUERY_LLM_BINDING", "bedrock")
+    monkeypatch.setenv("QUERY_LLM_MODEL", "us.amazon.nova-lite-v1:0")
+    monkeypatch.setenv(
+        "AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/lightrag-bedrock"
+    )
+    monkeypatch.setenv(
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "/var/run/secrets/eks.amazonaws.com/serviceaccount/token",
+    )
+
+    args = parse_args()
+
+    assert args.query_llm_binding == "bedrock"
 
 
 def test_bedrock_binding_rejects_partial_sigv4_pair(monkeypatch):
@@ -99,6 +127,18 @@ def test_bedrock_binding_rejects_partial_sigv4_pair(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["lightrag-server"])
     monkeypatch.setenv("LLM_BINDING", "bedrock")
     monkeypatch.setenv("EMBEDDING_BINDING", "ollama")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "akid")
+
+    with pytest.raises(ValueError, match="Bedrock LLM binding requires"):
+        parse_args()
+
+
+def test_bedrock_binding_rejects_partial_sigv4_pair_with_bearer_token(monkeypatch):
+    _clear_bedrock_auth_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.setenv("LLM_BINDING", "bedrock")
+    monkeypatch.setenv("EMBEDDING_BINDING", "ollama")
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "absk-test")
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "akid")
 
     with pytest.raises(ValueError, match="Bedrock LLM binding requires"):
@@ -135,6 +175,18 @@ def test_bedrock_role_requires_complete_role_sigv4_pair(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["lightrag-server"])
     monkeypatch.setenv("QUERY_LLM_BINDING", "bedrock")
     monkeypatch.setenv("QUERY_LLM_MODEL", "us.amazon.nova-lite-v1:0")
+    monkeypatch.setenv("QUERY_AWS_ACCESS_KEY_ID", "akid")
+
+    with pytest.raises(ValueError, match="Bedrock role 'query' requires"):
+        parse_args()
+
+
+def test_bedrock_role_rejects_partial_sigv4_pair_with_bearer_token(monkeypatch):
+    _clear_bedrock_auth_env(monkeypatch)
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.setenv("QUERY_LLM_BINDING", "bedrock")
+    monkeypatch.setenv("QUERY_LLM_MODEL", "us.amazon.nova-lite-v1:0")
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "absk-test")
     monkeypatch.setenv("QUERY_AWS_ACCESS_KEY_ID", "akid")
 
     with pytest.raises(ValueError, match="Bedrock role 'query' requires"):


### PR DESCRIPTION
### Description

- Bedrock startup currently rejects deployments without static AWS credentials or `AWS_BEARER_TOKEN_BEDROCK`.
- This prevents the use of IAM Roles for Service Accounts (IRSA), even though the Bedrock client already uses botocore's default credential chain.

### Changes

- Allow the default chain when no explicit credentials are configured; still reject incomplete explicit key pairs.
- Add coverage for IRSA configuration on base and role-specific Bedrock bindings.

