### PR TITLE
fix(llm): stop retrying permanent spend-stop 429s (LiteLLM budget_exceeded / OpenAI insufficient_quota)

### DIFF
--- a/lightrag/llm/_error_utils.py
+++ b/lightrag/llm/_error_utils.py
@@ -1,0 +1,58 @@
+"""Shared classification of OpenAI-style API errors.
+
+Lives outside ``lightrag/llm/openai.py`` so consumers that only need the
+classification -- e.g. ``lightrag.parser.docx.utils``, which treats the
+``openai`` package as an optional dependency -- can import it without pulling
+in the binding's own imports (``tiktoken``, ``numpy``, and the ``pipmaster``
+auto-install of ``openai`` at module import time).
+
+Deliberately dependency-free: it inspects only the parsed error envelope and
+the rendered message, never an exception class, so the caller decides which
+exception types the check applies to.
+"""
+
+from __future__ import annotations
+
+# HTTP 429 has two distinct meanings and only one of them is transient.
+#
+# - LiteLLM Proxy reports an exhausted spend budget as 429 with
+#   ``type == "budget_exceeded"`` (``litellm.proxy._types.ProxyErrorTypes``).
+# - OpenAI reports an exhausted account quota as 429 with
+#   ``type == "insufficient_quota"``.
+#
+# Neither clears on its own -- an operator has to raise or reset the budget, or
+# top up billing -- so backing off and retrying only burns the retry window and
+# then buries the one actionable message behind a ``tenacity.RetryError``.
+PERMANENT_RATE_LIMIT_ERROR_TYPES = frozenset(
+    {
+        "budget_exceeded",
+        "insufficient_quota",
+    }
+)
+
+
+def is_permanent_rate_limit_error(error: BaseException) -> bool:
+    """Report whether a 429 is a permanent spend stop rather than a throttle.
+
+    The OpenAI SDK unwraps the JSON error envelope before constructing the
+    exception (``data = body.get("error", body)`` in ``_make_status_error``),
+    so ``error.body`` is normally the inner object -- but proxies and SDK
+    versions differ, so both shapes are probed, with a substring check on the
+    rendered message as a last resort. The type slugs are specific enough that
+    a false positive would have to name one of them verbatim.
+    """
+    body = getattr(error, "body", None)
+    candidates = [body]
+    if isinstance(body, dict):
+        candidates.append(body.get("error"))
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        error_type = candidate.get("type")
+        if (
+            isinstance(error_type, str)
+            and error_type.strip().lower() in PERMANENT_RATE_LIMIT_ERROR_TYPES
+        ):
+            return True
+    rendered = str(error).lower()
+    return any(slug in rendered for slug in PERMANENT_RATE_LIMIT_ERROR_TYPES)

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -23,6 +23,7 @@ from tenacity import (
     retry,
     stop_after_attempt,
     wait_exponential,
+    retry_if_exception,
     retry_if_exception_type,
 )
 from lightrag.utils import (
@@ -35,6 +36,7 @@ from lightrag.utils import (
 
 from lightrag.api import __api_version__
 from lightrag.exceptions import EmptyTruncatedResponseError
+from lightrag.llm._error_utils import is_permanent_rate_limit_error
 
 import numpy as np
 import base64
@@ -91,6 +93,22 @@ class TransientBadRequestError(Exception):
     """
 
     pass
+
+
+def _is_retryable_rate_limit_error(error: BaseException) -> bool:
+    """tenacity predicate: retry 429s, except permanent spend stops.
+
+    Used instead of ``retry_if_exception_type(RateLimitError)`` so the original
+    RateLimitError still propagates to callers unchanged (upstream
+    ``except RateLimitError`` / ``isinstance`` checks keep working, and the
+    doc-status failure summary carries the provider's own message -- the
+    LiteLLM budget figures, or OpenAI's billing pointer -- instead of an opaque
+    RetryError). See :mod:`lightrag.llm._error_utils` for what counts as
+    permanent.
+    """
+    return isinstance(error, RateLimitError) and not is_permanent_rate_limit_error(
+        error
+    )
 
 
 def _validate_openai_response_format(response_format: Any | None) -> None:
@@ -232,7 +250,7 @@ def create_openai_async_client(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=4, max=10),
     retry=(
-        retry_if_exception_type(RateLimitError)
+        retry_if_exception(_is_retryable_rate_limit_error)
         | retry_if_exception_type(APIConnectionError)
         | retry_if_exception_type(APITimeoutError)
         | retry_if_exception_type(InvalidResponseError)
@@ -338,7 +356,10 @@ async def openai_complete_if_cache(
     Raises:
         InvalidResponseError: If the response from OpenAI is invalid or empty.
         APIConnectionError: If there is a connection error with the OpenAI API.
-        RateLimitError: If the OpenAI API rate limit is exceeded.
+        RateLimitError: If the OpenAI API rate limit is exceeded. Retried
+            with backoff, except for a permanent spend stop (a LiteLLM Proxy
+            ``budget_exceeded`` or an OpenAI ``insufficient_quota``), which
+            fails fast.
         APITimeoutError: If the OpenAI API request times out.
     """
     if history_messages is None:
@@ -458,7 +479,10 @@ async def openai_complete_if_cache(
             logger.warning(f"Failed to close OpenAI client: {close_error}")
         raise
     except RateLimitError as e:
-        logger.error(f"OpenAI API Rate Limit Error: {e}")
+        if is_permanent_rate_limit_error(e):
+            logger.error(f"OpenAI API Spend Limit Reached (not retrying): {e}")
+        else:
+            logger.error(f"OpenAI API Rate Limit Error: {e}")
         try:
             await openai_async_client.close()
         except Exception as close_error:
@@ -977,7 +1001,7 @@ async def nvidia_openai_complete(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=4, max=60),
     retry=(
-        retry_if_exception_type(RateLimitError)
+        retry_if_exception(_is_retryable_rate_limit_error)
         | retry_if_exception_type(APIConnectionError)
         | retry_if_exception_type(APITimeoutError)
         # Retry transient HTTP 5xx (OpenAI 500 / proxy upstream errors).
@@ -1047,7 +1071,10 @@ async def openai_embed(
 
     Raises:
         APIConnectionError: If there is a connection error with the OpenAI API.
-        RateLimitError: If the OpenAI API rate limit is exceeded.
+        RateLimitError: If the OpenAI API rate limit is exceeded. Retried
+            with backoff, except for a permanent spend stop (a LiteLLM Proxy
+            ``budget_exceeded`` or an OpenAI ``insufficient_quota``), which
+            fails fast.
         APITimeoutError: If the OpenAI API request times out.
     """
     # Apply context-based prefixes if provided

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -14,6 +14,7 @@ if not pm.is_installed("openai"):
 
 from openai import (
     APIConnectionError,
+    APIStatusError,
     RateLimitError,
     APITimeoutError,
     InternalServerError,
@@ -93,6 +94,24 @@ class TransientBadRequestError(Exception):
     """
 
     pass
+
+
+# Retry ownership moved wholly to tenacity when the client stopped carrying the
+# SDK's own loop (``max_retries=0``), so the outer loop has to cover everything
+# the SDK's body-blind ``_should_retry`` used to: 408 request timeouts and 409
+# lock timeouts. Neither is matched by any other predicate here -- ``_make_status_error``
+# maps 409 to ConflictError and has no branch for 408 at all, so it arrives as a
+# bare APIStatusError. (429 and >=500 are covered by the RateLimitError and
+# InternalServerError predicates.)
+_TRANSIENT_STATUS_CODES = frozenset({408, 409})
+
+
+def _is_transient_status_error(error: BaseException) -> bool:
+    """tenacity predicate: retry the transient statuses the SDK used to retry."""
+    return (
+        isinstance(error, APIStatusError)
+        and getattr(error, "status_code", None) in _TRANSIENT_STATUS_CODES
+    )
 
 
 def _is_retryable_rate_limit_error(error: BaseException) -> bool:
@@ -191,6 +210,10 @@ def create_openai_async_client(
     loop, making a transient failure cost up to 3x3 requests. Overridable
     through ``client_configs`` for anyone who wants the SDK's ``Retry-After``
     handling back.
+
+    Taking ownership means covering everything the SDK's loop covered:
+    connection errors, timeouts, 429 and >=500 already had predicates, and
+    ``_is_transient_status_error`` adds the 408 / 409 the SDK also retried.
     """
     if use_azure:
         from openai import AsyncAzureOpenAI
@@ -267,6 +290,8 @@ def create_openai_async_client(
     wait=wait_exponential(multiplier=1, min=4, max=10),
     retry=(
         retry_if_exception(_is_retryable_rate_limit_error)
+        # 408 / 409 -- retried by the SDK loop this client no longer runs.
+        | retry_if_exception(_is_transient_status_error)
         | retry_if_exception_type(APIConnectionError)
         | retry_if_exception_type(APITimeoutError)
         | retry_if_exception_type(InvalidResponseError)
@@ -1018,6 +1043,8 @@ async def nvidia_openai_complete(
     wait=wait_exponential(multiplier=1, min=4, max=60),
     retry=(
         retry_if_exception(_is_retryable_rate_limit_error)
+        # 408 / 409 -- retried by the SDK loop this client no longer runs.
+        | retry_if_exception(_is_transient_status_error)
         | retry_if_exception_type(APIConnectionError)
         | retry_if_exception_type(APITimeoutError)
         # Retry transient HTTP 5xx (OpenAI 500 / proxy upstream errors).

--- a/lightrag/llm/openai.py
+++ b/lightrag/llm/openai.py
@@ -175,10 +175,22 @@ def create_openai_async_client(
         timeout: Request timeout in seconds.
         client_configs: Additional configuration options for the AsyncOpenAI client.
             These will override any default configurations but will be overridden by
-            explicit parameters (api_key, base_url).
+            explicit parameters (api_key, base_url). Pass ``max_retries`` here to
+            re-enable the SDK's own retry loop (see below).
 
     Returns:
         An AsyncOpenAI or AsyncAzureOpenAI client instance.
+
+    Retry ownership: the client is built with ``max_retries=0`` so the tenacity
+    decorators on ``openai_complete_if_cache`` / ``openai_embed`` are the only
+    retry layer. The SDK defaults to ``max_retries=2`` and its ``_should_retry``
+    is body-blind -- it retries every 429, including the permanent spend stops
+    (LiteLLM ``budget_exceeded``, OpenAI ``insufficient_quota``) that the
+    tenacity predicate exists to fail fast on, so those would still cost three
+    HTTP requests plus SDK backoff per call. It also multiplied with the outer
+    loop, making a transient failure cost up to 3x3 requests. Overridable
+    through ``client_configs`` for anyone who wants the SDK's ``Retry-After``
+    handling back.
     """
     if use_azure:
         from openai import AsyncAzureOpenAI
@@ -193,6 +205,8 @@ def create_openai_async_client(
 
         # Create a merged config dict with precedence: explicit params > client_configs
         merged_configs = {
+            # Retry ownership belongs to the tenacity decorators; see docstring.
+            "max_retries": 0,
             **client_configs,
             "api_key": api_key,
         }
@@ -225,6 +239,8 @@ def create_openai_async_client(
 
         # Create a merged config dict with precedence: explicit params > client_configs > defaults
         merged_configs = {
+            # Retry ownership belongs to the tenacity decorators; see docstring.
+            "max_retries": 0,
             **client_configs,
             "default_headers": default_headers,
             "api_key": api_key,

--- a/lightrag/parser/docx/utils.py
+++ b/lightrag/parser/docx/utils.py
@@ -26,6 +26,8 @@ except ImportError:  # pragma: no cover - optional dependency
     openai = None
     HAS_OPENAI = False
 
+from lightrag.llm._error_utils import is_permanent_rate_limit_error
+
 
 def estimate_tokens(text: str) -> int:
     """
@@ -248,9 +250,13 @@ def is_openai_retryable(error: Exception) -> bool:
     - PermissionDeniedError (403): No access to resource
     - BadRequestError (400): Invalid request format
     - NotFoundError (404): Model or resource not found
+    - RateLimitError (429) that is a permanent spend stop: a LiteLLM Proxy
+      ``budget_exceeded`` or an OpenAI ``insufficient_quota``. Only an operator
+      raising the budget or topping up billing clears these, so backoff cannot
+      help.
 
     Retryable errors:
-    - RateLimitError (429): Rate limit exceeded
+    - RateLimitError (429): Rate limit exceeded (throughput throttle)
     - APIConnectionError: Network issues
     - InternalServerError (500): Server errors
     - APIStatusError with 502, 503, 504: Gateway/service errors
@@ -280,9 +286,10 @@ def is_openai_retryable(error: Exception) -> bool:
     if isinstance(error, openai.NotFoundError):
         return False
 
-    # Rate limit exceeded - should retry with backoff (429)
+    # Rate limit exceeded - should retry with backoff (429), unless the 429 is
+    # a permanent spend stop that no amount of backoff can clear.
     if isinstance(error, openai.RateLimitError):
-        return True
+        return not is_permanent_rate_limit_error(error)
 
     # API connection error - network issues, should retry
     if isinstance(error, openai.APIConnectionError):
@@ -294,8 +301,13 @@ def is_openai_retryable(error: Exception) -> bool:
 
     # For other APIStatusError, check HTTP status code
     if isinstance(error, openai.APIStatusError):
+        # A 429 reaching here is not a RateLimitError instance (a proxy may
+        # surface it as a bare APIStatusError), so it needs the same spend-stop
+        # check as the branch above.
+        if error.status_code == 429:
+            return not is_permanent_rate_limit_error(error)
         # Retryable server-side errors
-        return error.status_code in (429, 500, 502, 503, 504)
+        return error.status_code in (500, 502, 503, 504)
 
     # For unknown errors, default to retry (network issues, timeouts, etc.)
     return True

--- a/tests/llm/openai_impl/test_openai_permanent_rate_limit.py
+++ b/tests/llm/openai_impl/test_openai_permanent_rate_limit.py
@@ -220,3 +220,94 @@ async def test_embed_still_retries_ordinary_rate_limit(monkeypatch, no_retry_wai
         await openai_embed(["hello"])
 
     assert fake_client.calls == 3
+
+
+# ---------------------------------------------------------------------------
+# HTTP level -- the SDK has a retry loop of its own
+# ---------------------------------------------------------------------------
+#
+# The tests above stub ``chat.completions.create``, so they never exercise the
+# transport and cannot see the OpenAI SDK's own retries. The SDK defaults to
+# ``max_retries=2`` and its ``_should_retry`` is body-blind (it retries every
+# 429), so a permanent spend stop still cost three HTTP requests plus SDK
+# backoff even with the tenacity predicate in place. ``create_openai_async_client``
+# now builds the client with ``max_retries=0``; these tests count the requests
+# that actually reach the wire.
+
+
+def _counting_transport(counter: list[int], body: dict) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        counter[0] += 1
+        return httpx.Response(429, json={"error": body})
+
+    return httpx.MockTransport(handler)
+
+
+def _client_factory(transport: httpx.MockTransport):
+    """Build a fresh client per call, all sharing one counting transport.
+
+    Every tenacity attempt calls ``create_openai_async_client`` anew, and the
+    error handlers close the client they were given, so a single shared
+    instance would fail the second attempt with a connection error instead of
+    reaching the transport.
+    """
+    from lightrag.llm.openai import create_openai_async_client
+
+    def factory(**_kwargs):
+        return create_openai_async_client(
+            api_key="test-key",
+            base_url="https://proxy.example/v1",
+            client_configs={"http_client": httpx.AsyncClient(transport=transport)},
+        )
+
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_budget_exceeded_costs_exactly_one_http_request(
+    monkeypatch, no_retry_wait
+):
+    calls = [0]
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client",
+        _client_factory(_counting_transport(calls, BUDGET_BODY)),
+    )
+
+    with pytest.raises(RateLimitError):
+        await openai_complete_if_cache(model="gpt-4o-mini", prompt="hello")
+
+    assert calls[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_ordinary_429_costs_exactly_the_tenacity_attempts(
+    monkeypatch, no_retry_wait
+):
+    """With the SDK loop off, the request count is the tenacity attempt count.
+
+    Previously this was 3 x 3: the outer loop multiplied with the SDK's own.
+    """
+    calls = [0]
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client",
+        _client_factory(_counting_transport(calls, THROTTLE_BODY)),
+    )
+
+    with pytest.raises(RetryError):
+        await openai_complete_if_cache(model="gpt-4o-mini", prompt="hello")
+
+    assert calls[0] == 3
+
+
+def test_sdk_retries_are_off_by_default():
+    from lightrag.llm.openai import create_openai_async_client
+
+    assert create_openai_async_client(api_key="k").max_retries == 0
+
+
+def test_client_configs_can_restore_sdk_retries():
+    """Escape hatch: the SDK's Retry-After handling stays available on request."""
+    from lightrag.llm.openai import create_openai_async_client
+
+    client = create_openai_async_client(api_key="k", client_configs={"max_retries": 2})
+    assert client.max_retries == 2

--- a/tests/llm/openai_impl/test_openai_permanent_rate_limit.py
+++ b/tests/llm/openai_impl/test_openai_permanent_rate_limit.py
@@ -1,0 +1,222 @@
+"""A permanent spend stop must fail fast instead of being retried.
+
+LiteLLM reports an exhausted spend budget as HTTP 429 with
+``type == "budget_exceeded"``, which the OpenAI SDK surfaces as
+``RateLimitError`` -- indistinguishable, by type alone, from an ordinary
+throughput throttle. The bindings retried it three times with exponential
+backoff and then raised ``tenacity.RetryError``, so every remaining chunk in
+the run paid the full backoff window and the operator-actionable message
+("Budget has been exceeded! Team=... Max budget: 180.0") was buried behind an
+opaque wrapper.
+
+The budget only clears when an operator raises or resets it, so the retry
+predicate now excludes it while ordinary 429s keep their backoff. OpenAI's
+native ``insufficient_quota`` is the same shape of permanent 429 and is
+classified alongside it. The original ``RateLimitError`` still propagates
+unchanged -- callers doing ``except RateLimitError`` / ``isinstance`` keep
+working, and the failure summary carries the provider's own message.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from openai import RateLimitError
+from tenacity import RetryError, wait_none
+
+from lightrag.llm._error_utils import is_permanent_rate_limit_error
+from lightrag.llm.openai import openai_complete_if_cache, openai_embed
+
+pytestmark = pytest.mark.offline
+
+# Verbatim from the OpenAI SDK's own unwrapping: ``_make_status_error`` does
+# ``data = body.get("error", body)``, so ``error.body`` is the inner object.
+BUDGET_BODY = {
+    "message": (
+        "Budget has been exceeded! Team=6ef183de-04ba-4114-8ef6-4b628370bc8c "
+        "Current cost: 180.1173603404399, Max budget: 180.0"
+    ),
+    "type": "budget_exceeded",
+    "param": None,
+    "code": "429",
+}
+
+# OpenAI's own permanent 429: the account's billing quota is exhausted.
+QUOTA_BODY = {
+    "message": (
+        "You exceeded your current quota, please check your plan and billing details."
+    ),
+    "type": "insufficient_quota",
+    "param": None,
+    "code": "insufficient_quota",
+}
+
+THROTTLE_BODY = {
+    "message": "Rate limit reached for gpt-4o-mini. Please try again in 1s.",
+    "type": "requests",
+    "param": None,
+    "code": "rate_limit_exceeded",
+}
+
+
+def _make_rate_limit_error(body: object, message: str | None = None) -> RateLimitError:
+    request = httpx.Request("POST", "https://proxy.example/v1/chat/completions")
+    response = httpx.Response(status_code=429, request=request)
+    return RateLimitError(
+        message or f"Error code: 429 - {body}", response=response, body=body
+    )
+
+
+def _make_chat_client(error: Exception) -> SimpleNamespace:
+    return SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=AsyncMock(side_effect=error))
+        ),
+        close=AsyncMock(),
+    )
+
+
+class _FailingEmbeddingClient:
+    """Minimal async-context-manager client whose embeddings.create always fails."""
+
+    def __init__(self, error: Exception):
+        self.calls = 0
+        self._error = error
+        self.embeddings = SimpleNamespace(create=self._create)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def _create(self, **params):
+        self.calls += 1
+        raise self._error
+
+
+@pytest.fixture
+def no_retry_wait(monkeypatch):
+    """Strip the exponential backoff so the retrying cases stay fast.
+
+    ``wraps`` stores the ``AsyncRetrying`` instance on ``.retry`` and each call
+    copies it, so patching the attribute here reaches the per-call copy.
+    """
+    monkeypatch.setattr(openai_complete_if_cache.retry, "wait", wait_none())
+    monkeypatch.setattr(openai_embed.func.retry, "wait", wait_none())
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "body, message",
+    [
+        pytest.param(BUDGET_BODY, None, id="budget-unwrapped-body"),
+        pytest.param({"error": BUDGET_BODY}, None, id="budget-nested-envelope"),
+        pytest.param(QUOTA_BODY, None, id="quota-unwrapped-body"),
+        pytest.param({"error": QUOTA_BODY}, None, id="quota-nested-envelope"),
+        pytest.param(
+            None,
+            "Error code: 429 - {'error': {'message': 'Budget has been exceeded! "
+            "Team=x', 'type': 'budget_exceeded', 'param': None, 'code': '429'}}",
+            id="message-only",
+        ),
+    ],
+)
+def test_permanent_spend_stop_is_detected(body, message):
+    assert is_permanent_rate_limit_error(_make_rate_limit_error(body, message)) is True
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(THROTTLE_BODY, id="throughput-throttle"),
+        pytest.param({"error": THROTTLE_BODY}, id="nested-throughput-throttle"),
+        pytest.param(None, id="no-body"),
+        pytest.param("plain text error page", id="non-mapping-body"),
+    ],
+)
+def test_ordinary_rate_limit_is_not_a_spend_stop(body):
+    assert is_permanent_rate_limit_error(_make_rate_limit_error(body)) is False
+
+
+# ---------------------------------------------------------------------------
+# Retry behaviour -- the fix proof
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_complete_does_not_retry_budget_exceeded(monkeypatch, no_retry_wait):
+    """One attempt, and the provider's own RateLimitError reaches the caller."""
+    err = _make_rate_limit_error(BUDGET_BODY)
+    fake_client = _make_chat_client(err)
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client", lambda **kw: fake_client
+    )
+
+    with pytest.raises(RateLimitError) as excinfo:
+        await openai_complete_if_cache(model="gpt-4o-mini", prompt="hello")
+
+    assert fake_client.chat.completions.create.await_count == 1
+    # The actionable operator message survives instead of being wrapped away.
+    assert "Budget has been exceeded" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_complete_does_not_retry_insufficient_quota(monkeypatch, no_retry_wait):
+    """OpenAI's native exhausted-billing 429 is the same permanent stop."""
+    fake_client = _make_chat_client(_make_rate_limit_error(QUOTA_BODY))
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client", lambda **kw: fake_client
+    )
+
+    with pytest.raises(RateLimitError):
+        await openai_complete_if_cache(model="gpt-4o-mini", prompt="hello")
+
+    assert fake_client.chat.completions.create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_complete_still_retries_ordinary_rate_limit(monkeypatch, no_retry_wait):
+    """Stability: a throughput 429 keeps its three attempts and RetryError."""
+    err = _make_rate_limit_error(THROTTLE_BODY)
+    fake_client = _make_chat_client(err)
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client", lambda **kw: fake_client
+    )
+
+    with pytest.raises(RetryError):
+        await openai_complete_if_cache(model="gpt-4o-mini", prompt="hello")
+
+    assert fake_client.chat.completions.create.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_embed_does_not_retry_budget_exceeded(monkeypatch, no_retry_wait):
+    """LiteLLM meters embedding spend too, so the embed binding needs the same gate."""
+    fake_client = _FailingEmbeddingClient(_make_rate_limit_error(BUDGET_BODY))
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client", lambda **kw: fake_client
+    )
+
+    with pytest.raises(RateLimitError):
+        await openai_embed(["hello"])
+
+    assert fake_client.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_embed_still_retries_ordinary_rate_limit(monkeypatch, no_retry_wait):
+    fake_client = _FailingEmbeddingClient(_make_rate_limit_error(THROTTLE_BODY))
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client", lambda **kw: fake_client
+    )
+
+    with pytest.raises(RetryError):
+        await openai_embed(["hello"])
+
+    assert fake_client.calls == 3

--- a/tests/llm/openai_impl/test_openai_permanent_rate_limit.py
+++ b/tests/llm/openai_impl/test_openai_permanent_rate_limit.py
@@ -22,7 +22,7 @@ from unittest.mock import AsyncMock
 
 import httpx
 import pytest
-from openai import RateLimitError
+from openai import APIStatusError, RateLimitError
 from tenacity import RetryError, wait_none
 
 from lightrag.llm._error_utils import is_permanent_rate_limit_error
@@ -235,10 +235,12 @@ async def test_embed_still_retries_ordinary_rate_limit(monkeypatch, no_retry_wai
 # that actually reach the wire.
 
 
-def _counting_transport(counter: list[int], body: dict) -> httpx.MockTransport:
+def _counting_transport(
+    counter: list[int], body: dict | None, status_code: int = 429
+) -> httpx.MockTransport:
     def handler(request: httpx.Request) -> httpx.Response:
         counter[0] += 1
-        return httpx.Response(429, json={"error": body})
+        return httpx.Response(status_code, json={"error": body} if body else {})
 
     return httpx.MockTransport(handler)
 
@@ -263,18 +265,48 @@ def _client_factory(transport: httpx.MockTransport):
     return factory
 
 
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(BUDGET_BODY, id="budget-exceeded"),
+        pytest.param(QUOTA_BODY, id="insufficient-quota"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_budget_exceeded_costs_exactly_one_http_request(
-    monkeypatch, no_retry_wait
+async def test_spend_stop_costs_exactly_one_http_request(
+    monkeypatch, no_retry_wait, body
 ):
     calls = [0]
     monkeypatch.setattr(
         "lightrag.llm.openai.create_openai_async_client",
-        _client_factory(_counting_transport(calls, BUDGET_BODY)),
+        _client_factory(_counting_transport(calls, body)),
     )
 
     with pytest.raises(RateLimitError):
         await openai_complete_if_cache(model="gpt-4o-mini", prompt="hello")
+
+    assert calls[0] == 1
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(BUDGET_BODY, id="budget-exceeded"),
+        pytest.param(QUOTA_BODY, id="insufficient-quota"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_embed_spend_stop_costs_exactly_one_http_request(
+    monkeypatch, no_retry_wait, body
+):
+    calls = [0]
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client",
+        _client_factory(_counting_transport(calls, body)),
+    )
+
+    with pytest.raises(RateLimitError):
+        await openai_embed(["hello"])
 
     assert calls[0] == 1
 
@@ -311,3 +343,64 @@ def test_client_configs_can_restore_sdk_retries():
 
     client = create_openai_async_client(api_key="k", client_configs={"max_retries": 2})
     assert client.max_retries == 2
+
+
+# ---------------------------------------------------------------------------
+# Retry ownership -- what the SDK loop used to cover
+# ---------------------------------------------------------------------------
+#
+# ``max_retries=0`` moves the whole retry decision to tenacity, so the outer
+# loop must cover everything the SDK's ``_should_retry`` did. Connection
+# errors, timeouts, 429 and >=500 already had predicates; 408 and 409 did not.
+# ``_make_status_error`` maps 409 to ConflictError and has no branch for 408 at
+# all (it arrives as a bare APIStatusError), so neither matched anything.
+
+
+@pytest.mark.parametrize("status_code", [408, 409])
+@pytest.mark.asyncio
+async def test_complete_retries_transient_statuses(
+    monkeypatch, no_retry_wait, status_code
+):
+    calls = [0]
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client",
+        _client_factory(_counting_transport(calls, None, status_code)),
+    )
+
+    with pytest.raises(RetryError):
+        await openai_complete_if_cache(model="gpt-4o-mini", prompt="hello")
+
+    assert calls[0] == 3
+
+
+@pytest.mark.parametrize("status_code", [408, 409])
+@pytest.mark.asyncio
+async def test_embed_retries_transient_statuses(
+    monkeypatch, no_retry_wait, status_code
+):
+    calls = [0]
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client",
+        _client_factory(_counting_transport(calls, None, status_code)),
+    )
+
+    with pytest.raises(RetryError):
+        await openai_embed(["hello"])
+
+    assert calls[0] == 3
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 422])
+@pytest.mark.asyncio
+async def test_client_errors_still_fail_fast(monkeypatch, no_retry_wait, status_code):
+    """Ownership transfer must not widen: the SDK never retried these either."""
+    calls = [0]
+    monkeypatch.setattr(
+        "lightrag.llm.openai.create_openai_async_client",
+        _client_factory(_counting_transport(calls, None, status_code)),
+    )
+
+    with pytest.raises(APIStatusError):
+        await openai_complete_if_cache(model="gpt-4o-mini", prompt="hello")
+
+    assert calls[0] == 1

--- a/tests/parser/docx/test_is_openai_retryable_spend_stop.py
+++ b/tests/parser/docx/test_is_openai_retryable_spend_stop.py
@@ -1,0 +1,75 @@
+"""``is_openai_retryable`` must classify permanent spend stops as non-retryable.
+
+The helper's documented contract used to be "429 -> always retry", which is
+wrong for the two 429s that no backoff can clear: a LiteLLM Proxy
+``budget_exceeded`` and an OpenAI ``insufficient_quota``. It shares the
+classifier with the openai binding's tenacity predicate
+(``lightrag.llm._error_utils.is_permanent_rate_limit_error``) so the two cannot
+drift apart.
+"""
+
+import httpx
+import pytest
+from openai import APIStatusError, RateLimitError
+
+from lightrag.parser.docx.utils import is_openai_retryable
+
+pytestmark = pytest.mark.offline
+
+BUDGET_BODY = {
+    "message": "Budget has been exceeded! Team=abc Max budget: 180.0",
+    "type": "budget_exceeded",
+    "code": "429",
+}
+QUOTA_BODY = {
+    "message": "You exceeded your current quota.",
+    "type": "insufficient_quota",
+    "code": "insufficient_quota",
+}
+THROTTLE_BODY = {
+    "message": "Rate limit reached. Please try again in 1s.",
+    "type": "requests",
+    "code": "rate_limit_exceeded",
+}
+
+
+def _response(status_code: int) -> httpx.Response:
+    request = httpx.Request("POST", "https://proxy.example/v1/chat/completions")
+    return httpx.Response(status_code=status_code, request=request)
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        pytest.param(BUDGET_BODY, False, id="budget-exceeded"),
+        pytest.param(QUOTA_BODY, False, id="insufficient-quota"),
+        pytest.param(THROTTLE_BODY, True, id="throughput-throttle"),
+        pytest.param(None, True, id="no-body"),
+    ],
+)
+def test_rate_limit_error_classification(body, expected):
+    err = RateLimitError(
+        f"Error code: 429 - {body}", response=_response(429), body=body
+    )
+    assert is_openai_retryable(err) is expected
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        pytest.param(BUDGET_BODY, False, id="budget-exceeded"),
+        pytest.param(THROTTLE_BODY, True, id="throughput-throttle"),
+    ],
+)
+def test_bare_429_status_error_classification(body, expected):
+    """A proxy may surface a 429 as a plain APIStatusError, not RateLimitError."""
+    err = APIStatusError(
+        f"Error code: 429 - {body}", response=_response(429), body=body
+    )
+    assert is_openai_retryable(err) is expected
+
+
+@pytest.mark.parametrize("status_code", [500, 502, 503, 504])
+def test_server_errors_still_retryable(status_code):
+    err = APIStatusError("boom", response=_response(status_code), body=None)
+    assert is_openai_retryable(err) is True


