### PR TITLE
fix: move file-backend persistence off the event loop

### DIFF
--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -615,7 +615,8 @@ MAX_RESPONSE_TYPE_CHARS = 256
 MAX_QUERY_TOP_K = 1000
 MAX_QUERY_TOKEN_BUDGET = 1_000_000
 
-# Submission ceilings for the two single-worker CPU pools (tokenizer, chunking).
+# Submission ceilings for the three single-worker pools (tokenizer, chunking,
+# storage IO).
 # A ``ThreadPoolExecutor`` wait queue is unbounded, and freeing the event loop
 # means more requests can be in flight at once, so submissions need their own
 # limit. Deliberately fixed process-wide constants rather than anything derived
@@ -628,6 +629,13 @@ MAX_QUERY_TOKEN_BUDGET = 1_000_000
 # not refusal.
 TOKENIZER_SUBMIT_LIMIT = 8
 CHUNKING_SUBMIT_LIMIT = 8
+# Storage IO is not CPU-bound like the other two, but it needs the same ceiling
+# for a sharper reason: ``_flush_storages`` gathers ``index_done_callback`` over
+# every storage at once (a dozen for a default deployment), and a purge issues
+# several such flushes per document. Each waiter here holds its namespace lock,
+# so the ceiling also bounds how many namespaces can be locked waiting for one
+# worker.
+STORAGE_IO_SUBMIT_LIMIT = 8
 
 # Per-workspace ceiling on manual retry requests that have been published but
 # not yet ACKed (LR2 §10.1). The channel is sticky — a request survives until an

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -3,13 +3,18 @@ import os
 import time
 import asyncio
 from hashlib import md5
-from typing import Any, final
+from typing import Any, Awaitable, Callable, final
 import json
 import numpy as np
 from dataclasses import dataclass
 
 from lightrag.file_atomic import atomic_write, reap_orphan_tmp_files
-from lightrag.utils import logger, compute_mdhash_id, validate_workspace
+from lightrag.utils import (
+    logger,
+    compute_mdhash_id,
+    commit_in_storage_io,
+    validate_workspace,
+)
 from lightrag.base import BaseVectorStorage
 from lightrag.constants import DEFAULT_QUERY_PRIORITY
 
@@ -91,13 +96,22 @@ class FaissVectorDBStorage(BaseVectorStorage):
            ``index_done_callback`` completes. Reads in the gap between a
            writer's in-memory mutation and its commit may legitimately
            return the pre-update snapshot.
-        3. **Faiss + dict mutations are synchronous.** Under a
-           single-threaded asyncio event loop, ``index.add`` /
-           ``index.search`` / ``self._id_to_meta`` mutations cannot be
-           preempted by another coroutine, which gives them implicit
-           mutual exclusion. This is why most methods don't hold
-           ``_storage_lock`` while touching ``self._index`` /
-           ``self._id_to_meta``.
+        3. **Faiss + dict MUTATIONS are synchronous and stay on the
+           event loop.** ``index.add`` / ``index.remove_ids`` /
+           ``self._id_to_meta`` mutations cannot be preempted by another
+           coroutine, which gives them implicit mutual exclusion. This is
+           why most methods don't hold ``_storage_lock`` while touching
+           ``self._index`` / ``self._id_to_meta``.
+
+           ``_save_faiss_index`` is the one part that runs in a worker
+           thread, and it is compatible with this invariant because it
+           only READS: it takes its ``self._id_to_meta`` snapshot on the
+           loop before offloading, and it reads ``self._index`` while
+           holding ``_storage_lock``, which excludes every mutation
+           above. The only unlocked Faiss access, ``query``'s
+           ``index.search``, is a read as well. Moving a MUTATION (or an
+           unsnapshotted dict iteration) into the pool would break the
+           invariant and would require widening the lock scope instead.
 
     Cross-process sync protocol:
         Writer side (``index_done_callback``):
@@ -133,11 +147,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
         The lock is **non-reentrant**, so ``_flush_pending_locked`` /
         ``_remove_faiss_ids_locked`` / ``_save_faiss_index`` /
         ``_reload_index_from_disk_locked`` all require the caller to
-        already hold it and never re-enter via ``_get_index``. Routine
+        already hold it and never re-enter via ``_get_index`` — the last
+        of these runs its writes in a worker thread, where re-entering
+        would deadlock on a lock the caller already holds. Routine
         ``index.search`` outside ``_get_index`` and the synchronous
-        ``client_storage`` read rely on invariant (3) above — if either
-        premise is broken (e.g. Faiss calls moved to a thread pool),
-        the lock scope must be widened.
+        ``client_storage`` read rely on invariant (3) above; both are
+        reads, which is why they coexist with the offloaded save. Moving
+        a Faiss or dict MUTATION into a thread pool would break that
+        premise and require widening the lock scope.
 
     Caveat — synchronous ``client_storage`` reads:
         ``client_storage`` is a synchronous property and does **not** go
@@ -1202,7 +1219,9 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # needed — a reload resurrecting the removed version is taken out again
         # by the replay at the top of the next flush, rewrite preserved.
 
-    def _save_faiss_index(self):
+    async def _save_faiss_index(
+        self, on_committed: Callable[[], Awaitable[None]]
+    ) -> None:
         """Atomically persist ``self._index`` + ``self._id_to_meta`` to disk.
 
         Precondition: the caller must already hold ``_storage_lock`` (this is
@@ -1220,13 +1239,32 @@ class FaissVectorDBStorage(BaseVectorStorage):
         ``test_faiss_meta_inconsistency``; the ``index > meta`` direction is
         a known gap (logged on reload, not auto-repaired) — see class
         docstring *Storage model*.
-        """
-        atomic_write(
-            self._faiss_index_file,
-            lambda tmp: faiss.write_index(self._index, tmp),
-            self.workspace or "_",
-        )
 
+        Both writes run in the storage-IO pool rather than on the event loop:
+        together they rewrite the entire index and the entire metadata file, so
+        inline they froze every unrelated request for the duration. Measured on
+        faiss 1.14.2, both halves genuinely yield — ``faiss.write_index``
+        releases the GIL outright, and ``json.dump`` is the same cooperative
+        pure-Python encoder the JSON backends use.
+
+        The metadata snapshot is built HERE, on the loop, before the offload:
+        the worker must not iterate ``self._id_to_meta`` while the synchronous
+        ``client_storage`` property can read it. ``self._index`` is handed over
+        by reference, which is sound because the worker only READS it while
+        every mutation (``add`` / ``remove_ids`` / reload) happens under
+        ``_storage_lock`` — held for this whole call — and the one unlocked
+        Faiss access, ``query``'s ``index.search``, is also a read. The write
+        ORDER (index first, then meta) is preserved: it is what keeps the
+        crash skew in the tolerated direction.
+
+        ``on_committed`` carries the post-write bookkeeping (retire the redo
+        logs, flag the other processes, clear the dirty bit) into the same
+        uncancellable region as the write. It must not be inlined after this
+        call: a cancel delivered in between would leave both files published
+        with the other processes never told to reload them. It runs only if the
+        write succeeded — running it without a write would retire redo entries
+        for rows that were never persisted.
+        """
         # Save metadata dict to JSON, excluding __vector__ since vectors are
         # already stored in the Faiss index file and can be reconstructed on load.
         serializable_dict = {}
@@ -1234,11 +1272,26 @@ class FaissVectorDBStorage(BaseVectorStorage):
             filtered_meta = {k: v for k, v in meta.items() if k != "__vector__"}
             serializable_dict[str(fid)] = filtered_meta
 
+        index = self._index
+        index_file = self._faiss_index_file
+        meta_file = self._meta_file
+        workspace = self.workspace or "_"
+
         def _write_meta(tmp: str) -> None:
             with open(tmp, "w", encoding="utf-8") as f:
                 json.dump(serializable_dict, f)
 
-        atomic_write(self._meta_file, _write_meta, self.workspace or "_")
+        def _write_both() -> None:
+            # One submission for both files: two would take two permits and
+            # could interleave another namespace's commit between the halves.
+            atomic_write(
+                index_file,
+                lambda tmp: faiss.write_index(index, tmp),
+                workspace,
+            )
+            atomic_write(meta_file, _write_meta, workspace)
+
+        await commit_in_storage_io(_write_both, on_committed)
 
     def _load_faiss_index(self):
         """
@@ -1390,12 +1443,15 @@ class FaissVectorDBStorage(BaseVectorStorage):
             # aborts the batch; pending stays intact and _index_dirty stays
             # True (if only the save failed) for a later retry.
             await self._flush_pending_locked()
-            self._save_faiss_index()
-            self._unsaved_deletes.clear()  # the removals are durable now
-            self._unsaved_upserts.clear()  # the rows are durable now
-            await set_all_update_flags(self.namespace, workspace=self.workspace)
-            self.storage_updated.value = False
-            self._index_dirty = False
+
+            async def _committed() -> None:
+                self._unsaved_deletes.clear()  # the removals are durable now
+                self._unsaved_upserts.clear()  # the rows are durable now
+                await set_all_update_flags(self.namespace, workspace=self.workspace)
+                self.storage_updated.value = False
+                self._index_dirty = False
+
+            await self._save_faiss_index(_committed)
             return True
 
     @staticmethod
@@ -1775,9 +1831,12 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 # would rewrite both files and flag every other process
                 # for a full reload for no reason.
                 return
-            self._save_faiss_index()
-            self._unsaved_deletes.clear()  # the removals are durable now
-            self._unsaved_upserts.clear()  # the rows are durable now
-            await set_all_update_flags(self.namespace, workspace=self.workspace)
-            self.storage_updated.value = False
-            self._index_dirty = False
+
+            async def _committed() -> None:
+                self._unsaved_deletes.clear()  # the removals are durable now
+                self._unsaved_upserts.clear()  # the rows are durable now
+                await set_all_update_flags(self.namespace, workspace=self.workspace)
+                self.storage_updated.value = False
+                self._index_dirty = False
+
+            await self._save_faiss_index(_committed)

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -31,7 +31,7 @@ from lightrag.utils import (
     load_json,
     logger,
     validate_workspace,
-    run_in_storage_io,
+    commit_in_storage_io,
     write_json,
     get_pinyin_sort_key,
 )
@@ -300,24 +300,39 @@ class JsonDocStatusStorage(DocStatusStorage):
                 # serving HTTP would otherwise be blocked. Only the write moves
                 # -- `data_dict` is snapshotted above, on the loop, under the
                 # lock, so the worker thread touches nothing shared.
-                needs_reload = await run_in_storage_io(
-                    write_json, data_dict, self._file_name
-                )
+                write_outcome: dict[str, bool] = {}
 
