### PR TITLE
fix(kg): save FaissVectorDBStorage off the event loop

### DIFF
--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -3,13 +3,18 @@ import os
 import time
 import asyncio
 from hashlib import md5
-from typing import Any, final
+from typing import Any, Awaitable, Callable, final
 import json
 import numpy as np
 from dataclasses import dataclass
 
 from lightrag.file_atomic import atomic_write, reap_orphan_tmp_files
-from lightrag.utils import logger, compute_mdhash_id, validate_workspace
+from lightrag.utils import (
+    logger,
+    compute_mdhash_id,
+    commit_in_storage_io,
+    validate_workspace,
+)
 from lightrag.base import BaseVectorStorage
 from lightrag.constants import DEFAULT_QUERY_PRIORITY
 
@@ -91,13 +96,22 @@ class FaissVectorDBStorage(BaseVectorStorage):
            ``index_done_callback`` completes. Reads in the gap between a
            writer's in-memory mutation and its commit may legitimately
            return the pre-update snapshot.
-        3. **Faiss + dict mutations are synchronous.** Under a
-           single-threaded asyncio event loop, ``index.add`` /
-           ``index.search`` / ``self._id_to_meta`` mutations cannot be
-           preempted by another coroutine, which gives them implicit
-           mutual exclusion. This is why most methods don't hold
-           ``_storage_lock`` while touching ``self._index`` /
-           ``self._id_to_meta``.
+        3. **Faiss + dict MUTATIONS are synchronous and stay on the
+           event loop.** ``index.add`` / ``index.remove_ids`` /
+           ``self._id_to_meta`` mutations cannot be preempted by another
+           coroutine, which gives them implicit mutual exclusion. This is
+           why most methods don't hold ``_storage_lock`` while touching
+           ``self._index`` / ``self._id_to_meta``.
+
+           ``_save_faiss_index`` is the one part that runs in a worker
+           thread, and it is compatible with this invariant because it
+           only READS: it takes its ``self._id_to_meta`` snapshot on the
+           loop before offloading, and it reads ``self._index`` while
+           holding ``_storage_lock``, which excludes every mutation
+           above. The only unlocked Faiss access, ``query``'s
+           ``index.search``, is a read as well. Moving a MUTATION (or an
+           unsnapshotted dict iteration) into the pool would break the
+           invariant and would require widening the lock scope instead.
 
     Cross-process sync protocol:
         Writer side (``index_done_callback``):
@@ -133,11 +147,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
         The lock is **non-reentrant**, so ``_flush_pending_locked`` /
         ``_remove_faiss_ids_locked`` / ``_save_faiss_index`` /
         ``_reload_index_from_disk_locked`` all require the caller to
-        already hold it and never re-enter via ``_get_index``. Routine
+        already hold it and never re-enter via ``_get_index`` — the last
+        of these runs its writes in a worker thread, where re-entering
+        would deadlock on a lock the caller already holds. Routine
         ``index.search`` outside ``_get_index`` and the synchronous
-        ``client_storage`` read rely on invariant (3) above — if either
-        premise is broken (e.g. Faiss calls moved to a thread pool),
-        the lock scope must be widened.
+        ``client_storage`` read rely on invariant (3) above; both are
+        reads, which is why they coexist with the offloaded save. Moving
+        a Faiss or dict MUTATION into a thread pool would break that
+        premise and require widening the lock scope.
 
     Caveat — synchronous ``client_storage`` reads:
         ``client_storage`` is a synchronous property and does **not** go
@@ -1202,7 +1219,9 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # needed — a reload resurrecting the removed version is taken out again
         # by the replay at the top of the next flush, rewrite preserved.
 
-    def _save_faiss_index(self):
+    async def _save_faiss_index(
+        self, on_committed: Callable[[], Awaitable[None]]
+    ) -> None:
         """Atomically persist ``self._index`` + ``self._id_to_meta`` to disk.
 
         Precondition: the caller must already hold ``_storage_lock`` (this is
@@ -1220,13 +1239,32 @@ class FaissVectorDBStorage(BaseVectorStorage):
         ``test_faiss_meta_inconsistency``; the ``index > meta`` direction is
         a known gap (logged on reload, not auto-repaired) — see class
         docstring *Storage model*.
-        """
-        atomic_write(
-            self._faiss_index_file,
-            lambda tmp: faiss.write_index(self._index, tmp),
-            self.workspace or "_",
-        )
 
