### PR TITLE
fix(pipeline): keep generated failure summary within varchar(255)

### DIFF
--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -425,6 +425,14 @@ DUPLICATE_DEMOTION_METADATA_KEYS: tuple[str, ...] = (
 # a stale generated summary while real raw-document summaries are preserved —
 # keep every producer on this constant so the match never drifts.
 FILE_EXTRACTION_SUMMARY_PREFIX = "[File Extraction]"
+# Hard ceiling for a doc_status ``content_summary``. PostgreSQL declares the
+# column as ``varchar(255)``; the other backends are unconstrained, so this is
+# the narrowest storage the value must fit. Producers that BUILD a summary from
+# unbounded text (an error message, a document body) must budget against this
+# rather than against ``get_content_summary``'s own default, or a long enough
+# input makes the whole upsert fail on PostgreSQL — including the FAILED
+# transition itself, which then leaves the document stuck in PARSING.
+DOC_STATUS_CONTENT_SUMMARY_MAX_LENGTH = 255
 
 # Suffixes for parser artifact subdirectories under ``<input>/__parsed__/``.
 # Centralising them here keeps the sidecar writer, engine cache modules and

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -28,6 +28,7 @@ from lightrag.base import (
 )
 from lightrag.constants import (
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
+    DOC_STATUS_CONTENT_SUMMARY_MAX_LENGTH,
     DUPLICATE_DEMOTION_METADATA_KEYS,
     FILE_EXTRACTION_SUMMARY_PREFIX,
     FULL_DOCS_FORMAT_LIGHTRAG,
@@ -52,6 +53,15 @@ from lightrag.utils import (
     move_file_to_parsed_dir,
 )
 
+
+# Character budget for the error description inside a generated
+# ``[File Extraction]`` summary: the column ceiling minus the prefix and minus
+# the ellipsis ``get_content_summary`` appends when it truncates. Keeps the
+# concatenated summary within PostgreSQL's ``varchar(255)`` for an error
+# message of any length.
+_FILE_EXTRACTION_SUMMARY_ERROR_BUDGET = (
+    DOC_STATUS_CONTENT_SUMMARY_MAX_LENGTH - len(FILE_EXTRACTION_SUMMARY_PREFIX) - 3
+)
 
 PLACEHOLDER_DOCUMENT_SOURCES = {"", "no-file-path", "unknown_source"}
 SIDECAR_LOCATION_UNKNOWN = "unknown_source"
@@ -699,6 +709,13 @@ def doc_status_parse_failure_fields(
     directive whitelists, so the next transition (retry reset, PARSING)
     drops them automatically — mirroring how ``error_msg`` is cleared.
 
+    The generated summary is budgeted so that prefix + description +
+    ellipsis never exceeds ``DOC_STATUS_CONTENT_SUMMARY_MAX_LENGTH``.
+    ``get_content_summary``'s own 250-char default would overflow
+    PostgreSQL's ``varchar(255)`` once the prefix is prepended, and the
+    upsert that fails is the FAILED transition itself — the document would
+    silently stay in its previous in-flight status with no error recorded.
+
     ``engine_hint`` (the parse worker's resolved engine key, falling back
     to its queue-group id) is stamped as ``parse_engine`` only when the
     failure happened before the post-parse stamp put one on
@@ -717,8 +734,10 @@ def doc_status_parse_failure_fields(
     if not current_summary or current_summary.startswith(
         FILE_EXTRACTION_SUMMARY_PREFIX
     ):
-        extra_fields["content_summary"] = (
-            FILE_EXTRACTION_SUMMARY_PREFIX + get_content_summary(error_text)
+        extra_fields["content_summary"] = FILE_EXTRACTION_SUMMARY_PREFIX + (
+            get_content_summary(
+                error_text, max_length=_FILE_EXTRACTION_SUMMARY_ERROR_BUDGET
+            )
         )
     metadata_extra: dict[str, Any] = {
         "error_type": "file_extraction_error",

--- a/tests/pipeline/test_parse_failure_doc_status_fields.py
+++ b/tests/pipeline/test_parse_failure_doc_status_fields.py
@@ -33,7 +33,10 @@ import pytest
 
 from lightrag import LightRAG
 from lightrag.base import DocStatus
-from lightrag.constants import FULL_DOCS_FORMAT_PENDING_PARSE
+from lightrag.constants import (
+    DOC_STATUS_CONTENT_SUMMARY_MAX_LENGTH,
+    FULL_DOCS_FORMAT_PENDING_PARSE,
+)
 from lightrag.parser import registry
 from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
 from lightrag.utils_pipeline import doc_status_parse_failure_fields
@@ -126,10 +129,48 @@ def test_long_error_text_is_truncated_in_summary():
     )
     summary = extra["content_summary"]
     assert summary.startswith("[File Extraction]")
-    # get_content_summary caps the description at 250 chars (plus ellipsis).
-    assert len(summary) <= len("[File Extraction]") + 253
+    assert summary.endswith("...")
     # error_msg keeps the full text.
     assert extra["error_msg"] == long_error
+
+
+@pytest.mark.parametrize(
+    "error_text",
+    [
+        "x" * 1000,
+        # The real report: a CUDA OOM message from the MinerU parse worker,
+        # comfortably past the truncation threshold.
+        "CUDA out of memory. Tried to allocate 360.00 MiB. GPU 0 has a total "
+        "capacity of 22.03 GiB of which 109.94 MiB is free. Process 853701 has "
+        "3.85 GiB memory in use. Process 854340 has 18.06 GiB memory in use. Of "
+        "the allocated memory 3.08 GiB is allocated by PyTorch, and 344.55 MiB "
+        "is reserved by PyTorch but unallocated. If reserved but unallocated "
+        "memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments"
+        ":True to avoid fragmentation.  See documentation for Memory Management",
+        # Exactly at the boundary from the other side: prefix + description +
+        # ellipsis must land ON 255, never one over.
+        "y" * (DOC_STATUS_CONTENT_SUMMARY_MAX_LENGTH - len("[File Extraction]") - 2),
+    ],
+)
+def test_generated_summary_fits_the_doc_status_column(error_text):
+    """The generated summary must fit PostgreSQL's ``varchar(255)``.
+
+    ``get_content_summary``'s 250-char default plus the 17-char prefix and
+    the 3-char ellipsis produced a 270-char summary, so the FAILED upsert
+    itself was rejected by PostgreSQL ("value too long for type character
+    varying(255)"). Because status / error_msg / metadata ride the SAME
+    single-row upsert, nothing was recorded at all and the document stayed
+    in PARSING with no error — the pipeline then auto-resumed it, failed
+    the same way, and looped invisibly.
+    """
+    extra, _meta = doc_status_parse_failure_fields(
+        ValueError(error_text), status_doc={"content_summary": "", "metadata": {}}
+    )
+    summary = extra["content_summary"]
+    assert summary.startswith("[File Extraction]")
+    assert len(summary) <= DOC_STATUS_CONTENT_SUMMARY_MAX_LENGTH
+    # The full text still reaches the TEXT-typed error_msg column.
+    assert extra["error_msg"] == error_text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A parse-stage failure could not record its own `FAILED` status on PostgreSQL when the error message was long. The upsert was rejected, so the document stayed in `PARSING` with no error recorded — and then auto-resumed and failed the same way, invisibly.

## Motivation

Reported from a MinerU run that hit a CUDA OOM. The backend log shows both halves of the failure:

```
ERROR: Parse worker failed (mineru): MinerU local parse failed for task ...: CUDA out of memory. Tried to allocate 360.00 MiB. ...
ERROR: Failed to record FAILED status for doc-953716db7881ca3197956f8820c219cb: value too long for type character varying(255)
```

The document's `doc_status` still read `PARSING`, with no `error_msg` and no `metadata.error_type` / `error_stage`.

### Root cause

`doc_status_parse_failure_fields` builds the display summary as:

```python
FILE_EXTRACTION_SUMMARY_PREFIX + get_content_summary(error_text)
```

- `FILE_EXTRACTION_SUMMARY_PREFIX` = `"[File Extraction]"` — 17 chars
- `get_content_summary` caps at `max_length=250` and appends `"..."` — 253 chars

That is **270 chars**, while `LIGHTRAG_DOC_STATUS.content_summary` is declared `varchar(255)`. Any error message over 250 characters overflows — a CUDA OOM message is far past that.

`status`, `error_msg`, `metadata` and `content_summary` all ride the **same single-row** `INSERT ... ON CONFLICT DO UPDATE`, so one column overflowing discards the entire FAILED transition. The parse worker deliberately swallows the upsert exception (re-raising would kill the worker) and only logs, so the document silently keeps its previous status.

The consequence is worse than a missing message: `PARSING` is in `_AUTO_RESUME_DOC_STATUSES`, so the next pipeline run treats the document as a dead-process orphan and re-parses it. If the underlying condition persists (GPU still out of memory), the FAILED record fails to write again — the document loops between `PARSING` and re-parse, and the WebUI never shows why.

Only PostgreSQL declares a length on this column. JSON / Redis / MongoDB / OpenSearch `doc_status` are unconstrained and were writing the FAILED row correctly, which is why this only surfaces on PG deployments.

## What's changed

- **`lightrag/constants.py`** — new `DOC_STATUS_CONTENT_SUMMARY_MAX_LENGTH = 255`, documenting that PostgreSQL's `varchar(255)` is the narrowest storage a `content_summary` must fit, and that producers building one from unbounded text must budget against it.
- **`lightrag/utils_pipeline.py`** — the generated `[File Extraction]` summary now budgets the description as `255 - len(prefix) - 3`, so prefix + description + ellipsis lands exactly on 255 for an error message of any length. `error_msg` is `TEXT` and still carries the full text; only the display summary is shortened.
- **`tests/pipeline/test_parse_failure_doc_status_fields.py`** — a parametrized regression test over three inputs: a 1000-char message, the verbatim CUDA-OOM message from the report, and an exact-boundary string. The existing truncation test is kept, with its brittle `<= 17 + 253` bound replaced by an ellipsis assertion.

Other `content_summary` producers were audited and are bounded already: `get_content_summary(body_text)` carries no prefix (≤ 253), the duplicate-document summaries are fixed-shape (`[DUPLICATE:...] Original document: doc-<32 hex>`), and `apipeline_enqueue_error_documents` receives literal descriptions. This was the only site concatenating a prefix onto unbounded text.

## Why not widen the column

Migrating `content_summary` to `TEXT` is the more thorough fix and remains reasonable later. This PR takes the smaller change: no schema migration, no behavior difference on the unconstrained backends, and the value is a display summary that was already being truncated — 253 vs 235 characters of an error message is not a meaningful loss. The new constant makes the ceiling explicit for future producers either way.

## Verification

New regression test fails on the pre-fix code with the behavioral assertion (`AssertionError: assert 270 <= 255`) on both the synthetic and the real CUDA-OOM input, and passes after.

- `tests/pipeline/` — 684 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)