### PR TITLE
fix(extraction): stop dumping full chunk id list in KEEP skip log

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -2520,7 +2520,8 @@ async def _merge_nodes_then_upsert(
         ):
             if already_node:
                 logger.info(
-                    f"Skipped `{entity_name}`: KEEP old chunks {already_source_ids}/{len(full_source_ids)}"
+                    f"Skipped `{entity_name}`: KEEP old chunks "
+                    f"{len(existing_full_source_ids)}/{len(full_source_ids)} (limit {max_source_limit})"
                 )
                 existing_node_data = dict(already_node)
                 return existing_node_data
@@ -2899,7 +2900,8 @@ async def _merge_edges_then_upsert(
         ):
             if already_edge:
                 logger.info(
-                    f"Skipped `{src_id}`~`{tgt_id}`: KEEP old chunks  {already_source_ids}/{len(full_source_ids)}"
+                    f"Skipped `{src_id}`~`{tgt_id}`: KEEP old chunks "
+                    f"{len(existing_full_source_ids)}/{len(full_source_ids)} (limit {max_source_limit})"
                 )
                 existing_edge_data = dict(already_edge)
                 return existing_edge_data


### PR DESCRIPTION
## Summary

The `KEEP old chunks` skip logs in the entity/relation merge paths printed the **entire** `already_source_ids` list on every skipped merge. Replace it with the count pair the message was clearly meant to carry.

## Motivation

`already_source_ids` is a `list[str]` of chunk ids, interpolated against `len(full_source_ids)`:

```
Skipped `ENTITY`: KEEP old chunks ['chunk-abc…', 'chunk-def…', … 200 more …]/213
```

On a corpus that hits the source-ids cap this fires per entity and per relation, and each line grows with the cap — the log becomes unreadable and disproportionately large, while carrying no information that is not already persisted in the chunk-tracking row.

## What's changed

`lightrag/operate.py`, both skip sites (`_merge_nodes_then_upsert`, `_merge_edges_then_upsert`):

```diff
-f"Skipped `{entity_name}`: KEEP old chunks {already_source_ids}/{len(full_source_ids)}"
+f"Skipped `{entity_name}`: KEEP old chunks "
+f"{len(existing_full_source_ids)}/{len(full_source_ids)} (limit {max_source_limit})"
```

Two deliberate choices beyond "print the length":

- **Numerator is `existing_full_source_ids`, not `already_source_ids`.** The skip condition tests `len(existing_full_source_ids) >= max_source_limit`, so that is the number that explains *why* the merge was skipped. `already_source_ids` is only the graph node's truncated view of the authoritative chunk-tracking row (`apply_source_ids_limit`) and may legitimately be smaller than the cap — after a purge pruned tracking, or under a lower historical cap — which would print a self-contradictory pair such as `12/50` while the cap is `20`.
- **The cap is included**, so kept / total / reason read at a glance.

No extra debug-level dump of the full list was added: it is already persisted in the chunk-tracking row by the step-2 upsert that runs before this branch, and `apply_source_ids_limit` already debug-logs truncation events.

Also drops a stray double space in the relation-side message.

## What's broken

Nothing. Log-message-only change — no control flow, no storage writes, no return values touched. No test pinned either string (`grep -rn "KEEP old chunks" tests/` is empty).

## Testing

`./scripts/test.sh tests/extraction` — 274 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)