+        Both writes run in the storage-IO pool rather than on the event loop:
+        together they rewrite the entire index and the entire metadata file, so
+        inline they froze every unrelated request for the duration. Measured on
+        faiss 1.14.2, both halves genuinely yield — ``faiss.write_index``
+        releases the GIL outright, and ``json.dump`` is the same cooperative
+        pure-Python encoder the JSON backends use.
+
+        The metadata snapshot is built HERE, on the loop, before the offload:
+        the worker must not iterate ``self._id_to_meta`` while the synchronous
+        ``client_storage`` property can read it. ``self._index`` is handed over
+        by reference, which is sound because the worker only READS it while
+        every mutation (``add`` / ``remove_ids`` / reload) happens under
+        ``_storage_lock`` — held for this whole call — and the one unlocked
+        Faiss access, ``query``'s ``index.search``, is also a read. The write
+        ORDER (index first, then meta) is preserved: it is what keeps the
+        crash skew in the tolerated direction.
+
+        ``on_committed`` carries the post-write bookkeeping (retire the redo
+        logs, flag the other processes, clear the dirty bit) into the same
+        uncancellable region as the write. It must not be inlined after this
+        call: a cancel delivered in between would leave both files published
+        with the other processes never told to reload them. It runs only if the
+        write succeeded — running it without a write would retire redo entries
+        for rows that were never persisted.
+        """
         # Save metadata dict to JSON, excluding __vector__ since vectors are
         # already stored in the Faiss index file and can be reconstructed on load.
         serializable_dict = {}
@@ -1234,11 +1272,26 @@ class FaissVectorDBStorage(BaseVectorStorage):
             filtered_meta = {k: v for k, v in meta.items() if k != "__vector__"}
             serializable_dict[str(fid)] = filtered_meta
 
+        index = self._index
+        index_file = self._faiss_index_file
+        meta_file = self._meta_file
+        workspace = self.workspace or "_"
+
         def _write_meta(tmp: str) -> None:
             with open(tmp, "w", encoding="utf-8") as f:
                 json.dump(serializable_dict, f)
 
-        atomic_write(self._meta_file, _write_meta, self.workspace or "_")
+        def _write_both() -> None:
+            # One submission for both files: two would take two permits and
+            # could interleave another namespace's commit between the halves.
+            atomic_write(
+                index_file,
+                lambda tmp: faiss.write_index(index, tmp),
+                workspace,
+            )
+            atomic_write(meta_file, _write_meta, workspace)
+
+        await commit_in_storage_io(_write_both, on_committed)
 
     def _load_faiss_index(self):
         """
@@ -1390,12 +1443,15 @@ class FaissVectorDBStorage(BaseVectorStorage):
             # aborts the batch; pending stays intact and _index_dirty stays
             # True (if only the save failed) for a later retry.
             await self._flush_pending_locked()
-            self._save_faiss_index()
-            self._unsaved_deletes.clear()  # the removals are durable now
-            self._unsaved_upserts.clear()  # the rows are durable now
-            await set_all_update_flags(self.namespace, workspace=self.workspace)
-            self.storage_updated.value = False
-            self._index_dirty = False
+
+            async def _committed() -> None:
+                self._unsaved_deletes.clear()  # the removals are durable now
+                self._unsaved_upserts.clear()  # the rows are durable now
+                await set_all_update_flags(self.namespace, workspace=self.workspace)
+                self.storage_updated.value = False
+                self._index_dirty = False
+
+            await self._save_faiss_index(_committed)
             return True
 
     @staticmethod
@@ -1775,9 +1831,12 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 # would rewrite both files and flag every other process
                 # for a full reload for no reason.
                 return