### PR DESCRIPTION
## Description

HTTP 429 has two meanings and only one of them is transient.

- **LiteLLM Proxy** reports an exhausted spend budget as 429 with `type == "budget_exceeded"` (`litellm.proxy._types.ProxyErrorTypes`).
- **OpenAI** reports an exhausted account quota as 429 with `type == "insufficient_quota"`.

Both surface through the OpenAI SDK as `RateLimitError` — indistinguishable, by exception type alone, from an ordinary throughput throttle. So both `openai` bindings retried them three times with exponential backoff and then raised `tenacity.RetryError`. Every remaining chunk in an ingestion run paid the full backoff window, and the one operator-actionable message was buried behind an opaque wrapper:

```
openai.RateLimitError: Error code: 429 - {'error': {'message': 'Budget has been exceeded! Team=6ef1... Current cost: 180.1173603404399, Max budget: 180.0', 'type': 'budget_exceeded', 'param': None, 'code': '429'}}

The above exception was the direct cause of the following exception:
...
  File "/app/lightrag/api/lightrag_server.py", line 2139, in role_openai_complete
    return await openai_complete_if_cache(
  File ".../tenacity/__init__.py", line 414, in exc_check
    raise retry_exc from fut.exception()
tenacity.RetryError: RetryError[<Future at 0x7978ceae1b20 state=finished raised RateLimitError>]
```

