### PR TITLE
feat(sidecar): enrich query results with drawing attachments

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -145,6 +145,10 @@ from lightrag.operate import (
     naive_query,
     rebuild_knowledge_from_chunks,
 )
+from lightrag.sidecar.query_attachments import (
+    enrich_raw_data_attachments,
+    resolve_include_im_ids_for_enrich,
+)
 from lightrag.utils_pipeline import (
     CUSTOM_CHUNK_PATCH_METADATA_KEY,
     KG_RECOVERY_WARNINGS_METADATA_KEY,
@@ -160,7 +164,7 @@ from lightrag.utils_pipeline import (
     normalize_document_file_path,
     require_doc_status_record,
 )
-from lightrag.constants import GRAPH_FIELD_SEP, RELATION_NO_EVIDENCE_SOURCE_IDS
+from lightrag.constants import GRAPH_FIELD_SEP
 from lightrag.exceptions import (
     IndexFlushError,
     KGPurgeOperationConflictError,
@@ -391,7 +395,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
     # Directory
     # ---
-
+    # Dataclass defaults below; field() attaches per-attribute metadata/docstrings.
     working_dir: str = field(default="./rag_storage")
     """Directory where cache and temporary files are stored."""
 
@@ -1362,6 +1366,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             )
         self.embedding_token_limit = embedding_max_token_size
 
+
         # Fix global_config now
         global_config = self._build_global_config()
         # Restore original EmbeddingFunc object (asdict converts it to dict)
@@ -1369,6 +1374,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         _print_config = ",\n  ".join([f"{k} = {v}" for k, v in global_config.items()])
         logger.debug(f"LightRAG init with param:\n  {_print_config}\n")
+
 
         # Step 2: Apply priority wrapper decorator to EmbeddingFunc's inner func
         # Create a NEW EmbeddingFunc instance with the wrapped func to avoid mutating the caller's object
@@ -1383,6 +1389,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             )(self.embedding_func.func)
             # Use dataclasses.replace() to create a new instance, leaving the original unchanged
             self.embedding_func = replace(self.embedding_func, func=wrapped_func)
+
 
         # Initialize all storages
         self.key_string_value_json_storage_cls: type[BaseKVStorage] = get_storage_class(
@@ -1403,6 +1410,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         self.graph_storage_cls = partial(  # type: ignore
             self.graph_storage_cls, global_config=global_config
         )
+
 
         # Initialize document status storage
         self.doc_status_storage_cls = get_storage_class(self.doc_status_storage)
@@ -1566,6 +1574,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         self._storages_status = StoragesStatus.CREATED
 
     async def initialize_storages(self):
+        
         """Storage initialization must be called one by one to prevent deadlock"""
         if self._storages_status == StoragesStatus.CREATED:
             # Record the loop the storages (and their shared_storage locks) bind
@@ -1813,7 +1822,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         Returns:
             str: tracking ID for monitoring processing status
         """
-        # Generate track_id if not provided
+        # Generate track_id if not provided.
         if track_id is None:
             track_id = generate_track_id("insert")
 
@@ -1824,11 +1833,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         # carrier; runtime split args are an ainsert-only concern.
         from lightrag.parser.routing import resolve_chunk_options
 
+        # resolve_chunk_options returns a per-document chunk_options dict snapshot.
         chunk_opts = resolve_chunk_options(
             self.addon_params,
             split_by_character=split_by_character,
             split_by_character_only=split_by_character_only,
         )
+
+        # Enqueue documents; track_id lets callers poll ingest status while processing runs.
         await self.apipeline_enqueue_documents(
             input,
             ids,
@@ -1836,9 +1848,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             track_id,
             chunk_options=chunk_opts,
         )
+
+
+        # Drain the queue through the full ingest pipeline (chunk, embed, graph, etc.).
         await self.apipeline_process_enqueue_documents()
 
         return track_id
+
+
 
     # TODO: deprecated, use insert instead
     def insert_custom_chunks(
@@ -3470,9 +3487,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         Entity names and relationship endpoints are normalized with the same
         contract used by document extraction before any storage write begins.
-        A relationship weight is bounded below by its number of distinct real
-        evidence sources. Explicit weights may boost that baseline; omit the
-        relationship ``source_id`` to use a fractional source-less weight.
 
         .. warning:: (issue #3400 Phase 5 — direct-writer audit)
            This path is OUTSIDE the document-level recovery guarantee. It has
@@ -3491,10 +3505,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         update_storage = False
         try:
-            from lightrag.utils_graph import (
-                relation_evidence_source_ids,
-                validate_relation_weight,
-            )
 
             def _normalize_custom_kg_entity_name(value: Any, *, field: str) -> str:
                 if not isinstance(value, str):
@@ -3552,17 +3562,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         f"'{normalized_relationship_data['src_id']}': src_id and "
                         "tgt_id must be different entities"
                     )
-                source_id = relationship_data.get("source_id", "")
-                # This is still a custom-KG alias rather than the graph edge's
-                # persisted source_id. Validate its shape now, but defer the
-                # evidence floor until chunk_to_source_map resolves the alias.
-                relation_evidence_source_ids(source_id)
-                normalized_relationship_data["source_id"] = source_id
-                normalized_relationship_data["weight"] = validate_relation_weight(
-                    relationship_data.get("weight", 1.0),
-                    "",
-                    context=f"Custom KG relationships[{index}]",
-                )
                 normalized_relationships.append(normalized_relationship_data)
 
             # Insert chunks into vector storage
@@ -3577,6 +3576,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 pipeline busy flag, so leaving the loop here would let it encode
                 concurrently with a document being chunked.
                 """
+                nonlocal update_storage
                 for chunk_data in custom_kg.get("chunks", []):
                     chunk_content = sanitize_text_for_encoding(chunk_data["content"])
                     source_id = chunk_data["source_id"]
@@ -3604,30 +3604,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     }
                     all_chunks_data[chunk_id] = chunk_entry
                     chunk_to_source_map[source_id] = chunk_id
+                    update_storage = True
 
             await run_in_chunking_executor(_build_custom_kg_chunks)
 
-            # Validate the source IDs that will actually be persisted. Custom
-            # KG relationships refer to chunk aliases, and even a historical
-            # no-source placeholder can be a real alias that resolves to a
-            # chunk hash. This second pass must run before the chunk upserts
-            # below so an invalid mapped relation leaves every storage clean.
-            for index, relationship_data in enumerate(normalized_relationships):
-                source_alias = relationship_data["source_id"]
-                source_id = (
-                    chunk_to_source_map.get(source_alias, "UNKNOWN")
-                    if source_alias
-                    else ""
-                )
-                relationship_data["source_id"] = source_id
-                relationship_data["weight"] = validate_relation_weight(
-                    relationship_data["weight"],
-                    source_id,
-                    context=f"Custom KG relationships[{index}]",
-                )
-
             if all_chunks_data:
-                update_storage = True
                 await asyncio.gather(
                     self.chunks_vdb.upsert(all_chunks_data),
                     self.text_chunks.upsert(all_chunks_data),
@@ -3762,7 +3743,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 for relationship_data in deduped_relationships.values():
                     src_id = relationship_data["src_id"]
                     tgt_id = relationship_data["tgt_id"]
-                    source_id = relationship_data["source_id"]
+                    source_chunk_id = relationship_data.get("source_id", "UNKNOWN")
+                    source_id = chunk_to_source_map.get(source_chunk_id, "UNKNOWN")
                     file_path = normalize_document_file_path(
                         relationship_data.get("file_path", "custom_kg")
                     )
@@ -3792,7 +3774,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     normalized_src_id, normalized_tgt_id = sorted((src_id, tgt_id))
 
                     edge_data = {
-                        "weight": relationship_data["weight"],
+                        "weight": relationship_data.get("weight", 1.0),
                         "description": relationship_data["description"],
                         "keywords": relationship_data["keywords"],
                         "source_id": source_id,
@@ -3808,7 +3790,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                             "description": relationship_data["description"],
                             "keywords": relationship_data["keywords"],
                             "source_id": source_id,
-                            "weight": relationship_data["weight"],
+                            "weight": relationship_data.get("weight", 1.0),
                             "file_path": file_path,
                             "created_at": int(time.time()),
                         }
@@ -4016,7 +3998,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                             "tgt_id": str,           # Target entity name
                             "description": str,      # Relationship description
                             "keywords": str,         # Relationship keywords
-                            "weight": float,         # Evidence floor plus optional boost
+                            "weight": float,         # Relationship strength
                             "source_id": str,        # Source chunk references
                             "file_path": str,        # Origin file path
                             "created_at": str,       # Creation timestamp
@@ -4164,6 +4146,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             logger.info("[aquery_data] Query returned no results.")
         else:
             # Extract raw_data from QueryResult
+            if query_result.raw_data:
+                query_result.raw_data = await enrich_raw_data_attachments(
+                    query_result.raw_data,
+                    self.text_chunks,
+                    self.full_docs,
+                )
             final_data = query_result.raw_data or {}
 
             # Log final result counts - adapt to new data format from convert_to_user_format
@@ -4202,6 +4190,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         Returns:
             dict[str, Any]: Complete response with structured data and LLM response.
         """
+        
         logger.debug(f"[aquery_llm] Query param: {param}")
 
         global_config = self._build_global_config()
@@ -4222,6 +4211,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     system_prompt=system_prompt,
                     chunks_vdb=self.chunks_vdb,
                     progress_callback=progress_callback,
+                    full_docs_db=self.full_docs,
                 )
             elif param.mode == "naive":
                 query_result = await naive_query(
@@ -4233,6 +4223,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     system_prompt=system_prompt,
                     text_chunks_db=self.text_chunks,
                     progress_callback=progress_callback,
+                    full_docs_db=self.full_docs,
                 )
             elif param.mode == "bypass":
                 # Bypass mode: directly use LLM without knowledge retrieval
@@ -4301,6 +4292,26 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
             # Extract structured data from query result
             raw_data = query_result.raw_data or {}
+            metadata = raw_data.get("metadata")
+            deferred_attachment_enrich = (
+                query_result.is_streaming
+                and isinstance(metadata, dict)
+                and metadata.get("deferred_attachment_enrich")
+            )
+            if deferred_attachment_enrich:
+                if "data" not in raw_data or not isinstance(raw_data["data"], dict):
+                    raw_data["data"] = {}
+                raw_data["data"]["attachments"] = []
+            else:
+                include_im_ids = resolve_include_im_ids_for_enrich(
+                    raw_data, global_config
+                )
+                raw_data = await enrich_raw_data_attachments(
+                    raw_data,
+                    self.text_chunks,
+                    self.full_docs,
+                    include_im_ids=include_im_ids,
+                )
             raw_data["llm_response"] = {
                 "content": query_result.content
                 if not query_result.is_streaming
@@ -5357,13 +5368,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 graph_sources: list[str] = []
                 if self.entity_chunks:
                     stored_chunks = await self.entity_chunks.get_by_id(node_label)
-                    # NOTE(#3609): this deliberately keeps truthiness semantics and
-                    # does NOT distinguish a present-but-empty tracking row from an
-                    # absent one. Here an empty `existing_sources` falls back to the
-                    # graph `source_id` below; treating a present-empty row as
-                    # authoritative (as the edit paths now do) would instead route
-                    # the object into `entities_to_delete`, a deletion-behavior
-                    # change that needs its own issue + tests before being applied.
                     if stored_chunks and isinstance(stored_chunks, dict):
                         existing_sources = [
                             chunk_id
@@ -5429,11 +5433,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 if self.relation_chunks:
                     storage_key = make_relation_chunk_key(src, tgt)
                     stored_chunks = await self.relation_chunks.get_by_id(storage_key)
-                    # NOTE(#3609): as with the entity branch above, truthiness is
-                    # kept here on purpose — a present-but-empty relation tracking
-                    # row falls back to the graph `source_id` rather than being
-                    # treated as authoritative "tracks no chunks". Changing that is a
-                    # deletion-behavior change and belongs in its own issue + tests.
                     if stored_chunks and isinstance(stored_chunks, dict):
                         existing_sources = [
                             chunk_id
@@ -5501,23 +5500,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                 for edge_tuple, remaining in relation_chunk_updates.items():
                     if not remaining:
                         continue
-                    # relation_chunks is the authoritative chunk list, so the
-                    # historical no-evidence placeholders must not be written
-                    # into it. `remaining` inherits them from a legacy tracking
-                    # row or edge source_id (nothing subtracts them -- they are
-                    # not deleted chunk IDs). The stage-6 rebuild writes the same
-                    # rows filtered the same way; filtering here too keeps the
-                    # authoritative row clean across the whole purge, including
-                    # the summary-bearing rebuild window and a crash inside it.
-                    tracked = [
-                        chunk_id
-                        for chunk_id in remaining
-                        if chunk_id not in RELATION_NO_EVIDENCE_SOURCE_IDS
-                    ]
                     storage_key = make_relation_chunk_key(*edge_tuple)
                     relation_upsert_payload[storage_key] = {
-                        "chunk_ids": tracked,
-                        "count": len(tracked),
+                        "chunk_ids": remaining,
+                        "count": len(remaining),
                         "updated_at": current_time,
                     }
                 if relation_upsert_payload:
@@ -6685,10 +6671,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         Args:
             source_entity: Name of the source entity
             target_entity: Name of the target entity
-            updated_data: Dictionary containing updated attributes. The final
-                relation must satisfy ``weight >=`` its distinct real source
-                count; set ``source_id`` to an empty string in the same edit to
-                use a smaller fractional weight.
+            updated_data: Dictionary containing updated attributes, e.g. {"description": "new description", "keywords": "new keywords"}
 
         Returns:
             Dictionary containing updated relation information
@@ -6763,10 +6746,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         Args:
             source_entity: Name of the source entity
             target_entity: Name of the target entity
-            relation_data: Dictionary containing relation attributes. ``weight``
-                is the evidence-count floor plus an optional boost. It must be
-                at least the distinct real ``source_id`` count. Omit
-                ``source_id`` to create a source-less fractional-weight edge.
+            relation_data: Dictionary containing relation attributes, e.g. {"description": "description", "keywords": "keywords"}
 
         Returns:
             Dictionary containing created relation information
@@ -6805,10 +6785,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         Merges multiple source entities into a target entity, handling all relationships,
         and updating both the knowledge graph and vector database.
-
-        Redirected relations that collapse onto the same endpoint use
-        ``max(input weights, distinct merged evidence sources)`` so neither an
-        explicit boost nor the evidence-count floor regresses.
 
         Args:
             source_entities: List of source entity names to merge

--- a/lightrag/sidecar/query_attachments.py
+++ b/lightrag/sidecar/query_attachments.py
@@ -1,0 +1,883 @@
+"""Query-time sidecar join: collect drawing ``im-id`` values from retrieval
+``raw_data`` and resolve them to on-disk asset paths via ``drawings.json``.
+
+PR-1~3: scan retrieval ``raw_data`` and enrich ``data.attachments`` (full set).
+
+PR-4 adds candidate menus for Channel A (``format_drawing_menu_for_prompt``),
+``<present_drawings>`` parsing, and subset resolution via ``include_im_ids``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from lightrag.chunk_schema import normalize_chunk_sidecar
+from lightrag.utils import get_env_value, logger
+from lightrag.utils_pipeline import (
+    resolve_sidecar_uri,
+    sidecar_assets_dir_for_uri,
+    sidecar_modality_path,
+)
+
+if TYPE_CHECKING:
+    from lightrag.base import BaseKVStorage
+
+# im-{doc_hash}-{seq}, e.g. im-116da71bde652ed78cf28934d0712aa6-0002
+IM_ID_RE = re.compile(r"^im-(?P<doc_hash>[a-f0-9]+)-(?P<seq>\d+)$")
+DRAWING_TAG_RE = re.compile(
+    r'<drawing\b[^>]*\bid="(im-[^"]+)"',
+    flags=re.IGNORECASE,
+)
+PRESENT_DRAWINGS_TAG_RE = re.compile(
+    r"<present_drawings>\s*([^<]*?)\s*</present_drawings>",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+AttachmentDict = dict[str, Any]
+DrawingCandidateDict = dict[str, Any]
+
+DEFAULT_ATTACHMENT_CANDIDATE_TOP_K = 8
+
+PRESENT_DRAWINGS_METADATA_KEY = "present_drawings"
+DRAWING_CANDIDATE_WHITELIST_KEY = "drawing_candidate_whitelist"
+DEFERRED_ATTACHMENT_ENRICH_KEY = "deferred_attachment_enrich"
+
+_PRESENT_DRAWINGS_OPEN = "<present_drawings>"
+_STREAM_HOLDBACK_CHARS = len(_PRESENT_DRAWINGS_OPEN) + 40
+
+# Per-sidecar-uri cache for drawings.json payloads (process-local, read-only).
+_drawings_index_cache: dict[str, dict[str, Any]] = {}
+
+
+def is_im_id(value: str | None) -> bool:
+    """Return True when *value* matches the canonical drawing id form."""
+    if not value or not isinstance(value, str):
+        return False
+    return IM_ID_RE.match(value.strip()) is not None
+
+
+def doc_id_from_im_id(im_id: str) -> str | None:
+    """Derive ``doc-{hash}`` from ``im-{hash}-{seq}``."""
+    match = IM_ID_RE.match(im_id.strip())
+    if not match:
+        return None
+    return f"doc-{match.group('doc_hash')}"
+
+
+def doc_id_from_chunk_id(chunk_id: str | None) -> str | None:
+    """Parse ``doc-{hash}-…`` prefix from a chunk id."""
+    if not chunk_id or not isinstance(chunk_id, str):
+        return None
+    if chunk_id.startswith("doc-"):
+        rest = chunk_id[4:]
+        dash = rest.find("-")
+        if dash == -1:
+            return chunk_id
+        return f"doc-{rest[:dash]}"
+    return None
+
+
+def collect_im_ids_from_entities(entities: list[dict[str, Any]]) -> set[str]:
+    """Collect drawing ids from KG entity names."""
+    found: set[str] = set()
+    for entity in entities:
+        name = entity.get("entity_name") or entity.get("entity") or ""
+        if is_im_id(name):
+            found.add(name.strip())
+    return found
+
+
+def collect_im_ids_from_chunk_content(chunks: list[dict[str, Any]]) -> set[str]:
+    """Collect drawing ids embedded in chunk ``content`` as ``<drawing …/>`` tags."""
+    found: set[str] = set()
+    for chunk in chunks:
+        content = chunk.get("content") or ""
+        if not content:
+            continue
+        for match in DRAWING_TAG_RE.finditer(content):
+            im_id = match.group(1).strip()
+            if is_im_id(im_id):
+                found.add(im_id)
+    return found
+
+
+def collect_im_ids_from_sidecar_records(
+    chunk_records: list[dict[str, Any] | None],
+) -> set[str]:
+    """Collect drawing ids from persisted chunk ``sidecar`` metadata."""
+    found: set[str] = set()
+    for record in chunk_records:
+        if not record:
+            continue
+        sidecar = normalize_chunk_sidecar(record)
+        if not sidecar:
+            continue
+        for ref in sidecar.get("refs") or []:
+            if ref.get("type") == "drawing" and is_im_id(ref.get("id")):
+                found.add(ref["id"])
+        if sidecar.get("type") == "drawing" and is_im_id(sidecar.get("id")):
+            found.add(sidecar["id"])
+    return found
+
+
+def collect_im_ids(
+    raw_data: dict[str, Any],
+    chunk_records_by_id: dict[str, dict[str, Any] | None] | None = None,
+) -> set[str]:
+    """Gather all drawing im-ids referenced by the current retrieval ``raw_data``."""
+    data = raw_data.get("data") or {}
+    entities = data.get("entities") or []
+    chunks = data.get("chunks") or []
+
+    found = collect_im_ids_from_entities(entities)
+    found.update(collect_im_ids_from_chunk_content(chunks))
+
+    if chunk_records_by_id:
+        records = [
+            chunk_records_by_id.get(chunk.get("chunk_id") or "")
+            for chunk in chunks
+            if chunk.get("chunk_id")
+        ]
+        found.update(collect_im_ids_from_sidecar_records(records))
+
+    return found
+
+
+def collect_im_ids_ordered(
+    raw_data: dict[str, Any],
+    chunk_records_by_id: dict[str, dict[str, Any] | None] | None = None,
+) -> list[str]:
+    """Gather drawing im-ids in chunk appearance order (deduped).
+
+    Chunk ``<drawing>`` tags come first (retrieval order), then entity names,
+    then sidecar refs on persisted chunk records.
+    """
+    data = raw_data.get("data") or {}
+    chunks = data.get("chunks") or []
+    ordered: list[str] = []
+    seen: set[str] = set()
+
+    def _append(im_id: str) -> None:
+        im_id = im_id.strip()
+        if is_im_id(im_id) and im_id not in seen:
+            seen.add(im_id)
+            ordered.append(im_id)
+
+    for chunk in chunks:
+        content = chunk.get("content") or ""
+        for match in DRAWING_TAG_RE.finditer(content):
+            _append(match.group(1))
+
+    for entity in data.get("entities") or []:
+        name = entity.get("entity_name") or entity.get("entity") or ""
+        if is_im_id(name):
+            _append(name)
+
+    if chunk_records_by_id:
+        records = [
+            chunk_records_by_id.get(chunk.get("chunk_id") or "")
+            for chunk in chunks
+            if chunk.get("chunk_id")
+        ]
+        for record in records:
+            if not record:
+                continue
+            sidecar = normalize_chunk_sidecar(record)
+            if not sidecar:
+                continue
+            for ref in sidecar.get("refs") or []:
+                if ref.get("type") == "drawing" and is_im_id(ref.get("id")):
+                    _append(ref["id"])
+            if sidecar.get("type") == "drawing" and is_im_id(sidecar.get("id")):
+                _append(sidecar["id"])
+
+    return ordered
+
+
+def parse_present_drawings(text: str) -> tuple[str, list[str]]:
+    """Parse ``<present_drawings>…</present_drawings>`` from LLM output.
+
+    Returns ``(clean_markdown, selected_im_ids)``. When the tag is missing or
+    empty, ``selected_im_ids`` is ``[]``. Invalid token shapes are dropped.
+    """
+    if not text:
+        return "", []
+
+    match = PRESENT_DRAWINGS_TAG_RE.search(text)
+    if not match:
+        return text.strip(), []
+
+    inner = match.group(1).strip()
+    selected: list[str] = []
+    if inner:
+        for token in inner.split(","):
+            im_id = token.strip()
+            if is_im_id(im_id):
+                selected.append(im_id)
+
+    clean = PRESENT_DRAWINGS_TAG_RE.sub("", text).strip()
+    return clean, selected
+
+
+def filter_im_ids_by_whitelist(
+    selected: list[str],
+    allowed: set[str],
+) -> list[str]:
+    """Keep *selected* im-ids that appear in *allowed*, preserving order."""
+    if not selected or not allowed:
+        return []
+    seen: set[str] = set()
+    filtered: list[str] = []
+    for im_id in selected:
+        if im_id in allowed and im_id not in seen:
+            seen.add(im_id)
+            filtered.append(im_id)
+    return filtered
+
+
+def format_drawing_menu_for_prompt(
+    candidates: list[DrawingCandidateDict],
+) -> str:
+    """Format a lean drawing menu appendix for the query LLM prompt."""
+    lines = [
+        "## Optional figures (select only from the ids below; do not invent ids)",
+        "",
+    ]
+    if not candidates:
+        lines.extend(
+            [
+                "(No drawing candidates in this retrieval result.)",
+                "",
+                "Output at the end of your answer:",
+                "<present_drawings></present_drawings>",
+            ]
+        )
+        return "\n".join(lines)
+
+    for item in candidates:
+        im_id = item.get("im_id") or ""
+        title = str(item.get("title") or im_id).strip()
+        lines.append(f"- {im_id} | {title}")
+
+    lines.extend(
+        [
+            "",
+            "If the user needs original figures (form/dimensions/inspection diagrams), "
+            "end your answer with:",
+            "<present_drawings>im-…,im-…</present_drawings>",
+            "If no figures should be shown (e.g. bibliography / overview only), end with:",
+            "<present_drawings></present_drawings>",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _candidate_from_drawing_entry(
+    im_id: str,
+    doc_id: str,
+    entry: dict[str, Any],
+) -> DrawingCandidateDict:
+    candidate: DrawingCandidateDict = {"im_id": im_id, "doc_id": doc_id}
+    heading = entry.get("heading")
+    if heading:
+        candidate["heading"] = str(heading)
+    analysis = entry.get("llm_analyze_result")
+    if isinstance(analysis, dict):
+        title = analysis.get("name")
+        if title:
+            candidate["title"] = str(title)
+    if "title" not in candidate:
+        candidate["title"] = im_id
+    return candidate
+
+
+async def build_drawing_candidates(
+    raw_data: dict[str, Any],
+    text_chunks_db: BaseKVStorage | None,
+    full_docs_db: BaseKVStorage | None,
+    *,
+    top_k: int = DEFAULT_ATTACHMENT_CANDIDATE_TOP_K,
+) -> tuple[list[DrawingCandidateDict], set[str]]:
+    """Build ordered drawing candidates (metadata only) for PR-4 prompt menus.
+
+    Returns ``(candidates, whitelist)`` where *whitelist* is the set of im-ids
+    that may be selected for presentation. Uses ``verify_file=False`` so
+    missing assets still appear in the menu (Channel B skips them later).
+    """
+    if not raw_data or full_docs_db is None:
+        return [], set()
+
+    if "data" not in raw_data or not isinstance(raw_data["data"], dict):
+        return [], set()
+
+    data = raw_data["data"]
+    chunks = data.get("chunks") or []
+    chunk_ids = [c.get("chunk_id") for c in chunks if c.get("chunk_id")]
+    chunk_records_by_id = await _fetch_chunk_records(text_chunks_db, chunk_ids)
+
+    ordered_ids = collect_im_ids_ordered(raw_data, chunk_records_by_id)
+    if not ordered_ids:
+        return [], set()
+
+    if top_k > 0:
+        ordered_ids = ordered_ids[:top_k]
+
+    im_to_doc = build_im_to_doc_map(set(ordered_ids), chunk_records_by_id, chunks)
+
+    by_doc: dict[str, list[str]] = {}
+    for im_id in ordered_ids:
+        doc_id = im_to_doc.get(im_id) or doc_id_from_im_id(im_id)
+        if not doc_id:
+            continue
+        by_doc.setdefault(doc_id, []).append(im_id)
+
+    candidates: list[DrawingCandidateDict] = []
+    whitelist: set[str] = set()
+
+    for doc_id in sorted(by_doc.keys()):
+        doc_record = await full_docs_db.get_by_id(doc_id)
+        if not doc_record:
+            continue
+        sidecar_uri = doc_record.get("sidecar_location")
+        drawings_index = load_drawings_index(sidecar_uri)
+        if not drawings_index:
+            continue
+        for im_id in by_doc[doc_id]:
+            entry = drawings_index.get(im_id)
+            if not isinstance(entry, dict):
+                continue
+            # Metadata-only: do not require jpg on disk for the menu.
+            if not str(entry.get("path") or "").strip():
+                continue
+            candidate = _candidate_from_drawing_entry(im_id, doc_id, entry)
+            candidates.append(candidate)
+            whitelist.add(im_id)
+
+    # Preserve chunk order among resolved candidates.
+    order_index = {im_id: idx for idx, im_id in enumerate(ordered_ids)}
+    candidates.sort(key=lambda c: order_index.get(c["im_id"], len(order_index)))
+    return candidates, whitelist
+
+
+def get_attachment_present_mode(global_config: dict[str, Any] | None = None) -> str:
+    """Return ``llm_select`` or ``off`` (PR-4 presentation mode)."""
+    if global_config is not None:
+        mode = global_config.get("attachment_present_mode")
+        if mode is not None:
+            return str(mode).lower()
+    return get_env_value("ATTACHMENT_PRESENT_MODE", "off", str).lower()
+
+
+def get_attachment_candidate_top_k(global_config: dict[str, Any] | None = None) -> int:
+    if global_config is not None:
+        top_k = global_config.get("attachment_candidate_top_k")
+        if top_k is not None:
+            return int(top_k)
+    return get_env_value(
+        "ATTACHMENT_CANDIDATE_TOP_K",
+        DEFAULT_ATTACHMENT_CANDIDATE_TOP_K,
+        int,
+    )
+
+
+def is_llm_select_present_mode(global_config: dict[str, Any] | None = None) -> bool:
+    return get_attachment_present_mode(global_config) == "llm_select"
+
+
+def drawing_candidate_whitelist_from_raw_data(raw_data: dict[str, Any]) -> set[str]:
+    metadata = raw_data.get("metadata")
+    if not isinstance(metadata, dict):
+        return set()
+    raw_list = metadata.get(DRAWING_CANDIDATE_WHITELIST_KEY) or []
+    if not isinstance(raw_list, list):
+        return set()
+    return {im_id for im_id in raw_list if is_im_id(str(im_id))}
+
+
+async def append_drawing_menu_to_sys_prompt(
+    sys_prompt: str,
+    raw_data: dict[str, Any],
+    text_chunks_db: BaseKVStorage | None,
+    full_docs_db: BaseKVStorage | None,
+    global_config: dict[str, Any] | None,
+) -> str:
+    """Append the PR-4 lean drawing menu when ``llm_select`` mode is active."""
+    if not is_llm_select_present_mode(global_config):
+        return sys_prompt
+
+    top_k = get_attachment_candidate_top_k(global_config)
+    candidates, whitelist = await build_drawing_candidates(
+        raw_data,
+        text_chunks_db,
+        full_docs_db,
+        top_k=top_k,
+    )
+    metadata = raw_data.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+        raw_data["metadata"] = metadata
+    metadata[DRAWING_CANDIDATE_WHITELIST_KEY] = sorted(whitelist)
+    menu = format_drawing_menu_for_prompt(candidates)
+    return f"{sys_prompt}\n\n{menu}"
+
+
+def apply_present_drawings_to_raw_data(
+    raw_data: dict[str, Any],
+    llm_text: str,
+    *,
+    whitelist: set[str] | None = None,
+) -> str:
+    """Parse ``<present_drawings>``, store selection in metadata, return clean text."""
+    allowed = whitelist if whitelist is not None else drawing_candidate_whitelist_from_raw_data(
+        raw_data
+    )
+    clean, selected = parse_present_drawings(llm_text)
+    filtered = filter_im_ids_by_whitelist(selected, allowed)
+    metadata = raw_data.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+        raw_data["metadata"] = metadata
+    metadata[PRESENT_DRAWINGS_METADATA_KEY] = filtered
+
+    # Tags are stripped above; return the fully cleaned assistant text for callers.
+    return clean
+
+    
+
+
+def resolve_include_im_ids_for_enrich(
+    raw_data: dict[str, Any],
+    global_config: dict[str, Any] | None,
+) -> set[str] | None:
+    """Return ``None`` for v1.0 full enrich, or a (possibly empty) subset for PR-4."""
+    if not is_llm_select_present_mode(global_config):
+        return None
+
+    metadata = raw_data.get("metadata")
+    if not isinstance(metadata, dict):
+        return set()
+
+    if PRESENT_DRAWINGS_METADATA_KEY not in metadata:
+        # Streaming: LLM output not finalized yet.
+        return set()
+
+    selected = metadata.get(PRESENT_DRAWINGS_METADATA_KEY) or []
+    if not isinstance(selected, list):
+        return set()
+
+    whitelist = drawing_candidate_whitelist_from_raw_data(raw_data)
+    return set(filter_im_ids_by_whitelist([str(x) for x in selected], whitelist))
+
+
+class PresentDrawingsStreamWrapper:
+    """Wrap a streaming LLM iterator and strip trailing ``<present_drawings>`` tags.
+
+    After the stream completes, call :meth:`finalize_attachments` to parse the
+    full text, update ``raw_data`` metadata, and resolve sidecar attachments.
+    """
+
+    def __init__(
+        self,
+        source: AsyncIterator[str],
+        *,
+        raw_data: dict[str, Any],
+        whitelist: set[str],
+    ) -> None:
+        self._source = source
+        self._raw_data = raw_data
+        self._whitelist = whitelist
+        self._full_text = ""
+
+    def __aiter__(self) -> AsyncIterator[str]:
+        return self._stream_chunks()
+
+    async def _stream_chunks(self) -> AsyncIterator[str]:
+        pending = ""
+        open_tag = _PRESENT_DRAWINGS_OPEN.lower()
+        async for chunk in self._source:
+            if not chunk:
+                continue
+            self._full_text += chunk
+            pending += chunk
+            tag_idx = pending.lower().find(open_tag)
+            if tag_idx >= 0:
+                emit = pending[:tag_idx]
+                pending = pending[tag_idx:]
+                if emit:
+                    yield emit
+            elif len(pending) > _STREAM_HOLDBACK_CHARS:
+                emit = pending[:-_STREAM_HOLDBACK_CHARS]
+                pending = pending[-_STREAM_HOLDBACK_CHARS:]
+                if emit:
+                    yield emit
+        clean_tail, _ = parse_present_drawings(pending)
+        if clean_tail:
+            # Flush the final holdback buffer after stripping any trailing present_drawings tag.
+            yield clean_tail
+
+    async def finalize_attachments(
+        self,
+        text_chunks_db: BaseKVStorage | None,
+        full_docs_db: BaseKVStorage | None,
+        global_config: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Parse the accumulated stream and enrich ``raw_data`` attachments."""
+        apply_present_drawings_to_raw_data(
+            self._raw_data,
+            self._full_text,
+            whitelist=self._whitelist,
+        )
+        metadata = self._raw_data.get("metadata")
+        if isinstance(metadata, dict):
+            metadata[DEFERRED_ATTACHMENT_ENRICH_KEY] = False
+
+        include_im_ids = resolve_include_im_ids_for_enrich(
+            self._raw_data, global_config
+        )
+        return await enrich_raw_data_attachments(
+            self._raw_data,
+            text_chunks_db,
+            full_docs_db,
+            include_im_ids=include_im_ids,
+        )
+
+
+def wrap_present_drawings_stream(
+    source: AsyncIterator[str],
+    *,
+    raw_data: dict[str, Any],
+    whitelist: set[str],
+) -> PresentDrawingsStreamWrapper:
+    """Return a stream wrapper for PR-4 deferred attachment resolution."""
+    return PresentDrawingsStreamWrapper(
+        source,
+        raw_data=raw_data,
+        whitelist=whitelist,
+    )
+
+
+def is_present_drawings_stream_wrapper(
+    value: object,
+) -> bool:
+    return isinstance(value, PresentDrawingsStreamWrapper)
+
+
+def build_im_to_doc_map(
+    im_ids: set[str],
+    chunk_records_by_id: dict[str, dict[str, Any] | None] | None = None,
+    raw_chunks: list[dict[str, Any]] | None = None,
+) -> dict[str, str]:
+    """Map each im-id to a ``doc_id`` for sidecar lookup."""
+    mapping: dict[str, str] = {}
+
+    for im_id in im_ids:
+        doc_id = doc_id_from_im_id(im_id)
+        if doc_id:
+            mapping.setdefault(im_id, doc_id)
+
+    if chunk_records_by_id and raw_chunks:
+        for chunk in raw_chunks:
+            chunk_id = chunk.get("chunk_id") or ""
+            record = chunk_records_by_id.get(chunk_id)
+            doc_id = None
+            if record:
+                doc_id = record.get("full_doc_id") or doc_id_from_chunk_id(chunk_id)
+            else:
+                doc_id = doc_id_from_chunk_id(chunk_id)
+            if not doc_id:
+                continue
+            content = chunk.get("content") or ""
+            for match in DRAWING_TAG_RE.finditer(content):
+                im_id = match.group(1).strip()
+                if is_im_id(im_id):
+                    mapping.setdefault(im_id, doc_id)
+            sidecar = normalize_chunk_sidecar(record) if record else None
+            if sidecar and sidecar.get("type") == "drawing" and is_im_id(sidecar.get("id")):
+                mapping.setdefault(sidecar["id"], doc_id)
+
+    return mapping
+
+
+def load_drawings_index(sidecar_uri: str | None) -> dict[str, Any]:
+    """Load ``drawings.json`` for a sidecar URI (cached per URI string)."""
+    if not sidecar_uri:
+        return {}
+    cached = _drawings_index_cache.get(sidecar_uri)
+    if cached is not None:
+        return cached
+
+    drawings_path = sidecar_modality_path(sidecar_uri, "drawings")
+    if not drawings_path:
+        _drawings_index_cache[sidecar_uri] = {}
+        return {}
+
+    path = Path(drawings_path)
+    if not path.is_file():
+        logger.debug("[query_attachments] drawings.json missing: %s", drawings_path)
+        _drawings_index_cache[sidecar_uri] = {}
+        return {}
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "[query_attachments] Failed to read drawings index %s: %s",
+            drawings_path,
+            exc,
+        )
+        _drawings_index_cache[sidecar_uri] = {}
+        return {}
+
+    drawings = payload.get("drawings") if isinstance(payload, dict) else None
+    index = drawings if isinstance(drawings, dict) else {}
+    _drawings_index_cache[sidecar_uri] = index
+    return index
+
+
+def clear_drawings_index_cache() -> None:
+    """Clear the process-local drawings index cache (for tests)."""
+    _drawings_index_cache.clear()
+
+
+def _path_within_root(candidate: Path, root: Path) -> bool:
+    """Return True when *candidate* resolves under *root* (no path escape)."""
+    try:
+        candidate.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_asset_path(sidecar_uri: str | None, relative_path: str) -> Path | None:
+    """Resolve a drawings.json ``path`` field to an on-disk file."""
+    root = resolve_sidecar_uri(sidecar_uri)
+    if root is None or not relative_path:
+        return None
+    root_resolved = root.resolve()
+    candidate = (root / relative_path).resolve()
+    if candidate.is_file() and _path_within_root(candidate, root_resolved):
+        return candidate
+    assets_dir = sidecar_assets_dir_for_uri(sidecar_uri)
+    if assets_dir is not None:
+        nested = (assets_dir / Path(relative_path).name).resolve()
+        if nested.is_file() and _path_within_root(nested, root_resolved):
+            return nested
+    return None
+
+
+_DRAWING_MEDIA_TYPES: dict[str, str] = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "svg": "image/svg+xml",
+}
+
+
+def media_type_for_drawing_format(fmt: str | None) -> str:
+    """Map a sidecar drawing ``format`` field to an HTTP media type."""
+    if not fmt:
+        return "image/jpeg"
+    return _DRAWING_MEDIA_TYPES.get(str(fmt).lower(), "application/octet-stream")
+
+
+async def resolve_drawing_asset_file(
+    doc_id: str,
+    im_id: str,
+    full_docs_db: BaseKVStorage,
+) -> tuple[Path, str] | None:
+    """Resolve ``(doc_id, im_id)`` to an on-disk asset path and media type."""
+    if not is_im_id(im_id) or not doc_id:
+        return None
+
+    doc_record = await full_docs_db.get_by_id(doc_id)
+    if not doc_record:
+        return None
+
+    sidecar_uri = doc_record.get("sidecar_location")
+    drawings_index = load_drawings_index(sidecar_uri)
+    if not drawings_index:
+        return None
+
+    attachment = resolve_single_drawing(
+        im_id=im_id,
+        doc_id=doc_id,
+        sidecar_uri=sidecar_uri,
+        drawings_index=drawings_index,
+        verify_file=True,
+    )
+    if not attachment:
+        return None
+
+    asset_path = resolve_asset_path(sidecar_uri, str(attachment.get("path") or ""))
+    if asset_path is None:
+        return None
+
+    return asset_path, media_type_for_drawing_format(attachment.get("format"))
+
+
+def resolve_single_drawing(
+    *,
+    im_id: str,
+    doc_id: str,
+    sidecar_uri: str | None,
+    drawings_index: dict[str, Any],
+    verify_file: bool = True,
+) -> AttachmentDict | None:
+    """Resolve one ``(doc_id, im_id)`` pair to an attachment dict."""
+    entry = drawings_index.get(im_id)
+    if not isinstance(entry, dict):
+        logger.debug(
+            "[query_attachments] im-id %s not found in drawings index for %s",
+            im_id,
+            doc_id,
+        )
+        return None
+
+    relative_path = str(entry.get("path") or "").strip()
+    if not relative_path:
+        return None
+
+    if verify_file:
+        asset_path = resolve_asset_path(sidecar_uri, relative_path)
+        if asset_path is None:
+            logger.debug(
+                "[query_attachments] asset missing for %s: %s",
+                im_id,
+                relative_path,
+            )
+            return None
+
+    attachment: AttachmentDict = {
+        "im_id": im_id,
+        "doc_id": doc_id,
+        "type": "drawing",
+        "format": str(entry.get("format") or "jpg"),
+        "path": relative_path,
+    }
+    heading = entry.get("heading")
+    if heading:
+        attachment["heading"] = str(heading)
+    analysis = entry.get("llm_analyze_result")
+    if isinstance(analysis, dict):
+        title = analysis.get("name")
+        if title:
+            attachment["title"] = str(title)
+    return attachment
+
+
+async def _fetch_chunk_records(
+    text_chunks_db: BaseKVStorage | None,
+    chunk_ids: list[str],
+) -> dict[str, dict[str, Any] | None]:
+    """Batch-load text chunk records keyed by chunk id."""
+    if not text_chunks_db or not chunk_ids:
+        return {}
+    unique_ids = list(dict.fromkeys(chunk_ids))
+    records = await text_chunks_db.get_by_ids(unique_ids)
+    by_id: dict[str, dict[str, Any] | None] = {cid: None for cid in unique_ids}
+    for record in records:
+        if not record:
+            continue
+        cid = record.get("chunk_id") or record.get("_id") or record.get("id")
+        if cid:
+            by_id[str(cid)] = record
+    return by_id
+
+
+async def resolve_drawing_attachments(
+    im_ids: set[str],
+    im_to_doc: dict[str, str],
+    full_docs_db: BaseKVStorage,
+    *,
+    verify_file: bool = True,
+) -> list[AttachmentDict]:
+    """Resolve im-ids to attachment metadata via ``full_docs`` sidecar locations."""
+    if not im_ids or not im_to_doc:
+        return []
+
+    # Group im-ids by doc_id so we load each sidecar once.
+    by_doc: dict[str, list[str]] = {}
+    for im_id in sorted(im_ids):
+        doc_id = im_to_doc.get(im_id) or doc_id_from_im_id(im_id)
+        if not doc_id:
+            continue
+        by_doc.setdefault(doc_id, []).append(im_id)
+
+    attachments: list[AttachmentDict] = []
+    for doc_id in sorted(by_doc.keys()):
+        doc_record = await full_docs_db.get_by_id(doc_id)
+        if not doc_record:
+            logger.debug("[query_attachments] full_doc missing: %s", doc_id)
+            continue
+        sidecar_uri = doc_record.get("sidecar_location")
+        drawings_index = load_drawings_index(sidecar_uri)
+        if not drawings_index:
+            continue
+        for im_id in by_doc[doc_id]:
+            item = resolve_single_drawing(
+                im_id=im_id,
+                doc_id=doc_id,
+                sidecar_uri=sidecar_uri,
+                drawings_index=drawings_index,
+                verify_file=verify_file,
+            )
+            if item:
+                attachments.append(item)
+
+    return attachments
+
+
+async def enrich_raw_data_attachments(
+    raw_data: dict[str, Any],
+    text_chunks_db: BaseKVStorage | None,
+    full_docs_db: BaseKVStorage | None,
+    *,
+    verify_file: bool = True,
+    include_im_ids: set[str] | None = None,
+) -> dict[str, Any]:
+    """Enrich ``raw_data['data']['attachments']`` from the current retrieval result.
+
+    When *include_im_ids* is ``None`` (default), resolve every im-id found in the
+    retrieval result (PR-1~3 behaviour). When set, only those ids are resolved
+    (PR-4: after ``<present_drawings>`` parsing). An empty set yields no
+    attachments.
+
+    Never raises — failures degrade to an empty attachment list so query paths
+    remain unaffected.
+    """
+    if not raw_data:
+        return raw_data
+    if "data" not in raw_data or not isinstance(raw_data["data"], dict):
+        raw_data["data"] = {}
+
+    data = raw_data["data"]
+    chunks = data.get("chunks") or []
+    chunk_ids = [c.get("chunk_id") for c in chunks if c.get("chunk_id")]
+
+    chunk_records_by_id = await _fetch_chunk_records(text_chunks_db, chunk_ids)
+    im_ids = collect_im_ids(raw_data, chunk_records_by_id)
+    if include_im_ids is not None:
+        im_ids = {im_id for im_id in include_im_ids if is_im_id(im_id)}
+
+    if not im_ids:
+        data["attachments"] = []
+        return raw_data
+
+    if full_docs_db is None:
+        data["attachments"] = []
+        return raw_data
+
+    im_to_doc = build_im_to_doc_map(im_ids, chunk_records_by_id, chunks)
+    data["attachments"] = await resolve_drawing_attachments(
+        im_ids,
+        im_to_doc,
+        full_docs_db,
+        verify_file=verify_file,
+    )
+    return raw_data

--- a/scripts/print_attachments.py
+++ b/scripts/print_attachments.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+"""Print query ``attachments`` and optional sidecar asset URLs from a running server.
+
+Keep ``lightrag-server`` running in another terminal (use ``.venv\\Scripts\\lightrag-server``), then:
+
+    cd LightRAG
+    .venv\\Scripts\\python.exe scripts\\print_attachments.py
+    .venv\\Scripts\\python.exe scripts\\print_attachments.py --asset-urls
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import requests
+from dotenv import load_dotenv
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_QUERY = "部分螺纹螺钉型式尺寸"
+DEFAULT_MODE = "hybrid"
+
+
+def _base_url(host: str | None, port: int | None) -> str:
+    host = (host or os.getenv("HOST") or "127.0.0.1").strip()
+    port_raw = port if port is not None else os.getenv("PORT", "9621")
+    return f"http://{host}:{int(port_raw)}"
+
+
+def _auth_headers(api_key: str | None) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    key = api_key if api_key is not None else os.getenv("LIGHTRAG_API_KEY")
+    if key:
+        headers["X-API-Key"] = key.strip()
+    return headers
+
+
+def fetch_attachments(
+    *,
+    base_url: str,
+    query: str,
+    mode: str,
+    timeout: float,
+    api_key: str | None = None,
+) -> tuple[dict, list | None]:
+    """POST /query/data and return the full JSON body plus attachments list."""
+    url = f"{base_url.rstrip('/')}/query/data"
+    response = requests.post(
+        url,
+        json={"query": query, "mode": mode},
+        headers=_auth_headers(api_key),
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    attachments = (payload.get("data") or {}).get("attachments")
+    return payload, attachments
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Print data.attachments from POST /query/data (PR-1 verify)."
+    )
+    parser.add_argument(
+        "--query",
+        default=DEFAULT_QUERY,
+        help=f"Query text (default: {DEFAULT_QUERY!r})",
+    )
+    parser.add_argument(
+        "--mode",
+        default=DEFAULT_MODE,
+        choices=["local", "global", "hybrid", "mix", "naive"],
+        help=f"Retrieval mode (default: {DEFAULT_MODE})",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="Server host (default: HOST from .env or 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Server port (default: PORT from .env or 9621)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=120.0,
+        help="HTTP timeout in seconds (default: 120)",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help="X-API-Key header (default: LIGHTRAG_API_KEY from .env if set)",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Print the entire /query/data JSON response",
+    )
+    parser.add_argument(
+        "--asset-urls",
+        action="store_true",
+        help="Also print GET /documents/sidecar/assets URLs for each attachment",
+    )
+    args = parser.parse_args(argv)
+
+    load_dotenv(PROJECT_ROOT / ".env")
+    base_url = _base_url(args.host, args.port)
+
+    try:
+        payload, attachments = fetch_attachments(
+            base_url=base_url,
+            query=args.query,
+            mode=args.mode,
+            timeout=args.timeout,
+            api_key=args.api_key,
+        )
+    except requests.RequestException as exc:
+        print(f"Request failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.full:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+
+    print("status:", payload.get("status"))
+    print("message:", payload.get("message"))
+    data = payload.get("data") or {}
+    if "attachments" not in data:
+        print(
+            "attachments: (field missing — restart lightrag-server after PR-1 hook)",
+            file=sys.stderr,
+        )
+    print("attachments:")
+    print(json.dumps(attachments, ensure_ascii=False, indent=2))
+    if isinstance(attachments, list):
+        print(f"\n({len(attachments)} item(s))", file=sys.stderr)
+        if args.asset_urls:
+            print("\nasset_urls:", file=sys.stderr)
+            for item in attachments:
+                doc_id = item.get("doc_id")
+                im_id = item.get("im_id")
+                if doc_id and im_id:
+                    url = (
+                        f"{base_url.rstrip('/')}/documents/sidecar/assets"
+                        f"?doc_id={doc_id}&im_id={im_id}"
+                    )
+                    print(url)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/sidecar/conftest.py
+++ b/tests/sidecar/conftest.py
@@ -1,0 +1,3 @@
+"""Sidecar test fixtures."""
+
+pytest_plugins = ["tests.sidecar.conftest_query_attachments"]

--- a/tests/sidecar/conftest_query_attachments.py
+++ b/tests/sidecar/conftest_query_attachments.py
@@ -1,0 +1,56 @@
+"""Shared fixtures for query attachment resolver tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lightrag.utils_pipeline import sidecar_uri_for
+
+# Repo root: tests/sidecar/ -> LightRAG/ -> contributor/
+_CONTRIBUTOR_ROOT = Path(__file__).resolve().parents[3]
+GB_T_PARSED_DIR = (
+    _CONTRIBUTOR_ROOT
+    / "inputs"
+    / "__parsed__"
+    / "MinerU_markdown_GB_T_70.3-2023_3374_2089563653659709440.md.parsed"
+)
+
+# GB/T 70.3 fixture document id (stable hash from parsed sidecar tree).
+GB_T_DOC_ID = "doc-116da71bde652ed78cf28934d0712aa6"
+GB_T_IM_ID_0002 = "im-116da71bde652ed78cf28934d0712aa6-0002"
+GB_T_IM_0002_TITLE = "内六角沉头螺钉头部尺寸标注图"
+GB_T_JPG_SUFFIX = "image-ffda008de9ce.jpg"
+
+
+@pytest.fixture
+def gb_t_sidecar_uri() -> str:
+    if not GB_T_PARSED_DIR.is_dir():
+        pytest.skip(f"GB/T sidecar fixture missing: {GB_T_PARSED_DIR}")
+    return sidecar_uri_for(GB_T_PARSED_DIR)
+
+
+class FakeFullDocs:
+    """Minimal full_docs stub for sidecar resolution tests."""
+
+    def __init__(self, sidecar_uri: str):
+        self._uri = sidecar_uri
+
+    async def get_by_id(self, doc_id: str):
+        if doc_id == GB_T_DOC_ID:
+            return {"sidecar_location": self._uri}
+        return None
+
+
+REQUIRED_ATTACHMENT_KEYS = frozenset(
+    {"im_id", "doc_id", "type", "format", "path"}
+)
+
+
+def assert_valid_attachment(item: dict) -> None:
+    assert REQUIRED_ATTACHMENT_KEYS <= item.keys()
+    assert item["type"] == "drawing"
+    assert str(item["im_id"]).startswith("im-")
+    assert str(item["doc_id"]).startswith("doc-")
+

--- a/tests/sidecar/test_query_attachments_collect.py
+++ b/tests/sidecar/test_query_attachments_collect.py
@@ -1,0 +1,134 @@
+"""PR-1 L1 tests: collect drawing ``im-id`` values from retrieval ``raw_data``.
+
+These tests exercise the first layer of the attachment pipeline—gathering stable
+drawing identifiers from retrieval output and mapping each ``im-id`` to its
+source ``doc_id``. No disk I/O or HTTP calls are involved.
+
+Coverage:
+- Format helpers: ``is_im_id``, ``doc_id_from_im_id``, ``doc_id_from_chunk_id``
+- Three collection paths: KG entity names, chunk ``<drawing>`` tags, persisted sidecar metadata
+- ``collect_im_ids`` deduplication across all sources
+- ``build_im_to_doc_map`` reverse lookup from ``im-id`` to ``doc_id``
+
+All cases use in-memory fixtures and are marked ``@pytest.mark.offline``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.sidecar.query_attachments import (
+    build_im_to_doc_map,
+    collect_im_ids,
+    collect_im_ids_from_chunk_content,
+    collect_im_ids_from_entities,
+    collect_im_ids_from_sidecar_records,
+    doc_id_from_chunk_id,
+    doc_id_from_im_id,
+    is_im_id,
+)
+from tests.sidecar.conftest_query_attachments import GB_T_DOC_ID, GB_T_IM_ID_0002
+
+# Shared doc hash with the GB/T fixture so doc_id assertions stay consistent.
+_DOC_HASH = "116da71bde652ed78cf28934d0712aa6"
+# Locally defined first drawing id in this module (seq=0001).
+_IM_0001 = f"im-{_DOC_HASH}-0001"
+
+
+@pytest.mark.offline
+class TestImIdHelpers:
+    """Unit tests for im-id / doc_id / chunk_id parsing helpers."""
+
+    def test_is_im_id_valid(self):
+        """Accept canonical ids of the form ``im-{32hex}-{4digit}``."""
+        assert is_im_id(_IM_0001)
+        assert is_im_id(GB_T_IM_ID_0002)
+
+    def test_is_im_id_rejects_garbage(self):
+        """Reject empty strings, natural language, and non-im prefixes."""
+        assert not is_im_id("")
+        assert not is_im_id("图1")
+        assert not is_im_id("doc-abc-chunk-1")
+
+    def test_doc_id_from_im_id(self):
+        """Derive ``doc-{hash}`` from ``im-{hash}-{seq}``."""
+        assert doc_id_from_im_id(_IM_0001) == GB_T_DOC_ID
+
+    def test_doc_id_from_chunk_id(self):
+        """Parse owning doc_id from regular and mm-drawing chunk ids."""
+        assert (
+            doc_id_from_chunk_id(f"{GB_T_DOC_ID}-chunk-017") == GB_T_DOC_ID
+        )
+        assert (
+            doc_id_from_chunk_id(f"{GB_T_DOC_ID}-mm-drawing-000")
+            == GB_T_DOC_ID
+        )
+
+
+@pytest.mark.offline
+class TestCollectImIds:
+    """Integration-style tests for the three im-id collection paths."""
+
+    def test_entity_name_im_id(self):
+        """Path 1: collect when a KG entity name is itself an im-id."""
+        entities = [{"entity_name": _IM_0001}]
+        assert collect_im_ids_from_entities(entities) == {_IM_0001}
+
+    def test_chunk_content_drawing_tags(self):
+        """Path 2: parse every ``<drawing id="im-…"/>`` tag in chunk content."""
+        content = (
+            f'<drawing id="{_IM_0001}" format="jpg"/> '
+            f'<drawing id="{GB_T_IM_ID_0002}" format="jpg"/>'
+        )
+        chunks = [{"content": content}]
+        found = collect_im_ids_from_chunk_content(chunks)
+        assert found == {_IM_0001, GB_T_IM_ID_0002}
+
+    def test_chunk_content_no_drawing(self):
+        """Path 2 edge case: plain text chunks yield an empty set."""
+        assert collect_im_ids_from_chunk_content([{"content": "plain text"}]) == set()
+
+    def test_sidecar_id_on_mm_chunk(self):
+        """Path 3: read im-ids from persisted chunk sidecar type/id/refs metadata."""
+        records = [
+            {
+                "sidecar": {
+                    "type": "drawing",
+                    "id": _IM_0001,
+                    "refs": [{"type": "drawing", "id": _IM_0001}],
+                }
+            }
+        ]
+        assert collect_im_ids_from_sidecar_records(records) == {_IM_0001}
+
+    def test_collect_deduplicates(self):
+        """``collect_im_ids`` keeps one copy when the same id appears on multiple paths."""
+        raw_data = {
+            "data": {
+                "entities": [{"entity_name": _IM_0001}],
+                "chunks": [
+                    {
+                        "chunk_id": f"{GB_T_DOC_ID}-chunk-1",
+                        "content": f'<drawing id="{_IM_0001}"/>',
+                    }
+                ],
+            }
+        }
+        # chunk_records_by_id mimics text_chunks.get_by_ids sidecar lookups.
+        records = {
+            f"{GB_T_DOC_ID}-chunk-1": {
+                "sidecar": {
+                    "type": "drawing",
+                    "id": _IM_0001,
+                    "refs": [{"type": "drawing", "id": _IM_0001}],
+                }
+            }
+        }
+        assert collect_im_ids(raw_data, records) == {_IM_0001}
+
+    def test_build_im_to_doc_map_from_im_id(self):
+        """``build_im_to_doc_map`` can infer doc_id from the im-id hash segment alone."""
+        im_ids = {_IM_0001, GB_T_IM_ID_0002}
+        mapping = build_im_to_doc_map(im_ids)
+        assert mapping[_IM_0001] == GB_T_DOC_ID
+        assert mapping[GB_T_IM_ID_0002] == GB_T_DOC_ID

--- a/tests/sidecar/test_query_attachments_enrich.py
+++ b/tests/sidecar/test_query_attachments_enrich.py
@@ -1,0 +1,156 @@
+"""PR-1 L3 tests: ``enrich_raw_data_attachments`` end-to-end with mocked storage.
+
+Layer 3 wires L1 collection and L2 sidecar resolution together and writes the
+final ``raw_data["data"]["attachments"]`` list consumed by HTTP and the WebUI.
+
+Coverage:
+- Empty raw_data / no im-ids → stable structure or ``attachments: []``
+- Golden single ``<drawing>`` chunk → full attachment record
+- Missing ``full_docs`` → fail-soft empty attachments
+- Idempotent re-enrich → identical attachment list
+
+Uses ``FakeFullDocs`` for ``full_docs.get_by_id → sidecar_location`` and optional
+``FakeTextChunks`` for chunk-level doc mapping. Depends on the GB/T sidecar fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lightrag.sidecar.query_attachments import (
+    clear_drawings_index_cache,
+    enrich_raw_data_attachments,
+)
+from tests.sidecar.conftest_query_attachments import (
+    FakeFullDocs,
+    GB_T_DOC_ID,
+    GB_T_IM_ID_0002,
+    GB_T_IM_0002_TITLE,
+    GB_T_JPG_SUFFIX,
+    assert_valid_attachment,
+)
+
+_DOC_HASH = "116da71bde652ed78cf28934d0712aa6"
+_IM_0001 = f"im-{_DOC_HASH}-0001"
+
+
+class FakeTextChunks:
+    """Minimal text_chunks stub returning persisted chunk records by chunk_id."""
+
+    def __init__(self, records: dict[str, dict]):
+        self._records = records
+
+    async def get_by_ids(self, ids: list[str]):
+        return [self._records[cid] for cid in ids if cid in self._records]
+
+
+@pytest.fixture(autouse=True)
+def _clear_drawings_cache():
+    """Reset drawings.json cache so L2 disk reads do not leak between tests."""
+    clear_drawings_index_cache()
+    yield
+    clear_drawings_index_cache()
+
+
+@pytest.mark.offline
+class TestEnrichRawDataAttachments:
+    """End-to-end enrich: collect → resolve → write ``data.attachments``."""
+
+    @pytest.mark.asyncio
+    async def test_enrich_empty_raw_data(self, gb_t_sidecar_uri):
+        """Empty input dict is returned unchanged without creating a ``data`` key."""
+        raw = {}
+        result = await enrich_raw_data_attachments(
+            raw, None, FakeFullDocs(gb_t_sidecar_uri)
+        )
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_enrich_no_im_ids(self, gb_t_sidecar_uri):
+        """Chunks without drawing tags produce ``attachments: []``."""
+        raw = {"data": {"entities": [], "chunks": [{"content": "no drawings"}]}}
+        result = await enrich_raw_data_attachments(
+            raw, None, FakeFullDocs(gb_t_sidecar_uri)
+        )
+        assert result["data"]["attachments"] == []
+
+    @pytest.mark.asyncio
+    async def test_enrich_golden_shape(self, gb_t_sidecar_uri):
+        """Golden chunk with GB_T_IM_ID_0002 yields a valid attachment without mutating other fields.
+
+        Verifies the PR-1 contract:
+        - at least one attachment with expected jpg path and title
+        - ``assert_valid_attachment`` checks required keys
+        - references/chunks remain identical (enrich only appends attachments)
+        """
+        chunk_id = f"{GB_T_DOC_ID}-chunk-017"
+        raw = {
+            "data": {
+                "entities": [],
+                "chunks": [
+                    {
+                        "chunk_id": chunk_id,
+                        "content": f'<drawing id="{GB_T_IM_ID_0002}" format="jpg"/>',
+                        "file_path": "MinerU_markdown_GB_T_70.3-2023.md",
+                    }
+                ],
+                "references": [{"reference_id": "1", "file_path": "x.md"}],
+            }
+        }
+        # text_chunks supplies chunk-level full_doc_id for im-id → doc_id mapping.
+        text_chunks = FakeTextChunks(
+            {
+                chunk_id: {
+                    "chunk_id": chunk_id,
+                    "full_doc_id": GB_T_DOC_ID,
+                    "content": raw["data"]["chunks"][0]["content"],
+                }
+            }
+        )
+        refs_before = list(raw["data"]["references"])
+
+        result = await enrich_raw_data_attachments(
+            raw,
+            text_chunks,
+            FakeFullDocs(gb_t_sidecar_uri),
+        )
+
+        attachments = result["data"]["attachments"]
+        assert len(attachments) >= 1
+        golden = next(a for a in attachments if a["im_id"] == GB_T_IM_ID_0002)
+        assert_valid_attachment(golden)
+        assert GB_T_JPG_SUFFIX in golden["path"]
+        assert golden["title"] == GB_T_IM_0002_TITLE
+        assert result["data"]["references"] == refs_before
+        assert result["data"]["chunks"] == raw["data"]["chunks"]
+
+    @pytest.mark.asyncio
+    async def test_enrich_without_full_docs(self):
+        """When full_docs is unavailable, enrich degrades to ``attachments: []`` (fail-soft)."""
+        raw = {
+            "data": {
+                "chunks": [
+                    {"content": f'<drawing id="{_IM_0001}"/>', "chunk_id": "c1"}
+                ]
+            }
+        }
+        result = await enrich_raw_data_attachments(raw, None, None)
+        assert result["data"]["attachments"] == []
+
+    @pytest.mark.asyncio
+    async def test_enrich_idempotent(self, gb_t_sidecar_uri):
+        """Calling enrich twice on the same raw_data yields an identical attachment list."""
+        raw = {
+            "data": {
+                "chunks": [
+                    {
+                        "chunk_id": f"{GB_T_DOC_ID}-chunk-1",
+                        "content": f'<drawing id="{GB_T_IM_ID_0002}"/>',
+                    }
+                ]
+            }
+        }
+        full_docs = FakeFullDocs(gb_t_sidecar_uri)
+        first = await enrich_raw_data_attachments(raw, None, full_docs)
+        second = await enrich_raw_data_attachments(first, None, full_docs)
+        assert second["data"]["attachments"] == first["data"]["attachments"]

--- a/tests/sidecar/test_query_attachments_resolve.py
+++ b/tests/sidecar/test_query_attachments_resolve.py
@@ -1,0 +1,147 @@
+"""PR-1 L2 tests: resolve im-ids via sidecar ``drawings.json`` on disk.
+
+After L1 collects im-ids, L2 loads the sidecar index and maps each id to a
+local asset path plus attachment metadata (title, heading, format). These tests
+use the GB/T 70.3 parsed sidecar fixture when present.
+
+Coverage:
+- ``load_drawings_index`` — build im-id → metadata map from ``*.drawings.json``
+- ``resolve_asset_path`` — join relative sidecar paths to on-disk jpg files
+- ``resolve_single_drawing`` — produce a full attachment dict for one drawing
+- ``resolve_drawing_asset_file`` — async entry that looks up ``full_docs.sidecar_location``
+
+Golden target: ``GB_T_IM_ID_0002`` (counterbore head dimension figure).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lightrag.sidecar.query_attachments import (
+    clear_drawings_index_cache,
+    load_drawings_index,
+    resolve_asset_path,
+    resolve_single_drawing,
+)
+from tests.sidecar.conftest_query_attachments import (
+    FakeFullDocs,
+    GB_T_DOC_ID,
+    GB_T_IM_ID_0002,
+    GB_T_IM_0002_TITLE,
+    GB_T_JPG_SUFFIX,
+    GB_T_PARSED_DIR,
+)
+
+# Same doc hash as collect/conftest; _IM_0001 also exists in the GB/T drawings index.
+_DOC_HASH = "116da71bde652ed78cf28934d0712aa6"
+_IM_0001 = f"im-{_DOC_HASH}-0001"
+
+
+@pytest.fixture(autouse=True)
+def _clear_drawings_cache():
+    """Clear the process-local drawings.json cache before and after each case."""
+    clear_drawings_index_cache()
+    yield
+    clear_drawings_index_cache()
+
+
+@pytest.mark.offline
+class TestDrawingsResolve:
+    """Sidecar index loading and per-drawing attachment resolution."""
+
+    def test_load_drawings_index(self, gb_t_sidecar_uri):
+        """Return an im-id keyed dict; golden entry path ends with the expected jpg."""
+        index = load_drawings_index(gb_t_sidecar_uri)
+        assert _IM_0001 in index
+        assert GB_T_IM_ID_0002 in index
+        assert GB_T_JPG_SUFFIX in index[GB_T_IM_ID_0002]["path"]
+
+    def test_resolve_path_ffda008de9ce(self, gb_t_sidecar_uri):
+        """Resolve a relative sidecar path to an existing local asset file."""
+        index = load_drawings_index(gb_t_sidecar_uri)
+        rel = index[GB_T_IM_ID_0002]["path"]
+        asset = resolve_asset_path(gb_t_sidecar_uri, rel)
+        assert asset is not None
+        assert asset.name == GB_T_JPG_SUFFIX
+        assert asset.is_file()
+
+    def test_resolve_single_drawing_golden(self, gb_t_sidecar_uri):
+        """Golden im-0002 resolves with full attachment fields including heading."""
+        index = load_drawings_index(gb_t_sidecar_uri)
+        item = resolve_single_drawing(
+            im_id=GB_T_IM_ID_0002,
+            doc_id=GB_T_DOC_ID,
+            sidecar_uri=gb_t_sidecar_uri,
+            drawings_index=index,
+        )
+        assert item is not None
+        assert item["im_id"] == GB_T_IM_ID_0002
+        assert item["doc_id"] == GB_T_DOC_ID
+        assert item["type"] == "drawing"
+        assert GB_T_JPG_SUFFIX in item["path"]
+        assert item["title"] == GB_T_IM_0002_TITLE
+        assert item["heading"] == "4.1 型式尺寸"
+
+    @pytest.mark.asyncio
+    async def test_resolve_drawing_asset_file_golden(self, gb_t_sidecar_uri):
+        """Async helper returns (Path, media_type) via FakeFullDocs sidecar lookup."""
+        from lightrag.sidecar.query_attachments import resolve_drawing_asset_file
+
+        resolved = await resolve_drawing_asset_file(
+            GB_T_DOC_ID,
+            GB_T_IM_ID_0002,
+            FakeFullDocs(gb_t_sidecar_uri),
+        )
+        assert resolved is not None
+        asset_path, media_type = resolved
+        assert asset_path.name == GB_T_JPG_SUFFIX
+        assert media_type == "image/jpeg"
+
+    def test_missing_im_id_skipped(self, gb_t_sidecar_uri):
+        """Unknown im-ids return None instead of raising."""
+        index = load_drawings_index(gb_t_sidecar_uri)
+        assert (
+            resolve_single_drawing(
+                im_id="im-deadbeefdeadbeefdeadbeefdeadbeef-9999",
+                doc_id=GB_T_DOC_ID,
+                sidecar_uri=gb_t_sidecar_uri,
+                drawings_index=index,
+            )
+            is None
+        )
+
+    def test_missing_sidecar_returns_empty_index(self):
+        """None or remote-only URIs yield an empty index without errors."""
+        assert load_drawings_index(None) == {}
+        assert load_drawings_index("s3://bucket/x/") == {}
+
+    def test_missing_jpg_skipped(self, gb_t_sidecar_uri, tmp_path):
+        """When verify_file=True and the jpg is absent, resolution returns None."""
+        # Synthetic index entry pointing at a path that does not exist on disk.
+        index = {
+            _IM_0001: {
+                "id": _IM_0001,
+                "format": "jpg",
+                "path": "missing.blocks.assets/no-such-file.jpg",
+            }
+        }
+        assert (
+            resolve_single_drawing(
+                im_id=_IM_0001,
+                doc_id=GB_T_DOC_ID,
+                sidecar_uri=gb_t_sidecar_uri,
+                drawings_index=index,
+            )
+            is None
+        )
+
+    def test_drawings_json_readable(self):
+        """Self-check: GB/T fixture directory contains a readable drawings.json payload."""
+        if not GB_T_PARSED_DIR.is_dir():
+            pytest.skip("GB/T fixture missing")
+        drawings_files = list(GB_T_PARSED_DIR.glob("*.drawings.json"))
+        assert drawings_files
+        payload = json.loads(drawings_files[0].read_text(encoding="utf-8"))
+        assert "drawings" in payload


### PR DESCRIPTION
## Description

Library-only change (PR-1 of 4): after retrieval, collect stable drawing im-ids, join sidecar metadata from drawings.json, and populate **attachments** on query result data. No changes to prompts, LLM output, HTTP routes, or the WebUI.

Both `aquery_data` and `aquery_llm` now expose `data.attachments` alongside existing entities, chunks, and references. Missing sidecars, missing files, or zero hits degrade to an empty list without failing the query.

> PR-4 hooks exist in tree; with ATTACHMENT_PRESENT_MODE=off (default), PR-1 enriches the full retrieved set and stands alone for review.

## Related Issues

Part of #3738

**Stack:** PR-1 → PR-2 → PR-3 → (optional) PR-4  
**Depends on:** none

## Changes Made

| Type | File | Notes |
|------|------|-------|
| **New** | `lightrag/sidecar/query_attachments.py` | Collect IDs, read `drawings.json`, build records; `enrich_raw_data_attachments` (errors → `[]`) |
| **New** | `tests/sidecar/test_query_attachments_*.py`, `conftest_query_attachments.py` | Layered tests with GB/T 70.3 fixture (23 cases) |
| **New** | `scripts/print_attachments.py` | Optional debug helper |
| **Modified** | `lightrag/lightrag.py` (`aquery_data`, `aquery_llm`) | Enrich before return |

**Per-item `attachments` fields:**

| Field | Description |
|-------|-------------|
| `im_id` | Stable ID, e.g. `im-{doc_hash}-{seq}` |
| `doc_id` | Source document |
| `type` | Always `drawing` |
| `format` | Asset format, e.g. `jpg` |
| `path` | Relative path under sidecar (server-side; clients fetch via `doc_id` + `im_id`, not `path`) |
| `title` | From VLM `llm_analyze_result.name` |
| `heading` | Section heading from `drawings.json` (optional) |

**Example:**

```json
"attachments": [{
  "im_id": "im-116da71bde652ed78cf28934d0712aa6-0002",
  "doc_id": "doc-116da71bde652ed78cf28934d0712aa6",
  "type": "drawing",
  "format": "jpg",
  "path": "….blocks.assets/image-ffda008de9ce.jpg",
  "title": "Countersunk hex socket screw head dimensions",
  "heading": "4.1 Form and dimensions"
}]
```

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

**Test plan:**

```bash
python -m pytest tests/sidecar/test_query_attachments_collect.py \
                 tests/sidecar/test_query_attachments_resolve.py \
                 tests/sidecar/test_query_attachments_enrich.py -q
```

| File | # | Focus |
|------|:-:|-------|
| `test_query_attachments_collect.py` | 10 | ID parsing, multi-source collection, dedup, doc mapping |
| `test_query_attachments_resolve.py` | 8 | `drawings.json`, path resolution, title/heading |
| `test_query_attachments_enrich.py` | 5 | Writes to `data.attachments`, empty fallback, idempotency |

Follow-up PRs (same issue): PR-2 HTTP API, PR-3 WebUI, PR-4 optional LLM subset selection.