-            self._save_faiss_index()
-            self._unsaved_deletes.clear()  # the removals are durable now
-            self._unsaved_upserts.clear()  # the rows are durable now
-            await set_all_update_flags(self.namespace, workspace=self.workspace)
-            self.storage_updated.value = False
-            self._index_dirty = False
+
+            async def _committed() -> None:
+                self._unsaved_deletes.clear()  # the removals are durable now
+                self._unsaved_upserts.clear()  # the rows are durable now
+                await set_all_update_flags(self.namespace, workspace=self.workspace)
+                self.storage_updated.value = False
+                self._index_dirty = False
+
+            await self._save_faiss_index(_committed)

--- a/tests/kg/faiss_impl/test_atomic_write_faiss.py
+++ b/tests/kg/faiss_impl/test_atomic_write_faiss.py
@@ -4,6 +4,11 @@ The save path produces two files (``.index`` and ``.meta.json``). Each one
 must land via tmp + rename so a crash during either write preserves the
 prior snapshot. Cross-file consistency between the two renames is
 intentionally out of scope (declared in the PR).
+
+Both writes run in the storage-IO worker pool, so these tests are async and
+exercise the offloaded path end to end: the failure modes below (a raising
+``os.replace``, a raising ``json.dump``) happen in the worker thread, and the
+exception has to cross back to the awaiting caller intact.
 """
 
 import json
@@ -42,6 +47,11 @@ def _make_storage(tmp_path, namespace: str = "vectors") -> FaissVectorDBStorage:
     )
 
 
+async def _noop() -> None:
+    """Post-commit hook stand-in: these tests are about the writes themselves."""
+    return None
+
+
 def _seed(storage: FaissVectorDBStorage, marker: str) -> None:
     """Push a single vector tagged with ``marker`` into the in-memory state."""
     vec = np.ones((1, 4), dtype=np.float32)
@@ -52,10 +62,10 @@ def _seed(storage: FaissVectorDBStorage, marker: str) -> None:
 
 
 @pytest.mark.offline
-def test_save_faiss_index_publishes_both_files_cleanly(tmp_path):
+async def test_save_faiss_index_publishes_both_files_cleanly(tmp_path):
     storage = _make_storage(tmp_path)
     _seed(storage, "v1")
-    storage._save_faiss_index()
+    await storage._save_faiss_index(_noop)
 
     assert os.path.exists(storage._faiss_index_file)
     assert os.path.exists(storage._meta_file)
@@ -66,12 +76,12 @@ def test_save_faiss_index_publishes_both_files_cleanly(tmp_path):
 
 
 @pytest.mark.offline
-def test_save_faiss_index_replace_crash_preserves_prior_index(tmp_path):
+async def test_save_faiss_index_replace_crash_preserves_prior_index(tmp_path):
     """If ``os.replace`` raises while renaming the ``.index`` tmp, the old
     ``.index`` must remain loadable by ``faiss.read_index``."""
     storage = _make_storage(tmp_path)
     _seed(storage, "v1")
-    storage._save_faiss_index()
+    await storage._save_faiss_index(_noop)
     assert os.path.exists(storage._faiss_index_file)
 
     # Bump in-memory state to v2 and then crash the .index rename.
@@ -82,7 +92,7 @@ def test_save_faiss_index_replace_crash_preserves_prior_index(tmp_path):
         side_effect=OSError("simulated crash"),
     ):
         with pytest.raises(OSError, match="simulated crash"):
-            storage._save_faiss_index()
+            await storage._save_faiss_index(_noop)
 
     # Reload the destination — must still be the v1 single-vector index.
     reloaded = faiss.read_index(storage._faiss_index_file)
@@ -92,12 +102,12 @@ def test_save_faiss_index_replace_crash_preserves_prior_index(tmp_path):
 
 
 @pytest.mark.offline
-def test_save_faiss_meta_write_failure_preserves_prior_meta(tmp_path):
+async def test_save_faiss_meta_write_failure_preserves_prior_meta(tmp_path):
     """A failure inside the meta ``write_fn`` (after the index has been
     written) must leave the previous ``.meta.json`` intact."""
     storage = _make_storage(tmp_path)
     _seed(storage, "v1")
-    storage._save_faiss_index()
+    await storage._save_faiss_index(_noop)
     assert json.load(open(storage._meta_file))
 
     real_dump = json.dump
@@ -114,7 +124,7 @@ def test_save_faiss_meta_write_failure_preserves_prior_meta(tmp_path):
     _seed(storage, "v2")
     with patch("lightrag.kg.faiss_impl.json.dump", side_effect=explode_on_second_dump):
         with pytest.raises(RuntimeError, match="simulated meta failure"):
-            storage._save_faiss_index()
+            await storage._save_faiss_index(_noop)
     assert seen, "patched json.dump must have been invoked"
 
     # .meta.json must still parse and still reflect v1.

--- a/tests/kg/faiss_impl/test_faiss_deferred_delete.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_delete.py
@@ -275,7 +275,7 @@ async def test_failed_delete_rebuild_keeps_tombstones_for_retry(tmp_path, monkey
 def _fail_save(storage, monkeypatch):
     """Make the next save(s) raise, simulating a transient IO failure."""
 
-    def boom():
+    async def boom(_on_committed):
         raise OSError("transient disk error")
 
     monkeypatch.setattr(storage, "_save_faiss_index", boom)

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -437,12 +437,12 @@ async def test_finalize_retries_save_after_flush_failure(tmp_path):
     original_save = storage._save_faiss_index
     save_calls = 0
 
-    def fail_once():
+    async def fail_once(on_committed):
         nonlocal save_calls
         save_calls += 1
         if save_calls == 1:
             raise OSError("boom")
-        original_save()
+        await original_save(on_committed)
 
     storage._save_faiss_index = fail_once
 
@@ -509,7 +509,7 @@ async def test_index_done_callback_save_failure_raises(tmp_path):
 
     original_save = storage._save_faiss_index
 
-    def fail_save():
+    async def fail_save(_on_committed):
         raise OSError("save boom")
 
     storage._save_faiss_index = fail_save
@@ -839,7 +839,7 @@ async def test_drop_pending_does_not_rollback_materialized(tmp_path):
     # materialized-but-unsaved (dirty) and the pending buffer is emptied.
     await storage.upsert({"id1": {"content": "alpha"}})
 
-    def fail_save():
+    async def fail_save(_on_committed):
         raise OSError("save boom")
 
     storage._save_faiss_index = fail_save
@@ -1082,7 +1082,7 @@ def _make_save_fail(storage):
     """Make ``_save_faiss_index`` raise; returns a restore callable."""
     original = storage._save_faiss_index
 
-    def boom():
+    async def boom(_on_committed):
         raise OSError("disk full")
 
     storage._save_faiss_index = boom

--- a/tests/kg/faiss_impl/test_faiss_write_off_event_loop.py
+++ b/tests/kg/faiss_impl/test_faiss_write_off_event_loop.py
@@ -1,0 +1,262 @@
+"""``FaissVectorDBStorage`` persistence must not block the event loop.
+
+``_save_faiss_index`` rewrites the whole ``.index`` and the whole
+``.meta.json``. Run inline on the loop, a large index froze every unrelated
+request for the duration — the same failure mode the JSON and GraphML backends
+had. Measured on faiss 1.14.2 both halves genuinely yield: ``faiss.write_index``
+releases the GIL, and ``json.dump`` is the cooperative pure-Python encoder.
+
+Two properties are pinned here:
+
+* the loop keeps running while the files are written;
+* the ``_id_to_meta`` snapshot is taken on the loop BEFORE the offload, so the
+  worker never iterates a dict that unlocked readers/writers can still touch;
+* a cancelled commit still runs its bookkeeping, so the two published files are
+  never left with the other processes unaware of them.
+"""
+
+import asyncio
+import json
+import os
+import threading
+import time
+
+import numpy as np
+import pytest
+
+faiss = pytest.importorskip("faiss")
+
+from lightrag.kg import faiss_impl  # noqa: E402
+from lightrag.kg.faiss_impl import FaissVectorDBStorage  # noqa: E402
+from lightrag.utils import EmbeddingFunc  # noqa: E402
+
+pytestmark = pytest.mark.offline
+
+
+def _make_storage(tmp_path, namespace: str = "vectors") -> FaissVectorDBStorage:
+    def _unused(*_args, **_kwargs):  # pragma: no cover — never called here
+        raise AssertionError("embedding_func must not be invoked by save path")
+
+    return FaissVectorDBStorage(
+        namespace=namespace,
+        workspace="",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 1,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=4, func=_unused),
+    )
+
+
+async def _noop() -> None:
+    """Post-commit hook stand-in for the tests that call the save directly."""
+    return None
+
+
+def _seed(storage: FaissVectorDBStorage, marker: str) -> None:
+    storage._index.add(np.ones((1, 4), dtype=np.float32))
+    storage._id_to_meta = {
+        storage._index.ntotal - 1: {"__id__": marker, "content": marker}
+    }
+
+
+class _Heartbeat:
+    """Counts how often the event loop gets to run us."""
+
+    def __init__(self):
+        self.beats = 0
+        self._stop = False
+        self._task = None
+
+    async def __aenter__(self):
+        async def _run():
+            while not self._stop:
+                self.beats += 1
+                await asyncio.sleep(0)
+
+        self._task = asyncio.create_task(_run())
+        await asyncio.sleep(0)
+        return self
+
+    async def __aexit__(self, *_exc):
+        self._stop = True
+        await self._task
+
+
+async def test_save_keeps_the_event_loop_running(tmp_path, monkeypatch):
+    """The loop must keep being scheduled while the index is written.
+
+    Fix-proof: before the offload, ``_save_faiss_index`` ran the write inline,
+    so the 200 ms spent inside the patched ``write_index`` was 200 ms in which
+    the heartbeat below could not advance at all — ``after == before``.
+    """
+    storage = _make_storage(tmp_path)
+    _seed(storage, "v1")
+
+    real_write_index = faiss_impl.faiss.write_index
+    observed: list[tuple[int, int]] = []
+
+    async with _Heartbeat() as heartbeat:
+
+        def slow_write_index(index, path):
+            before = heartbeat.beats
+            time.sleep(0.2)
+            observed.append((before, heartbeat.beats))
+            return real_write_index(index, path)
+
+        monkeypatch.setattr(faiss_impl.faiss, "write_index", slow_write_index)
+        await storage._save_faiss_index(_noop)
+
+    assert observed, "patched write_index was never called"
+    before, after = observed[0]
+    assert after > before, (
+        "the event loop did not advance while the index was being written "
+        f"(beats {before} -> {after})"
+    )
+
+    # The write still has to be correct, not merely non-blocking.
+    assert faiss.read_index(storage._faiss_index_file).ntotal == 1
+    meta = json.load(open(storage._meta_file))
+    assert next(iter(meta.values()))["__id__"] == "v1"
+
+
+async def test_metadata_snapshot_is_taken_before_the_offload(tmp_path, monkeypatch):
+    """A mutation racing the write must not reach the file being written.
+
+    ``client_storage`` reads ``_id_to_meta`` without the lock, so the worker
+    must serialize a snapshot rather than the live dict. This test mutates the
+    dict while the worker is parked inside ``write_index``; if the snapshot
+    were built in the worker the extra row would land on disk (or the
+    iteration would raise ``RuntimeError: dictionary changed size``).
+    """
+    storage = _make_storage(tmp_path)
+    _seed(storage, "v1")
+
+    real_write_index = faiss_impl.faiss.write_index
+    inside_write = threading.Event()
+    may_finish = threading.Event()
+
+    def parked_write_index(index, path):
+        inside_write.set()
+        assert may_finish.wait(timeout=5), "writer was never released"
+        return real_write_index(index, path)
+
+    monkeypatch.setattr(faiss_impl.faiss, "write_index", parked_write_index)
+
+    save = asyncio.create_task(storage._save_faiss_index(_noop))
+    while not inside_write.is_set():
+        await asyncio.sleep(0.01)
+
+    # The loop is free (that is the point of the offload), so an unlocked
+    # reader/writer can run right here.
+    storage._id_to_meta[999] = {"__id__": "late", "content": "late"}
+    may_finish.set()
+    await save
+
+    meta = json.load(open(storage._meta_file))
+    assert "999" not in meta, "the worker serialized the live dict, not a snapshot"
+    assert [entry["__id__"] for entry in meta.values()] == ["v1"]
+
+
+async def test_cancelled_save_still_completes_both_files(tmp_path, monkeypatch):
+    """Cancelling the caller must not abandon a half-written pair of files.
+
+    The caller holds ``_storage_lock`` across the save; returning early would
+    release it while the worker is still writing. ``run_in_storage_io`` is
+    uncancellable once submitted, which keeps the pre-change guarantee (a
+    synchronous write could not be cancelled at all).
+    """
+    storage = _make_storage(tmp_path)
+    _seed(storage, "v1")
+
+    real_write_index = faiss_impl.faiss.write_index
+    inside_write = threading.Event()
+    may_finish = threading.Event()
+
+    def parked_write_index(index, path):
+        inside_write.set()
+        assert may_finish.wait(timeout=5), "writer was never released"
+        return real_write_index(index, path)
+
+    monkeypatch.setattr(faiss_impl.faiss, "write_index", parked_write_index)
+
+    save = asyncio.create_task(storage._save_faiss_index(_noop))
+    while not inside_write.is_set():
+        await asyncio.sleep(0.01)
+
+    save.cancel()
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not save.done(), "caller returned while the worker was still writing"
+
+    may_finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await save
+
+    assert os.path.exists(storage._faiss_index_file)
+    assert os.path.exists(storage._meta_file)
+    assert faiss.read_index(storage._faiss_index_file).ntotal == 1
+    leftovers = [p for p in os.listdir(tmp_path) if ".tmp." in p]
+    assert leftovers == [], f"unexpected tmp residue: {leftovers}"
+
+
+async def test_cancelled_commit_still_notifies_and_retires_the_redo_logs(
+    tmp_path, monkeypatch
+):
+    """A cancelled commit must not publish both files and skip its bookkeeping.
+
+    `set_all_update_flags` is what tells the other processes to reload; skipped,
+    they keep serving the previous index. The redo logs would likewise keep rows
+    that are already durable. Both live in the hook that `commit_in_storage_io`
+    runs inside the write's uncancellable region.
+
+    Fix-proof: inline the bookkeeping after the offload instead and `flagged`
+    stays empty — the P2 Codex raised on #3740, in this backend.
+    """
+    from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+
+    finalize_share_data()
+    initialize_share_data()
+    try:
+        storage = _make_storage(tmp_path)
+        await storage.initialize()
+        _seed(storage, "v1")
+        storage._index_dirty = True
+
+        flagged: list[str] = []
+        real_write_index = faiss_impl.faiss.write_index
+        inside_write = threading.Event()
+        may_finish = threading.Event()
+
+        async def spy_set_all_update_flags(namespace, workspace=None):
+            flagged.append(namespace)
+
+        def parked_write_index(index, path):
+            inside_write.set()
+            assert may_finish.wait(timeout=5), "writer was never released"
+            return real_write_index(index, path)
+
+        monkeypatch.setattr(
+            faiss_impl, "set_all_update_flags", spy_set_all_update_flags
+        )
+        monkeypatch.setattr(faiss_impl.faiss, "write_index", parked_write_index)
+
+        commit = asyncio.create_task(storage.index_done_callback())
+        while not inside_write.is_set():
+            await asyncio.sleep(0.01)
+
+        commit.cancel()
+        may_finish.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await commit
+
+        assert flagged == ["vectors"], (
+            "a cancelled commit published both files without telling the other "
+            f"processes to reload them (flagged={flagged})"
+        )
+        assert storage._index_dirty is False, "dirty bit survived a durable save"
+        assert storage._unsaved_upserts == {}, "redo log kept rows that are on disk"
+    finally:
+        finalize_share_data()


### PR DESCRIPTION
## Summary

Moves `FaissVectorDBStorage._save_faiss_index` into the storage-IO worker pool, so committing the Faiss index no longer freezes the event loop.

**Stacked on #3740** — base is `fix/storage-io-off-event-loop`, which adds the `run_in_storage_io` / `commit_in_storage_io` pool this PR consumes. Review/merge that one first; the diff here is only the Faiss backend.

## Motivation

#3740 moved the JSON, NanoVectorDB and NetworkX backends off the loop and deferred Faiss, because two premises needed checking first: whether `faiss.write_index` releases the GIL (a C call that holds it would make the offload pointless), and whether the unlocked `_id_to_meta` read paths tolerate a worker thread. Both check out.

Measured on faiss 1.14.2, 60k × 512 `IndexFlatIP` (123 MB index, 15 MB meta) — a worker thread does the work while a busy main thread counts how often it gets scheduled:

| operation | duration | main-thread ticks/s |
|---|---|---|
| `faiss.write_index` | 0.05s | 1,222,265 |
| `json.dump` (meta.json) | 0.25s | 159,890 |
| control: pure-Python loop | 0.14s | 1,544 |

`write_index` releases the GIL outright; `json.dump` is the same cooperative pure-Python encoder the JSON backends use. Neither half holds the GIL the way a monolithic C call would, so unlike Nano's base64 step there is no residual stall here. Note the metadata file, not the index, is the slower half.

## What's changed

- `_save_faiss_index` becomes a coroutine and submits both `atomic_write` calls as **one** unit of work to the pool. One submission, not two: two would take two permits and could interleave another namespace's commit between the halves. The write order (index first, then meta) is preserved — it is what keeps the crash skew in the direction `_load_faiss_index` tolerates.
- The `_id_to_meta` snapshot is built **on the loop, before the offload**. The synchronous `client_storage` property reads that dict without the lock, so the worker must serialize a snapshot rather than the live mapping.
- `self._index` is handed over by reference. Sound because the worker only READS it while `_storage_lock` — held across the whole call — excludes every mutation (`add` / `remove_ids` / reload), and the one unlocked Faiss access, `query`'s `index.search`, is a read as well.
- Post-write bookkeeping (retire the redo logs, flag the other processes, clear the dirty bit) goes through `commit_in_storage_io`, so it cannot be separated from a write that already landed. This mirrors the fix in #3740 for the Codex finding there: inlined after the offload, a cancel would leave both files published with the other processes never told to reload them.
- Class docstring invariant 3 named this exact change as its breaking condition ("if either premise is broken (e.g. Faiss calls moved to a thread pool), the lock scope must be widened"). Rewritten to state what actually holds now: mutations stay on the loop, only the read-only save is offloaded.
- Every test double for `_save_faiss_index` became `async def` and takes the commit hook. A synchronous double wrapping the original would call the new coroutine without awaiting it — the save would silently not happen, and the fault-injection tests would degrade from asserting `OSError` to passing on a `TypeError`.

## What could break

The offload runs inside `_storage_lock`, so callers that go through `_get_index` still wait for the commit — this frees the event loop, not the Faiss namespace lock. Queries against *this* vector namespace can still queue behind a commit; every other endpoint keeps being served.

Uncancellable once submitted, matching the synchronous write it replaces (which could not be cancelled at all). Cancelling the caller mid-write defers `CancelledError` until both files have landed **and** the bookkeeping has run, so the lock is never released with a half-written pair or an unnotified namespace behind it.

## Tests

4 new cases in `tests/kg/faiss_impl/test_faiss_write_off_event_loop.py`:
- the loop keeps advancing while the index is written;
- a row added to `_id_to_meta` mid-write does not reach the file (proves the snapshot precedes the offload);
- a cancelled caller still waits for both files, leaving no tmp residue;
- a cancelled commit still flagged the namespace for the other processes.

Each fails against the shape it guards — verified by hand.

Ran `tests/kg/faiss_impl` + `tests/utils`: **294 passed**. Full suite green locally (CI does not trigger on a non-`main` base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)