Neither condition clears on its own — an operator has to raise or reset the budget, or top up billing — so retrying can never succeed.

## Related Issues

N/A — reported directly from a LiteLLM Proxy deployment (traceback above).

## Changes Made

**New `lightrag/llm/_error_utils.py`** — dependency-free classifier for permanent spend stops.

It lives outside the binding on purpose: `lightrag/parser/docx/utils.py` treats `openai` as an optional dependency, and importing `lightrag.llm.openai` from there would pull in `tiktoken`/`numpy` and trigger that module's `pipmaster` auto-install of `openai` at import time.

Detection probes three shapes, so proxy and SDK packaging differences all hit:
1. the unwrapped body — the SDK's `_make_status_error` does `data = body.get("error", body)`, so `error.body` is normally the *inner* object;
2. the nested `{"error": {...}}` envelope;
3. the rendered message, as a last resort. The type slugs are specific enough that a false positive would have to name one verbatim.

**`lightrag/llm/openai.py`** — both `@retry` decorators (`openai_complete_if_cache` **and** `openai_embed`; LiteLLM meters embedding spend too) now use a `retry_if_exception` predicate built on that classifier. Ordinary 429s keep their three attempts.

Deliberately **no wrapper exception**: the original `RateLimitError` propagates unchanged, so upstream `except RateLimitError` / `isinstance` checks keep working, and the doc-status failure summary carries the provider's own message (the budget figures, or OpenAI's billing pointer) instead of `RetryError[...]`. The `except RateLimitError` handler and both `Raises:` docstrings were updated to match.