-                # If data was sanitized, reload cleaned data to update shared
-                # memory. Deliberately NOT offloaded: this branch writes back
-                # into the shared dict, and it only runs for payloads that fail
-                # to encode.
-                if needs_reload:
-                    logger.info(
-                        f"[{self.workspace}] Reloading sanitized data into shared memory for {self.namespace}"
+                def _write() -> None:
+                    write_outcome["needs_reload"] = write_json(
+                        data_dict, self._file_name
                     )
-                    cleaned_data = load_json(self._file_name)
-                    if cleaned_data is not None:
-                        self._data.clear()
-                        self._data.update(cleaned_data)
 
-                await clear_all_update_flags(self.namespace, workspace=self.workspace)
+                async def _committed() -> None:
+                    # Reconciliation belongs INSIDE the write's uncancellable
+                    # region. The sanitized file is already published at this
+                    # point, so a cancellation landing between the two would
+                    # leave the shared dict holding the rows that failed to
+                    # encode — diverging from disk until some later flush
+                    # happens to sanitize again. Before the offload the write
+                    # and this branch were one unpreemptable synchronous block,
+                    # which is the guarantee being restored here.
+                    #
+                    # Still not offloaded itself: it writes back into the shared
+                    # dict, and it only runs for payloads that fail to encode.
+                    if write_outcome.get("needs_reload"):
+                        logger.info(
+                            f"[{self.workspace}] Reloading sanitized data into shared memory for {self.namespace}"
+                        )
+                        cleaned_data = load_json(self._file_name)
+                        if cleaned_data is not None:
+                            self._data.clear()
+                            self._data.update(cleaned_data)
+
+                    await clear_all_update_flags(
+                        self.namespace, workspace=self.workspace
+                    )
+
+                await commit_in_storage_io(_write, _committed)
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         """Insert/update doc-status records and **persist immediately**.

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -31,6 +31,7 @@ from lightrag.utils import (
     load_json,
     logger,
     validate_workspace,
+    run_in_storage_io,
     write_json,
     get_pinyin_sort_key,
 )
@@ -274,9 +275,13 @@ class JsonDocStatusStorage(DocStatusStorage):
         """Flush dirty shared memory to disk and clear all dirty flags.
 
         Identical commit protocol to ``JsonKVStorage.index_done_callback``
-        (snapshot the shared dict → ``write_json`` → if sanitization
-        happened reload the cleaned data → ``clear_all_update_flags``).
+        (snapshot the shared dict → ``write_json`` off the event loop → if
+        sanitization happened reload the cleaned data → ``clear_all_update_flags``).
         See ``JsonKVStorage`` docstring for details.
+
+        This is the highest-frequency writer of the three file backends:
+        ``upsert`` persists on every call, so a purge journalling four phases
+        per document commits this file four times for that document alone.
         """
         async with self._storage_lock:
             if self.storage_updated.value:
@@ -290,10 +295,19 @@ class JsonDocStatusStorage(DocStatusStorage):
                     f"[{self.workspace}] Process {os.getpid()} doc status writting {len(data_dict)} records to {self.namespace}"
                 )
 
-                # Write JSON and check if sanitization was applied
-                needs_reload = write_json(data_dict, self._file_name)
+                # Off the event loop: this rewrites the whole file, which on a
+                # large corpus takes seconds during which the single worker
+                # serving HTTP would otherwise be blocked. Only the write moves
+                # -- `data_dict` is snapshotted above, on the loop, under the
+                # lock, so the worker thread touches nothing shared.
+                needs_reload = await run_in_storage_io(
+                    write_json, data_dict, self._file_name
+                )
 
-                # If data was sanitized, reload cleaned data to update shared memory
+                # If data was sanitized, reload cleaned data to update shared
+                # memory. Deliberately NOT offloaded: this branch writes back
+                # into the shared dict, and it only runs for payloads that fail
+                # to encode.
                 if needs_reload:
                     logger.info(
                         f"[{self.workspace}] Reloading sanitized data into shared memory for {self.namespace}"

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -12,7 +12,7 @@ from lightrag.utils import (
     load_json,
     logger,
     validate_workspace,
-    run_in_storage_io,
+    commit_in_storage_io,
     write_json,
 )
 from lightrag.exceptions import StorageNotInitializedError
@@ -249,24 +249,39 @@ class JsonKVStorage(BaseKVStorage):
                 # serving HTTP would otherwise be blocked. Only the write moves
                 # -- `data_dict` is snapshotted above, on the loop, under the
                 # lock, so the worker thread touches nothing shared.
-                needs_reload = await run_in_storage_io(
-                    write_json, data_dict, self._file_name
-                )
+                write_outcome: dict[str, bool] = {}
 
-                # If data was sanitized, reload cleaned data to update shared
-                # memory. Deliberately NOT offloaded: this branch writes back
-                # into the shared dict, and it only runs for payloads that fail
-                # to encode.
-                if needs_reload:
-                    logger.info(
-                        f"[{self.workspace}] Reloading sanitized data into shared memory for {self.namespace}"
+                def _write() -> None:
+                    write_outcome["needs_reload"] = write_json(
+                        data_dict, self._file_name
                     )
-                    cleaned_data = load_json(self._file_name)
-                    if cleaned_data is not None:
-                        self._data.clear()
-                        self._data.update(cleaned_data)
 
-                await clear_all_update_flags(self.namespace, workspace=self.workspace)
+                async def _committed() -> None:
+                    # Reconciliation belongs INSIDE the write's uncancellable
+                    # region. The sanitized file is already published at this
+                    # point, so a cancellation landing between the two would
+                    # leave the shared dict holding the rows that failed to
+                    # encode — diverging from disk until some later flush
+                    # happens to sanitize again. Before the offload the write
+                    # and this branch were one unpreemptable synchronous block,
+                    # which is the guarantee being restored here.
+                    #
+                    # Still not offloaded itself: it writes back into the shared
+                    # dict, and it only runs for payloads that fail to encode.
+                    if write_outcome.get("needs_reload"):
+                        logger.info(
+                            f"[{self.workspace}] Reloading sanitized data into shared memory for {self.namespace}"
+                        )
+                        cleaned_data = load_json(self._file_name)
+                        if cleaned_data is not None:
+                            self._data.clear()
+                            self._data.update(cleaned_data)
+
+                    await clear_all_update_flags(
+                        self.namespace, workspace=self.workspace
+                    )
+
+                await commit_in_storage_io(_write, _committed)
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         async with self._storage_lock:

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -12,6 +12,7 @@ from lightrag.utils import (
     load_json,
     logger,
     validate_workspace,
+    run_in_storage_io,
     write_json,
 )
 from lightrag.exceptions import StorageNotInitializedError
@@ -209,7 +210,10 @@ class JsonKVStorage(BaseKVStorage):
                return.
             2. Snapshot ``self._data`` (converting from ``Manager.dict``
                proxy to a plain ``dict`` so the JSON encoder doesn't trip
-               over the proxy) and write it via ``write_json``.
+               over the proxy) and write it via ``write_json``, which runs
+               in the storage-IO pool rather than on the event loop. The
+               snapshot is taken here, on the loop, so the worker thread
+               only ever reads a private dict.
             3. If ``write_json`` reports sanitization was applied, the
                on-disk file no longer matches what was in memory — reload
                the cleaned data back into ``self._data`` under the same
@@ -240,10 +244,19 @@ class JsonKVStorage(BaseKVStorage):
                     f"[{self.workspace}] Process {os.getpid()} KV writting {data_count} records to {self.namespace}"
                 )
 
-                # Write JSON and check if sanitization was applied
-                needs_reload = write_json(data_dict, self._file_name)
+                # Off the event loop: this rewrites the whole file, which on a
+                # large corpus takes seconds during which the single worker
+                # serving HTTP would otherwise be blocked. Only the write moves
+                # -- `data_dict` is snapshotted above, on the loop, under the
+                # lock, so the worker thread touches nothing shared.
+                needs_reload = await run_in_storage_io(
+                    write_json, data_dict, self._file_name
+                )
 
-                # If data was sanitized, reload cleaned data to update shared memory
+                # If data was sanitized, reload cleaned data to update shared
+                # memory. Deliberately NOT offloaded: this branch writes back
+                # into the shared dict, and it only runs for payloads that fail
+                # to encode.
                 if needs_reload:
                     logger.info(
                         f"[{self.workspace}] Reloading sanitized data into shared memory for {self.namespace}"

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -3,8 +3,9 @@ import base64
 import json
 import os
 import zlib
+from functools import partial
 from hashlib import md5
-from typing import Any, final
+from typing import Any, Awaitable, Callable, final
 from dataclasses import dataclass
 import numpy as np
 import time
@@ -13,7 +14,7 @@ from lightrag.file_atomic import atomic_write, reap_orphan_tmp_files
 from lightrag.utils import (
     logger,
     compute_mdhash_id,
-    run_in_storage_io,
+    commit_in_storage_io,
     validate_workspace,
 )
 
@@ -691,7 +692,9 @@ class NanoVectorDBStorage(BaseVectorStorage):
         # needed — a reload resurrecting the removed version is taken out again
         # by the replay at the top of the next flush, rewrite preserved.
 
-    async def _save_to_disk_locked(self) -> None:
+    async def _save_to_disk_locked(
+        self, on_committed: Callable[[], Awaitable[None]]
+    ) -> None:
         """Atomically persist ``self._client`` and notify other processes.
 
         Precondition: the caller must already hold ``_storage_lock``. Factored
@@ -708,9 +711,17 @@ class NanoVectorDBStorage(BaseVectorStorage):
           ``self._client.storage_file`` to the tmp sibling for the duration of
           the save, so a coroutine that got in during the write would observe
           the client pointing at a path that is about to be renamed away.
-        * ``run_in_storage_io`` therefore refuses to return before the worker
+        * ``commit_in_storage_io`` therefore refuses to return before the worker
           finishes, even when the caller is cancelled — matching the old
           synchronous write, which could not be cancelled at all.
+
+        ``on_committed`` carries the post-write bookkeeping (retire the redo
+        logs, flag the other processes, clear the dirty bit) into that same
+        uncancellable region. It must not be inlined after this call: a cancel
+        delivered in between would leave the file published with the other
+        processes never told to reload it, and would strand the redo logs. It
+        runs only if the write succeeded — running it without a write would
+        retire redo entries for rows that were never persisted.
 
         Only PART of the stall goes away. ``NanoVectorDB.save()`` base64-encodes
         the entire matrix through ``tobytes()`` and ``b64encode()``, two single C
@@ -728,8 +739,14 @@ class NanoVectorDBStorage(BaseVectorStorage):
             finally:
                 self._client.storage_file = original
 
-        await run_in_storage_io(
-            atomic_write, self._client_file_name, _save_atomic, self.workspace or "_"
+        await commit_in_storage_io(
+            partial(
+                atomic_write,
+                self._client_file_name,
+                _save_atomic,
+                self.workspace or "_",
+            ),
+            on_committed,
         )
 
     async def query(
@@ -1076,12 +1093,15 @@ class NanoVectorDBStorage(BaseVectorStorage):
             # aborts the batch; pending stays intact and _client_dirty stays
             # True (if only the save failed) for a later retry.
             await self._flush_pending_locked()
-            await self._save_to_disk_locked()
-            self._unsaved_deletes.clear()  # the removals are durable now
-            self._unsaved_upserts.clear()  # the rows are durable now
-            await set_all_update_flags(self.namespace, workspace=self.workspace)
-            self.storage_updated.value = False
-            self._client_dirty = False
+
+            async def _committed() -> None:
+                self._unsaved_deletes.clear()  # the removals are durable now
+                self._unsaved_upserts.clear()  # the rows are durable now
+                await set_all_update_flags(self.namespace, workspace=self.workspace)
+                self.storage_updated.value = False
+                self._client_dirty = False
+
+            await self._save_to_disk_locked(_committed)
             return True
 
     @staticmethod
@@ -1466,9 +1486,12 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 # the whole file and flag every other process for a full
                 # reload for no reason.
                 return
-            await self._save_to_disk_locked()
-            self._unsaved_deletes.clear()  # the removals are durable now
-            self._unsaved_upserts.clear()  # the rows are durable now
-            await set_all_update_flags(self.namespace, workspace=self.workspace)
-            self.storage_updated.value = False
-            self._client_dirty = False
+
+            async def _committed() -> None:
+                self._unsaved_deletes.clear()  # the removals are durable now
+                self._unsaved_upserts.clear()  # the rows are durable now
+                await set_all_update_flags(self.namespace, workspace=self.workspace)
+                self.storage_updated.value = False
+                self._client_dirty = False
+
+            await self._save_to_disk_locked(_committed)

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -13,6 +13,7 @@ from lightrag.file_atomic import atomic_write, reap_orphan_tmp_files
 from lightrag.utils import (
     logger,
     compute_mdhash_id,
+    run_in_storage_io,
     validate_workspace,
 )
 
@@ -690,7 +691,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
         # needed — a reload resurrecting the removed version is taken out again
         # by the replay at the top of the next flush, rewrite preserved.
 
-    def _save_to_disk_locked(self) -> None:
+    async def _save_to_disk_locked(self) -> None:
         """Atomically persist ``self._client`` and notify other processes.
 
         Precondition: the caller must already hold ``_storage_lock``. Factored
@@ -699,6 +700,24 @@ class NanoVectorDBStorage(BaseVectorStorage):
         path is on the instance, so we temporarily redirect ``storage_file`` to
         the per-writer tmp and let ``atomic_write`` own the rename; the original
         path is restored on every path (success and exception).
+
+        Runs in the storage-IO pool rather than on the event loop. Two
+        consequences the caller must respect:
+
+        * The lock has to stay held for the whole call. ``_save_atomic`` swaps
+          ``self._client.storage_file`` to the tmp sibling for the duration of
+          the save, so a coroutine that got in during the write would observe
+          the client pointing at a path that is about to be renamed away.
+        * ``run_in_storage_io`` therefore refuses to return before the worker
+          finishes, even when the caller is cancelled — matching the old
+          synchronous write, which could not be cancelled at all.
+
+        Only PART of the stall goes away. ``NanoVectorDB.save()`` base64-encodes
+        the entire matrix through ``tobytes()`` and ``b64encode()``, two single C
+        calls that hold the GIL for their whole duration no matter which thread
+        they run on; a 400 MB matrix still stalls the loop for that stretch. The
+        ``json.dump`` that follows is the cooperative part. Fixing the encode
+        needs a chunked or binary format and is tracked separately.
         """
 
         def _save_atomic(tmp: str) -> None:
@@ -709,7 +728,9 @@ class NanoVectorDBStorage(BaseVectorStorage):
             finally:
                 self._client.storage_file = original
 
-        atomic_write(self._client_file_name, _save_atomic, self.workspace or "_")
+        await run_in_storage_io(
+            atomic_write, self._client_file_name, _save_atomic, self.workspace or "_"
+        )
 
     async def query(
         self, query: str, top_k: int, query_embedding: list[float] = None
@@ -1055,7 +1076,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
             # aborts the batch; pending stays intact and _client_dirty stays
             # True (if only the save failed) for a later retry.
             await self._flush_pending_locked()
-            self._save_to_disk_locked()
+            await self._save_to_disk_locked()
             self._unsaved_deletes.clear()  # the removals are durable now
             self._unsaved_upserts.clear()  # the rows are durable now
             await set_all_update_flags(self.namespace, workspace=self.workspace)
@@ -1445,7 +1466,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 # the whole file and flag every other process for a full
                 # reload for no reason.
                 return
-            self._save_to_disk_locked()
+            await self._save_to_disk_locked()
             self._unsaved_deletes.clear()  # the removals are durable now
             self._unsaved_upserts.clear()  # the rows are durable now
             await set_all_update_flags(self.namespace, workspace=self.workspace)

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -267,6 +267,7 @@ class NetworkXStorage(BaseGraphStorage):
         # Created lazily by _gate(): asyncio.Event binds to a loop on first
         # wait, and instances are constructed outside any running loop.
         self._commit_gate = None
+        self._commit_gate_loop = None
 
         reap_orphan_tmp_files(self._graphml_xml_file, workspace=self.workspace or "_")
 
@@ -299,10 +300,27 @@ class NetworkXStorage(BaseGraphStorage):
         See *Commit gate* in the class docstring. Lazily created so the
         ``asyncio.Event`` binds to whichever loop first waits on it, which is
         never the loop-less ``__post_init__``.
+
+        Rebuilt when the running loop changes. An ``asyncio.Event`` binds to a
+        loop the first time a ``wait()`` actually suspends on it, and from then
+        on ``wait()`` from any other loop raises "is bound to a different event
+        loop". A single instance CAN legitimately outlive its loop: the
+        synchronous wrappers let calls through on a fresh loop once the original
+        ``owning_loop`` has closed (see ``_run_sync`` — the common
+        ``rag = asyncio.run(initialize_rag())`` shape), and a gate bound during
+        some earlier commit would then break the next one.
+
+        Rebinding is safe rather than a race: a commit in flight holds
+        ``_storage_lock`` and runs on the loop being replaced, so reaching here
+        on a different loop means no commit of ours is outstanding and an open
+        gate is the correct state. Lazily rebuilt here, not eagerly in
+        ``initialize()``, because that is not where the loop change shows up.
         """
-        if self._commit_gate is None:
+        loop = asyncio.get_running_loop()
+        if self._commit_gate is None or self._commit_gate_loop is not loop:
             self._commit_gate = asyncio.Event()
             self._commit_gate.set()
+            self._commit_gate_loop = loop
         return self._commit_gate
 
     async def _get_graph(self):

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from collections import deque
 from dataclasses import dataclass
@@ -10,6 +11,7 @@ from lightrag.utils import (
     logger,
     validate_xml_attributes,
     validate_workspace,
+    run_in_storage_io,
 )
 from lightrag.base import BaseGraphStorage
 import networkx as nx
@@ -62,7 +64,43 @@ class NetworkXStorage(BaseGraphStorage):
            preempted by another coroutine, which gives them implicit
            mutual exclusion over ``self._graph``. This is why the methods
            below don't have to hold ``_storage_lock`` while calling into
-           ``graph``.
+           ``graph``. The one place that is NOT on the event loop is the
+           GraphML serialization, which runs in the storage-IO pool — see
+           *Commit gate* below for what re-establishes the exclusion there.
+
+    Commit gate:
+        ``index_done_callback`` hands ``self._graph`` to a worker thread,
+        which iterates ``graph._node`` / ``graph._adj`` for the length of
+        the write. Invariant (3) does not cover that: a coroutine on the
+        loop could mutate the graph mid-iteration, tearing the snapshot or
+        raising ``RuntimeError: dictionary changed size during iteration``
+        from inside the writer.
+
+        ``_commit_gate`` is an ``asyncio.Event``, set except while this
+        process is serializing. The committer clears it inside
+        ``_storage_lock`` and restores it in a ``finally`` (every path,
+        cancellation included — leaking a cleared gate once deadlocks every
+        later graph operation in this workspace). ``_get_graph`` waits on it.
+
+        **Holding ``_storage_lock`` across the write is NOT sufficient on
+        its own**, which is why the gate exists as well. Releasing a
+        ``NamespaceLock`` runs the release on a fresh task and awaits a
+        shield, so ``__aexit__`` always suspends at least once. A mutator
+        that has read ``self._graph`` and is suspended in that release is
+        past the lock and would resume — and mutate — while the worker
+        thread is iterating. The gate is therefore checked AFTER
+        ``_get_graph``'s lock block, i.e. after the last suspension point:
+        from the ``is_set()`` check through the caller's synchronous
+        ``graph.add_node()`` there is no ``await``, so no commit can start
+        in the middle of a mutation.
+
+        The gate sits at ``_get_graph``, the single choke point every read
+        and write goes through, rather than in the seven mutators. Reads are
+        gated too. That is deliberate and free: a reader already has to pass
+        ``_storage_lock``, which the committer holds throughout, so the gate
+        adds no wait it did not already have — and a ``for_write=True``
+        variant would buy nothing while forking the semantics of the one
+        choke point.
 
     Cross-process sync protocol (identical in shape to
     ``NanoVectorDBStorage`` — see that class's docstring for the canonical
@@ -90,10 +128,13 @@ class NetworkXStorage(BaseGraphStorage):
         spanning both intra-process coroutines and inter-process workers.
         It wraps only the *reload* and *commit* critical sections, not
         every ``graph.xxx`` call. Operating on ``graph`` outside the lock
-        is safe today *because of invariant (3)* — if either premise is
-        ever broken (e.g. ``graph.xxx`` is moved to a thread pool, or
-        networkx is swapped for an async graph library), the lock scope
-        must be widened to cover the mutation/read itself.
+        is safe *because of invariant (3)* plus the commit gate, which
+        covers the one case invariant (3) does not: the serialization
+        running in a worker thread. If invariant (3) is broken further —
+        ``graph.xxx`` itself moved to a thread pool, or networkx swapped
+        for an async graph library — the gate is no longer enough either
+        and the lock scope must be widened to cover the mutation/read
+        itself.
 
     Implementation differences from ``NanoVectorDBStorage`` (same design,
     different surface):
@@ -223,6 +264,9 @@ class NetworkXStorage(BaseGraphStorage):
         self._storage_lock = None
         self.storage_updated = None
         self._graph = None
+        # Created lazily by _gate(): asyncio.Event binds to a loop on first
+        # wait, and instances are constructed outside any running loop.
+        self._commit_gate = None
 
         reap_orphan_tmp_files(self._graphml_xml_file, workspace=self.workspace or "_")
 
@@ -248,6 +292,18 @@ class NetworkXStorage(BaseGraphStorage):
         self._storage_lock = get_namespace_lock(
             self.namespace, workspace=self.workspace
         )
+
+    def _gate(self) -> asyncio.Event:
+        """The commit gate: set except while this process is serializing.
+
+        See *Commit gate* in the class docstring. Lazily created so the
+        ``asyncio.Event`` binds to whichever loop first waits on it, which is
+        never the loop-less ``__post_init__``.
+        """
+        if self._commit_gate is None:
+            self._commit_gate = asyncio.Event()
+            self._commit_gate.set()
+        return self._commit_gate
 
     async def _get_graph(self):
         """Return the live ``networkx.Graph``, reloading from disk if needed.
@@ -284,7 +340,26 @@ class NetworkXStorage(BaseGraphStorage):
                 # Reset update flag
                 self.storage_updated.value = False
 
-            return self._graph
+            graph = self._graph
+
+        # The gate is checked HERE, after the lock block, and that placement is
+        # the whole point -- see *Commit gate* in the class docstring. Holding
+        # _storage_lock in the committer does not exclude a caller that is
+        # already past this method's lock body: releasing a NamespaceLock runs
+        # the release on a fresh task and awaits a shield, so __aexit__ ALWAYS
+        # suspends at least once. Such a caller would resume and mutate
+        # self._graph while the committer's worker thread iterates graph._node /
+        # graph._adj.
+        #
+        # After this check there is no suspension point left: is_set() does not
+        # await, so the caller's synchronous graph.add_node() / remove_node()
+        # cannot have a commit start in the middle of it.
+        #
+        # A loop, not one wait(): a woken waiter's wait() returns True even if a
+        # second committer has cleared the gate again in the meantime.
+        while not self._gate().is_set():
+            await self._gate().wait()
+        return graph
 
     async def has_node(self, node_id: str) -> bool:
         graph = await self._get_graph()
@@ -866,10 +941,22 @@ class NetworkXStorage(BaseGraphStorage):
 
         # Acquire lock and perform persistence
         async with self._storage_lock:
+            # Close the commit gate for the duration of the serialization: the
+            # worker thread iterates graph._node / graph._adj, and a concurrent
+            # add_node/remove_node would tear the snapshot (or raise
+            # "dictionary changed size during iteration" from inside the writer).
+            # The lock alone is not enough -- see _get_graph.
+            gate = self._gate()
+            gate.clear()
             try:
-                # Save data to disk
-                NetworkXStorage.write_nx_graph(
-                    self._graph, self._graphml_xml_file, self.workspace
+                # Save data to disk, off the event loop. The name is resolved at
+                # call time on purpose: test_networkx_index_done.py monkeypatches
+                # write_nx_graph, and hoisting the reference would leave that
+                # test green while testing nothing.
+                await run_in_storage_io(
+                    lambda: NetworkXStorage.write_nx_graph(
+                        self._graph, self._graphml_xml_file, self.workspace
+                    )
                 )
                 # Notify other processes that data has been updated
                 await set_all_update_flags(self.namespace, workspace=self.workspace)
@@ -884,6 +971,10 @@ class NetworkXStorage(BaseGraphStorage):
                 # aligns this backend with the others (faiss/nano raise too).
                 logger.error(f"[{self.workspace}] Error saving graph: {e}")
                 raise
+            finally:
+                # Every path, including CancelledError. Leaking a cleared gate
+                # once deadlocks every later graph operation in this workspace.
+                gate.set()
 
         return True
 

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -11,7 +11,7 @@ from lightrag.utils import (
     logger,
     validate_xml_attributes,
     validate_workspace,
-    run_in_storage_io,
+    commit_in_storage_io,
 )
 from lightrag.base import BaseGraphStorage
 import networkx as nx
@@ -953,15 +953,22 @@ class NetworkXStorage(BaseGraphStorage):
                 # call time on purpose: test_networkx_index_done.py monkeypatches
                 # write_nx_graph, and hoisting the reference would leave that
                 # test green while testing nothing.
-                await run_in_storage_io(
+                async def _committed() -> None:
+                    # Runs inside the same uncancellable region as the write,
+                    # and only if the write landed. Inlined after the offload it
+                    # would be skippable by a cancel, leaving the new GraphML
+                    # published while every other process keeps reading the
+                    # previous one until some later commit happens to notify it.
+                    await set_all_update_flags(self.namespace, workspace=self.workspace)
+                    # Reset own update flag to avoid self-reloading
+                    self.storage_updated.value = False
+
+                await commit_in_storage_io(
                     lambda: NetworkXStorage.write_nx_graph(
                         self._graph, self._graphml_xml_file, self.workspace
-                    )
+                    ),
+                    _committed,
                 )
-                # Notify other processes that data has been updated
-                await set_all_update_flags(self.namespace, workspace=self.workspace)
-                # Reset own update flag to avoid self-reloading
-                self.storage_updated.value = False
                 return True  # Return success
             except Exception as e:
                 # Raise (do NOT swallow + return False): _insert_done's

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -2725,28 +2725,37 @@ def _consume_future_exception(fut: "asyncio.Future") -> None:
         fut.exception()
 
 
-async def bounded_submit(
+async def _bounded_submit_impl(
     executor: ThreadPoolExecutor,
     semaphore: asyncio.Semaphore,
     fn: Callable[..., Any],
-    /,
-    *args: Any,
-    **kwargs: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    wait_for_completion: bool,
 ) -> Any:
-    """Run ``fn`` in ``executor`` under a permit owned by the executor future.
+    """Shared body of :func:`bounded_submit` and :func:`run_in_storage_io`.
 
-    Args:
-        executor: destination pool.
-        semaphore: submission ceiling for this pool, from :func:`get_loop_semaphore`.
-        fn: synchronous callable to run in the pool.
-        *args, **kwargs: forwarded to ``fn``.
+    Private, and takes ``args`` / ``kwargs`` as explicit containers rather than
+    ``*args, **kwargs``, so the control flag can never collide with an argument
+    meant for ``fn``. ``bounded_submit`` forwards its ``**kwargs`` verbatim, so
+    putting ``wait_for_completion`` on its own signature would either make it
+    positional-only (before the ``/``, where passing it by keyword would silently
+    forward it to ``fn`` instead of setting it) or steal a legitimate argument of
+    ``fn`` (after ``*args``).
 
-    Returns:
-        Whatever ``fn`` returns.
+    ``wait_for_completion`` selects what happens AFTER the work is submitted:
 
-    Cancelling the caller does not cancel the thread: the work runs to completion
-    and only then is the permit returned. That is deliberate — see the module
-    comment above.
+    * ``False`` — cancelling the caller returns immediately. The thread still
+      runs to completion and still owns the permit; the caller just stops
+      waiting for it.
+    * ``True`` — the caller refuses to return until the worker is done, because
+      the worker may be halfway through mutating state the caller's lock is
+      protecting (see :func:`run_in_storage_io`).
+
+    Either way the permit wait itself stays cancellable: nothing has been
+    submitted at that point, so a cancelled caller leaves no work in flight and
+    can release whatever lock it holds immediately.
     """
     await semaphore.acquire()
     try:
@@ -2772,7 +2781,78 @@ async def bounded_submit(
 
     async_future = asyncio.wrap_future(concurrent_future)
     async_future.add_done_callback(_consume_future_exception)
-    return await asyncio.shield(async_future)
+
+    if not wait_for_completion:
+        return await asyncio.shield(async_future)
+
+    # Loop + shield, not a single shield: a lone ``await asyncio.shield(...)``
+    # returns immediately on RE-cancellation, so a second cancel would let the
+    # caller escape while the thread is still running. Same shape and same reason
+    # as ``_KeyedLockContext.__aexit__`` in ``lightrag/kg/shared_storage.py``.
+    pending_cancel: Optional[asyncio.CancelledError] = None
+    while not async_future.done():
+        try:
+            await asyncio.shield(async_future)
+        except asyncio.CancelledError as exc:
+            if async_future.cancelled():
+                # The submitted work itself was cancelled — it did not run to
+                # completion and we must not pretend it did.
+                raise
+            pending_cancel = pending_cancel or exc
+        except BaseException:
+            # The worker failed. Do NOT let that exception out from here: a
+            # cancellation recorded on an earlier round has to take precedence,
+            # and deciding that is the block below's job. The exception stays on
+            # ``async_future`` and is re-raised by ``result()`` (or logged) once
+            # the loop has established which one wins. Anything raised while the
+            # future is still pending came from elsewhere and still propagates.
+            if not async_future.done():
+                raise
+            break
+
+    if pending_cancel is not None:
+        # The caller gets CancelledError, so nobody will ever see the worker's
+        # exception. ``_consume_future_exception`` already marked it retrieved
+        # (no "exception was never retrieved" noise at GC time); log it so the
+        # failure is not lost entirely.
+        if not async_future.cancelled():
+            worker_exc = async_future.exception()
+            if worker_exc is not None:
+                logger.error(
+                    f"Offloaded work failed while its caller was cancelled: {worker_exc}"
+                )
+        raise pending_cancel
+    return async_future.result()
+
+
+async def bounded_submit(
+    executor: ThreadPoolExecutor,
+    semaphore: asyncio.Semaphore,
+    fn: Callable[..., Any],
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Run ``fn`` in ``executor`` under a permit owned by the executor future.
+
+    Args:
+        executor: destination pool.
+        semaphore: submission ceiling for this pool, from :func:`get_loop_semaphore`.
+        fn: synchronous callable to run in the pool.
+        *args, **kwargs: forwarded to ``fn`` verbatim. This function declares no
+            keyword arguments of its own, so ``fn`` may use any parameter name.
+
+    Returns:
+        Whatever ``fn`` returns.
+
+    Cancelling the caller does not cancel the thread: the work runs to completion
+    and only then is the permit returned. That is deliberate — see the module
+    comment above. Callers that must not RETURN before the thread finishes use
+    :func:`run_in_storage_io` instead.
+    """
+    return await _bounded_submit_impl(
+        executor, semaphore, fn, args, kwargs, wait_for_completion=False
+    )
 
 
 # Semaphores are per event loop, executors are per process. ``asyncio.Semaphore``
@@ -2885,6 +2965,83 @@ async def run_in_chunking_executor(fn: Callable[..., Any], *args: Any, **kwargs)
     semaphore = get_loop_semaphore("chunking", CHUNKING_SUBMIT_LIMIT)
     return await bounded_submit(
         get_chunking_executor(), semaphore, partial(fn, *args, **kwargs)
+    )
+
+
+# ---------------------------------------------------------------------------
+# File-backend persistence off the event loop
+# ---------------------------------------------------------------------------
+#
+# The file backends rewrite their whole file on every commit, synchronously, on
+# the event loop: ``write_json`` for the JSON KV / doc-status stores,
+# ``nx.write_graphml`` for NetworkX, ``NanoVectorDB.save`` for nano. A single
+# ``_insert_done`` flushes every storage, and a document purge issues several of
+# them, so on a large corpus the loop stops serving HTTP for seconds at a time —
+# the same failure mode as GHSA-26pm-px5v-8c4w, in a different place.
+#
+# One worker. Those commits are ALREADY serialized today: ``_flush_storages``
+# gathers them, but each synchronous write runs to completion without yielding,
+# so they happen one after another anyway. A single worker preserves that
+# concurrency exactly while freeing the loop. More workers would only make the
+# pure-Python encoders (``json.dump`` with ``indent``, GraphML's per-element
+# loop) contend for the GIL with each other AND with the loop — turning "the
+# loop is blocked for N seconds" into "the loop is starved for N seconds",
+# which is worse.
+#
+# Not the default executor: that one is shared with
+# ``UnifiedLock._acquire_mp_lock_in_executor``, password hashing and ``stat``
+# calls, and parking it behind a multi-second file write would delay work that
+# has to run promptly.
+#
+# Invariants for anything submitted here:
+#   * no nested submission to this pool — one worker plus a held permit
+#     deadlocks;
+#   * no calling back into the storage layer (``_get_client`` / ``_get_graph``):
+#     they take ``NamespaceLock``, which the caller already holds and which is
+#     not reentrant;
+#   * therefore the pool holds no locks, so it cannot take part in a cycle.
+
+_STORAGE_IO_EXECUTOR: Optional[ThreadPoolExecutor] = None
+_STORAGE_IO_EXECUTOR_GUARD = threading.Lock()
+
+
+def get_storage_io_executor() -> ThreadPoolExecutor:
+    """The process-wide single-worker pool used for file-backend persistence."""
+    global _STORAGE_IO_EXECUTOR
+    if _STORAGE_IO_EXECUTOR is None:
+        with _STORAGE_IO_EXECUTOR_GUARD:
+            if _STORAGE_IO_EXECUTOR is None:
+                _STORAGE_IO_EXECUTOR = ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="lightrag-storage-io"
+                )
+    return _STORAGE_IO_EXECUTOR
+
+
+async def run_in_storage_io(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Run a synchronous storage-persistence callable off the event loop.
+
+    Uncancellable once submitted, unlike :func:`bounded_submit`. Callers hold
+    their storage lock across this call and the worker may be halfway through
+    mutating shared state — ``NanoVectorDBStorage`` points its client's
+    ``storage_file`` at the temporary sibling for the duration of the save.
+    Returning early would release the lock with that state still swapped, a
+    window the synchronous write being replaced here did not have, because it
+    could not be cancelled at all.
+
+    The wait for a submission permit stays cancellable: at that point nothing has
+    been submitted, so a cancelled caller leaves no half-written file behind and
+    releases its lock immediately.
+    """
+    from lightrag.constants import STORAGE_IO_SUBMIT_LIMIT
+
+    semaphore = get_loop_semaphore("storage_io", STORAGE_IO_SUBMIT_LIMIT)
+    return await _bounded_submit_impl(
+        get_storage_io_executor(),
+        semaphore,
+        fn,
+        args,
+        kwargs,
+        wait_for_completion=True,
     )
 
 

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -26,6 +26,7 @@ from hashlib import md5
 from pathlib import Path
 from typing import (
     Any,
+    Awaitable,
     Protocol,
     Callable,
     TYPE_CHECKING,
@@ -2725,6 +2726,40 @@ def _consume_future_exception(fut: "asyncio.Future") -> None:
         fut.exception()
 
 
+async def _wait_deferring_cancellation(
+    future: "asyncio.Future",
+    pending_cancel: Optional[asyncio.CancelledError],
+) -> Optional[asyncio.CancelledError]:
+    """Await ``future`` to completion, deferring cancellation of the caller.
+
+    Loop + shield, not a single shield: a lone ``await asyncio.shield(...)``
+    returns immediately on RE-cancellation, so a second cancel would let the
+    caller escape while the work is still running. Same shape and same reason as
+    ``_KeyedLockContext.__aexit__`` in ``lightrag/kg/shared_storage.py``.
+
+    Returns the cancellation to re-raise once every step is done (the first one
+    seen, if any). Cancelling ``future`` ITSELF still propagates immediately: it
+    did not run to completion and we must not pretend it did.
+    """
+    while not future.done():
+        try:
+            await asyncio.shield(future)
+        except asyncio.CancelledError as exc:
+            if future.cancelled():
+                raise
+            pending_cancel = pending_cancel or exc
+        except BaseException:
+            # The awaited work failed. Do NOT let that exception out from here: a
+            # cancellation recorded on an earlier round has to take precedence,
+            # and deciding that is the caller's job. The exception stays on
+            # ``future`` for the caller to re-raise or log. Anything raised while
+            # the future is still pending came from elsewhere and propagates.
+            if not future.done():
+                raise
+            break
+    return pending_cancel
+
+
 async def _bounded_submit_impl(
     executor: ThreadPoolExecutor,
     semaphore: asyncio.Semaphore,
@@ -2733,6 +2768,7 @@ async def _bounded_submit_impl(
     kwargs: dict[str, Any],
     *,
     wait_for_completion: bool,
+    on_committed: Optional[Callable[[], Awaitable[Any]]] = None,
 ) -> Any:
     """Shared body of :func:`bounded_submit` and :func:`run_in_storage_io`.
 
@@ -2756,6 +2792,21 @@ async def _bounded_submit_impl(
     Either way the permit wait itself stays cancellable: nothing has been
     submitted at that point, so a cancelled caller leaves no work in flight and
     can release whatever lock it holds immediately.
+
+    ``on_committed`` (requires ``wait_for_completion``) is the bookkeeping that
+    must not be separated from a write that already landed — flipping other
+    processes' reload flags, retiring a redo log. It runs inside the SAME
+    uncancellable region as the write, and only when the write actually
+    succeeded:
+
+    * write succeeded → ``on_committed`` runs to completion, and only then is a
+      deferred cancellation re-raised;
+    * ``fn`` raised → ``on_committed`` does NOT run and the exception
+      propagates; the write did not land, so its bookkeeping must not either;
+    * cancelled while waiting for a permit → ``on_committed`` does NOT run,
+      because nothing was ever submitted. That is load-bearing, not tidiness:
+      Nano's bookkeeping retires the redo log, and running it without a write
+      would discard rows that were never persisted.
     """
     await semaphore.acquire()
     try:
@@ -2783,45 +2834,39 @@ async def _bounded_submit_impl(
     async_future.add_done_callback(_consume_future_exception)
 
     if not wait_for_completion:
+        if on_committed is not None:
+            raise ValueError("on_committed requires wait_for_completion")
         return await asyncio.shield(async_future)
 
-    # Loop + shield, not a single shield: a lone ``await asyncio.shield(...)``
-    # returns immediately on RE-cancellation, so a second cancel would let the
-    # caller escape while the thread is still running. Same shape and same reason
-    # as ``_KeyedLockContext.__aexit__`` in ``lightrag/kg/shared_storage.py``.
-    pending_cancel: Optional[asyncio.CancelledError] = None
-    while not async_future.done():
-        try:
-            await asyncio.shield(async_future)
-        except asyncio.CancelledError as exc:
-            if async_future.cancelled():
-                # The submitted work itself was cancelled — it did not run to
-                # completion and we must not pretend it did.
-                raise
-            pending_cancel = pending_cancel or exc
-        except BaseException:
-            # The worker failed. Do NOT let that exception out from here: a
-            # cancellation recorded on an earlier round has to take precedence,
-            # and deciding that is the block below's job. The exception stays on
-            # ``async_future`` and is re-raised by ``result()`` (or logged) once
-            # the loop has established which one wins. Anything raised while the
-            # future is still pending came from elsewhere and still propagates.
-            if not async_future.done():
-                raise
-            break
+    pending_cancel = await _wait_deferring_cancellation(async_future, None)
+
+    write_exc = None if async_future.cancelled() else async_future.exception()
+
+    commit_exc: Optional[BaseException] = None
+    if write_exc is None and on_committed is not None:
+        # The write landed, so its bookkeeping is no longer optional: a cancel
+        # here would leave the file published with the other processes never told
+        # to reload it. Deferred through this step too — without the second wait
+        # the gap simply moves one layer down, onto whatever this awaits.
+        commit_future = asyncio.ensure_future(on_committed())
+        commit_future.add_done_callback(_consume_future_exception)
+        pending_cancel = await _wait_deferring_cancellation(
+            commit_future, pending_cancel
+        )
+        if not commit_future.cancelled():
+            commit_exc = commit_future.exception()
 
     if pending_cancel is not None:
-        # The caller gets CancelledError, so nobody will ever see the worker's
-        # exception. ``_consume_future_exception`` already marked it retrieved
-        # (no "exception was never retrieved" noise at GC time); log it so the
+        # The caller gets CancelledError, so nobody will ever see these.
+        # ``_consume_future_exception`` already marked them retrieved (no
+        # "exception was never retrieved" noise at GC time); log them so the
         # failure is not lost entirely.
-        if not async_future.cancelled():
-            worker_exc = async_future.exception()
-            if worker_exc is not None:
-                logger.error(
-                    f"Offloaded work failed while its caller was cancelled: {worker_exc}"
-                )
+        for label, exc in (("Offloaded work", write_exc), ("Commit hook", commit_exc)):
+            if exc is not None:
+                logger.error(f"{label} failed while its caller was cancelled: {exc}")
         raise pending_cancel
+    if commit_exc is not None:
+        raise commit_exc
     return async_future.result()
 
 
@@ -3042,6 +3087,43 @@ async def run_in_storage_io(fn: Callable[..., Any], *args: Any, **kwargs: Any) -
         args,
         kwargs,
         wait_for_completion=True,
+    )
+
+
+async def commit_in_storage_io(
+    fn: Callable[[], Any],
+    on_committed: Callable[[], Awaitable[Any]],
+) -> Any:
+    """``run_in_storage_io`` for a write whose bookkeeping must not be orphaned.
+
+    Backends that publish a file and then tell the other processes to reload it
+    (``set_all_update_flags``) have two steps that must not come apart. A cancel
+    landing between them leaves the file published while every other worker keeps
+    reading the previous snapshot, until some later commit happens to fix it.
+
+    The synchronous writes this replaces had the same gap — with the loop frozen
+    for the whole write, cancellation could only be delivered at the first
+    suspension point after it, which in multiprocess mode is the lock acquire
+    inside ``set_all_update_flags``, before any flag is flipped. Freeing the
+    event loop makes the window far easier to hit, so it is closed here rather
+    than left to grow.
+
+    ``fn`` takes no arguments (wrap it in a lambda or ``partial``), which keeps
+    this signature clear of the keyword-forwarding hazard ``run_in_storage_io``
+    has to live with. ``on_committed`` runs ONLY if ``fn`` succeeded — see
+    ``_bounded_submit_impl`` for why running it otherwise would lose data.
+    """
+    from lightrag.constants import STORAGE_IO_SUBMIT_LIMIT
+
+    semaphore = get_loop_semaphore("storage_io", STORAGE_IO_SUBMIT_LIMIT)
+    return await _bounded_submit_impl(
+        get_storage_io_executor(),
+        semaphore,
+        fn,
+        (),
+        {},
+        wait_for_completion=True,
+        on_committed=on_committed,
     )
 
 

--- a/tests/kg/faiss_impl/test_atomic_write_faiss.py
+++ b/tests/kg/faiss_impl/test_atomic_write_faiss.py
@@ -4,6 +4,11 @@ The save path produces two files (``.index`` and ``.meta.json``). Each one
 must land via tmp + rename so a crash during either write preserves the
 prior snapshot. Cross-file consistency between the two renames is
 intentionally out of scope (declared in the PR).
+
+Both writes run in the storage-IO worker pool, so these tests are async and
+exercise the offloaded path end to end: the failure modes below (a raising
+``os.replace``, a raising ``json.dump``) happen in the worker thread, and the
+exception has to cross back to the awaiting caller intact.
 """
 
 import json
@@ -42,6 +47,11 @@ def _make_storage(tmp_path, namespace: str = "vectors") -> FaissVectorDBStorage:
     )
 
 
+async def _noop() -> None:
+    """Post-commit hook stand-in: these tests are about the writes themselves."""
+    return None
+
+
 def _seed(storage: FaissVectorDBStorage, marker: str) -> None:
     """Push a single vector tagged with ``marker`` into the in-memory state."""
     vec = np.ones((1, 4), dtype=np.float32)
@@ -52,10 +62,10 @@ def _seed(storage: FaissVectorDBStorage, marker: str) -> None:
 
 
 @pytest.mark.offline
-def test_save_faiss_index_publishes_both_files_cleanly(tmp_path):
+async def test_save_faiss_index_publishes_both_files_cleanly(tmp_path):
     storage = _make_storage(tmp_path)
     _seed(storage, "v1")
-    storage._save_faiss_index()
+    await storage._save_faiss_index(_noop)
 
     assert os.path.exists(storage._faiss_index_file)
     assert os.path.exists(storage._meta_file)
@@ -66,12 +76,12 @@ def test_save_faiss_index_publishes_both_files_cleanly(tmp_path):
 
 
 @pytest.mark.offline
-def test_save_faiss_index_replace_crash_preserves_prior_index(tmp_path):
+async def test_save_faiss_index_replace_crash_preserves_prior_index(tmp_path):
     """If ``os.replace`` raises while renaming the ``.index`` tmp, the old
     ``.index`` must remain loadable by ``faiss.read_index``."""
     storage = _make_storage(tmp_path)
     _seed(storage, "v1")
-    storage._save_faiss_index()
+    await storage._save_faiss_index(_noop)
     assert os.path.exists(storage._faiss_index_file)
 
     # Bump in-memory state to v2 and then crash the .index rename.
@@ -82,7 +92,7 @@ def test_save_faiss_index_replace_crash_preserves_prior_index(tmp_path):
         side_effect=OSError("simulated crash"),
     ):
         with pytest.raises(OSError, match="simulated crash"):
-            storage._save_faiss_index()
+            await storage._save_faiss_index(_noop)
 
     # Reload the destination — must still be the v1 single-vector index.
     reloaded = faiss.read_index(storage._faiss_index_file)
@@ -92,12 +102,12 @@ def test_save_faiss_index_replace_crash_preserves_prior_index(tmp_path):
 
 
 @pytest.mark.offline
-def test_save_faiss_meta_write_failure_preserves_prior_meta(tmp_path):
+async def test_save_faiss_meta_write_failure_preserves_prior_meta(tmp_path):
     """A failure inside the meta ``write_fn`` (after the index has been
     written) must leave the previous ``.meta.json`` intact."""
     storage = _make_storage(tmp_path)
     _seed(storage, "v1")
-    storage._save_faiss_index()
+    await storage._save_faiss_index(_noop)
     assert json.load(open(storage._meta_file))
 
     real_dump = json.dump
@@ -114,7 +124,7 @@ def test_save_faiss_meta_write_failure_preserves_prior_meta(tmp_path):
     _seed(storage, "v2")
     with patch("lightrag.kg.faiss_impl.json.dump", side_effect=explode_on_second_dump):
         with pytest.raises(RuntimeError, match="simulated meta failure"):
-            storage._save_faiss_index()
+            await storage._save_faiss_index(_noop)
     assert seen, "patched json.dump must have been invoked"
 
     # .meta.json must still parse and still reflect v1.

--- a/tests/kg/faiss_impl/test_faiss_deferred_delete.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_delete.py
@@ -275,7 +275,7 @@ async def test_failed_delete_rebuild_keeps_tombstones_for_retry(tmp_path, monkey
 def _fail_save(storage, monkeypatch):
     """Make the next save(s) raise, simulating a transient IO failure."""
 
-    def boom():
+    async def boom(_on_committed):
         raise OSError("transient disk error")
 
     monkeypatch.setattr(storage, "_save_faiss_index", boom)

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -437,12 +437,12 @@ async def test_finalize_retries_save_after_flush_failure(tmp_path):
     original_save = storage._save_faiss_index
     save_calls = 0
 
-    def fail_once():
+    async def fail_once(on_committed):
         nonlocal save_calls
         save_calls += 1
         if save_calls == 1:
             raise OSError("boom")
-        original_save()
+        await original_save(on_committed)
 
     storage._save_faiss_index = fail_once
 
@@ -509,7 +509,7 @@ async def test_index_done_callback_save_failure_raises(tmp_path):
 
     original_save = storage._save_faiss_index
 
-    def fail_save():
+    async def fail_save(_on_committed):
         raise OSError("save boom")
 
     storage._save_faiss_index = fail_save
@@ -839,7 +839,7 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     # materialized-but-unsaved (dirty) and the pending buffer is emptied.
     await storage.upsert({"id1": {"content": "alpha"}})
 
-    def fail_save():
+    async def fail_save(_on_committed):
         raise OSError("save boom")
 
     storage._save_faiss_index = fail_save
@@ -1082,7 +1082,7 @@ def _make_save_fail(storage):
     """Make ``_save_faiss_index`` raise; returns a restore callable."""
     original = storage._save_faiss_index
 
-    def boom():
+    async def boom(_on_committed):
         raise OSError("disk full")
 
     storage._save_faiss_index = boom

--- a/tests/kg/faiss_impl/test_faiss_write_off_event_loop.py
+++ b/tests/kg/faiss_impl/test_faiss_write_off_event_loop.py
@@ -1,0 +1,262 @@
+"""``FaissVectorDBStorage`` persistence must not block the event loop.
+
+``_save_faiss_index`` rewrites the whole ``.index`` and the whole
+``.meta.json``. Run inline on the loop, a large index froze every unrelated
+request for the duration — the same failure mode the JSON and GraphML backends
+had. Measured on faiss 1.14.2 both halves genuinely yield: ``faiss.write_index``
+releases the GIL, and ``json.dump`` is the cooperative pure-Python encoder.
+
+Two properties are pinned here:
+
+* the loop keeps running while the files are written;
+* the ``_id_to_meta`` snapshot is taken on the loop BEFORE the offload, so the
+  worker never iterates a dict that unlocked readers/writers can still touch;
+* a cancelled commit still runs its bookkeeping, so the two published files are
+  never left with the other processes unaware of them.
+"""
+
+import asyncio
+import json
+import os
+import threading
+import time
+
+import numpy as np
+import pytest
+
+faiss = pytest.importorskip("faiss")
+
+from lightrag.kg import faiss_impl  # noqa: E402
+from lightrag.kg.faiss_impl import FaissVectorDBStorage  # noqa: E402
+from lightrag.utils import EmbeddingFunc  # noqa: E402
+
+pytestmark = pytest.mark.offline
+
+
+def _make_storage(tmp_path, namespace: str = "vectors") -> FaissVectorDBStorage:
+    def _unused(*_args, **_kwargs):  # pragma: no cover — never called here
+        raise AssertionError("embedding_func must not be invoked by save path")
+
+    return FaissVectorDBStorage(
+        namespace=namespace,
+        workspace="",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 1,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=4, func=_unused),
+    )
+
+
+async def _noop() -> None:
+    """Post-commit hook stand-in for the tests that call the save directly."""
+    return None
+
+
+def _seed(storage: FaissVectorDBStorage, marker: str) -> None:
+    storage._index.add(np.ones((1, 4), dtype=np.float32))
+    storage._id_to_meta = {
+        storage._index.ntotal - 1: {"__id__": marker, "content": marker}
+    }
+
+
+class _Heartbeat:
+    """Counts how often the event loop gets to run us."""
+
+    def __init__(self):
+        self.beats = 0
+        self._stop = False
+        self._task = None
+
+    async def __aenter__(self):
+        async def _run():
+            while not self._stop:
+                self.beats += 1
+                await asyncio.sleep(0)
+
+        self._task = asyncio.create_task(_run())
+        await asyncio.sleep(0)
+        return self
+
+    async def __aexit__(self, *_exc):
+        self._stop = True
+        await self._task
+
+
+async def test_save_keeps_the_event_loop_running(tmp_path, monkeypatch):
+    """The loop must keep being scheduled while the index is written.
+
+    Fix-proof: before the offload, ``_save_faiss_index`` ran the write inline,
+    so the 200 ms spent inside the patched ``write_index`` was 200 ms in which
+    the heartbeat below could not advance at all — ``after == before``.
+    """
+    storage = _make_storage(tmp_path)
+    _seed(storage, "v1")
+
+    real_write_index = faiss_impl.faiss.write_index
+    observed: list[tuple[int, int]] = []
+
+    async with _Heartbeat() as heartbeat:
+
+        def slow_write_index(index, path):
+            before = heartbeat.beats
+            time.sleep(0.2)
+            observed.append((before, heartbeat.beats))
+            return real_write_index(index, path)
+
+        monkeypatch.setattr(faiss_impl.faiss, "write_index", slow_write_index)
+        await storage._save_faiss_index(_noop)
+
+    assert observed, "patched write_index was never called"
+    before, after = observed[0]
+    assert after > before, (
+        "the event loop did not advance while the index was being written "
+        f"(beats {before} -> {after})"
+    )
+
+    # The write still has to be correct, not merely non-blocking.
+    assert faiss.read_index(storage._faiss_index_file).ntotal == 1
+    meta = json.load(open(storage._meta_file))
+    assert next(iter(meta.values()))["__id__"] == "v1"
+
+
+async def test_metadata_snapshot_is_taken_before_the_offload(tmp_path, monkeypatch):
+    """A mutation racing the write must not reach the file being written.
+
+    ``client_storage`` reads ``_id_to_meta`` without the lock, so the worker
+    must serialize a snapshot rather than the live dict. This test mutates the
+    dict while the worker is parked inside ``write_index``; if the snapshot
+    were built in the worker the extra row would land on disk (or the
+    iteration would raise ``RuntimeError: dictionary changed size``).
+    """
+    storage = _make_storage(tmp_path)
+    _seed(storage, "v1")
+
+    real_write_index = faiss_impl.faiss.write_index
+    inside_write = threading.Event()
+    may_finish = threading.Event()
+
+    def parked_write_index(index, path):
+        inside_write.set()
+        assert may_finish.wait(timeout=5), "writer was never released"
+        return real_write_index(index, path)
+
+    monkeypatch.setattr(faiss_impl.faiss, "write_index", parked_write_index)
+
+    save = asyncio.create_task(storage._save_faiss_index(_noop))
+    while not inside_write.is_set():
+        await asyncio.sleep(0.01)
+
+    # The loop is free (that is the point of the offload), so an unlocked
+    # reader/writer can run right here.
+    storage._id_to_meta[999] = {"__id__": "late", "content": "late"}
+    may_finish.set()
+    await save
+
+    meta = json.load(open(storage._meta_file))
+    assert "999" not in meta, "the worker serialized the live dict, not a snapshot"
+    assert [entry["__id__"] for entry in meta.values()] == ["v1"]
+
+
+async def test_cancelled_save_still_completes_both_files(tmp_path, monkeypatch):
+    """Cancelling the caller must not abandon a half-written pair of files.
+
+    The caller holds ``_storage_lock`` across the save; returning early would
+    release it while the worker is still writing. ``run_in_storage_io`` is
+    uncancellable once submitted, which keeps the pre-change guarantee (a
+    synchronous write could not be cancelled at all).
+    """
+    storage = _make_storage(tmp_path)
+    _seed(storage, "v1")
+
+    real_write_index = faiss_impl.faiss.write_index
+    inside_write = threading.Event()
+    may_finish = threading.Event()
+
+    def parked_write_index(index, path):
+        inside_write.set()
+        assert may_finish.wait(timeout=5), "writer was never released"
+        return real_write_index(index, path)
+
+    monkeypatch.setattr(faiss_impl.faiss, "write_index", parked_write_index)
+
+    save = asyncio.create_task(storage._save_faiss_index(_noop))
+    while not inside_write.is_set():
+        await asyncio.sleep(0.01)
+
+    save.cancel()
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not save.done(), "caller returned while the worker was still writing"
+
+    may_finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await save
+
+    assert os.path.exists(storage._faiss_index_file)
+    assert os.path.exists(storage._meta_file)
+    assert faiss.read_index(storage._faiss_index_file).ntotal == 1
+    leftovers = [p for p in os.listdir(tmp_path) if ".tmp." in p]
+    assert leftovers == [], f"unexpected tmp residue: {leftovers}"
+
+
+async def test_cancelled_commit_still_notifies_and_retires_the_redo_logs(
+    tmp_path, monkeypatch
+):
+    """A cancelled commit must not publish both files and skip its bookkeeping.
+
+    `set_all_update_flags` is what tells the other processes to reload; skipped,
+    they keep serving the previous index. The redo logs would likewise keep rows
+    that are already durable. Both live in the hook that `commit_in_storage_io`
+    runs inside the write's uncancellable region.
+
+    Fix-proof: inline the bookkeeping after the offload instead and `flagged`
+    stays empty — the P2 Codex raised on #3740, in this backend.
+    """
+    from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+
+    finalize_share_data()
+    initialize_share_data()
+    try:
+        storage = _make_storage(tmp_path)
+        await storage.initialize()
+        _seed(storage, "v1")
+        storage._index_dirty = True
+
+        flagged: list[str] = []
+        real_write_index = faiss_impl.faiss.write_index
+        inside_write = threading.Event()
+        may_finish = threading.Event()
+
+        async def spy_set_all_update_flags(namespace, workspace=None):
+            flagged.append(namespace)
+
+        def parked_write_index(index, path):
+            inside_write.set()
+            assert may_finish.wait(timeout=5), "writer was never released"
+            return real_write_index(index, path)
+
+        monkeypatch.setattr(
+            faiss_impl, "set_all_update_flags", spy_set_all_update_flags
+        )
+        monkeypatch.setattr(faiss_impl.faiss, "write_index", parked_write_index)
+
+        commit = asyncio.create_task(storage.index_done_callback())
+        while not inside_write.is_set():
+            await asyncio.sleep(0.01)
+
+        commit.cancel()
+        may_finish.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await commit
+
+        assert flagged == ["vectors"], (
+            "a cancelled commit published both files without telling the other "
+            f"processes to reload them (flagged={flagged})"
+        )
+        assert storage._index_dirty is False, "dirty bit survived a durable save"
+        assert storage._unsaved_upserts == {}, "redo log kept rows that are on disk"
+    finally:
+        finalize_share_data()

--- a/tests/kg/json_impl/test_json_commit_reconciliation.py
+++ b/tests/kg/json_impl/test_json_commit_reconciliation.py
@@ -1,0 +1,155 @@
+"""A cancelled JSON commit must not skip its sanitize reconciliation.
+
+``write_json`` falls back to a sanitizing encoder when the payload cannot be
+encoded, and reports that via ``needs_reload`` so the caller can read the
+cleaned file back into the shared dict. Before the write moved off the event
+loop, the write and that read-back were one unpreemptable synchronous block —
+a cancellation could only be delivered at the ``clear_all_update_flags`` await
+that follows. Offloading the write opened a suspension point between them:
+the sanitized file gets published while the shared dict keeps the rows that
+failed to encode, and the two stay divergent until some later flush happens to
+sanitize again.
+
+``commit_in_storage_io`` puts the reconciliation back inside the write's
+uncancellable region, which is what these tests pin.
+"""
+
+import asyncio
+import json
+import threading
+
+import pytest
+
+from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
+from lightrag.kg.json_kv_impl import JsonKVStorage
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+async def _make_kv(tmp_path) -> JsonKVStorage:
+    storage = JsonKVStorage(
+        namespace="text_chunks",
+        workspace="ws",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=None,
+    )
+    await storage.initialize()
+    return storage
+
+
+async def _make_doc_status(tmp_path) -> JsonDocStatusStorage:
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        workspace="ws",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=None,
+    )
+    await storage.initialize()
+    return storage
+
+
+def _parked_sanitizing_write(module, inside_write, may_finish, cleaned_payload):
+    """Stand in for ``write_json``: park, publish cleaned data, report reload."""
+
+    def _write(data_dict, file_name):
+        inside_write.set()
+        assert may_finish.wait(timeout=5), "writer was never released"
+        with open(file_name, "w", encoding="utf-8") as f:
+            json.dump(cleaned_payload, f)
+        return True  # sanitization happened -> caller must reload
+
+    return _write
+
+
+@pytest.mark.parametrize(
+    "factory, namespace, row",
+    [
+        (_make_kv, "text_chunks", {"content": "alpha"}),
+        (
+            _make_doc_status,
+            "doc_status",
+            {"status": "processed", "file_path": "a.pdf"},
+        ),
+    ],
+    ids=["kv", "doc_status"],
+)
+async def test_cancelled_commit_still_reconciles_sanitized_data(
+    tmp_path, monkeypatch, factory, namespace, row
+):
+    """Cancel mid-write: the cleaned file must still be read back into memory.
+
+    Fix-proof: route the write through ``run_in_storage_io`` and inline the
+    ``needs_reload`` branch after it, and ``_data`` keeps the pre-sanitization
+    row — the divergence Codex flagged on #3740.
+    """
+    storage = await factory(tmp_path)
+    await storage.upsert({"id1": row})
+
+    module = type(storage).__module__
+    inside_write = threading.Event()
+    may_finish = threading.Event()
+    cleaned_payload = {"id1": dict(row, content_was="sanitized")}
+
+    monkeypatch.setattr(
+        f"{module}.write_json",
+        _parked_sanitizing_write(module, inside_write, may_finish, cleaned_payload),
+    )
+    # doc_status persists on upsert, so mark it dirty again for this commit.
+    storage.storage_updated.value = True
+
+    commit = asyncio.create_task(storage.index_done_callback())
+    while not inside_write.is_set():
+        await asyncio.sleep(0.01)
+
+    commit.cancel()
+    may_finish.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await commit
+
+    assert storage._data["id1"].get("content_was") == "sanitized", (
+        "a cancelled commit published the sanitized file but left the shared "
+        f"dict unreconciled: {dict(storage._data['id1'])}"
+    )
+
+
+@pytest.mark.parametrize(
+    "factory, row",
+    [
+        (_make_kv, {"content": "alpha"}),
+        (_make_doc_status, {"status": "processed", "file_path": "a.pdf"}),
+    ],
+    ids=["kv", "doc_status"],
+)
+async def test_reconciliation_is_skipped_when_the_write_fails(
+    tmp_path, monkeypatch, factory, row
+):
+    """No write, no reconciliation — and the failure must surface."""
+    storage = await factory(tmp_path)
+    await storage.upsert({"id1": row})
+
+    module = type(storage).__module__
+    reloads: list[str] = []
+
+    def _boom(data_dict, file_name):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(f"{module}.write_json", _boom)
+    monkeypatch.setattr(
+        f"{module}.load_json", lambda *a, **k: reloads.append("read") or {}
+    )
+    storage.storage_updated.value = True
+
+    with pytest.raises(OSError, match="disk full"):
+        await storage.index_done_callback()
+
+    assert reloads == [], "reconciled a write that never landed"

--- a/tests/kg/json_impl/test_json_write_off_event_loop.py
+++ b/tests/kg/json_impl/test_json_write_off_event_loop.py
@@ -1,0 +1,216 @@
+"""The JSON backends must not rewrite their file on the event loop.
+
+``index_done_callback`` serializes the whole store. Done inline in an ``async
+def`` that is seconds of a frozen event loop on a large corpus, which is what
+made the WebUI freeze while a purge ran: /health, /documents/pipeline_status and
+/documents/paginated all hang together because a single uvicorn worker has one
+loop.
+
+Each test here runs a heartbeat coroutine and blocks inside the write for a
+fixed wall-clock interval. The heartbeat can only advance if the write left the
+loop, so the assertion is deterministic rather than timing-sensitive: 200ms of
+``asyncio.sleep(0)`` iterations is tens of thousands of beats when the loop is
+free, and exactly zero when it is not.
+
+The companion test at the bottom pins the other half of the contract: the write
+runs INSIDE the storage lock, so a concurrent writer waits for it rather than
+mutating the store while the worker thread serializes it.
+"""
+
+import asyncio
+import json
+import threading
+import time
+
+import pytest
+
+from lightrag.kg import json_doc_status_impl, json_kv_impl
+from lightrag.kg.json_doc_status_impl import JsonDocStatusStorage
+from lightrag.kg.json_kv_impl import JsonKVStorage
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+
+pytestmark = pytest.mark.offline
+
+BLOCK_SECONDS = 0.2
+
+
+class _Heartbeat:
+    """Counts event-loop iterations so a blocked loop is directly observable."""
+
+    def __init__(self):
+        self.beats = 0
+        self._stop = False
+        self._task = None
+
+    async def _run(self):
+        while not self._stop:
+            self.beats += 1
+            await asyncio.sleep(0)
+
+    def start(self):
+        self._task = asyncio.create_task(self._run())
+        return self
+
+    async def stop(self):
+        self._stop = True
+        if self._task is not None:
+            await self._task
+
+
+@pytest.fixture
+def shared_storage():
+    initialize_share_data(workers=1)
+    yield
+    finalize_share_data()
+
+
+async def _make_kv(tmp_path):
+    storage = JsonKVStorage(
+        namespace="text_chunks",
+        workspace="",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=None,
+    )
+    await storage.initialize()
+    return storage
+
+
+async def _make_doc_status(tmp_path):
+    storage = JsonDocStatusStorage(
+        namespace="doc_status",
+        workspace="",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=None,
+    )
+    await storage.initialize()
+    return storage
+
+
+def _blocking_spy(module, heartbeat, observed):
+    """Wrap the module's ``write_json`` with a real, GIL-releasing block."""
+    real_write_json = module.write_json
+
+    def spy(payload, path):
+        before = heartbeat.beats
+        time.sleep(BLOCK_SECONDS)
+        observed.append((before, heartbeat.beats))
+        return real_write_json(payload, path)
+
+    return spy
+
+
+async def test_kv_commit_keeps_the_event_loop_running(
+    tmp_path, monkeypatch, shared_storage
+):
+    """Fix-proof: called inline, ``time.sleep`` freezes the loop and beats tie."""
+    storage = await _make_kv(tmp_path)
+    await storage.upsert({"chunk-1": {"content": "hello"}})
+
+    observed = []
+    heartbeat = _Heartbeat().start()
+    monkeypatch.setattr(
+        json_kv_impl, "write_json", _blocking_spy(json_kv_impl, heartbeat, observed)
+    )
+
+    await storage.index_done_callback()
+    await heartbeat.stop()
+
+    assert observed, "write_json was never called"
+    before, after = observed[0]
+    assert after > before, "event loop was blocked for the whole write"
+
+    with open(storage._file_name, encoding="utf-8") as handle:
+        assert json.load(handle)["chunk-1"]["content"] == "hello"
+
+
+async def test_doc_status_commit_keeps_the_event_loop_running(
+    tmp_path, monkeypatch, shared_storage
+):
+    storage = await _make_doc_status(tmp_path)
+
+    observed = []
+    heartbeat = _Heartbeat().start()
+    monkeypatch.setattr(
+        json_doc_status_impl,
+        "write_json",
+        _blocking_spy(json_doc_status_impl, heartbeat, observed),
+    )
+
+    # upsert persists on every call for this backend.
+    await storage.upsert(
+        {
+            "doc-1": {
+                "status": "processed",
+                "content_summary": "s",
+                "content_length": 1,
+                "file_path": "a.pdf",
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        }
+    )
+    await heartbeat.stop()
+
+    assert observed, "write_json was never called"
+    before, after = observed[0]
+    assert after > before, "event loop was blocked for the whole write"
+
+    with open(storage._file_name, encoding="utf-8") as handle:
+        assert json.load(handle)["doc-1"]["status"] == "processed"
+
+
+async def test_a_concurrent_upsert_waits_for_the_in_flight_write(
+    tmp_path, monkeypatch, shared_storage
+):
+    """The offload stays inside ``_storage_lock``, so writers still serialize.
+
+    Freeing the event loop is the point of the change, but it must not free
+    other coroutines to mutate the store while the worker thread is serializing
+    the snapshot. Move the offload outside the lock and the first assertion
+    fails: the upsert completes while the write is still in flight.
+
+    It also checks the resulting ordering is coherent: the file published by the
+    in-flight commit predates the concurrent upsert, and a later commit contains
+    it.
+    """
+    storage = await _make_kv(tmp_path)
+    await storage.upsert({"chunk-1": {"content": "first"}})
+
+    release = threading.Event()
+    entered = threading.Event()
+    real_write_json = json_kv_impl.write_json
+
+    def blocking_write(payload, path):
+        entered.set()
+        assert release.wait(timeout=5), "write was never released"
+        return real_write_json(payload, path)
+
+    monkeypatch.setattr(json_kv_impl, "write_json", blocking_write)
+
+    commit = asyncio.create_task(storage.index_done_callback())
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 2
+    while not entered.is_set():
+        assert loop.time() < deadline, "write never started"
+        await asyncio.sleep(0.01)
+
+    upsert = asyncio.create_task(storage.upsert({"chunk-2": {"content": "second"}}))
+    for _ in range(20):
+        await asyncio.sleep(0)
+    assert not upsert.done(), "upsert ran while a commit was in flight"
+
+    release.set()
+    await commit
+    await upsert
+
+    with open(storage._file_name, encoding="utf-8") as handle:
+        published = json.load(handle)
+    assert "chunk-1" in published
+    assert "chunk-2" not in published, "the in-flight snapshot must not grow"
+
+    monkeypatch.setattr(json_kv_impl, "write_json", real_write_json)
+    await storage.index_done_callback()
+    with open(storage._file_name, encoding="utf-8") as handle:
+        final = json.load(handle)
+    assert final["chunk-1"]["content"] == "first"
+    assert final["chunk-2"]["content"] == "second"

--- a/tests/kg/nano_impl/test_nano_deferred_delete.py
+++ b/tests/kg/nano_impl/test_nano_deferred_delete.py
@@ -28,6 +28,17 @@ from lightrag.utils import EmbeddingFunc, compute_mdhash_id  # noqa: E402
 DIM = 8
 
 
+async def _failing_save() -> None:
+    """Async stand-in for ``_save_to_disk_locked`` that always fails.
+
+    ``_save_to_disk_locked`` is a coroutine function (its write runs in the
+    storage-IO pool), so a synchronous stand-in silently changes what these
+    tests prove: the caller would await ``None`` and they would pass on a
+    ``TypeError`` instead of on the ``OSError`` they are about.
+    """
+    raise OSError("disk full")
+
+
 @pytest.fixture(autouse=True)
 def _shared_data():
     finalize_share_data()
@@ -205,7 +216,12 @@ async def test_finalize_skips_the_save_when_queued_deletes_change_nothing(tmp_pa
 
     saves: list[int] = []
     original = storage._save_to_disk_locked
-    storage._save_to_disk_locked = lambda: (saves.append(1), original())[1]
+
+    async def counting_save():
+        saves.append(1)
+        return await original()
+
+    storage._save_to_disk_locked = counting_save
 
     await storage.delete(["never-inserted"])
     await storage.finalize()
@@ -323,7 +339,7 @@ async def test_delete_survives_a_failed_save_then_a_concurrent_commit(tmp_path):
 
     # The flush applies the delete, then the save fails.
     original_save = writer._save_to_disk_locked
-    writer._save_to_disk_locked = lambda: (_ for _ in ()).throw(OSError("disk full"))
+    writer._save_to_disk_locked = _failing_save
     with pytest.raises(OSError):
         await writer.index_done_callback()
     assert set(writer._unsaved_deletes) == {"id1"}, "retained until the save lands"
@@ -386,7 +402,7 @@ async def test_replay_does_not_remove_a_newer_row_under_the_same_id(tmp_path):
     await _seed(writer, {"id1": "old"})
 
     original_save = writer._save_to_disk_locked
-    writer._save_to_disk_locked = lambda: (_ for _ in ()).throw(OSError("disk full"))
+    writer._save_to_disk_locked = _failing_save
     await writer.delete(["id1"])
     with pytest.raises(OSError):
         await writer.index_done_callback()
@@ -419,7 +435,7 @@ async def test_an_id_that_matched_nothing_is_never_replayed(tmp_path):
     await _seed(writer, {"seed": "s"})
 
     original_save = writer._save_to_disk_locked
-    writer._save_to_disk_locked = lambda: (_ for _ in ()).throw(OSError("disk full"))
+    writer._save_to_disk_locked = _failing_save
     await writer.upsert({"other": {"content": "o"}})
     with pytest.raises(OSError):
         await writer.index_done_callback()  # client is now dirty
@@ -452,7 +468,7 @@ async def test_repeated_failed_saves_do_not_re_delete_each_time(tmp_path):
     _spy_client_delete(storage, calls)
 
     original_save = storage._save_to_disk_locked
-    storage._save_to_disk_locked = lambda: (_ for _ in ()).throw(OSError("disk full"))
+    storage._save_to_disk_locked = _failing_save
     await storage.delete(["id1"])
     for _ in range(4):
         with pytest.raises(OSError):
@@ -468,7 +484,7 @@ def _make_save_fail(storage):
     """Make ``_save_to_disk_locked`` raise; returns a restore callable."""
     original = storage._save_to_disk_locked
 
-    def boom():
+    async def boom():
         raise OSError("disk full")
 
     storage._save_to_disk_locked = boom

--- a/tests/kg/nano_impl/test_nano_deferred_delete.py
+++ b/tests/kg/nano_impl/test_nano_deferred_delete.py
@@ -28,13 +28,17 @@ from lightrag.utils import EmbeddingFunc, compute_mdhash_id  # noqa: E402
 DIM = 8
 
 
-async def _failing_save() -> None:
+async def _failing_save(_on_committed) -> None:
     """Async stand-in for ``_save_to_disk_locked`` that always fails.
 
     ``_save_to_disk_locked`` is a coroutine function (its write runs in the
     storage-IO pool), so a synchronous stand-in silently changes what these
     tests prove: the caller would await ``None`` and they would pass on a
     ``TypeError`` instead of on the ``OSError`` they are about.
+
+    It also takes the post-commit bookkeeping hook. A stand-in that fails must
+    never run it — the write did not land, so retiring the redo logs would
+    discard rows that were never persisted.
     """
     raise OSError("disk full")
 
@@ -217,9 +221,9 @@ async def test_finalize_skips_the_save_when_queued_deletes_change_nothing(tmp_pa
     saves: list[int] = []
     original = storage._save_to_disk_locked
 
-    async def counting_save():
+    async def counting_save(on_committed):
         saves.append(1)
-        return await original()
+        return await original(on_committed)
 
     storage._save_to_disk_locked = counting_save
 
@@ -484,7 +488,7 @@ def _make_save_fail(storage):
     """Make ``_save_to_disk_locked`` raise; returns a restore callable."""
     original = storage._save_to_disk_locked
 
-    async def boom():
+    async def boom(_on_committed):
         raise OSError("disk full")
 
     storage._save_to_disk_locked = boom

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -399,12 +399,12 @@ async def test_finalize_retries_save_after_flush_failure(tmp_path):
     original_save = storage._save_to_disk_locked
     save_calls = 0
 
-    async def fail_once():
+    async def fail_once(on_committed):
         nonlocal save_calls
         save_calls += 1
         if save_calls == 1:
             raise OSError("boom")
-        await original_save()
+        await original_save(on_committed)
 
     storage._save_to_disk_locked = fail_once
 
@@ -458,7 +458,7 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     # materialized-but-unsaved (dirty) and the pending buffer is emptied.
     await storage.upsert({"id1": {"content": "alpha"}})
 
-    async def fail_save():
+    async def fail_save(_on_committed):
         raise OSError("save boom")
 
     storage._save_to_disk_locked = fail_save
@@ -490,7 +490,7 @@ def _make_save_fail(storage):
     """Make ``_save_to_disk_locked`` raise; returns a restore callable."""
     original = storage._save_to_disk_locked
 
-    async def boom():
+    async def boom(_on_committed):
         raise OSError("disk full")
 
     storage._save_to_disk_locked = boom

--- a/tests/kg/nano_impl/test_nano_deferred_embedding.py
+++ b/tests/kg/nano_impl/test_nano_deferred_embedding.py
@@ -399,12 +399,12 @@ async def test_finalize_retries_save_after_flush_failure(tmp_path):
     original_save = storage._save_to_disk_locked
     save_calls = 0
 
-    def fail_once():
+    async def fail_once():
         nonlocal save_calls
         save_calls += 1
         if save_calls == 1:
             raise OSError("boom")
-        original_save()
+        await original_save()
 
     storage._save_to_disk_locked = fail_once
 
@@ -458,7 +458,7 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     # materialized-but-unsaved (dirty) and the pending buffer is emptied.
     await storage.upsert({"id1": {"content": "alpha"}})
 
-    def fail_save():
+    async def fail_save():
         raise OSError("save boom")
 
     storage._save_to_disk_locked = fail_save
@@ -490,7 +490,7 @@ def _make_save_fail(storage):
     """Make ``_save_to_disk_locked`` raise; returns a restore callable."""
     original = storage._save_to_disk_locked
 
-    def boom():
+    async def boom():
         raise OSError("disk full")
 
     storage._save_to_disk_locked = boom

--- a/tests/kg/nano_impl/test_nano_save_off_event_loop.py
+++ b/tests/kg/nano_impl/test_nano_save_off_event_loop.py
@@ -167,3 +167,53 @@ async def test_cancelled_commit_restores_storage_file(tmp_path, monkeypatch):
     assert observed_during_write, "the write body never ran"
     assert observed_during_write[0] != storage._client_file_name
     assert storage._client.storage_file == storage._client_file_name
+
+
+async def test_cancelled_commit_still_notifies_and_retires_the_redo_logs(
+    tmp_path, monkeypatch
+):
+    """A cancelled commit must not save and then skip its bookkeeping.
+
+    Two things are stranded if it does: the other processes are never told to
+    reload (``set_all_update_flags``), and the redo logs keep rows that ARE on
+    disk, so a later commit replays them. Both live in the hook that
+    ``commit_in_storage_io`` runs inside the write's uncancellable region.
+
+    Fix-proof: inline the bookkeeping after the offload instead, and ``flagged``
+    stays empty with ``_client_dirty`` still True — the P2 Codex raised on #3740.
+    """
+    storage = await _make_storage(tmp_path)
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    flagged: list[str] = []
+    inside_save = threading.Event()
+    may_finish = threading.Event()
+    real_save = nano_vectordb.NanoVectorDB.save
+
+    async def spy_set_all_update_flags(namespace, workspace=None):
+        flagged.append(namespace)
+
+    def parked_save(self):
+        inside_save.set()
+        assert may_finish.wait(timeout=5), "writer was never released"
+        return real_save(self)
+
+    monkeypatch.setattr(nano_impl, "set_all_update_flags", spy_set_all_update_flags)
+    monkeypatch.setattr(nano_vectordb.NanoVectorDB, "save", parked_save)
+
+    commit = asyncio.create_task(storage.index_done_callback())
+    while not inside_save.is_set():
+        await asyncio.sleep(0.01)
+
+    commit.cancel()
+    may_finish.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await commit
+
+    assert flagged == ["test_vectors"], (
+        "a cancelled commit saved without telling the other processes to "
+        f"reload (flagged={flagged})"
+    )
+    assert storage._client_dirty is False, "the dirty bit survived a durable save"
+    assert storage._unsaved_upserts == {}, "redo log kept rows that are on disk"

--- a/tests/kg/nano_impl/test_nano_save_off_event_loop.py
+++ b/tests/kg/nano_impl/test_nano_save_off_event_loop.py
@@ -1,0 +1,169 @@
+"""``NanoVectorDBStorage`` must not save on the event loop.
+
+Nano's commit is only a PARTIAL win from the offload, and these tests say so
+explicitly rather than overstating it. ``NanoVectorDB.save()`` base64-encodes
+the whole matrix through ``tobytes()`` + ``b64encode()`` — two single C calls
+that hold the GIL wherever they run — before a cooperative ``json.dump``. So the
+assertion here is "the loop advances during the write", never "the stall is
+gone".
+
+The second test is the sharper one: the save temporarily points
+``client.storage_file`` at the tmp sibling, so a cancelled caller that returned
+early would release ``_storage_lock`` with that swap still in place, and the
+next coroutine through the lock would see a client aimed at a path that is about
+to be renamed away. The old synchronous write had no such window because it
+could not be cancelled at all.
+"""
+
+import asyncio
+import threading
+import time
+
+import numpy as np
+import pytest
+
+nano_vectordb = pytest.importorskip("nano_vectordb")
+
+import lightrag.kg.nano_vector_db_impl as nano_impl  # noqa: E402
+from lightrag.kg.nano_vector_db_impl import NanoVectorDBStorage  # noqa: E402
+from lightrag.kg.shared_storage import (  # noqa: E402
+    finalize_share_data,
+    initialize_share_data,
+)
+from lightrag.utils import EmbeddingFunc  # noqa: E402
+
+pytestmark = pytest.mark.offline
+
+DIM = 8
+BLOCK_SECONDS = 0.2
+
+
+class _DeterministicEmbed:
+    async def __call__(self, texts, **kwargs):
+        return np.array(
+            [np.full(DIM, (abs(hash(t)) % 97) + 1, dtype=np.float32) for t in texts]
+        )
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+async def _make_storage(tmp_path) -> NanoVectorDBStorage:
+    storage = NanoVectorDBStorage(
+        namespace="test_vectors",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 32,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(
+            embedding_dim=DIM, max_token_size=512, func=_DeterministicEmbed()
+        ),
+        meta_fields={"content"},
+    )
+    await storage.initialize()
+    return storage
+
+
+class _Heartbeat:
+    def __init__(self):
+        self.beats = 0
+        self._stop = False
+        self._task = None
+
+    async def _run(self):
+        while not self._stop:
+            self.beats += 1
+            await asyncio.sleep(0)
+
+    def start(self):
+        self._task = asyncio.create_task(self._run())
+        return self
+
+    async def stop(self):
+        self._stop = True
+        if self._task is not None:
+            await self._task
+
+
+async def _wait_for(predicate, *, timeout=2.0):
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        assert loop.time() < deadline, "timed out waiting for condition"
+        await asyncio.sleep(0.01)
+
+
+async def test_commit_keeps_the_event_loop_running(tmp_path, monkeypatch):
+    """Fix-proof: called inline, ``time.sleep`` freezes the loop and beats tie."""
+    storage = await _make_storage(tmp_path)
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    observed = []
+    heartbeat = _Heartbeat().start()
+    real_atomic_write = nano_impl.atomic_write
+
+    def blocking_atomic_write(path, write_fn, workspace):
+        before = heartbeat.beats
+        time.sleep(BLOCK_SECONDS)
+        observed.append((before, heartbeat.beats))
+        return real_atomic_write(path, write_fn, workspace)
+
+    monkeypatch.setattr(nano_impl, "atomic_write", blocking_atomic_write)
+
+    await storage.index_done_callback()
+    await heartbeat.stop()
+
+    assert observed, "the save never ran"
+    before, after = observed[0]
+    assert after > before, "event loop was blocked for the whole save"
+    assert (await storage.get_by_id("id1"))["content"] == "alpha"
+
+
+async def test_cancelled_commit_restores_storage_file(tmp_path, monkeypatch):
+    """A cancelled commit must not leave the client pointing at the tmp file.
+
+    Fix-proof: with a cancellable offload the caller returns as soon as it is
+    cancelled, while the worker is still inside ``_save_atomic`` with
+    ``storage_file`` swapped — so the assertion below reads the tmp path.
+    """
+    storage = await _make_storage(tmp_path)
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    entered = threading.Event()
+    release = threading.Event()
+    observed_during_write = []
+    real_save = storage._client.save
+
+    def blocking_save():
+        # ``_save_atomic`` has already swapped storage_file to the tmp sibling
+        # by the time save() runs -- this IS the state that must not be
+        # observable from the loop.
+        observed_during_write.append(storage._client.storage_file)
+        entered.set()
+        assert release.wait(timeout=5), "write was never released"
+        return real_save()
+
+    storage._client.save = blocking_save
+
+    commit = asyncio.create_task(storage.index_done_callback())
+    await _wait_for(entered.is_set)
+
+    commit.cancel()
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not commit.done(), "caller returned mid-save with storage_file swapped"
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await commit
+
+    assert observed_during_write, "the write body never ran"
+    assert observed_during_write[0] != storage._client_file_name
+    assert storage._client.storage_file == storage._client_file_name

--- a/tests/kg/networkx_impl/test_networkx_commit_gate.py
+++ b/tests/kg/networkx_impl/test_networkx_commit_gate.py
@@ -333,3 +333,56 @@ async def test_cancelled_commit_still_notifies_the_other_processes(
     )
     # And the gate is back open, so later graph work is not deadlocked.
     await asyncio.wait_for(storage.upsert_node("B", {"entity_id": "B"}), timeout=2)
+
+
+def test_gate_is_rebound_after_the_owning_loop_closes(tmp_path):
+    """One instance, two loops: the gate must not stay bound to the dead one.
+
+    ``asyncio.Event`` binds to a loop the first time a ``wait()`` suspends on
+    it, and afterwards ``wait()`` from another loop raises "is bound to a
+    different event loop". A ``NetworkXStorage`` can outlive its loop — the
+    synchronous wrappers let calls through on a fresh loop once the original
+    ``owning_loop`` has closed (``_run_sync``, i.e. the common
+    ``rag = asyncio.run(initialize_rag())`` shape) — so a gate bound during an
+    earlier commit would break the next one.
+
+    Deliberately NOT an async test: it needs two real loops, and the failure
+    only appears on the second one. Fix-proof: drop the ``_commit_gate_loop``
+    check from ``_gate()`` and the second ``asyncio.run`` raises RuntimeError.
+    """
+    initialize_share_data()
+    try:
+        storage = None
+
+        async def first_loop():
+            nonlocal storage
+            storage = await _make_storage(tmp_path)
+            await storage.upsert_node("A", {"entity_id": "A"})
+            # Force a real suspension on the gate so it binds to THIS loop.
+            gate = storage._gate()
+            gate.clear()
+            waiter = asyncio.create_task(storage._get_graph())
+            await _wait_for(lambda: not waiter.done())
+            for _ in range(5):
+                await asyncio.sleep(0)
+            gate.set()
+            await waiter
+            assert storage._commit_gate_loop is asyncio.get_running_loop()
+
+        asyncio.run(first_loop())
+
+        bound_to = storage._commit_gate
+
+        async def second_loop():
+            # A commit that closes and reopens the gate: with the stale Event
+            # still in place, the mutator's wait() below raises RuntimeError.
+            await storage.index_done_callback()
+            await asyncio.wait_for(
+                storage.upsert_node("B", {"entity_id": "B"}), timeout=2
+            )
+            assert storage._commit_gate is not bound_to, "gate was not rebound"
+            assert storage._commit_gate_loop is asyncio.get_running_loop()
+
+        asyncio.run(second_loop())
+    finally:
+        finalize_share_data()

--- a/tests/kg/networkx_impl/test_networkx_commit_gate.py
+++ b/tests/kg/networkx_impl/test_networkx_commit_gate.py
@@ -282,3 +282,54 @@ async def test_a_woken_waiter_rechecks_the_gate_before_proceeding(tmp_path):
     gate.set()
     await asyncio.wait_for(mutator, timeout=2)
     assert storage._graph.has_node("n2")
+
+
+async def test_cancelled_commit_still_notifies_the_other_processes(
+    tmp_path, monkeypatch
+):
+    """A cancelled commit must not publish the file and skip the notification.
+
+    ``set_all_update_flags`` is what tells every other worker to reload. Skipped,
+    they keep serving the previous graph until some later commit happens to
+    notify them. The write is already durable at that point, so the bookkeeping
+    runs inside the same uncancellable region (``commit_in_storage_io``).
+
+    Fix-proof: inline ``set_all_update_flags`` after the offload instead, and
+    ``flagged`` stays empty — this is the P2 Codex raised on #3740.
+    """
+    storage = await _make_storage(tmp_path)
+    await storage.upsert_node("A", {"entity_id": "A"})
+
+    flagged: list[str] = []
+    real_write = NetworkXStorage.write_nx_graph
+    inside_write = threading.Event()
+    may_finish = threading.Event()
+
+    async def spy_set_all_update_flags(namespace, workspace=None):
+        flagged.append(namespace)
+
+    def parked_write(graph, path, workspace="_"):
+        inside_write.set()
+        assert may_finish.wait(timeout=5), "writer was never released"
+        return real_write(graph, path, workspace)
+
+    monkeypatch.setattr(
+        "lightrag.kg.networkx_impl.set_all_update_flags", spy_set_all_update_flags
+    )
+    monkeypatch.setattr(NetworkXStorage, "write_nx_graph", staticmethod(parked_write))
+
+    commit = asyncio.create_task(storage.index_done_callback())
+    await _wait_for(inside_write.is_set)
+
+    commit.cancel()
+    may_finish.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await commit
+
+    assert flagged == ["chunk_entity_relation"], (
+        "a cancelled commit published the graph without telling the other "
+        f"processes to reload it (flagged={flagged})"
+    )
+    # And the gate is back open, so later graph work is not deadlocked.
+    await asyncio.wait_for(storage.upsert_node("B", {"entity_id": "B"}), timeout=2)

--- a/tests/kg/networkx_impl/test_networkx_commit_gate.py
+++ b/tests/kg/networkx_impl/test_networkx_commit_gate.py
@@ -1,0 +1,284 @@
+"""GraphML serialization off the event loop, and the gate that makes it safe.
+
+The commit hands ``self._graph`` to a worker thread that iterates
+``graph._node`` / ``graph._adj``. Invariant (3) in the class docstring — "networkx
+operations are fully synchronous, so the event loop gives them implicit mutual
+exclusion" — stops covering that, because the loop keeps running. ``_commit_gate``
+re-establishes the exclusion.
+
+Holding ``_storage_lock`` across the write is NOT sufficient on its own, and
+``test_a_mutator_suspended_in_lock_release_cannot_mutate_during_a_commit`` is
+about exactly that gap: ``NamespaceLock.__aexit__`` runs its release on a fresh
+task and awaits a shield, so it always suspends at least once. A mutator
+suspended there is already past the lock body and would resume mid-write.
+
+Note what each test proves. The heartbeat test is the one that fails against the
+pre-change code. The gate tests are vacuous there (no thread, no window); what
+they pin is the intermediate mistake of offloading the write WITHOUT the gate,
+verified by hand while writing them:
+
+    $ # with `gate.clear()` / `finally: gate.set()` removed
+    $ pytest tests/kg/networkx_impl/test_networkx_commit_gate.py
+    FAILED ...::test_a_mutator_suspended_in_lock_release_cannot_mutate_during_a_commit
+    E   AssertionError: mutator was not held back by the gate
+    FAILED ...::test_gate_is_restored_when_the_committer_is_cancelled
+    E   AssertionError: gate must stay closed during the write
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from lightrag.kg.networkx_impl import NetworkXStorage
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+
+pytestmark = pytest.mark.offline
+
+BLOCK_SECONDS = 0.2
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+async def _make_storage(tmp_path) -> NetworkXStorage:
+    storage = NetworkXStorage(
+        namespace="chunk_entity_relation",
+        workspace="ws",
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=None,
+    )
+    await storage.initialize()
+    return storage
+
+
+class _Heartbeat:
+    def __init__(self):
+        self.beats = 0
+        self._stop = False
+        self._task = None
+
+    async def _run(self):
+        while not self._stop:
+            self.beats += 1
+            await asyncio.sleep(0)
+
+    def start(self):
+        self._task = asyncio.create_task(self._run())
+        return self
+
+    async def stop(self):
+        self._stop = True
+        if self._task is not None:
+            await self._task
+
+
+async def _wait_for(predicate, *, timeout=2.0):
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        assert loop.time() < deadline, "timed out waiting for condition"
+        await asyncio.sleep(0.01)
+
+
+async def test_commit_keeps_the_event_loop_running(tmp_path, monkeypatch):
+    """Fix-proof: called inline, ``time.sleep`` freezes the loop and beats tie.
+
+    This also confirms the monkeypatch still bites, i.e. that the commit
+    resolves ``write_nx_graph`` at call time instead of hoisting a reference —
+    the same property ``test_networkx_index_done.py`` depends on to prove the
+    save error is not swallowed.
+    """
+    storage = await _make_storage(tmp_path)
+    await storage.upsert_node("n1", {"entity_id": "n1"})
+
+    observed = []
+    heartbeat = _Heartbeat().start()
+    real_write = NetworkXStorage.write_nx_graph
+
+    def blocking_write(graph, file_name, workspace="_"):
+        before = heartbeat.beats
+        time.sleep(BLOCK_SECONDS)
+        observed.append((before, heartbeat.beats))
+        return real_write(graph, file_name, workspace)
+
+    monkeypatch.setattr(NetworkXStorage, "write_nx_graph", staticmethod(blocking_write))
+
+    await storage.index_done_callback()
+    await heartbeat.stop()
+
+    assert observed, "write_nx_graph was never called"
+    before, after = observed[0]
+    assert after > before, "event loop was blocked for the whole write"
+    assert await storage.has_node("n1")
+
+
+async def test_a_mutator_suspended_in_lock_release_cannot_mutate_during_a_commit(
+    tmp_path, monkeypatch
+):
+    """The window the lock alone leaves open, closed by the gate.
+
+    A mutator is parked inside ``NamespaceLock.__aexit__`` — past the lock body,
+    holding a reference to the graph, about to mutate it. The committer then
+    starts. The writer thread asserts the graph does not change under it.
+    """
+    storage = await _make_storage(tmp_path)
+    await storage.upsert_node("n1", {"entity_id": "n1"})
+
+    # Park the next lock release until we say so.
+    from lightrag.kg import shared_storage
+
+    release_reached = asyncio.Event()
+    let_release_finish = asyncio.Event()
+    arm = {"on": False}
+    real_aexit = shared_storage.NamespaceLock.__aexit__
+
+    async def parking_aexit(self, *exc_info):
+        result = await real_aexit(self, *exc_info)
+        if arm["on"]:
+            arm["on"] = False
+            release_reached.set()
+            await let_release_finish.wait()
+        return result
+
+    monkeypatch.setattr(shared_storage.NamespaceLock, "__aexit__", parking_aexit)
+
+    async def suspended_mutator():
+        arm["on"] = True
+        await storage.upsert_node("n2", {"entity_id": "n2"})
+
+    mutator = asyncio.create_task(suspended_mutator())
+    await asyncio.wait_for(release_reached.wait(), timeout=2)
+
+    entered = threading.Event()
+    release_write = threading.Event()
+    stable = {"ok": None}
+    real_write = NetworkXStorage.write_nx_graph
+
+    def blocking_write(graph, file_name, workspace="_"):
+        seen = graph.number_of_nodes()
+        entered.set()
+        assert release_write.wait(timeout=5), "write was never released"
+        stable["ok"] = graph.number_of_nodes() == seen
+        return real_write(graph, file_name, workspace)
+
+    monkeypatch.setattr(NetworkXStorage, "write_nx_graph", staticmethod(blocking_write))
+
+    commit = asyncio.create_task(storage.index_done_callback())
+    await _wait_for(entered.is_set)
+
+    # Release the mutator: it resumes past the lock and tries to mutate while
+    # the writer thread is iterating.
+    let_release_finish.set()
+    for _ in range(20):
+        await asyncio.sleep(0)
+    assert not mutator.done(), "mutator was not held back by the gate"
+
+    release_write.set()
+    await commit
+    await mutator
+
+    assert stable["ok"] is True, "graph mutated while the writer was iterating it"
+    assert await storage.has_node("n2"), "the mutation must still land afterwards"
+
+
+async def test_gate_is_restored_when_the_write_raises(tmp_path, monkeypatch):
+    """A failed commit must not leave the gate closed.
+
+    ``asyncio.wait_for`` turns "gate leaked" from a hang into a failure.
+    """
+    storage = await _make_storage(tmp_path)
+    await storage.upsert_node("n1", {"entity_id": "n1"})
+
+    def boom(graph, file_name, workspace="_"):
+        raise OSError("save boom")
+
+    monkeypatch.setattr(NetworkXStorage, "write_nx_graph", staticmethod(boom))
+
+    with pytest.raises(OSError, match="save boom"):
+        await storage.index_done_callback()
+
+    assert storage._gate().is_set()
+    await asyncio.wait_for(storage.upsert_node("n2", {"entity_id": "n2"}), timeout=2)
+
+
+async def test_gate_is_restored_when_the_committer_is_cancelled(tmp_path, monkeypatch):
+    """Cancellation must restore the gate, and only after the worker is done."""
+    storage = await _make_storage(tmp_path)
+    await storage.upsert_node("n1", {"entity_id": "n1"})
+
+    entered = threading.Event()
+    release_write = threading.Event()
+    real_write = NetworkXStorage.write_nx_graph
+
+    def blocking_write(graph, file_name, workspace="_"):
+        entered.set()
+        assert release_write.wait(timeout=5), "write was never released"
+        return real_write(graph, file_name, workspace)
+
+    monkeypatch.setattr(NetworkXStorage, "write_nx_graph", staticmethod(blocking_write))
+
+    commit = asyncio.create_task(storage.index_done_callback())
+    await _wait_for(entered.is_set)
+
+    commit.cancel()
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not commit.done(), "committer returned while the writer was running"
+    assert not storage._gate().is_set(), "gate must stay closed during the write"
+
+    release_write.set()
+    with pytest.raises(asyncio.CancelledError):
+        await commit
+
+    assert storage._gate().is_set()
+    await asyncio.wait_for(storage.upsert_node("n2", {"entity_id": "n2"}), timeout=2)
+
+
+async def test_a_woken_waiter_rechecks_the_gate_before_proceeding(tmp_path):
+    """``while not is_set(): await wait()``, not a single ``wait()``.
+
+    ``Event.wait()`` returns True for every waiter the ``set()`` woke, even if
+    the flag was cleared again before that waiter got to run. A second committer
+    taking over immediately after the first one finishes is exactly that
+    sequence, so a lone ``await gate.wait()`` would let the mutator through
+    while the new commit is already serializing.
+
+    Driven through the gate directly rather than through two real commits: a
+    mutator queued behind a running commit waits on ``_storage_lock``, not on
+    the gate, and the lock is FIFO — it would be handed the lock before the
+    second committer ever got it. The interleaving this pins is a property of
+    the gate, and this is the deterministic way to reach it.
+    """
+    storage = await _make_storage(tmp_path)
+    await storage.upsert_node("n1", {"entity_id": "n1"})
+
+    gate = storage._gate()
+    gate.clear()
+
+    mutator = asyncio.create_task(storage.upsert_node("n2", {"entity_id": "n2"}))
+    for _ in range(20):
+        await asyncio.sleep(0)
+    assert not mutator.done(), "mutator did not stop at the closed gate"
+    # Read the graph directly: has_node() goes through _get_graph too, so it
+    # would queue on the gate as well and hang this test.
+    assert not storage._graph.has_node("n2")
+
+    # First committer finishes and the second one takes over before the woken
+    # mutator is scheduled.
+    gate.set()
+    gate.clear()
+    for _ in range(20):
+        await asyncio.sleep(0)
+    assert not mutator.done(), "waiter slipped through after being woken"
+    assert not storage._graph.has_node("n2")
+
+    gate.set()
+    await asyncio.wait_for(mutator, timeout=2)
+    assert storage._graph.has_node("n2")

--- a/tests/utils/test_storage_io_offload.py
+++ b/tests/utils/test_storage_io_offload.py
@@ -1,0 +1,302 @@
+"""Offline tests for the storage-IO offload helpers.
+
+The file backends used to rewrite their whole file synchronously on the event
+loop. ``run_in_storage_io`` moves that write to a single-worker pool, which
+introduces a window the synchronous code did not have: the caller holds its
+namespace lock across the write, so a cancelled caller must NOT return while the
+worker is still touching shared state.
+
+Pinned here:
+
+* once the work is submitted, the caller waits for it — through repeated
+  cancellation, which a lone ``asyncio.shield`` does not survive;
+* while merely waiting for a submission permit, the caller stays cancellable —
+  nothing is in flight yet, and refusing to return there would keep the caller's
+  lock held for the whole queue;
+* splitting the body out of ``bounded_submit`` did not change its forwarding
+  contract: it still declares no keyword arguments of its own.
+"""
+
+import asyncio
+import itertools
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from lightrag import utils as lr_utils
+from lightrag.utils import (
+    _bounded_submit_impl,
+    bounded_submit,
+    get_storage_io_executor,
+    run_in_storage_io,
+)
+
+pytestmark = pytest.mark.offline
+
+
+class _CountingExecutor(ThreadPoolExecutor):
+    """ThreadPoolExecutor that records how many submissions it accepted."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.submissions = 0
+
+    def submit(self, *args, **kwargs):
+        self.submissions += 1
+        return super().submit(*args, **kwargs)
+
+
+class _BlockingWork:
+    """A callable that parks in the worker thread until released."""
+
+    def __init__(self, result="value", exc=None):
+        self.started = threading.Event()
+        self.release = threading.Event()
+        self.finished_at = None
+        self._result = result
+        self._exc = exc
+
+    def __call__(self):
+        self.started.set()
+        assert self.release.wait(timeout=5), "work was never released"
+        self.finished_at = next(_ORDER)
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+_ORDER = itertools.count()
+
+
+async def _wait_for(predicate, *, timeout=2.0):
+    """Await a thread-set condition without blocking the loop."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        assert loop.time() < deadline, "timed out waiting for condition"
+        await asyncio.sleep(0.01)
+
+
+async def test_cancelled_caller_waits_for_the_submitted_worker():
+    """A cancelled caller must not return while its worker is still running.
+
+    Fix-proof: with the pre-change semantics (``wait_for_completion=False``,
+    i.e. a bare ``bounded_submit``) the task completes as soon as it is
+    cancelled, so ``task.done()`` is True before the worker is released and the
+    ordering assertion at the end sees the caller return first.
+    """
+    work = _BlockingWork()
+    task = asyncio.create_task(run_in_storage_io(work))
+
+    await _wait_for(work.started.is_set)
+    task.cancel()
+    # Give the cancellation every chance to land: if the caller were allowed to
+    # return early it would already be done here.
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not task.done(), "caller returned while the worker was still running"
+
+    work.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    returned_at = next(_ORDER)
+
+    assert work.finished_at is not None
+    assert work.finished_at < returned_at
+
+
+async def test_repeated_cancellation_does_not_release_the_caller(monkeypatch):
+    """Three cancellations, each proven to land in a distinct shield round.
+
+    A lone ``await asyncio.shield(fut)`` returns immediately when the awaiting
+    coroutine is cancelled again, so an implementation that catches
+    ``CancelledError`` once and shields once would escape on the second cancel.
+    Sleeping between cancels cannot prove they landed in different rounds — the
+    scheduler is free to collapse them — so each cancel here waits for the spy
+    to observe the NEXT entry into ``asyncio.shield``.
+    """
+    entries = itertools.count(1)
+    seen = {}
+    real_shield = asyncio.shield
+
+    def spy_shield(awaitable, **kwargs):
+        seen.setdefault(next(entries), asyncio.Event()).set()
+        return real_shield(awaitable, **kwargs)
+
+    def entered(n):
+        return seen.setdefault(n, asyncio.Event()).is_set()
+
+    monkeypatch.setattr(asyncio, "shield", spy_shield)
+
+    work = _BlockingWork()
+    task = asyncio.create_task(run_in_storage_io(work))
+
+    await _wait_for(work.started.is_set)
+    for round_number in range(1, 4):
+        # Round N's shield is already active; cancel it and require the helper
+        # to re-enter shield for round N+1 before cancelling again.
+        await _wait_for(lambda n=round_number: entered(n))
+        task.cancel()
+        await _wait_for(lambda n=round_number: entered(n + 1))
+        assert not task.done(), "caller escaped after a repeated cancellation"
+
+    work.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert work.finished_at is not None
+
+
+async def test_worker_exception_propagates_when_not_cancelled():
+    boom = OSError("disk full")
+    work = _BlockingWork(exc=boom)
+    task = asyncio.create_task(run_in_storage_io(work))
+
+    await _wait_for(work.started.is_set)
+    work.release.set()
+
+    with pytest.raises(OSError, match="disk full"):
+        await task
+
+
+async def test_cancellation_wins_over_a_worker_exception(caplog, monkeypatch):
+    """Cancel + IO failure: CancelledError wins, the failure is still logged.
+
+    The worker's exception can never reach the caller once the caller is being
+    cancelled, so it must not vanish silently, and it must not resurface as an
+    "exception was never retrieved" callback either.
+
+    The cancellation must be observed by the helper BEFORE the worker fails,
+    otherwise this races: a worker that finishes first ends the wait loop with
+    no deferred cancellation and the caller legitimately sees the OSError. The
+    shield spy below pins the ordering instead of hoping for it.
+    """
+    handled = []
+    asyncio.get_running_loop().set_exception_handler(
+        lambda _loop, context: handled.append(context)
+    )
+
+    entries = itertools.count(1)
+    seen = {}
+    real_shield = asyncio.shield
+
+    def spy_shield(awaitable, **kwargs):
+        seen.setdefault(next(entries), asyncio.Event()).set()
+        return real_shield(awaitable, **kwargs)
+
+    monkeypatch.setattr(asyncio, "shield", spy_shield)
+
+    work = _BlockingWork(exc=OSError("disk full"))
+    task = asyncio.create_task(run_in_storage_io(work))
+
+    await _wait_for(work.started.is_set)
+    await _wait_for(lambda: seen.setdefault(1, asyncio.Event()).is_set())
+    task.cancel()
+    # Re-entering shield proves the cancellation was caught and deferred.
+    await _wait_for(lambda: seen.setdefault(2, asyncio.Event()).is_set())
+    work.release.set()
+
+    # lightrag's logger does not propagate, so caplog needs it turned on.
+    lr_logger = logging.getLogger("lightrag")
+    previous = lr_logger.propagate
+    lr_logger.propagate = True
+    try:
+        with caplog.at_level(logging.ERROR, logger="lightrag"):
+            with pytest.raises(asyncio.CancelledError):
+                await task
+    finally:
+        lr_logger.propagate = previous
+
+    assert any("disk full" in record.getMessage() for record in caplog.records)
+
+    # Force the finalizer that would report an unretrieved exception.
+    del work, task
+    for _ in range(3):
+        await asyncio.sleep(0)
+    assert not any(
+        "never retrieved" in str(context.get("message", "")) for context in handled
+    )
+
+
+async def test_cancellation_while_waiting_for_a_permit_never_submits():
+    """Waiting for a permit stays cancellable, and cancels before submitting.
+
+    Nothing is in flight while a caller waits for a permit, so refusing to
+    return there would keep its storage lock held for the whole queue ahead of
+    it — and would still submit the work afterwards, producing a disk write
+    after the cancellation.
+    """
+    executor = _CountingExecutor(max_workers=1)
+    semaphore = asyncio.Semaphore(1)
+    holder = _BlockingWork()
+
+    try:
+        held = asyncio.create_task(
+            _bounded_submit_impl(
+                executor, semaphore, holder, (), {}, wait_for_completion=True
+            )
+        )
+        await _wait_for(holder.started.is_set)
+        assert executor.submissions == 1
+
+        queued = _BlockingWork()
+        waiting = asyncio.create_task(
+            _bounded_submit_impl(
+                executor, semaphore, queued, (), {}, wait_for_completion=True
+            )
+        )
+        await _wait_for(lambda: semaphore.locked())
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+        waiting.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiting
+
+        assert executor.submissions == 1, "cancelled caller still submitted work"
+        assert not queued.started.is_set()
+
+        holder.release.set()
+        await held
+    finally:
+        holder.release.set()
+        executor.shutdown(wait=True)
+
+
+async def test_bounded_submit_still_forwards_every_keyword_to_fn():
+    """``bounded_submit`` declares no keyword arguments of its own.
+
+    The control flag lives on the private ``_bounded_submit_impl`` precisely so
+    that a target function may use the name ``wait_for_completion`` itself. Put
+    the flag on ``bounded_submit`` after ``*args`` and this fails: the value is
+    swallowed as the control flag instead of reaching ``fn``.
+    """
+    executor = ThreadPoolExecutor(max_workers=1)
+    semaphore = asyncio.Semaphore(1)
+
+    def target(*, wait_for_completion):
+        return wait_for_completion
+
+    try:
+        result = await bounded_submit(
+            executor, semaphore, target, wait_for_completion="payload"
+        )
+    finally:
+        executor.shutdown(wait=True)
+
+    assert result == "payload"
+
+
+def test_storage_io_executor_is_a_single_worker_named_pool():
+    """Configuration pin: the pool's shape is load-bearing, not incidental.
+
+    One worker keeps the commits as serialized as they are today; the name makes
+    the thread identifiable in a stack dump taken during a long write.
+    """
+    executor = get_storage_io_executor()
+
+    assert executor is get_storage_io_executor()
+    assert executor._max_workers == 1
+    assert executor._thread_name_prefix == "lightrag-storage-io"
+    assert lr_utils._STORAGE_IO_EXECUTOR is executor

--- a/tests/utils/test_storage_io_offload.py
+++ b/tests/utils/test_storage_io_offload.py
@@ -14,7 +14,10 @@ Pinned here:
   nothing is in flight yet, and refusing to return there would keep the caller's
   lock held for the whole queue;
 * splitting the body out of ``bounded_submit`` did not change its forwarding
-  contract: it still declares no keyword arguments of its own.
+  contract: it still declares no keyword arguments of its own;
+* ``commit_in_storage_io`` keeps a landed write and its bookkeeping together:
+  the hook runs inside the same uncancellable region, and only if the write
+  actually happened.
 """
 
 import asyncio
@@ -29,6 +32,7 @@ from lightrag import utils as lr_utils
 from lightrag.utils import (
     _bounded_submit_impl,
     bounded_submit,
+    commit_in_storage_io,
     get_storage_io_executor,
     run_in_storage_io,
 )
@@ -300,3 +304,159 @@ def test_storage_io_executor_is_a_single_worker_named_pool():
     assert executor._max_workers == 1
     assert executor._thread_name_prefix == "lightrag-storage-io"
     assert lr_utils._STORAGE_IO_EXECUTOR is executor
+
+
+# ---------------------------------------------------------------------------
+# commit_in_storage_io: a landed write and its bookkeeping must not come apart
+# ---------------------------------------------------------------------------
+
+
+async def test_commit_hook_completes_before_a_deferred_cancellation():
+    """Cancelled mid-write, the bookkeeping still runs — before CancelledError.
+
+    This is the case Codex flagged on #3740: the GraphML file is already
+    published, so skipping ``set_all_update_flags`` leaves every other worker
+    reading the previous snapshot indefinitely.
+
+    Fix-proof: route the same work through ``run_in_storage_io`` and inline the
+    hook after it, and the hook never runs at all — the ordering list ends at
+    ["write", "cancelled"].
+    """
+    order = []
+    work = _BlockingWork()
+
+    async def on_committed():
+        # An await here on purpose: a second cancel would otherwise land on it,
+        # which is exactly what the deferring wait has to absorb.
+        await asyncio.sleep(0)
+        order.append("committed")
+
+    task = asyncio.create_task(commit_in_storage_io(work, on_committed))
+
+    await _wait_for(work.started.is_set)
+    task.cancel()
+    work.release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    order.append("cancelled")
+
+    assert order == ["committed", "cancelled"], order
+
+
+async def test_commit_hook_does_not_run_when_waiting_for_a_permit_is_cancelled():
+    """No submission means no write, so the bookkeeping must NOT run.
+
+    Load-bearing rather than tidiness: Nano's hook retires the redo logs. Running
+    it without a write would discard rows that were never persisted.
+    """
+    executor = _CountingExecutor(max_workers=1)
+    semaphore = asyncio.Semaphore(1)
+    holder = _BlockingWork()
+    hook_ran = []
+
+    async def on_committed():
+        hook_ran.append(1)
+
+    try:
+        held = asyncio.create_task(
+            _bounded_submit_impl(
+                executor,
+                semaphore,
+                holder,
+                (),
+                {},
+                wait_for_completion=True,
+                on_committed=on_committed,
+            )
+        )
+        await _wait_for(holder.started.is_set)
+
+        queued = _BlockingWork()
+        waiting = asyncio.create_task(
+            _bounded_submit_impl(
+                executor,
+                semaphore,
+                queued,
+                (),
+                {},
+                wait_for_completion=True,
+                on_committed=on_committed,
+            )
+        )
+        await _wait_for(lambda: semaphore.locked())
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+        waiting.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiting
+
+        assert executor.submissions == 1
+        assert not queued.started.is_set()
+        assert hook_ran == [], "bookkeeping ran for a write that never happened"
+
+        holder.release.set()
+        await held
+        assert hook_ran == [1], "the write that DID land must run its bookkeeping"
+    finally:
+        holder.release.set()
+        executor.shutdown(wait=True)
+
+
+async def test_commit_hook_does_not_run_when_the_write_raises():
+    """A failed write must not have its bookkeeping applied."""
+    hook_ran = []
+
+    async def on_committed():
+        hook_ran.append(1)
+
+    work = _BlockingWork(exc=OSError("disk full"))
+    task = asyncio.create_task(commit_in_storage_io(work, on_committed))
+
+    await _wait_for(work.started.is_set)
+    work.release.set()
+
+    with pytest.raises(OSError, match="disk full"):
+        await task
+    assert hook_ran == []
+
+
+async def test_commit_hook_failure_surfaces_when_not_cancelled():
+    """Bookkeeping that fails must be reported, not swallowed.
+
+    The write landed but the namespace was never flagged, so the caller has to
+    hear about it — ``_insert_done`` only detects failures via exceptions.
+    """
+
+    async def on_committed():
+        raise RuntimeError("flag update failed")
+
+    work = _BlockingWork()
+    work.release.set()
+
+    with pytest.raises(RuntimeError, match="flag update failed"):
+        await commit_in_storage_io(work, on_committed)
+
+
+async def test_on_committed_requires_wait_for_completion():
+    """The hook is meaningless without the uncancellable wait — reject it."""
+    executor = ThreadPoolExecutor(max_workers=1)
+    semaphore = asyncio.Semaphore(1)
+
+    async def on_committed():  # pragma: no cover — never reached
+        raise AssertionError("must not run")
+
+    try:
+        with pytest.raises(ValueError, match="wait_for_completion"):
+            await _bounded_submit_impl(
+                executor,
+                semaphore,
+                lambda: None,
+                (),
+                {},
+                wait_for_completion=False,
+                on_committed=on_committed,
+            )
+    finally:
+        executor.shutdown(wait=True)


### PR DESCRIPTION
## Summary

The file-backed storage backends rewrite their whole file on every commit, **synchronously, on the event loop**. This moves those writes to a dedicated single-worker thread pool so the loop keeps serving HTTP while a commit is in flight.

## Motivation

Reported symptom: with a large corpus, the WebUI freezes while a batch of failed documents is repeatedly retried, with the backend log sitting on `[purge] doc-...: deleted 369 chunk(s) from storage`.

The mechanism:

- `index_done_callback` serializes the entire store inline in an `async def` — `write_json` for the JSON KV / doc-status backends, `nx.write_graphml` for NetworkX, `NanoVectorDB.save` for nano.
- `_insert_done` flushes **all 12 storages** (`_index_storages`), including `llm_response_cache` and the GraphML file — usually the two largest files in `rag_storage`.
- A single document purge calls `_insert_done` **twice**, plus one `doc_status` flush for each of the four purge-journal phases. Frequent pipeline restarts make those windows dense.
- `lightrag-server` forces `workers=1` in uvicorn mode, so a blocked loop takes every endpoint down with it: `/health`, `/documents/pipeline_status` and `/documents/paginated` all hang together.

Offloading is effective here because none of these encoders holds the GIL monolithically: `write_json` uses `json.dump(fp)` with `indent=2` (the C one-shot encoder is excluded both by `indent` and by not being `_one_shot`), and `write_graphml_lxml` streams through a pure-Python per-element loop.

## What's changed

**`lightrag/utils.py`** — `bounded_submit`'s body moves to a private `_bounded_submit_impl` that takes a `wait_for_completion` flag. `bounded_submit`'s public signature and its "all `**kwargs` are forwarded verbatim to `fn`" contract are unchanged: a control keyword on that signature would either be positional-only (before the `/`, where passing it by keyword silently forwards it to `fn`) or steal a legitimate argument of `fn` (after `*args`). Adds `get_storage_io_executor()` (one worker, `lightrag-storage-io`) and `run_in_storage_io()`.

The uncancellable region starts at `executor.submit()`, **not** at the permit wait. A caller still queued for a permit has nothing in flight, so it stays cancellable — otherwise a cancelled flush would hold its namespace lock for the whole queue ahead of it and then still write to disk after the cancellation.

**`json_kv_impl` / `json_doc_status_impl`** — only the write moves. The `self._data.copy()` snapshot stays on the loop inside the lock, so the worker reads a private dict and the Manager RPC count is unchanged. The sanitize-reload branch also stays on the loop: it writes back into the shared dict.

**`nano_vector_db_impl`** — `_save_to_disk_locked` becomes a coroutine. The lock is held for the whole call because `_save_atomic` points `client.storage_file` at the tmp sibling for the duration of the save.

**`networkx_impl`** — the commit hands `self._graph` to a worker thread that iterates `graph._node` / `graph._adj`, which invariant (3) in the class docstring no longer covers. A new `_commit_gate` (`asyncio.Event`, cleared only while this process serializes) restores the exclusion.

Holding `_storage_lock` across the write is **not** sufficient by itself: releasing a `NamespaceLock` runs the release on a fresh task and awaits a shield, so `__aexit__` always suspends at least once, and a mutator suspended there is already past the lock body. The gate is therefore checked **after** `_get_graph`'s lock block — after the last suspension point — so from `is_set()` through the caller's synchronous mutation there is no `await`. It sits at `_get_graph`, the single choke point, rather than in the seven mutators.

Both classes' concurrency-invariant docstrings are rewritten; the NetworkX one explicitly named this change as what would break it.

## What this does and does not fix

Every callback takes its own `_storage_lock` **before** entering the single-worker queue, so a namespace can be holding its lock while queued.

- `/health` and `/documents/pipeline_status` keep responding during a commit — they depend on no committing namespace's lock.
- `/documents/paginated` is no longer frozen by unrelated namespaces (GraphML, LLM cache) writing on the loop. It still waits on the doc-status lock when a purge journal, status transition or upload commits doc-status itself. That short wait is accepted behaviour.
- Graph query endpoints can still wait while a GraphML commit is queued and writing.
- **nano is a partial win.** `NanoVectorDB.save()` base64-encodes the whole matrix via `tobytes()` + `b64encode()` — two single C calls that hold the GIL wherever they run — so a large matrix still stalls the loop for that stretch. Only the `json.dump` that follows is cooperative. A chunked or binary format is a separate change.

Not in this PR: faiss (same shape, but needs an audit of its lock-free `_id_to_meta` reads and a measurement of whether `faiss.write_index` releases the GIL); the read/parse paths (`_reload_client_from_disk_locked`, `_get_graph`'s reload, `initialize()`'s `load_json`), which only ever run in reader processes; and reducing the number of purge flushes, which touches the #3400 fail-closed ordering contract.

## Tests

New:

- `tests/utils/test_storage_io_offload.py` — cancellation waits for the submitted worker; survives repeated cancellation (each cancel proven to land in a distinct `asyncio.shield` round via a spy, since sleeping cannot prove the scheduler did not collapse them); cancel + IO failure prefers `CancelledError` while still logging the failure and producing no "never retrieved" callback; a caller waiting for a permit cancels **without** submitting; `bounded_submit` still forwards a `wait_for_completion` keyword to `fn`.
- `tests/kg/json_impl/test_json_write_off_event_loop.py`, `tests/kg/nano_impl/test_nano_save_off_event_loop.py`, `tests/kg/networkx_impl/test_networkx_commit_gate.py` — a heartbeat coroutine samples the loop from inside a blocking write. Against the pre-change code these fail with `assert 0 > 0`: the loop cannot advance at all. Also: a concurrent `upsert` stays pending while a commit is in flight (proving the offload stayed inside the lock), and a cancelled nano commit leaves `storage_file` restored.
- The gate tests are vacuous against the pre-change code (no thread, no window). What they pin is the intermediate mistake of offloading **without** the gate; removing `gate.clear()` / `finally: gate.set()` was verified by hand to fail two of them, and the record is in the module docstring.

Converting `_save_to_disk_locked` to a coroutine silently degrades synchronous test doubles — the caller awaits `None`, so the fault-injection tests would pass on a `TypeError` instead of the `OSError` they are about. All 25 references across the two nano test modules were converted (five were lambdas, expanded to `async def`). One counting double called the coroutine without awaiting it, so the save silently did not run while the test stayed green.

Full suite: **7162 passed, 200 skipped** (`./scripts/test.sh tests`), run because `lightrag/utils.py` is cross-cutting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