**`lightrag/parser/docx/utils.py`** — `is_openai_retryable` documented and implemented "429 → always retry". It now shares the same classifier, including for a bare `APIStatusError` carrying status 429 (a proxy may surface one that is not a `RateLimitError` instance).

**`create_openai_async_client` now passes `max_retries=0`** (both the OpenAI and Azure branches) — see the behaviour-change note below.

⚠️ **Behaviour change beyond the 429 classification.** The predicate above only owned the *outer* loop. The client was built without `max_retries`, so the SDK's default of 2 applied, and its `_should_retry` is necessarily body-blind (at that point the response body may not have been read yet) — it retries every 429, including the permanent spend stops the predicate exists to fail fast on. The two loops also multiplied. Requests that actually reach the wire:

| case | before | after |
|---|---|---|
| `budget_exceeded` / `insufficient_quota` 429 | 3 | **1** |
| ordinary 429 (throughput throttle) | 9 (3 tenacity × 3 SDK) | **3** |
| transient connection error / 5xx | up to 9 | **3** |
| 408 request timeout / 409 lock timeout | 3 (SDK only) | **3** (tenacity) |
| 400 / 401 / 403 / 404 / 422 | 1 | **1** |

So the tenacity decorators become the single retry layer, and **transient failures now get 3 attempts instead of up to 9, without the SDK's `Retry-After` handling**. `max_retries: 0` is placed *before* the `client_configs` spread, so an operator who wants the SDK loop back can pass `client_configs={"max_retries": 2}`; a test pins that escape hatch.

Taking ownership means covering everything the SDK's loop covered. Connection errors, timeouts, 429 and >=500 already had predicates; **408 and 409 did not**, and neither matched anything by type — `_make_status_error` maps 409 to `ConflictError` and has no branch for 408 at all, so it arrives as a bare `APIStatusError`. `_is_transient_status_error` restores both to the outer loop at the same 3 attempts they had under the SDK. Their exhaustion now raises `RetryError` rather than the raw status error, which is how every other retryable status already behaved.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

### Test evidence

New regression tests:

- `tests/llm/openai_impl/test_openai_permanent_rate_limit.py` — classification across all three body shapes for both slugs; complete/embed pairs of "not retried" / "still retried"; and **HTTP-level** tests that drive a real client over an `httpx.MockTransport` and count the requests reaching the wire.
- `tests/parser/docx/test_is_openai_retryable_spend_stop.py` — pins the `is_openai_retryable` contract, including the bare-`APIStatusError` 429 path.

Subsets run (per AGENTS.md, mirroring the changed modules):

- `./scripts/test.sh tests/llm tests/parser/docx` — **1358 passed**

Every fix-proof is **behavior-level**, not import-level:

- Reverting only the two retry predicates (keeping the new symbols) makes the two "not retried" tests fail with exactly the reported `tenacity.RetryError[<Future ... raised RateLimitError>]` after 3 calls.
- Shrinking the slug set back to `budget_exceeded` only, and restoring the old `is_openai_retryable` 429 branches, fails 6 of the new tests and no others.
- Reverting `max_retries=0` makes the HTTP-level tests report 3 and 9 requests instead of 1 and 3.
- Removing `_is_transient_status_error` drops 408/409 to 1 request on both complete and embed. Measured directly against a `MockTransport` with pre-PR client construction, the SDK loop gave them 3 — so this is the number the predicate restores, not a new one.
- A companion case pins that the transfer did not *widen*: 400/401/403/404/422 still cost exactly 1 request.

### Scope

Only the `openai` binding is changed — that is the path a LiteLLM Proxy is used through. The `retry_if_exception_type(RateLimitError)` decorators in `nvidia_openai`, `zhipu`, `ollama`, `lmdeploy`, `lollms`, `hf`, `llama_index_impl` and `voyageai` are deliberately left alone; they can adopt the shared classifier if the same symptom is reported against them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
