### PR TITLE
fix(webui): keep the document list refreshing when the backend stalls

### DIFF
--- a/lightrag_webui/src/api/lightrag.test.ts
+++ b/lightrag_webui/src/api/lightrag.test.ts
@@ -263,3 +263,45 @@ describe('isUserAbortError', () => {
     expect(apiModule.isUserAbortError(undefined, new Error('network down'))).toBe(false)
   })
 })
+
+describe('response interceptor', () => {
+  test('an HTTP failure carries its status, not just a formatted message', async () => {
+    // The interceptor rewrites every non-401 AxiosError into a plain Error.
+    // Without the status as a property, callers that branch on it (the
+    // document list treats a 4xx as permanent and must not let it trip the
+    // refresh circuit breaker) see only `undefined` and fall back to
+    // "unknown, retry".
+    apiModule.__setAxiosAdapterForTests(async () => {
+      throw {
+        response: {
+          status: 404,
+          statusText: 'Not Found',
+          data: { detail: 'no such workspace' }
+        },
+        config: { url: '/documents/pipeline_status' }
+      }
+    })
+
+    try {
+      const failure = await apiModule
+        .getPipelineStatus()
+        .then(() => null)
+        .catch((error: unknown) => error as Error & { status?: number })
+
+      expect(failure).toBeInstanceOf(Error)
+      expect(failure?.status).toBe(404)
+      expect(failure?.message).toContain('404 Not Found')
+      expect(failure?.message).toContain('no such workspace')
+    } finally {
+      apiModule.__setAxiosAdapterForTests(undefined)
+    }
+  })
+
+  test('toHttpRequestError builds the same shape directly', () => {
+    const error = apiModule.toHttpRequestError(422, 'Unprocessable Entity', { detail: 'bad' }, '/documents/paginated')
+
+    expect(error.status).toBe(422)
+    expect(error.message).toContain('422 Unprocessable Entity')
+    expect(error.message).toContain('/documents/paginated')
+  })
+})

--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -1,5 +1,11 @@
 import axios, { AxiosError } from 'axios'
-import { backendBaseUrl, popularLabelsDefaultLimit, searchLabelsDefaultLimit } from '@/lib/constants'
+import {
+  backendBaseUrl,
+  healthCheckTimeout,
+  pipelineStatusTimeout,
+  popularLabelsDefaultLimit,
+  searchLabelsDefaultLimit
+} from '@/lib/constants'
 import type { SupportedFileTypes } from '@/lib/fileTypes'
 import { errorMessage } from '@/lib/utils'
 import { useSettingsStore } from '@/stores/settings'
@@ -559,7 +565,13 @@ export const checkHealth = async (): Promise<
   LightragStatus | { status: 'error'; message: string }
 > => {
   try {
-    const response = await axiosInstance.get('/health')
+    // Explicit timeout: the axios instance sets none, so a backend whose
+    // event loop is blocked would leave this request hanging and the health
+    // state would neither succeed nor fail. Kept below healthCheckInterval
+    // so probes cannot pile up.
+    const response = await axiosInstance.get('/health', {
+      timeout: healthCheckTimeout * 1000
+    })
     return response.data
   } catch (error) {
     return {
@@ -1013,7 +1025,9 @@ export const getAuthStatus = async (): Promise<AuthStatusResponse> => {
 }
 
 export const getPipelineStatus = async (): Promise<PipelineStatusResponse> => {
-  const response = await axiosInstance.get('/documents/pipeline_status')
+  const response = await axiosInstance.get('/documents/pipeline_status', {
+    timeout: pipelineStatusTimeout * 1000
+  })
   return response.data
 }
 

--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError } from 'axios'
 import {
   backendBaseUrl,
+  documentFetchTimeoutMessage,
   healthCheckTimeout,
   pipelineStatusTimeout,
   popularLabelsDefaultLimit,
@@ -443,6 +444,29 @@ axiosInstance.interceptors.request.use((config) => {
 })
 
 // Interceptor：handle token renewal and authentication errors
+/**
+ * An HTTP error surfaced by the response interceptor.
+ *
+ * The status is carried as a property, not only inside the message: callers
+ * branch on it (e.g. the document list treats a 4xx as a permanent client
+ * error that must not trip its circuit breaker), and a plain Error left them
+ * unable to tell a 404 from a network failure.
+ */
+export type HttpRequestError = Error & { status?: number }
+
+export const toHttpRequestError = (
+  status: number,
+  statusText: string,
+  data: unknown,
+  url?: string
+): HttpRequestError => {
+  const error = new Error(
+    `${status} ${statusText}\n${JSON.stringify(data)}\n${url}`
+  ) as HttpRequestError
+  error.status = status
+  return error
+}
+
 axiosInstance.interceptors.response.use(
   (response) => {
     // ========== Check for new token from backend ==========
@@ -526,10 +550,11 @@ axiosInstance.interceptors.response.use(
         navigationService.navigateToLogin();
         return Promise.reject(new Error('Authentication required'));
       }
-      throw new Error(
-        `${error.response.status} ${error.response.statusText}\n${JSON.stringify(
-          error.response.data
-        )}\n${error.config?.url}`
+      throw toHttpRequestError(
+        error.response.status,
+        error.response.statusText,
+        error.response.data,
+        error.config?.url
       )
     }
     throw error
@@ -1243,6 +1268,14 @@ export const __setPaginatedDocumentsPostForTests = (
 }
 
 /**
+ * Swap the axios adapter so a test can drive a response (or an HTTP failure)
+ * through the real request/response interceptors. Pass undefined to restore.
+ */
+export const __setAxiosAdapterForTests = (adapter: any): void => {
+  axiosInstance.defaults.adapter = adapter
+}
+
+/**
  * Get documents with pagination support
  * @param request The pagination request parameters
  * @returns Promise with paginated documents response
@@ -1260,7 +1293,7 @@ export const getDocumentsPaginated = async (request: DocumentsRequest): Promise<
 export const getDocumentsPaginatedWithTimeout = (
   request: DocumentsRequest,
   timeoutMs: number = 30000,
-  errorMsg: string = 'Document fetch timeout'
+  errorMsg: string = documentFetchTimeoutMessage
 ): Promise<PaginatedDocsResponse> => {
   const { requestEntry, release } = subscribeToPaginatedDocumentsRequest(request)
 

--- a/lightrag_webui/src/components/documents/PipelineStatusDialog.tsx
+++ b/lightrag_webui/src/components/documents/PipelineStatusDialog.tsx
@@ -73,12 +73,26 @@ export default function PipelineStatusDialog({
   useEffect(() => {
     if (!open) return
 
+    // The 2s cadence is shorter than the request timeout, so without these two
+    // guards a stalled backend would pile up one in-flight request and one
+    // error toast per tick.
+    let inFlight = false
+    let failureNotified = false
+
     const fetchStatus = async () => {
+      if (inFlight) return
+      inFlight = true
       try {
         const data = await getPipelineStatus()
         setStatus(data)
+        failureNotified = false
       } catch (err) {
-        toast.error(t('documentPanel.pipelineStatus.errors.fetchFailed', { error: errorMessage(err) }))
+        if (!failureNotified) {
+          failureNotified = true
+          toast.error(t('documentPanel.pipelineStatus.errors.fetchFailed', { error: errorMessage(err) }))
+        }
+      } finally {
+        inFlight = false
       }
     }
 

--- a/lightrag_webui/src/components/ui/PaginationControls.tsx
+++ b/lightrag_webui/src/components/ui/PaginationControls.tsx
@@ -55,6 +55,14 @@ export default function PaginationControls({
 
   // Handle page input submit
   const handlePageInputSubmit = useCallback(() => {
+    if (isLoading) {
+      // Match the four button handlers. The input is disabled while loading, so
+      // the only way in is the browser's blur-on-disable; snap the box back so
+      // a refused submit does not leave a page number that disagrees with the
+      // rows on screen.
+      setInputPage(currentPage.toString())
+      return
+    }
     const pageNum = parseInt(inputPage, 10)
     if (!isNaN(pageNum) && pageNum >= 1 && pageNum <= totalPages) {
       onPageChange(pageNum)
@@ -62,7 +70,7 @@ export default function PaginationControls({
       // Reset to current page if invalid
       setInputPage(currentPage.toString())
     }
-  }, [inputPage, totalPages, onPageChange, currentPage])
+  }, [inputPage, totalPages, onPageChange, currentPage, isLoading])
 
   // Handle page input key press
   const handlePageInputKeyPress = useCallback((e: React.KeyboardEvent) => {

--- a/lightrag_webui/src/components/ui/PaginationControls.tsx
+++ b/lightrag_webui/src/components/ui/PaginationControls.tsx
@@ -13,6 +13,13 @@ export type PaginationControlsProps = {
   totalCount: number
   onPageChange: (page: number) => void
   onPageSizeChange: (pageSize: number) => void
+  /**
+   * Disables every control while a refresh runs. This is UX — no double-submit
+   * flicker — NOT the correctness guarantee: DocumentManager's refresh queue
+   * serializes requests and requestVersion discards stale responses, so even a
+   * click landing in the gap between paint and effect flush resolves to the
+   * user's last intent.
+   */
   isLoading?: boolean
   compact?: boolean
   className?: string

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -428,15 +428,6 @@ export default function DocumentManager() {
   const [docs, setDocs] = useState<DocsStatusesResponse | null>(null)
 
   const currentTab = useSettingsStore.use.currentTab()
-  // Read from runRefreshRequest's catch, which runs long after the render that
-  // issued the request — a paginated fetch can take up to its 30s timeout to
-  // land. A ref, NOT a dependency of that callback: adding currentTab there
-  // changes its identity on every tab switch, and the central fetch effect
-  // depends on it transitively, so each switch would issue a fresh request.
-  const documentsTabActiveRef = useRef(currentTab === 'documents')
-  useEffect(() => {
-    documentsTabActiveRef.current = currentTab === 'documents'
-  }, [currentTab])
   const showFileName = useSettingsStore.use.showFileName()
   const setShowFileName = useSettingsStore.use.setShowFileName()
   const documentsPageSize = useSettingsStore.use.documentsPageSize()
@@ -964,15 +955,7 @@ export default function DocumentManager() {
         // but must not keep holding the probe slot either: the finally settles
         // it below.
 
-        // Report only while the document list is the view the user is on.
-        // TabsContent uses forceMount, so isMountedRef stays true after a tab
-        // switch, and a request that was already in flight when the user left
-        // can land up to 30s later. Without this it would re-create the global
-        // notice that the tab-change effect had just dismissed — with polling
-        // stopped, nothing could ever clear it again. Cancelling those requests
-        // instead would be the heavier fix for the same symptom; not reporting
-        // a list the user is not looking at is the behaviour we want anyway.
-        if (errorClassification.shouldShowToast && documentsTabActiveRef.current) {
+        if (errorClassification.shouldShowToast) {
           // One notice for an ongoing outage, not one per failed poll. Every
           // retryable failure means the list is stale and staying stale, so the
           // notice stands until a response clears it (fetchPage dismisses it on
@@ -992,9 +975,18 @@ export default function DocumentManager() {
           // A permanent 4xx is not an outage — the backend answered, and the
           // breaker has just been cleared above — so it keeps the ordinary
           // auto-dismissing toast.
+          //
+          // Persistence additionally requires that something still polls: the
+          // interval is the only thing that can produce the successful response
+          // that dismisses this. TabsContent uses forceMount, so a request that
+          // was in flight when the user left the tab keeps running and lands
+          // here up to 30s later, after the polling effect stopped the
+          // interval — an Infinity toast raised then could never be cleared.
+          // Showing it is fine, and intended; making it permanent is not.
+          const clearable = pollingIntervalRef.current !== null
           toast.error(t('documentPanel.documentManager.errors.loadFailed', { error: errorMessage(err) }), {
             id: DOCUMENT_REFRESH_FAILURE_TOAST_ID,
-            duration: errorClassification.shouldRetry ? Infinity : undefined
+            duration: errorClassification.shouldRetry && clearable ? Infinity : undefined
           });
         }
       }

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -428,6 +428,15 @@ export default function DocumentManager() {
   const [docs, setDocs] = useState<DocsStatusesResponse | null>(null)
 
   const currentTab = useSettingsStore.use.currentTab()
+  // Read from runRefreshRequest's catch, which runs long after the render that
+  // issued the request — a paginated fetch can take up to its 30s timeout to
+  // land. A ref, NOT a dependency of that callback: adding currentTab there
+  // changes its identity on every tab switch, and the central fetch effect
+  // depends on it transitively, so each switch would issue a fresh request.
+  const documentsTabActiveRef = useRef(currentTab === 'documents')
+  useEffect(() => {
+    documentsTabActiveRef.current = currentTab === 'documents'
+  }, [currentTab])
   const showFileName = useSettingsStore.use.showFileName()
   const setShowFileName = useSettingsStore.use.setShowFileName()
   const documentsPageSize = useSettingsStore.use.documentsPageSize()
@@ -955,7 +964,15 @@ export default function DocumentManager() {
         // but must not keep holding the probe slot either: the finally settles
         // it below.
 
-        if (errorClassification.shouldShowToast) {
+        // Report only while the document list is the view the user is on.
+        // TabsContent uses forceMount, so isMountedRef stays true after a tab
+        // switch, and a request that was already in flight when the user left
+        // can land up to 30s later. Without this it would re-create the global
+        // notice that the tab-change effect had just dismissed — with polling
+        // stopped, nothing could ever clear it again. Cancelling those requests
+        // instead would be the heavier fix for the same symptom; not reporting
+        // a list the user is not looking at is the behaviour we want anyway.
+        if (errorClassification.shouldShowToast && documentsTabActiveRef.current) {
           // One notice for an ongoing outage, not one per failed poll. Every
           // retryable failure means the list is stale and staying stale, so the
           // notice stands until a response clears it (fetchPage dismisses it on

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -938,7 +938,13 @@ export default function DocumentManager() {
         admit: (request) =>
           request.type !== 'intelligent' ||
           !request.auto ||
-          admitAutomaticRefresh()
+          admitAutomaticRefresh(),
+        // Automatic refreshes rank below everything else in the pending slot.
+        // Admission is evaluated where the request is issued, so an `auto`
+        // request the breaker will refuse there must not be able to discard a
+        // page change or a manual refresh that would have run.
+        priority: (request) =>
+          request.type === 'intelligent' && request.auto ? 0 : 1
       }),
     [refreshQueue, runRefreshRequest, admitAutomaticRefresh]
   );

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -62,6 +62,7 @@ import {
   type CircuitBreakerState
 } from '@/features/documentRefreshCircuitBreaker'
 import { classifyDocumentRefreshError } from '@/features/documentRefreshErrors'
+import { createRefreshQueue } from '@/features/documentRefreshQueue'
 
 type StatusDisplayConfig = {
   labelKey: string
@@ -464,8 +465,6 @@ export default function DocumentManager() {
   // Add refs to track previous pipelineActive state and current interval
   const prevPipelineActiveRef = useRef<boolean | undefined>(undefined);
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const activeRefreshPromiseRef = useRef<Promise<void> | null>(null);
-  const pendingRefreshRequestRef = useRef<RefreshRequest | null>(null);
   const latestRefreshRequestVersionRef = useRef(0);
   // Throttle gate: all auto-driven /documents/paginated entrances funnel through
   // refreshDocumentsThrottled() to enforce a minimum 2s wall-clock interval.
@@ -776,7 +775,7 @@ export default function DocumentManager() {
   // Read-only check for a request that was already queued: it must not take
   // the half-open slot, so it only gets to run while the breaker is closed.
   const isAutomaticRefreshBlocked = useCallback(
-    () => isCircuitBreakerBlocked(circuitBreakerRef.current),
+    () => isCircuitBreakerBlocked(circuitBreakerRef.current, Date.now()),
     []
   );
 
@@ -923,54 +922,26 @@ export default function DocumentManager() {
     buildDocumentsRequest
   ]);
 
-  const enqueueRefresh = useCallback(async (refreshRequest: RefreshRequest) => {
-    if (activeRefreshPromiseRef.current) {
-      pendingRefreshRequestRef.current = refreshRequest;
-      await activeRefreshPromiseRef.current;
-      return;
-    }
+  // One queue for the component's lifetime: it owns the in-flight/pending
+  // state, so rebuilding it would drop a request mid-flight. The handlers ride
+  // along with each enqueue instead of being captured at construction.
+  const [refreshQueue] = useState(() => createRefreshQueue<RefreshRequest>());
 
-    // A queued automatic refresh must clear the breaker again before it runs:
-    // the request it waited behind may have been the half-open probe, and the
-    // breaker admitted exactly one request, not a follow-up. Dropping it is
-    // safe — the polling timer re-issues one as soon as the breaker allows.
-    const takeNextRequest = (): RefreshRequest | null => {
-      const pending = pendingRefreshRequestRef.current;
-      pendingRefreshRequestRef.current = null;
-
-      if (
-        pending &&
-        pending.type === 'intelligent' &&
-        pending.auto &&
-        isAutomaticRefreshBlocked()
-      ) {
-        return null;
-      }
-
-      return pending;
-    };
-
-    const refreshLoopPromise = (async () => {
-      let nextRequest: RefreshRequest | null = refreshRequest;
-
-      while (nextRequest) {
-        pendingRefreshRequestRef.current = null;
-        await runRefreshRequest(nextRequest);
-        nextRequest = takeNextRequest();
-      }
-    })();
-
-    activeRefreshPromiseRef.current = refreshLoopPromise;
-
-    try {
-      await refreshLoopPromise;
-    } finally {
-      if (activeRefreshPromiseRef.current === refreshLoopPromise) {
-        activeRefreshPromiseRef.current = null;
-      }
-      pendingRefreshRequestRef.current = null;
-    }
-  }, [runRefreshRequest, isAutomaticRefreshBlocked]);
+  const enqueueRefresh = useCallback(
+    (refreshRequest: RefreshRequest) =>
+      refreshQueue.enqueue(refreshRequest, {
+        runRequest: runRefreshRequest,
+        // The single admission point for automatic refreshes, evaluated where
+        // the request is actually issued — first request and queued request
+        // alike. Manual refresh and page/filter/sort changes are untagged and
+        // always run: explicit user intent is the escape hatch.
+        admit: (request) =>
+          request.type !== 'intelligent' ||
+          !request.auto ||
+          admitAutomaticRefresh()
+      }),
+    [refreshQueue, runRefreshRequest, admitAutomaticRefresh]
+  );
 
   // Intelligent refresh function: handles all boundary cases
   const handleIntelligentRefresh = useCallback(async (options: {
@@ -1131,7 +1102,10 @@ export default function DocumentManager() {
 
     pollingIntervalRef.current = setInterval(() => {
       if (!isMountedRef.current) return;
-      if (!admitAutomaticRefresh()) return;
+      // Read-only: the admission itself happens in the refresh queue, at the
+      // point the request is issued. Skipping here just avoids walking the
+      // throttle gate for a request that would be dropped anyway.
+      if (isAutomaticRefreshBlocked()) return;
       // refreshDocumentsThrottled is fire-and-forget; the breaker is fed from
       // inside runRefreshRequest (recordSuccess on a real response,
       // recordFailure in its catch), never from this tick — a tick proves
@@ -1139,7 +1113,7 @@ export default function DocumentManager() {
       // the breaker from ever opening.
       refreshDocumentsThrottled();
     }, intervalMs);
-  }, [refreshDocumentsThrottled, clearPollingInterval, admitAutomaticRefresh]);
+  }, [refreshDocumentsThrottled, clearPollingInterval, isAutomaticRefreshBlocked]);
 
   const scanDocuments = useCallback(async () => {
     try {

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -385,6 +385,13 @@ type RefreshRequest =
     requestVersion: number;
   };
 
+/**
+ * Stable id for the document-refresh failure toast, so repeated failures
+ * update one notice in place instead of stacking. Dismissed by the first
+ * successful response.
+ */
+const DOCUMENT_REFRESH_FAILURE_TOAST_ID = 'document-refresh-failed'
+
 export default function DocumentManager() {
   // Track component mount status
   const isMountedRef = useRef(true);
@@ -847,6 +854,7 @@ export default function DocumentManager() {
       ): Promise<PaginatedDocsResponse> => {
         const response = await getDocumentsPaginatedWithTimeout(pageRequest, timeoutMs)
         recordSuccess()
+        toast.dismiss(DOCUMENT_REFRESH_FAILURE_TOAST_ID)
         return response
       }
 
@@ -931,7 +939,18 @@ export default function DocumentManager() {
         // it below.
 
         if (errorClassification.shouldShowToast) {
-          toast.error(t('documentPanel.documentManager.errors.loadFailed', { error: errorMessage(err) }));
+          // One notice, not one per failure. A backend that is down is polled
+          // for as long as the tab is open (capped by the breaker's backoff at
+          // roughly one probe a minute), and nothing else in the UI reports it
+          // — a failed /health only feeds the API key alert — so going silent
+          // would leave the list stale without saying so.
+          //
+          // Read AFTER the breaker update above: a permanent 4xx closes the
+          // breaker, and that toast should auto-dismiss like any other.
+          toast.error(t('documentPanel.documentManager.errors.loadFailed', { error: errorMessage(err) }), {
+            id: DOCUMENT_REFRESH_FAILURE_TOAST_ID,
+            duration: circuitBreakerRef.current.isOpen ? Infinity : undefined
+          });
         }
       }
     } finally {

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -59,6 +59,7 @@ import {
   isCircuitBreakerBlocked,
   recordCircuitBreakerFailure,
   resetCircuitBreaker,
+  settleCircuitBreakerProbe,
   type CircuitBreakerState
 } from '@/features/documentRefreshCircuitBreaker'
 import { classifyDocumentRefreshError } from '@/features/documentRefreshErrors'
@@ -793,6 +794,16 @@ export default function DocumentManager() {
     circuitBreakerRef.current = resetCircuitBreaker();
   }, []);
 
+  // Return the half-open probe slot for an outcome that proves nothing about
+  // reachability. Idempotent, so it can be called unconditionally from the one
+  // place every request path passes through.
+  const settleProbe = useCallback(() => {
+    circuitBreakerRef.current = settleCircuitBreakerProbe(
+      circuitBreakerRef.current,
+      Date.now()
+    );
+  }, []);
+
   // Handle page size change - update state and save to store
   const handlePageSizeChange = useCallback((newPageSize: number) => {
     if (newPageSize === pagination.page_size) return;
@@ -900,15 +911,35 @@ export default function DocumentManager() {
       if (isMountedRef.current) {
         const errorClassification = classifyDocumentRefreshError(err);
 
+        if (errorClassification.shouldRetry) {
+          // No answer at all, or an answer that is itself a back-off signal
+          // (408/429). shouldRetry outranks provesBackendResponsive by design.
+          recordFailure();
+        } else if (errorClassification.provesBackendResponsive) {
+          // A permanent 4xx: the application parsed and routed the request and
+          // answered. Reachability is proven, so the breaker must be CLEARED
+          // rather than left holding a stale failure count that would let three
+          // non-consecutive failures open it.
+          recordSuccess();
+        }
+        // Anything left — a cancellation — proves nothing and must not reset,
+        // but must not keep holding the probe slot either: the finally settles
+        // it below.
+
         if (errorClassification.shouldShowToast) {
           toast.error(t('documentPanel.documentManager.errors.loadFailed', { error: errorMessage(err) }));
         }
-
-        if (errorClassification.shouldRetry) {
-          recordFailure();
-        }
       }
     } finally {
+      // The probe slot is held for the lifetime of ONE real request, so every
+      // exit path must return it. recordSuccess / recordFailure already clear
+      // it; this covers the paths that do neither — a cancellation, and the
+      // unmount early return at the top of this function, which precedes every
+      // record call. Idempotent, hence unconditional: the invariant is "every
+      // exit returns the slot", and finally is the only construct that states
+      // it. An else-branch in the catch would cover today's paths and silently
+      // reopen the hole the next time an early return is added.
+      settleProbe();
       if (isMountedRef.current) {
         setIsRefreshing(false);
       }
@@ -918,6 +949,7 @@ export default function DocumentManager() {
     updateComponentState,
     recordFailure,
     recordSuccess,
+    settleProbe,
     handlePageSizeChange,
     buildDocumentsRequest
   ]);

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -35,6 +35,7 @@ import {
   DocStatus,
   DocStatusResponse,
   DocumentsRequest,
+  PaginatedDocsResponse,
   PaginationInfo
 } from '@/api/lightrag'
 import { errorMessage } from '@/lib/utils'
@@ -52,6 +53,13 @@ import {
   type StatusFilter
 } from '@/features/documentStatusFilters'
 import { hasDocumentWarning } from '@/features/documentRecoveryWarnings'
+import {
+  evaluateCircuitBreaker,
+  initialCircuitBreakerState,
+  recordCircuitBreakerFailure,
+  resetCircuitBreaker,
+  type CircuitBreakerState
+} from '@/features/documentRefreshCircuitBreaker'
 
 type StatusDisplayConfig = {
   labelKey: string
@@ -463,20 +471,10 @@ export default function DocumentManager() {
   const probeTimersRef = useRef<ReturnType<typeof setTimeout>[] | null>(null);
   const probeActiveRef = useRef(false);
 
-  // Add retry mechanism state (read by circuit breaker via setRetryState only).
-  const [, setRetryState] = useState({
-    count: 0,
-    lastError: null as Error | null,
-    isBackingOff: false
-  });
-
-  // Add circuit breaker state
-  const [circuitBreakerState, setCircuitBreakerState] = useState({
-    isOpen: false,
-    failureCount: 0,
-    lastFailureTime: null as number | null,
-    nextRetryTime: null as number | null
-  });
+  // Circuit breaker guarding the automatic /documents/paginated polling.
+  // Transitions live in features/documentRefreshCircuitBreaker (unit-tested);
+  // this ref just holds the current state.
+  const circuitBreakerRef = useRef<CircuitBreakerState>(initialCircuitBreakerState);
 
 
   // Handle checkbox change for individual documents
@@ -777,58 +775,31 @@ export default function DocumentManager() {
     return { type: 'unknown', shouldRetry: true, shouldShowToast: true };
   }, []);
 
-  // Circuit breaker utility functions
+  // Circuit breaker utility functions. State lives in a ref, not useState: the
+  // breaker is read from timer callbacks only, and a state write would change
+  // startPollingInterval's identity and make the polling useEffect tear down
+  // and recreate the interval, resetting its phase on every failure.
   const isCircuitBreakerOpen = useCallback(() => {
-    if (!circuitBreakerState.isOpen) return false;
-
-    const now = Date.now();
-    if (circuitBreakerState.nextRetryTime && now >= circuitBreakerState.nextRetryTime) {
-      // Reset circuit breaker to half-open state
-      setCircuitBreakerState(prev => ({
-        ...prev,
-        isOpen: false,
-        failureCount: Math.max(0, prev.failureCount - 1)
-      }));
-      return false;
-    }
-
-    return true;
-  }, [circuitBreakerState]);
-
-  const recordFailure = useCallback((error: Error) => {
-    const now = Date.now();
-    setCircuitBreakerState(prev => {
-      const newFailureCount = prev.failureCount + 1;
-      const shouldOpen = newFailureCount >= 3; // Open after 3 failures
-
-      return {
-        isOpen: shouldOpen,
-        failureCount: newFailureCount,
-        lastFailureTime: now,
-        nextRetryTime: shouldOpen ? now + (Math.pow(2, newFailureCount) * 1000) : null
-      };
-    });
-
-    setRetryState(prev => ({
-      count: prev.count + 1,
-      lastError: error,
-      isBackingOff: true
-    }));
+    const { state, isOpen } = evaluateCircuitBreaker(
+      circuitBreakerRef.current,
+      Date.now()
+    );
+    circuitBreakerRef.current = state;
+    return isOpen;
   }, []);
 
-  const recordSuccess = useCallback(() => {
-    setCircuitBreakerState({
-      isOpen: false,
-      failureCount: 0,
-      lastFailureTime: null,
-      nextRetryTime: null
-    });
+  const recordFailure = useCallback(() => {
+    circuitBreakerRef.current = recordCircuitBreakerFailure(
+      circuitBreakerRef.current,
+      Date.now()
+    );
+  }, []);
 
-    setRetryState({
-      count: 0,
-      lastError: null,
-      isBackingOff: false
-    });
+  // Call ONLY when a response actually came back. Recording success on a
+  // fire-and-forget refresh (what the polling tick used to do) clears the
+  // failure counter on every tick and the breaker can never open.
+  const recordSuccess = useCallback(() => {
+    circuitBreakerRef.current = resetCircuitBreaker();
   }, []);
 
   // Handle page size change - update state and save to store
@@ -860,9 +831,22 @@ export default function DocumentManager() {
       const { query, requestVersion } = refreshRequest
       const isStaleRequest = () => requestVersion !== latestRefreshRequestVersionRef.current
 
+      // Single entrance for the paginated fetch so the circuit breaker is fed
+      // by real responses. A 200 proves the backend is reachable even when the
+      // payload is then discarded as stale, so success is recorded before any
+      // staleness check.
+      const fetchPage = async (
+        pageRequest: DocumentsRequest,
+        timeoutMs?: number
+      ): Promise<PaginatedDocsResponse> => {
+        const response = await getDocumentsPaginatedWithTimeout(pageRequest, timeoutMs)
+        recordSuccess()
+        return response
+      }
+
       if (refreshRequest.type === 'manual') {
         const request = buildDocumentsRequest(query, 1)
-        const response = await getDocumentsPaginatedWithTimeout(request)
+        const response = await fetchPage(request)
 
         if (!isMountedRef.current || isStaleRequest()) return;
 
@@ -893,7 +877,7 @@ export default function DocumentManager() {
         const { customTimeout } = refreshRequest;
         const pageToFetch = query.page;
         const request = buildDocumentsRequest(query, pageToFetch)
-        const response = await getDocumentsPaginatedWithTimeout(request, customTimeout)
+        const response = await fetchPage(request, customTimeout)
 
         if (!isMountedRef.current || isStaleRequest()) return;
 
@@ -903,10 +887,7 @@ export default function DocumentManager() {
 
           if (pageToFetch !== lastPage) {
             const lastPageRequest = buildDocumentsRequest(query, lastPage)
-            const lastPageResponse = await getDocumentsPaginatedWithTimeout(
-              lastPageRequest,
-              customTimeout
-            )
+            const lastPageResponse = await fetchPage(lastPageRequest, customTimeout)
 
             if (!isMountedRef.current || isStaleRequest()) return;
 
@@ -933,7 +914,7 @@ export default function DocumentManager() {
         }
 
         if (errorClassification.shouldRetry) {
-          recordFailure(err as Error);
+          recordFailure();
         }
       }
     } finally {
@@ -946,6 +927,7 @@ export default function DocumentManager() {
     updateComponentState,
     classifyError,
     recordFailure,
+    recordSuccess,
     handlePageSizeChange,
     buildDocumentsRequest
   ]);
@@ -1136,12 +1118,14 @@ export default function DocumentManager() {
     pollingIntervalRef.current = setInterval(() => {
       if (!isMountedRef.current) return;
       if (isCircuitBreakerOpen()) return;
-      // refreshDocumentsThrottled is fire-and-forget; errors are surfaced via
-      // toast/recordFailure inside runRefreshRequest.
+      // refreshDocumentsThrottled is fire-and-forget; the breaker is fed from
+      // inside runRefreshRequest (recordSuccess on a real response,
+      // recordFailure in its catch), never from this tick — a tick proves
+      // nothing about the backend and clearing the counter here is what kept
+      // the breaker from ever opening.
       refreshDocumentsThrottled();
-      recordSuccess();
     }, intervalMs);
-  }, [refreshDocumentsThrottled, clearPollingInterval, isCircuitBreakerOpen, recordSuccess]);
+  }, [refreshDocumentsThrottled, clearPollingInterval, isCircuitBreakerOpen]);
 
   const scanDocuments = useCallback(async () => {
     try {
@@ -1209,14 +1193,21 @@ export default function DocumentManager() {
   // during scan classification / upload enqueue, well before the new doc rows
   // appear in /documents/paginated. Without this, the UI would stall in 30s
   // idle polling for several seconds after the user clicked scan/upload.
+  // A failed health check no longer stops the list: it drops polling to the
+  // idle cadence instead. Latching health=false used to clear the interval
+  // outright, so a single 504 from a busy backend froze the document list until
+  // the next successful /health probe. The circuit breaker (fed by real
+  // responses) is what throttles a backend that is genuinely down.
   useEffect(() => {
-    if (currentTab !== 'documents' || !health) {
+    if (currentTab !== 'documents') {
       clearPollingInterval();
       return
     }
 
     const hasActiveDocuments = hasActiveDocumentsStatus(statusCounts);
-    const pollingInterval = (hasActiveDocuments || pipelineActive) ? 5000 : 30000;
+    const pollingInterval = health
+      ? ((hasActiveDocuments || pipelineActive) ? 5000 : 30000)
+      : 30000;
 
     startPollingInterval(pollingInterval);
 

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -412,6 +412,10 @@ export default function DocumentManager() {
     return () => {
       isMountedRef.current = false;
       window.removeEventListener('beforeunload', handleBeforeUnload);
+      // The Toaster is mounted above the router, so the outage notice outlives
+      // this component: without this it would still be on screen after a
+      // logout, with nothing left that could ever dismiss it.
+      toast.dismiss(DOCUMENT_REFRESH_FAILURE_TOAST_ID);
     };
   }, []);
 
@@ -1293,6 +1297,15 @@ export default function DocumentManager() {
   useEffect(() => {
     if (currentTab !== 'documents') {
       clearPollingInterval();
+      // Retiring the notice with the polling that would clear it. Nothing
+      // refreshes the document list while another tab is up, so a standing
+      // outage notice could never be dismissed by a successful response, and
+      // the Toaster renders it globally — it would sit over the graph or
+      // retrieval view indefinitely. An unmount cleanup does not cover this:
+      // TabsContent uses forceMount, so this component stays mounted while
+      // another tab is active. Returning to Documents re-creates the notice on
+      // the next failure, which is the correct behaviour.
+      toast.dismiss(DOCUMENT_REFRESH_FAILURE_TOAST_ID);
       return
     }
 

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -757,9 +757,17 @@ export default function DocumentManager() {
     sort_direction: query.sortDirection
   }), [])
 
-  // Utility function to update component state
-  const updateComponentState = useCallback((response: any) => {
-    setPagination(response.pagination);
+  // Utility function to update component state.
+  //
+  // `page` is passed in rather than read off the response: the displayed page
+  // number is what THIS request asked for (or an explicit boundary correction),
+  // never what the response echoed back. Request serialization plus the
+  // requestVersion guard make a stale response unreachable today, so this
+  // changes no behaviour; deriving the page locally means neither a backend
+  // echo bug nor a future relaxation of either layer can surface as a page
+  // number rolling backwards under the user.
+  const updateComponentState = useCallback((response: any, page: number) => {
+    setPagination({ ...response.pagination, page });
     setCurrentPageDocs(response.documents);
     setStatusCounts(response.status_counts);
 
@@ -867,7 +875,9 @@ export default function DocumentManager() {
         if (response.pagination.total_count < query.pageSize && query.pageSize !== 10) {
           handlePageSizeChange(10);
         } else {
-          setPagination(response.pagination);
+          // Manual refresh always requests page 1; same rule as
+          // updateComponentState — the page shown is the page asked for.
+          setPagination({ ...response.pagination, page: 1 });
           setCurrentPageDocs(response.documents);
           setStatusCounts(response.status_counts);
 
@@ -906,7 +916,10 @@ export default function DocumentManager() {
             if (!isMountedRef.current || isStaleRequest()) return;
 
             setPageByStatus(prev => ({ ...prev, [query.statusFilter]: lastPage }));
-            updateComponentState(lastPageResponse);
+            // Explicit: pageByStatus is only read when the status filter
+            // changes, so this call is the only thing moving pagination.page
+            // to the corrected page.
+            updateComponentState(lastPageResponse, lastPage);
             return;
           }
         }
@@ -916,7 +929,7 @@ export default function DocumentManager() {
             ? prev
             : { ...prev, [query.statusFilter]: pageToFetch }
         ));
-        updateComponentState(response);
+        updateComponentState(response, pageToFetch);
       }
 
     } catch (err) {

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -952,17 +952,28 @@ export default function DocumentManager() {
         // it below.
 
         if (errorClassification.shouldShowToast) {
-          // One notice, not one per failure. A backend that is down is polled
-          // for as long as the tab is open (capped by the breaker's backoff at
-          // roughly one probe a minute), and nothing else in the UI reports it
-          // — a failed /health only feeds the API key alert — so going silent
-          // would leave the list stale without saying so.
+          // One notice for an ongoing outage, not one per failed poll. Every
+          // retryable failure means the list is stale and staying stale, so the
+          // notice stands until a response clears it (fetchPage dismisses it on
+          // success). StatusIndicator's red dot covers the plain "backend is
+          // unreachable" case, but not this one: it tracks /health, so a
+          // backend that answers /health while /documents/paginated keeps
+          // failing shows green over a frozen list, and it is not rendered at
+          // all when the user turns health checks off.
           //
-          // Read AFTER the breaker update above: a permanent 4xx closes the
-          // breaker, and that toast should auto-dismiss like any other.
+          // The stable id alone is NOT enough: it merges into a toast that is
+          // still on screen, and the default 4s lifetime always expires before
+          // the next poll (5s at its fastest, 30s once health drops). Every
+          // failure would create a fresh toast, which is the flood this is
+          // meant to remove. Gating persistence on the breaker being OPEN had
+          // the same hole for the failures that precede the threshold.
+          //
+          // A permanent 4xx is not an outage — the backend answered, and the
+          // breaker has just been cleared above — so it keeps the ordinary
+          // auto-dismissing toast.
           toast.error(t('documentPanel.documentManager.errors.loadFailed', { error: errorMessage(err) }), {
             id: DOCUMENT_REFRESH_FAILURE_TOAST_ID,
-            duration: circuitBreakerRef.current.isOpen ? Infinity : undefined
+            duration: errorClassification.shouldRetry ? Infinity : undefined
           });
         }
       }

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -467,10 +467,14 @@ export default function DocumentManager() {
   const prevPipelineActiveRef = useRef<boolean | undefined>(undefined);
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const latestRefreshRequestVersionRef = useRef(0);
-  // Throttle gate: all auto-driven /documents/paginated entrances funnel through
-  // refreshDocumentsThrottled() to enforce a minimum 2s wall-clock interval.
+  // Throttle gate: every /documents/paginated entrance that is not a direct
+  // page/filter/sort change funnels through refreshDocumentsThrottled() to
+  // enforce a minimum 2s wall-clock interval.
   const lastPaginatedAtRef = useRef(0);
   const pendingPaginatedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Intent tag the pending trailing timer will fire with. Held outside the
+  // closure so a user-intent call arriving during the wait can upgrade it.
+  const pendingPaginatedIsAutoRef = useRef(true);
   // Activity probe: exponential-backoff burst of /health calls that stops once
   // pipelineActive flips true. Holds the pending setTimeout ids so re-entry can
   // reset the schedule to t=0.
@@ -1006,19 +1010,32 @@ export default function DocumentManager() {
   // here. If the wall-clock gap since the last paginated request is >= 2s, fire
   // immediately; otherwise schedule a single trailing call at the 2s boundary
   // and drop any further calls into that pending slot (natural coalescing).
-  const refreshDocumentsThrottled = useCallback(() => {
-    const fire = () => {
+  const refreshDocumentsThrottled = useCallback((options: { auto?: boolean } = {}) => {
+    // Defaults to automatic: the timers are the common caller. Callers that
+    // follow a user action (upload, scan, delete) pass auto: false so the
+    // breaker cannot refuse the refresh their action earned.
+    const auto = options.auto ?? true
+    const fire = (isAuto: boolean) => {
       lastPaginatedAtRef.current = Date.now()
-      handleIntelligentRefresh({ auto: true }).catch((err) => {
+      handleIntelligentRefresh({ auto: isAuto }).catch((err) => {
         console.error('Throttled document refresh failed:', err)
       })
     }
     const gap = Date.now() - lastPaginatedAtRef.current
     if (gap >= 2000) {
-      fire()
+      fire(auto)
       return
     }
-    if (pendingPaginatedTimerRef.current !== null) return
+    if (pendingPaginatedTimerRef.current !== null) {
+      // A user-intent call arriving while an automatic trailing timer waits
+      // must UPGRADE it, not be dropped — the same defect the refresh queue's
+      // pending slot had, one layer up. The tag decides whether the queue's
+      // admission gate may refuse this request 2s from now, so dropping the
+      // call here would make the queue's priority rule unreachable.
+      // Monotonic: once intent, intent for the rest of this window.
+      if (!auto) pendingPaginatedIsAutoRef.current = false
+      return
+    }
     // Snapshot the query identity. If page/filter/sort changes while we wait,
     // the page-change useEffect bumps latestRefreshRequestVersionRef AND fires
     // its own paginated request on the new query. Our trailing closure still
@@ -1027,11 +1044,12 @@ export default function DocumentManager() {
     // (its requestVersion would be the newly-bumped value, so the in-flight
     // stale-check inside runRefreshRequest can't catch it).
     const versionAtSchedule = latestRefreshRequestVersionRef.current
+    pendingPaginatedIsAutoRef.current = auto
     pendingPaginatedTimerRef.current = setTimeout(() => {
       pendingPaginatedTimerRef.current = null
       if (!isMountedRef.current) return
       if (versionAtSchedule !== latestRefreshRequestVersionRef.current) return
-      fire()
+      fire(pendingPaginatedIsAutoRef.current)
     }, 2000 - gap)
   }, [handleIntelligentRefresh]);
 
@@ -1050,6 +1068,11 @@ export default function DocumentManager() {
     const timers: ReturnType<typeof setTimeout>[] = []
     const probeSchedule = [0, 1000, 2000, 4000, 8000, 16000] as const
     const refreshAt = new Set<number>([0, 2000, 4000, 8000, 16000])
+    // The probe follows a user action (scan / upload), so its FIRST refresh
+    // carries that intent and must not be refusable by the breaker. The rest
+    // of the burst is speculative — it polls for work the action may have
+    // started — so tagging all five as intent would let one click bypass the
+    // breaker five times.
     const cleanup = () => {
       timers.forEach((id) => clearTimeout(id))
       if (probeTimersRef.current === timers) {
@@ -1073,7 +1096,7 @@ export default function DocumentManager() {
           return
         }
         if (refreshAt.has(delay)) {
-          refreshDocumentsThrottled()
+          refreshDocumentsThrottled({ auto: delay !== 0 })
         }
         // Exit conditions (in priority order):
         //  - pipelineActive=true AND the document list has caught up: the 5s
@@ -1173,7 +1196,7 @@ export default function DocumentManager() {
         // scanning_skipped_pipeline_busy: a single check+refresh is enough,
         // no need to start the probe (pipeline is already active).
         useBackendState.getState().check().catch(() => undefined);
-        refreshDocumentsThrottled();
+        refreshDocumentsThrottled({ auto: false });
       }
     } catch (err) {
       if (isMountedRef.current) {
@@ -1296,9 +1319,13 @@ export default function DocumentManager() {
     // Reset health check timer with 1 second delay to avoid race condition
     useBackendState.getState().resetHealthCheckTimerDelayed(1000)
 
+    // A completed delete is user intent: refresh unconditionally rather than
+    // waiting for a poll tick the breaker may refuse.
+    refreshDocumentsThrottled({ auto: false })
+
     // Schedule a health check 2 seconds after successful clear
     startPollingInterval(2000)
-  }, [startPollingInterval])
+  }, [refreshDocumentsThrottled, startPollingInterval])
 
   // Handle documents cleared callback with proper interval reset
   const handleDocumentsCleared = useCallback(async () => {
@@ -1459,7 +1486,7 @@ export default function DocumentManager() {
             ) : null}
             <UploadDocumentsDialog
               onUploadBatchAccepted={() => startActivityProbe('upload')}
-              onDocumentsUploaded={async () => { refreshDocumentsThrottled() }}
+              onDocumentsUploaded={async () => { refreshDocumentsThrottled({ auto: false }) }}
             />
             <PipelineStatusDialog
               open={showPipelineStatus}

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -54,12 +54,14 @@ import {
 } from '@/features/documentStatusFilters'
 import { hasDocumentWarning } from '@/features/documentRecoveryWarnings'
 import {
-  evaluateCircuitBreaker,
+  admitCircuitBreakerRequest,
   initialCircuitBreakerState,
+  isCircuitBreakerBlocked,
   recordCircuitBreakerFailure,
   resetCircuitBreaker,
   type CircuitBreakerState
 } from '@/features/documentRefreshCircuitBreaker'
+import { classifyDocumentRefreshError } from '@/features/documentRefreshErrors'
 
 type StatusDisplayConfig = {
   labelKey: string
@@ -370,6 +372,10 @@ type RefreshRequest =
     query: QuerySnapshot;
     customTimeout?: number;
     requestVersion: number;
+    // Issued by the polling timer / activity probe rather than by a user
+    // action. Only these are subject to the circuit breaker: a page change or
+    // a manual refresh is an explicit intent and stays the escape hatch.
+    auto?: boolean;
   }
   | {
     type: 'manual';
@@ -750,43 +756,29 @@ export default function DocumentManager() {
   }, []);
 
 
-  // Enhanced error classification
-  const classifyError = useCallback((error: any) => {
-    if (error.name === 'AbortError') {
-      return { type: 'cancelled', shouldRetry: false, shouldShowToast: false };
-    }
-
-    if (error.message === 'Request timeout') {
-      return { type: 'timeout', shouldRetry: true, shouldShowToast: true };
-    }
-
-    if (error.message?.includes('Network Error') || error.code === 'NETWORK_ERROR') {
-      return { type: 'network', shouldRetry: true, shouldShowToast: true };
-    }
-
-    if (error.status >= 500) {
-      return { type: 'server', shouldRetry: true, shouldShowToast: true };
-    }
-
-    if (error.status >= 400 && error.status < 500) {
-      return { type: 'client', shouldRetry: false, shouldShowToast: true };
-    }
-
-    return { type: 'unknown', shouldRetry: true, shouldShowToast: true };
-  }, []);
-
   // Circuit breaker utility functions. State lives in a ref, not useState: the
   // breaker is read from timer callbacks only, and a state write would change
   // startPollingInterval's identity and make the polling useEffect tear down
   // and recreate the interval, resetting its phase on every failure.
-  const isCircuitBreakerOpen = useCallback(() => {
-    const { state, isOpen } = evaluateCircuitBreaker(
+  // Ask for permission to issue one automatic request. Past the backoff
+  // deadline this admits a single half-open probe and keeps the breaker open
+  // until that probe settles, so the ticks that arrive during its (up to 30s)
+  // lifetime do not slip through behind it.
+  const admitAutomaticRefresh = useCallback(() => {
+    const { state, admitted } = admitCircuitBreakerRequest(
       circuitBreakerRef.current,
       Date.now()
     );
     circuitBreakerRef.current = state;
-    return isOpen;
+    return admitted;
   }, []);
+
+  // Read-only check for a request that was already queued: it must not take
+  // the half-open slot, so it only gets to run while the breaker is closed.
+  const isAutomaticRefreshBlocked = useCallback(
+    () => isCircuitBreakerBlocked(circuitBreakerRef.current),
+    []
+  );
 
   const recordFailure = useCallback(() => {
     circuitBreakerRef.current = recordCircuitBreakerFailure(
@@ -907,7 +899,7 @@ export default function DocumentManager() {
 
     } catch (err) {
       if (isMountedRef.current) {
-        const errorClassification = classifyError(err);
+        const errorClassification = classifyDocumentRefreshError(err);
 
         if (errorClassification.shouldShowToast) {
           toast.error(t('documentPanel.documentManager.errors.loadFailed', { error: errorMessage(err) }));
@@ -925,7 +917,6 @@ export default function DocumentManager() {
   }, [
     t,
     updateComponentState,
-    classifyError,
     recordFailure,
     recordSuccess,
     handlePageSizeChange,
@@ -939,13 +930,33 @@ export default function DocumentManager() {
       return;
     }
 
+    // A queued automatic refresh must clear the breaker again before it runs:
+    // the request it waited behind may have been the half-open probe, and the
+    // breaker admitted exactly one request, not a follow-up. Dropping it is
+    // safe — the polling timer re-issues one as soon as the breaker allows.
+    const takeNextRequest = (): RefreshRequest | null => {
+      const pending = pendingRefreshRequestRef.current;
+      pendingRefreshRequestRef.current = null;
+
+      if (
+        pending &&
+        pending.type === 'intelligent' &&
+        pending.auto &&
+        isAutomaticRefreshBlocked()
+      ) {
+        return null;
+      }
+
+      return pending;
+    };
+
     const refreshLoopPromise = (async () => {
       let nextRequest: RefreshRequest | null = refreshRequest;
 
       while (nextRequest) {
         pendingRefreshRequestRef.current = null;
         await runRefreshRequest(nextRequest);
-        nextRequest = pendingRefreshRequestRef.current;
+        nextRequest = takeNextRequest();
       }
     })();
 
@@ -959,14 +970,16 @@ export default function DocumentManager() {
       }
       pendingRefreshRequestRef.current = null;
     }
-  }, [runRefreshRequest]);
+  }, [runRefreshRequest, isAutomaticRefreshBlocked]);
 
   // Intelligent refresh function: handles all boundary cases
-  const handleIntelligentRefresh = useCallback(async (
-    targetPage?: number,
-    resetToFirst?: boolean,
+  const handleIntelligentRefresh = useCallback(async (options: {
+    targetPage?: number
+    resetToFirst?: boolean
     customTimeout?: number
-  ) => {
+    auto?: boolean
+  } = {}) => {
+    const { targetPage, resetToFirst, customTimeout, auto } = options
     const page = resetToFirst ? 1 : (targetPage || pagination.page)
     const query = buildQuerySnapshot({ page })
     const requestVersion = latestRefreshRequestVersionRef.current
@@ -975,7 +988,8 @@ export default function DocumentManager() {
       type: 'intelligent',
       query,
       customTimeout,
-      requestVersion
+      requestVersion,
+      auto
     });
   }, [buildQuerySnapshot, enqueueRefresh, pagination.page]);
 
@@ -986,7 +1000,7 @@ export default function DocumentManager() {
   const refreshDocumentsThrottled = useCallback(() => {
     const fire = () => {
       lastPaginatedAtRef.current = Date.now()
-      handleIntelligentRefresh().catch((err) => {
+      handleIntelligentRefresh({ auto: true }).catch((err) => {
         console.error('Throttled document refresh failed:', err)
       })
     }
@@ -1117,7 +1131,7 @@ export default function DocumentManager() {
 
     pollingIntervalRef.current = setInterval(() => {
       if (!isMountedRef.current) return;
-      if (isCircuitBreakerOpen()) return;
+      if (!admitAutomaticRefresh()) return;
       // refreshDocumentsThrottled is fire-and-forget; the breaker is fed from
       // inside runRefreshRequest (recordSuccess on a real response,
       // recordFailure in its catch), never from this tick — a tick proves
@@ -1125,7 +1139,7 @@ export default function DocumentManager() {
       // the breaker from ever opening.
       refreshDocumentsThrottled();
     }, intervalMs);
-  }, [refreshDocumentsThrottled, clearPollingInterval, isCircuitBreakerOpen]);
+  }, [refreshDocumentsThrottled, clearPollingInterval, admitAutomaticRefresh]);
 
   const scanDocuments = useCallback(async () => {
     try {

--- a/lightrag_webui/src/features/documentRefreshCircuitBreaker.test.ts
+++ b/lightrag_webui/src/features/documentRefreshCircuitBreaker.test.ts
@@ -4,9 +4,11 @@ import {
   CIRCUIT_BREAKER_FAILURE_THRESHOLD,
   CIRCUIT_BREAKER_MAX_BACKOFF_MS,
   CIRCUIT_BREAKER_MAX_FAILURE_COUNT,
+  CIRCUIT_BREAKER_PROBE_TIMEOUT_MS,
+  admitCircuitBreakerRequest,
   circuitBreakerBackoffMs,
-  evaluateCircuitBreaker,
   initialCircuitBreakerState,
+  isCircuitBreakerBlocked,
   recordCircuitBreakerFailure,
   resetCircuitBreaker,
   type CircuitBreakerState
@@ -24,13 +26,16 @@ const failTimes = (
   return next
 }
 
+const openBreaker = (now: number): CircuitBreakerState =>
+  failTimes(CIRCUIT_BREAKER_FAILURE_THRESHOLD, now)
+
 describe('documentRefreshCircuitBreaker', () => {
   test('stays closed below the threshold and opens at it', () => {
     const now = 1_000_000
 
     expect(failTimes(1, now).isOpen).toBe(false)
     expect(failTimes(2, now).isOpen).toBe(false)
-    expect(failTimes(CIRCUIT_BREAKER_FAILURE_THRESHOLD, now).isOpen).toBe(true)
+    expect(openBreaker(now).isOpen).toBe(true)
   })
 
   test('backoff is capped instead of growing without bound', () => {
@@ -47,9 +52,9 @@ describe('documentRefreshCircuitBreaker', () => {
   })
 
   test('failure counter is capped', () => {
-    const state = failTimes(50, 1_000_000)
-
-    expect(state.failureCount).toBe(CIRCUIT_BREAKER_MAX_FAILURE_COUNT)
+    expect(failTimes(50, 1_000_000).failureCount).toBe(
+      CIRCUIT_BREAKER_MAX_FAILURE_COUNT
+    )
   })
 
   test('backoff helper clamps at the max delay', () => {
@@ -59,38 +64,96 @@ describe('documentRefreshCircuitBreaker', () => {
     expect(circuitBreakerBackoffMs(30)).toBe(CIRCUIT_BREAKER_MAX_BACKOFF_MS)
   })
 
+  test('admits everything while closed', () => {
+    const decision = admitCircuitBreakerRequest(initialCircuitBreakerState, 1)
+
+    expect(decision.admitted).toBe(true)
+    expect(decision.state).toBe(initialCircuitBreakerState)
+  })
+
   test('blocks requests while the backoff window is open', () => {
     const now = 1_000_000
-    const open = failTimes(CIRCUIT_BREAKER_FAILURE_THRESHOLD, now)
+    const open = openBreaker(now)
 
-    const decision = evaluateCircuitBreaker(open, now + 1)
+    const decision = admitCircuitBreakerRequest(open, now + 1)
 
-    expect(decision.isOpen).toBe(true)
+    expect(decision.admitted).toBe(false)
     expect(decision.state).toEqual(open)
   })
 
-  test('half-opens once the backoff window elapses, decrementing the counter', () => {
+  test('half-open admits exactly one probe and stays open until it settles', () => {
     const now = 1_000_000
-    const open = failTimes(CIRCUIT_BREAKER_FAILURE_THRESHOLD, now)
+    const open = openBreaker(now)
+    const deadline = open.nextRetryTime!
 
-    const decision = evaluateCircuitBreaker(open, open.nextRetryTime!)
+    const first = admitCircuitBreakerRequest(open, deadline)
+    expect(first.admitted).toBe(true)
+    // The breaker must NOT close on admission: closing here is what let every
+    // later poll tick through while the probe was still in flight.
+    expect(first.state.isOpen).toBe(true)
+    expect(first.state.halfOpenSince).toBe(deadline)
+    expect(isCircuitBreakerBlocked(first.state)).toBe(true)
 
-    expect(decision.isOpen).toBe(false)
-    expect(decision.state.isOpen).toBe(false)
-    expect(decision.state.failureCount).toBe(open.failureCount - 1)
-    expect(decision.state.nextRetryTime).toBeNull()
+    // Poll ticks arriving while the probe is unsettled get nothing.
+    for (const offset of [1, 5_000, 10_000, 30_000]) {
+      const next = admitCircuitBreakerRequest(first.state, deadline + offset)
+      expect(next.admitted).toBe(false)
+      expect(next.state).toEqual(first.state)
+    }
   })
 
-  test('a closed breaker is returned untouched', () => {
-    const state = failTimes(1, 1_000_000)
-    const decision = evaluateCircuitBreaker(state, 2_000_000)
+  test('a probe that never settles does not wedge the breaker shut', () => {
+    const now = 1_000_000
+    const open = openBreaker(now)
+    const deadline = open.nextRetryTime!
+    const probing = admitCircuitBreakerRequest(open, deadline).state
 
-    expect(decision.isOpen).toBe(false)
-    expect(decision.state).toBe(state)
+    const stillBlocked = admitCircuitBreakerRequest(
+      probing,
+      deadline + CIRCUIT_BREAKER_PROBE_TIMEOUT_MS - 1
+    )
+    expect(stillBlocked.admitted).toBe(false)
+
+    const readmitted = admitCircuitBreakerRequest(
+      probing,
+      deadline + CIRCUIT_BREAKER_PROBE_TIMEOUT_MS
+    )
+    expect(readmitted.admitted).toBe(true)
+    expect(readmitted.state.halfOpenSince).toBe(
+      deadline + CIRCUIT_BREAKER_PROBE_TIMEOUT_MS
+    )
   })
 
-  test('a real response clears the whole state', () => {
+  test('a failed probe re-arms the backoff and clears the probe slot', () => {
+    const now = 1_000_000
+    const open = openBreaker(now)
+    const deadline = open.nextRetryTime!
+    const probing = admitCircuitBreakerRequest(open, deadline).state
+
+    const failed = recordCircuitBreakerFailure(probing, deadline + 30_000)
+
+    expect(failed.isOpen).toBe(true)
+    expect(failed.halfOpenSince).toBeNull()
+    expect(failed.failureCount).toBe(open.failureCount + 1)
+    expect(failed.nextRetryTime).toBe(
+      deadline + 30_000 + circuitBreakerBackoffMs(failed.failureCount)
+    )
+    expect(admitCircuitBreakerRequest(failed, deadline + 30_001).admitted).toBe(false)
+  })
+
+  test('a successful probe clears the whole state', () => {
     expect(resetCircuitBreaker()).toEqual(initialCircuitBreakerState)
     expect(resetCircuitBreaker()).not.toBe(initialCircuitBreakerState)
+    expect(isCircuitBreakerBlocked(resetCircuitBreaker())).toBe(false)
+  })
+
+  test('isCircuitBreakerBlocked reports the open state without admitting', () => {
+    const now = 1_000_000
+    const open = openBreaker(now)
+
+    // Past the deadline a probe COULD be admitted, but a read-only check must
+    // not hand out that slot — the queued-request path relies on this.
+    expect(isCircuitBreakerBlocked(open)).toBe(true)
+    expect(open.halfOpenSince).toBeNull()
   })
 })

--- a/lightrag_webui/src/features/documentRefreshCircuitBreaker.test.ts
+++ b/lightrag_webui/src/features/documentRefreshCircuitBreaker.test.ts
@@ -11,6 +11,7 @@ import {
   isCircuitBreakerBlocked,
   recordCircuitBreakerFailure,
   resetCircuitBreaker,
+  settleCircuitBreakerProbe,
   type CircuitBreakerState
 } from '@/features/documentRefreshCircuitBreaker'
 
@@ -156,5 +157,92 @@ describe('documentRefreshCircuitBreaker', () => {
     expect(isCircuitBreakerBlocked(open, now + 1)).toBe(true)
     expect(isCircuitBreakerBlocked(open, open.nextRetryTime!)).toBe(false)
     expect(open.halfOpenSince).toBeNull()
+  })
+
+  describe('settleCircuitBreakerProbe', () => {
+    const openWithProbe = (now: number) => {
+      let state = initialCircuitBreakerState
+      for (let i = 0; i < CIRCUIT_BREAKER_FAILURE_THRESHOLD; i += 1) {
+        state = recordCircuitBreakerFailure(state, now)
+      }
+      const admission = admitCircuitBreakerRequest(state, state.nextRetryTime!)
+      expect(admission.admitted).toBe(true)
+      return admission.state
+    }
+
+    test('returns the probe slot without moving the failure counter', () => {
+      const probing = openWithProbe(1_000)
+      const settledAt = probing.halfOpenSince! + 50
+
+      const settled = settleCircuitBreakerProbe(probing, settledAt)
+
+      expect(settled.halfOpenSince).toBeNull()
+      expect(settled.failureCount).toBe(probing.failureCount)
+      expect(settled.isOpen).toBe(true)
+    })
+
+    test('re-stamps the backoff instead of leaving nextRetryTime in the past', () => {
+      // Returning the slot alone is not enough: nextRetryTime is already past
+      // by the time a probe runs, so the very next poll tick would be admitted
+      // as another probe immediately.
+      const probing = openWithProbe(1_000)
+      const settledAt = probing.halfOpenSince! + 50
+
+      const settled = settleCircuitBreakerProbe(probing, settledAt)
+      const expected = settledAt + circuitBreakerBackoffMs(settled.failureCount)
+
+      expect(settled.nextRetryTime).toBe(expected)
+      expect(admitCircuitBreakerRequest(settled, expected - 1).admitted).toBe(false)
+      expect(admitCircuitBreakerRequest(settled, expected).admitted).toBe(true)
+    })
+
+    test('an unsettled probe blocks automatic refreshes for the whole probe timeout', () => {
+      // The regression: a request that recorded neither side left halfOpenSince
+      // stamped, so every tick was refused until CIRCUIT_BREAKER_PROBE_TIMEOUT_MS
+      // — 45s of stalled polling bought by a request that took 50ms.
+      const probing = openWithProbe(1_000)
+      const respondedAt = probing.halfOpenSince! + 50
+
+      expect(admitCircuitBreakerRequest(probing, respondedAt).admitted).toBe(false)
+      expect(
+        admitCircuitBreakerRequest(
+          probing,
+          probing.halfOpenSince! + CIRCUIT_BREAKER_PROBE_TIMEOUT_MS - 1
+        ).admitted
+      ).toBe(false)
+
+      // Settling it releases the breaker on its own backoff instead.
+      const settled = settleCircuitBreakerProbe(probing, respondedAt)
+      expect(settled.nextRetryTime).toBeLessThan(
+        probing.halfOpenSince! + CIRCUIT_BREAKER_PROBE_TIMEOUT_MS
+      )
+    })
+
+    test('is a no-op when no probe is in flight', () => {
+      // The precondition for calling it unconditionally from a finally block.
+      const closed = initialCircuitBreakerState
+      expect(settleCircuitBreakerProbe(closed, 5_000)).toBe(closed)
+
+      const failedOnce = recordCircuitBreakerFailure(closed, 5_000)
+      expect(settleCircuitBreakerProbe(failedOnce, 6_000)).toBe(failedOnce)
+    })
+  })
+
+  test('an answer from the application does not leave a stale failure count', () => {
+    // Consumer contract, pinned here because DocumentManager has no component
+    // test: a permanent 4xx resets the breaker, so failures separated by one
+    // cannot accumulate. CIRCUIT_BREAKER_FAILURE_THRESHOLD documents itself as
+    // CONSECUTIVE failures, and only a reset makes that true.
+    let state = initialCircuitBreakerState
+    state = recordCircuitBreakerFailure(state, 1_000)
+    state = recordCircuitBreakerFailure(state, 2_000)
+    expect(state.isOpen).toBe(false)
+
+    // ... a 403 arrives: the application answered, so the breaker resets.
+    state = resetCircuitBreaker()
+
+    state = recordCircuitBreakerFailure(state, 4_000)
+    expect(state.failureCount).toBe(1)
+    expect(state.isOpen).toBe(false)
   })
 })

--- a/lightrag_webui/src/features/documentRefreshCircuitBreaker.test.ts
+++ b/lightrag_webui/src/features/documentRefreshCircuitBreaker.test.ts
@@ -92,7 +92,7 @@ describe('documentRefreshCircuitBreaker', () => {
     // later poll tick through while the probe was still in flight.
     expect(first.state.isOpen).toBe(true)
     expect(first.state.halfOpenSince).toBe(deadline)
-    expect(isCircuitBreakerBlocked(first.state)).toBe(true)
+    expect(isCircuitBreakerBlocked(first.state, deadline)).toBe(true)
 
     // Poll ticks arriving while the probe is unsettled get nothing.
     for (const offset of [1, 5_000, 10_000, 30_000]) {
@@ -144,16 +144,17 @@ describe('documentRefreshCircuitBreaker', () => {
   test('a successful probe clears the whole state', () => {
     expect(resetCircuitBreaker()).toEqual(initialCircuitBreakerState)
     expect(resetCircuitBreaker()).not.toBe(initialCircuitBreakerState)
-    expect(isCircuitBreakerBlocked(resetCircuitBreaker())).toBe(false)
+    expect(isCircuitBreakerBlocked(resetCircuitBreaker(), 1)).toBe(false)
   })
 
   test('isCircuitBreakerBlocked reports the open state without admitting', () => {
     const now = 1_000_000
     const open = openBreaker(now)
 
-    // Past the deadline a probe COULD be admitted, but a read-only check must
-    // not hand out that slot — the queued-request path relies on this.
-    expect(isCircuitBreakerBlocked(open)).toBe(true)
+    // Blocked inside the backoff window, and unblocked at the deadline — but
+    // either way the read must not hand out the half-open slot.
+    expect(isCircuitBreakerBlocked(open, now + 1)).toBe(true)
+    expect(isCircuitBreakerBlocked(open, open.nextRetryTime!)).toBe(false)
     expect(open.halfOpenSince).toBeNull()
   })
 })

--- a/lightrag_webui/src/features/documentRefreshCircuitBreaker.test.ts
+++ b/lightrag_webui/src/features/documentRefreshCircuitBreaker.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+  CIRCUIT_BREAKER_MAX_BACKOFF_MS,
+  CIRCUIT_BREAKER_MAX_FAILURE_COUNT,
+  circuitBreakerBackoffMs,
+  evaluateCircuitBreaker,
+  initialCircuitBreakerState,
+  recordCircuitBreakerFailure,
+  resetCircuitBreaker,
+  type CircuitBreakerState
+} from '@/features/documentRefreshCircuitBreaker'
+
+const failTimes = (
+  count: number,
+  now: number,
+  state: CircuitBreakerState = initialCircuitBreakerState
+): CircuitBreakerState => {
+  let next = state
+  for (let i = 0; i < count; i += 1) {
+    next = recordCircuitBreakerFailure(next, now)
+  }
+  return next
+}
+
+describe('documentRefreshCircuitBreaker', () => {
+  test('stays closed below the threshold and opens at it', () => {
+    const now = 1_000_000
+
+    expect(failTimes(1, now).isOpen).toBe(false)
+    expect(failTimes(2, now).isOpen).toBe(false)
+    expect(failTimes(CIRCUIT_BREAKER_FAILURE_THRESHOLD, now).isOpen).toBe(true)
+  })
+
+  test('backoff is capped instead of growing without bound', () => {
+    const now = 1_000_000
+    // The inline implementation this module replaced computed
+    // `Math.pow(2, failureCount) * 1000` with no cap on the exponent or the
+    // counter, so ten consecutive failures produced 2 ** 10 * 1000 =
+    // 1_024_000 ms (~17 minutes) of silence on the document list.
+    const state = failTimes(10, now)
+
+    expect(state.nextRetryTime).not.toBeNull()
+    expect(state.nextRetryTime! - now).toBe(CIRCUIT_BREAKER_MAX_BACKOFF_MS)
+    expect(state.nextRetryTime! - now).not.toBe(2 ** 10 * 1000)
+  })
+
+  test('failure counter is capped', () => {
+    const state = failTimes(50, 1_000_000)
+
+    expect(state.failureCount).toBe(CIRCUIT_BREAKER_MAX_FAILURE_COUNT)
+  })
+
+  test('backoff helper clamps at the max delay', () => {
+    expect(circuitBreakerBackoffMs(3)).toBe(8_000)
+    expect(circuitBreakerBackoffMs(5)).toBe(32_000)
+    expect(circuitBreakerBackoffMs(6)).toBe(CIRCUIT_BREAKER_MAX_BACKOFF_MS)
+    expect(circuitBreakerBackoffMs(30)).toBe(CIRCUIT_BREAKER_MAX_BACKOFF_MS)
+  })
+
+  test('blocks requests while the backoff window is open', () => {
+    const now = 1_000_000
+    const open = failTimes(CIRCUIT_BREAKER_FAILURE_THRESHOLD, now)
+
+    const decision = evaluateCircuitBreaker(open, now + 1)
+
+    expect(decision.isOpen).toBe(true)
+    expect(decision.state).toEqual(open)
+  })
+
+  test('half-opens once the backoff window elapses, decrementing the counter', () => {
+    const now = 1_000_000
+    const open = failTimes(CIRCUIT_BREAKER_FAILURE_THRESHOLD, now)
+
+    const decision = evaluateCircuitBreaker(open, open.nextRetryTime!)
+
+    expect(decision.isOpen).toBe(false)
+    expect(decision.state.isOpen).toBe(false)
+    expect(decision.state.failureCount).toBe(open.failureCount - 1)
+    expect(decision.state.nextRetryTime).toBeNull()
+  })
+
+  test('a closed breaker is returned untouched', () => {
+    const state = failTimes(1, 1_000_000)
+    const decision = evaluateCircuitBreaker(state, 2_000_000)
+
+    expect(decision.isOpen).toBe(false)
+    expect(decision.state).toBe(state)
+  })
+
+  test('a real response clears the whole state', () => {
+    expect(resetCircuitBreaker()).toEqual(initialCircuitBreakerState)
+    expect(resetCircuitBreaker()).not.toBe(initialCircuitBreakerState)
+  })
+})

--- a/lightrag_webui/src/features/documentRefreshCircuitBreaker.ts
+++ b/lightrag_webui/src/features/documentRefreshCircuitBreaker.ts
@@ -98,15 +98,6 @@ export const resetCircuitBreaker = (): CircuitBreakerState => ({
   ...initialCircuitBreakerState
 })
 
-/**
- * Read-only view for callers that must not admit a probe — e.g. deciding
- * whether a queued automatic refresh may still run after the request ahead of
- * it settled. A half-open probe belongs to whoever was admitted by
- * `admitCircuitBreakerRequest`, so anything else stays blocked while the
- * breaker is open.
- */
-export const isCircuitBreakerBlocked = (state: CircuitBreakerState): boolean =>
-  state.isOpen
 
 /**
  * Ask the breaker to admit one request, applying the half-open transition.
@@ -140,3 +131,15 @@ export const admitCircuitBreakerRequest = (
 
   return { state, admitted: false }
 }
+
+/**
+ * Read-only "would a request be admitted right now?" check, for callers that
+ * must not consume the half-open slot — e.g. a polling tick deciding whether
+ * it is worth walking the throttle gate at all. The admission itself must
+ * still go through admitCircuitBreakerRequest at the point the request is
+ * issued.
+ */
+export const isCircuitBreakerBlocked = (
+  state: CircuitBreakerState,
+  now: number
+): boolean => !admitCircuitBreakerRequest(state, now).admitted

--- a/lightrag_webui/src/features/documentRefreshCircuitBreaker.ts
+++ b/lightrag_webui/src/features/documentRefreshCircuitBreaker.ts
@@ -19,11 +19,17 @@
  *    success hook right after a fire-and-forget refresh, so every polling tick
  *    cleared the failure counter and the breaker never opened at all.
  * 3. **Half-open admits exactly one probe.** The breaker stays OPEN while the
- *    probe is in flight; only its settlement (recordSuccess / recordFailure)
- *    moves it on. Simply flipping `isOpen` to false at the deadline would let
- *    every subsequent poll tick through for as long as the probe takes to
- *    fail — with a 5s poll cadence and a 30s request timeout, that is several
- *    ticks, and the request they queue up would bypass the breaker entirely.
+ *    probe is in flight; only its settlement moves it on. Simply flipping
+ *    `isOpen` to false at the deadline would let every subsequent poll tick
+ *    through for as long as the probe takes to fail — with a 5s poll cadence
+ *    and a 30s request timeout, that is several ticks, and the request they
+ *    queue up would bypass the breaker entirely.
+ * 4. **Every outcome settles the probe.** There are three, not two:
+ *    recordSuccess (a response arrived), recordCircuitBreakerFailure (no
+ *    answer, or an answer that is itself a back-off signal), and
+ *    settleCircuitBreakerProbe (the outcome proves nothing but the slot must
+ *    still be returned). A path that records none of them holds the slot until
+ *    the probe timeout, stalling automatic refreshes for 45s at a time.
  */
 
 export type CircuitBreakerState = {
@@ -49,12 +55,17 @@ export const CIRCUIT_BREAKER_MAX_FAILURE_COUNT = 6
 export const CIRCUIT_BREAKER_MAX_BACKOFF_MS = 60_000
 
 /**
- * How long a half-open probe may stay unsettled before the breaker admits
- * another one. Every admitted probe should settle through recordSuccess /
- * recordFailure (the paginated fetch has its own 30s timeout), but an admission
- * that never turns into a request — the caller's throttle gate can coalesce it
- * into an already-running refresh — would otherwise wedge the breaker closed
- * forever. Must stay above the request timeout so it never races a live probe.
+ * Last-resort ceiling on how long a half-open probe may stay unsettled before
+ * the breaker admits another one.
+ *
+ * Every outcome settles the probe at once — success and retryable failure
+ * through recordSuccess / recordFailure, everything else through
+ * settleCircuitBreakerProbe at the caller's single exit point. If this timeout
+ * is ever what unblocks the breaker, a settle path was missed; that is a bug,
+ * not the design. It exists only so such a bug degrades into a slow retry
+ * instead of a permanent wedge.
+ *
+ * Must stay above the request timeout so it never races a live probe.
  */
 export const CIRCUIT_BREAKER_PROBE_TIMEOUT_MS = 45_000
 
@@ -97,6 +108,39 @@ export const recordCircuitBreakerFailure = (
 export const resetCircuitBreaker = (): CircuitBreakerState => ({
   ...initialCircuitBreakerState
 })
+
+/**
+ * Settle a half-open probe whose outcome says nothing about reachability — a
+ * cancelled request, or a caller that returned before it could record either
+ * side.
+ *
+ * The slot is held for the lifetime of ONE real request and every exit path
+ * must return it: leaving `halfOpenSince` stamped blocks every automatic
+ * refresh until CIRCUIT_BREAKER_PROBE_TIMEOUT_MS, which is 45s of stalled
+ * polling bought by a request that may have taken 50ms.
+ *
+ * The failure counter must not move — nothing was learned — but the backoff
+ * window IS re-stamped: `nextRetryTime` is already in the past by the time a
+ * probe is running, so returning the slot without it would let the very next
+ * poll tick admit another probe immediately.
+ *
+ * A no-op when no probe is in flight, so callers may invoke it unconditionally
+ * from a single choke point.
+ */
+export const settleCircuitBreakerProbe = (
+  state: CircuitBreakerState,
+  now: number
+): CircuitBreakerState => {
+  if (state.halfOpenSince === null) {
+    return state
+  }
+
+  return {
+    ...state,
+    halfOpenSince: null,
+    nextRetryTime: now + circuitBreakerBackoffMs(state.failureCount)
+  }
+}
 
 
 /**

--- a/lightrag_webui/src/features/documentRefreshCircuitBreaker.ts
+++ b/lightrag_webui/src/features/documentRefreshCircuitBreaker.ts
@@ -1,0 +1,108 @@
+/**
+ * Circuit breaker state machine for the document list refresh path
+ * (`POST /documents/paginated`).
+ *
+ * Extracted from DocumentManager so the transitions are unit-testable — the
+ * project has no React component test setup, so inline component state cannot
+ * be covered. Same pattern as documentStatusFilters / documentRecoveryWarnings.
+ *
+ * Two invariants this module exists to enforce:
+ *
+ * 1. **Backoff is bounded.** The previous inline implementation used a raw
+ *    `2 ** failureCount * 1000` with no cap on either the exponent or the
+ *    counter, so a backend that stayed down long enough could silence the
+ *    document list for tens of minutes (failureCount=10 -> ~17 min). The
+ *    counter is capped at CIRCUIT_BREAKER_MAX_FAILURE_COUNT and the delay at
+ *    CIRCUIT_BREAKER_MAX_BACKOFF_MS.
+ * 2. **Success is success.** Callers must record a success only when a
+ *    response actually came back. The previous implementation called its
+ *    success hook right after a fire-and-forget refresh, so every polling tick
+ *    cleared the failure counter and the breaker never opened at all.
+ */
+
+export type CircuitBreakerState = {
+  isOpen: boolean
+  failureCount: number
+  lastFailureTime: number | null
+  nextRetryTime: number | null
+}
+
+/** Consecutive failures required to open the breaker. */
+export const CIRCUIT_BREAKER_FAILURE_THRESHOLD = 3
+
+/** Hard cap on the failure counter, which bounds the exponent. */
+export const CIRCUIT_BREAKER_MAX_FAILURE_COUNT = 6
+
+/** Hard cap on the backoff delay. */
+export const CIRCUIT_BREAKER_MAX_BACKOFF_MS = 60_000
+
+export const initialCircuitBreakerState: CircuitBreakerState = {
+  isOpen: false,
+  failureCount: 0,
+  lastFailureTime: null,
+  nextRetryTime: null
+}
+
+/** Exponential backoff for `failureCount`, clamped to the max delay. */
+export const circuitBreakerBackoffMs = (failureCount: number): number =>
+  Math.min(2 ** failureCount * 1000, CIRCUIT_BREAKER_MAX_BACKOFF_MS)
+
+/**
+ * Record one failed request. Opens the breaker once the threshold is reached
+ * and stamps the next retry time.
+ */
+export const recordCircuitBreakerFailure = (
+  state: CircuitBreakerState,
+  now: number
+): CircuitBreakerState => {
+  const failureCount = Math.min(
+    state.failureCount + 1,
+    CIRCUIT_BREAKER_MAX_FAILURE_COUNT
+  )
+  const isOpen = failureCount >= CIRCUIT_BREAKER_FAILURE_THRESHOLD
+
+  return {
+    isOpen,
+    failureCount,
+    lastFailureTime: now,
+    nextRetryTime: isOpen ? now + circuitBreakerBackoffMs(failureCount) : null
+  }
+}
+
+/** A real response came back: clear everything. */
+export const resetCircuitBreaker = (): CircuitBreakerState => ({
+  ...initialCircuitBreakerState
+})
+
+/**
+ * Decide whether a request may go out now, applying the half-open transition.
+ *
+ * Returns the (possibly updated) state alongside the decision so the caller
+ * can store it — the half-open step mutates the counter, and dropping that
+ * write would re-open the breaker on the very next evaluation.
+ */
+export const evaluateCircuitBreaker = (
+  state: CircuitBreakerState,
+  now: number
+): { state: CircuitBreakerState; isOpen: boolean } => {
+  if (!state.isOpen) {
+    return { state, isOpen: false }
+  }
+
+  if (state.nextRetryTime !== null && now >= state.nextRetryTime) {
+    // Half-open: let exactly one request through. The counter is decremented
+    // rather than cleared so a backend that is still down re-opens with a
+    // comparable delay instead of restarting the ramp from zero.
+    return {
+      state: {
+        ...state,
+        isOpen: false,
+        failureCount: Math.max(0, state.failureCount - 1),
+        nextRetryTime: null
+      },
+      isOpen: false
+    }
+  }
+
+  return { state, isOpen: true }
+}

--- a/lightrag_webui/src/features/documentRefreshCircuitBreaker.ts
+++ b/lightrag_webui/src/features/documentRefreshCircuitBreaker.ts
@@ -6,7 +6,7 @@
  * project has no React component test setup, so inline component state cannot
  * be covered. Same pattern as documentStatusFilters / documentRecoveryWarnings.
  *
- * Two invariants this module exists to enforce:
+ * Three invariants this module exists to enforce:
  *
  * 1. **Backoff is bounded.** The previous inline implementation used a raw
  *    `2 ** failureCount * 1000` with no cap on either the exponent or the
@@ -18,6 +18,12 @@
  *    response actually came back. The previous implementation called its
  *    success hook right after a fire-and-forget refresh, so every polling tick
  *    cleared the failure counter and the breaker never opened at all.
+ * 3. **Half-open admits exactly one probe.** The breaker stays OPEN while the
+ *    probe is in flight; only its settlement (recordSuccess / recordFailure)
+ *    moves it on. Simply flipping `isOpen` to false at the deadline would let
+ *    every subsequent poll tick through for as long as the probe takes to
+ *    fail — with a 5s poll cadence and a 30s request timeout, that is several
+ *    ticks, and the request they queue up would bypass the breaker entirely.
  */
 
 export type CircuitBreakerState = {
@@ -25,6 +31,12 @@ export type CircuitBreakerState = {
   failureCount: number
   lastFailureTime: number | null
   nextRetryTime: number | null
+  /**
+   * When the half-open probe was admitted, or null when no probe is in
+   * flight. The breaker keeps `isOpen: true` for its duration: a probe is an
+   * exception granted to one request, not a state change.
+   */
+  halfOpenSince: number | null
 }
 
 /** Consecutive failures required to open the breaker. */
@@ -36,11 +48,22 @@ export const CIRCUIT_BREAKER_MAX_FAILURE_COUNT = 6
 /** Hard cap on the backoff delay. */
 export const CIRCUIT_BREAKER_MAX_BACKOFF_MS = 60_000
 
+/**
+ * How long a half-open probe may stay unsettled before the breaker admits
+ * another one. Every admitted probe should settle through recordSuccess /
+ * recordFailure (the paginated fetch has its own 30s timeout), but an admission
+ * that never turns into a request — the caller's throttle gate can coalesce it
+ * into an already-running refresh — would otherwise wedge the breaker closed
+ * forever. Must stay above the request timeout so it never races a live probe.
+ */
+export const CIRCUIT_BREAKER_PROBE_TIMEOUT_MS = 45_000
+
 export const initialCircuitBreakerState: CircuitBreakerState = {
   isOpen: false,
   failureCount: 0,
   lastFailureTime: null,
-  nextRetryTime: null
+  nextRetryTime: null,
+  halfOpenSince: null
 }
 
 /** Exponential backoff for `failureCount`, clamped to the max delay. */
@@ -48,8 +71,8 @@ export const circuitBreakerBackoffMs = (failureCount: number): number =>
   Math.min(2 ** failureCount * 1000, CIRCUIT_BREAKER_MAX_BACKOFF_MS)
 
 /**
- * Record one failed request. Opens the breaker once the threshold is reached
- * and stamps the next retry time.
+ * Record one failed request, closing any half-open probe. Opens the breaker
+ * once the threshold is reached and stamps the next retry time.
  */
 export const recordCircuitBreakerFailure = (
   state: CircuitBreakerState,
@@ -65,44 +88,55 @@ export const recordCircuitBreakerFailure = (
     isOpen,
     failureCount,
     lastFailureTime: now,
-    nextRetryTime: isOpen ? now + circuitBreakerBackoffMs(failureCount) : null
+    nextRetryTime: isOpen ? now + circuitBreakerBackoffMs(failureCount) : null,
+    halfOpenSince: null
   }
 }
 
-/** A real response came back: clear everything. */
+/** A real response came back: clear everything, probe included. */
 export const resetCircuitBreaker = (): CircuitBreakerState => ({
   ...initialCircuitBreakerState
 })
 
 /**
- * Decide whether a request may go out now, applying the half-open transition.
+ * Read-only view for callers that must not admit a probe — e.g. deciding
+ * whether a queued automatic refresh may still run after the request ahead of
+ * it settled. A half-open probe belongs to whoever was admitted by
+ * `admitCircuitBreakerRequest`, so anything else stays blocked while the
+ * breaker is open.
+ */
+export const isCircuitBreakerBlocked = (state: CircuitBreakerState): boolean =>
+  state.isOpen
+
+/**
+ * Ask the breaker to admit one request, applying the half-open transition.
  *
  * Returns the (possibly updated) state alongside the decision so the caller
- * can store it — the half-open step mutates the counter, and dropping that
- * write would re-open the breaker on the very next evaluation.
+ * can store it — admitting a probe stamps `halfOpenSince`, and dropping that
+ * write would admit an unbounded number of them.
  */
-export const evaluateCircuitBreaker = (
+export const admitCircuitBreakerRequest = (
   state: CircuitBreakerState,
   now: number
-): { state: CircuitBreakerState; isOpen: boolean } => {
+): { state: CircuitBreakerState; admitted: boolean } => {
   if (!state.isOpen) {
-    return { state, isOpen: false }
+    return { state, admitted: true }
+  }
+
+  if (state.halfOpenSince !== null) {
+    // A probe is in flight. Admit a replacement only once it is so old that it
+    // cannot still be a live request (see CIRCUIT_BREAKER_PROBE_TIMEOUT_MS).
+    if (now - state.halfOpenSince < CIRCUIT_BREAKER_PROBE_TIMEOUT_MS) {
+      return { state, admitted: false }
+    }
+    return { state: { ...state, halfOpenSince: now }, admitted: true }
   }
 
   if (state.nextRetryTime !== null && now >= state.nextRetryTime) {
-    // Half-open: let exactly one request through. The counter is decremented
-    // rather than cleared so a backend that is still down re-opens with a
-    // comparable delay instead of restarting the ramp from zero.
-    return {
-      state: {
-        ...state,
-        isOpen: false,
-        failureCount: Math.max(0, state.failureCount - 1),
-        nextRetryTime: null
-      },
-      isOpen: false
-    }
+    // Half-open: admit exactly one probe. `isOpen` deliberately stays true —
+    // the breaker closes only when the probe reports success.
+    return { state: { ...state, halfOpenSince: now }, admitted: true }
   }
 
-  return { state, isOpen: true }
+  return { state, admitted: false }
 }

--- a/lightrag_webui/src/features/documentRefreshErrors.test.ts
+++ b/lightrag_webui/src/features/documentRefreshErrors.test.ts
@@ -80,6 +80,19 @@ describe('classifyDocumentRefreshError', () => {
     expect(classifyDocumentRefreshError(coded).type).toBe('network')
   })
 
+  test('the code axios actually uses is recognised', () => {
+    // AxiosError.ERR_NETWORK, not 'NETWORK_ERROR'. The message fallback covered
+    // this in practice, but only while the browser's ProgressEvent carries no
+    // message of its own — adapters/xhr.js prefers event.message when present.
+    const coded = new Error('') as Error & { code?: string }
+    coded.code = 'ERR_NETWORK'
+
+    const classification = classifyDocumentRefreshError(coded)
+    expect(classification.type).toBe('network')
+    expect(classification.shouldRetry).toBe(true)
+    expect(classification.provesBackendResponsive).toBe(false)
+  })
+
   test('anything unrecognised stays retryable', () => {
     expect(classifyDocumentRefreshError(new Error('boom'))).toEqual({
       type: 'unknown',

--- a/lightrag_webui/src/features/documentRefreshErrors.test.ts
+++ b/lightrag_webui/src/features/documentRefreshErrors.test.ts
@@ -19,7 +19,8 @@ describe('classifyDocumentRefreshError', () => {
     expect(classifyDocumentRefreshError(error)).toEqual({
       type: 'cancelled',
       shouldRetry: false,
-      shouldShowToast: false
+      shouldShowToast: false,
+      provesBackendResponsive: false
     })
   })
 
@@ -30,7 +31,8 @@ describe('classifyDocumentRefreshError', () => {
     expect(classifyDocumentRefreshError(new Error(documentFetchTimeoutMessage))).toEqual({
       type: 'timeout',
       shouldRetry: true,
-      shouldShowToast: true
+      shouldShowToast: true,
+      provesBackendResponsive: false
     })
   })
 
@@ -44,6 +46,9 @@ describe('classifyDocumentRefreshError', () => {
       expect(classification.type).toBe('client')
       expect(classification.shouldRetry).toBe(false)
       expect(classification.shouldShowToast).toBe(true)
+      // The application answered, so the reachability breaker must be cleared
+      // rather than left holding a stale failure count.
+      expect(classification.provesBackendResponsive).toBe(true)
     }
   })
 
@@ -60,6 +65,10 @@ describe('classifyDocumentRefreshError', () => {
       const classification = classifyDocumentRefreshError(httpError(status))
       expect(classification.type).toBe('server')
       expect(classification.shouldRetry).toBe(true)
+      // A 502/504 is the standard signal of a stalled backend or the proxy in
+      // front of it — exactly what the breaker exists to detect. It must never
+      // read as proof of life, however much it is "an HTTP response".
+      expect(classification.provesBackendResponsive).toBe(false)
     }
   })
 
@@ -75,7 +84,8 @@ describe('classifyDocumentRefreshError', () => {
     expect(classifyDocumentRefreshError(new Error('boom'))).toEqual({
       type: 'unknown',
       shouldRetry: true,
-      shouldShowToast: true
+      shouldShowToast: true,
+      provesBackendResponsive: false
     })
     expect(classifyDocumentRefreshError(null).type).toBe('unknown')
     expect(classifyDocumentRefreshError(undefined).type).toBe('unknown')

--- a/lightrag_webui/src/features/documentRefreshErrors.test.ts
+++ b/lightrag_webui/src/features/documentRefreshErrors.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test'
+
+import { classifyDocumentRefreshError } from '@/features/documentRefreshErrors'
+import { documentFetchTimeoutMessage } from '@/lib/constants'
+
+// Shaped like what the API layer's response interceptor throws.
+const httpError = (status: number): Error & { status?: number } => {
+  const error = new Error(`${status} Error\n{}\n/documents/paginated`) as Error & {
+    status?: number
+  }
+  error.status = status
+  return error
+}
+
+describe('classifyDocumentRefreshError', () => {
+  test('an aborted request is neither retried nor reported', () => {
+    const error = new DOMException('Aborted', 'AbortError')
+
+    expect(classifyDocumentRefreshError(error)).toEqual({
+      type: 'cancelled',
+      shouldRetry: false,
+      shouldShowToast: false
+    })
+  })
+
+  test('the paginated fetch timeout is retryable', () => {
+    // Pinned against the actual message getDocumentsPaginatedWithTimeout
+    // rejects with; the previous inline classifier matched 'Request timeout',
+    // which never occurs, so timeouts silently fell through to 'unknown'.
+    expect(classifyDocumentRefreshError(new Error(documentFetchTimeoutMessage))).toEqual({
+      type: 'timeout',
+      shouldRetry: true,
+      shouldShowToast: true
+    })
+  })
+
+  test('permanent client errors must not count against the breaker', () => {
+    // The interceptor used to throw a bare Error with the status only inside
+    // the message, so these landed in 'unknown' -> shouldRetry: true. With a
+    // breaker that actually works, three of them in a row would open it and
+    // stall the document list on a condition retrying can never fix.
+    for (const status of [400, 403, 404, 422]) {
+      const classification = classifyDocumentRefreshError(httpError(status))
+      expect(classification.type).toBe('client')
+      expect(classification.shouldRetry).toBe(false)
+      expect(classification.shouldShowToast).toBe(true)
+    }
+  })
+
+  test('transient client errors keep the retry treatment', () => {
+    for (const status of [408, 429]) {
+      const classification = classifyDocumentRefreshError(httpError(status))
+      expect(classification.type).toBe('client')
+      expect(classification.shouldRetry).toBe(true)
+    }
+  })
+
+  test('server errors are retryable', () => {
+    for (const status of [500, 502, 503, 504]) {
+      const classification = classifyDocumentRefreshError(httpError(status))
+      expect(classification.type).toBe('server')
+      expect(classification.shouldRetry).toBe(true)
+    }
+  })
+
+  test('network failures are retryable', () => {
+    expect(classifyDocumentRefreshError(new Error('Network Error')).type).toBe('network')
+
+    const coded = new Error('boom') as Error & { code?: string }
+    coded.code = 'NETWORK_ERROR'
+    expect(classifyDocumentRefreshError(coded).type).toBe('network')
+  })
+
+  test('anything unrecognised stays retryable', () => {
+    expect(classifyDocumentRefreshError(new Error('boom'))).toEqual({
+      type: 'unknown',
+      shouldRetry: true,
+      shouldShowToast: true
+    })
+    expect(classifyDocumentRefreshError(null).type).toBe('unknown')
+    expect(classifyDocumentRefreshError(undefined).type).toBe('unknown')
+  })
+})

--- a/lightrag_webui/src/features/documentRefreshErrors.ts
+++ b/lightrag_webui/src/features/documentRefreshErrors.ts
@@ -95,7 +95,18 @@ export const classifyDocumentRefreshError = (
     }
   }
 
-  if (message.includes('Network Error') || candidate?.code === 'NETWORK_ERROR') {
+  // axios reports transport failures as AxiosError.ERR_NETWORK; the legacy
+  // 'NETWORK_ERROR' spelling this used to check never matches anything it
+  // throws. The message test alone is not enough either: axios only falls back
+  // to the literal 'Network Error' when the browser's ProgressEvent carries no
+  // message of its own (adapters/xhr.js), so a browser that supplies one drops
+  // the failure into 'unknown'. Same retry treatment either way, but the type
+  // is what anything reading these classifications branches on.
+  if (
+    message.includes('Network Error') ||
+    candidate?.code === 'ERR_NETWORK' ||
+    candidate?.code === 'NETWORK_ERROR'
+  ) {
     return {
       type: 'network',
       shouldRetry: true,

--- a/lightrag_webui/src/features/documentRefreshErrors.ts
+++ b/lightrag_webui/src/features/documentRefreshErrors.ts
@@ -1,0 +1,70 @@
+import { documentFetchTimeoutMessage } from '@/lib/constants'
+
+/**
+ * Classification of a failed `/documents/paginated` refresh.
+ *
+ * `shouldRetry` doubles as "counts against the circuit breaker": a permanent
+ * client error is not evidence that the backend is unreachable, so it must not
+ * push the document list into backoff.
+ */
+export type RefreshErrorClassification = {
+  type: 'cancelled' | 'timeout' | 'network' | 'server' | 'client' | 'unknown'
+  shouldRetry: boolean
+  shouldShowToast: boolean
+}
+
+// 408 Request Timeout and 429 Too Many Requests are the two 4xx codes that
+// describe a transient condition, so they keep the retry/backoff treatment.
+const RETRYABLE_CLIENT_STATUSES = new Set([408, 429])
+
+/**
+ * Classify a document-refresh failure.
+ *
+ * Extracted from DocumentManager so the status handling is testable. It reads
+ * `status` off the error, which the API layer's response interceptor attaches
+ * (see toHttpRequestError). Before that existed the interceptor threw a bare
+ * Error, so every 4xx fell through to `unknown` and was treated as retryable —
+ * harmless while the breaker was inert, but with a working breaker three
+ * permanent 403/404/422 responses in a row would have opened it.
+ */
+export const classifyDocumentRefreshError = (
+  error: unknown
+): RefreshErrorClassification => {
+  const candidate = error as {
+    name?: unknown
+    message?: unknown
+    code?: unknown
+    status?: unknown
+  } | null
+
+  if (candidate?.name === 'AbortError') {
+    return { type: 'cancelled', shouldRetry: false, shouldShowToast: false }
+  }
+
+  const message = typeof candidate?.message === 'string' ? candidate.message : ''
+
+  if (message === documentFetchTimeoutMessage) {
+    return { type: 'timeout', shouldRetry: true, shouldShowToast: true }
+  }
+
+  const status = typeof candidate?.status === 'number' ? candidate.status : null
+
+  if (status !== null) {
+    if (status >= 500) {
+      return { type: 'server', shouldRetry: true, shouldShowToast: true }
+    }
+    if (status >= 400) {
+      return {
+        type: 'client',
+        shouldRetry: RETRYABLE_CLIENT_STATUSES.has(status),
+        shouldShowToast: true
+      }
+    }
+  }
+
+  if (message.includes('Network Error') || candidate?.code === 'NETWORK_ERROR') {
+    return { type: 'network', shouldRetry: true, shouldShowToast: true }
+  }
+
+  return { type: 'unknown', shouldRetry: true, shouldShowToast: true }
+}

--- a/lightrag_webui/src/features/documentRefreshErrors.ts
+++ b/lightrag_webui/src/features/documentRefreshErrors.ts
@@ -11,6 +11,23 @@ export type RefreshErrorClassification = {
   type: 'cancelled' | 'timeout' | 'network' | 'server' | 'client' | 'unknown'
   shouldRetry: boolean
   shouldShowToast: boolean
+  /**
+   * The application parsed and routed this request and answered definitively.
+   * That is positive proof the backend is healthy, so the reachability breaker
+   * must be CLEARED, not merely left alone: `failureCount` only ever resets on
+   * proof of life, and keeping a stale count across such an answer lets three
+   * NON-consecutive failures open a breaker whose threshold is documented as
+   * consecutive.
+   *
+   * Deliberately false for 5xx: a 502/504 is the standard signal of a stalled
+   * backend or the proxy in front of it, which is exactly what this breaker
+   * exists to detect. False for a cancellation or a transport failure too — no
+   * answer was received at all.
+   *
+   * `shouldRetry` outranks this at the consumer: a 429 does prove the backend
+   * answered, but it is also an instruction to slow down, so backoff wins.
+   */
+  provesBackendResponsive: boolean
 }
 
 // 408 Request Timeout and 429 Too Many Requests are the two 4xx codes that
@@ -38,33 +55,59 @@ export const classifyDocumentRefreshError = (
   } | null
 
   if (candidate?.name === 'AbortError') {
-    return { type: 'cancelled', shouldRetry: false, shouldShowToast: false }
+    return {
+      type: 'cancelled',
+      shouldRetry: false,
+      shouldShowToast: false,
+      provesBackendResponsive: false
+    }
   }
 
   const message = typeof candidate?.message === 'string' ? candidate.message : ''
 
   if (message === documentFetchTimeoutMessage) {
-    return { type: 'timeout', shouldRetry: true, shouldShowToast: true }
+    return {
+      type: 'timeout',
+      shouldRetry: true,
+      shouldShowToast: true,
+      provesBackendResponsive: false
+    }
   }
 
   const status = typeof candidate?.status === 'number' ? candidate.status : null
 
   if (status !== null) {
     if (status >= 500) {
-      return { type: 'server', shouldRetry: true, shouldShowToast: true }
+      return {
+        type: 'server',
+        shouldRetry: true,
+        shouldShowToast: true,
+        provesBackendResponsive: false
+      }
     }
     if (status >= 400) {
       return {
         type: 'client',
         shouldRetry: RETRYABLE_CLIENT_STATUSES.has(status),
-        shouldShowToast: true
+        shouldShowToast: true,
+        provesBackendResponsive: true
       }
     }
   }
 
   if (message.includes('Network Error') || candidate?.code === 'NETWORK_ERROR') {
-    return { type: 'network', shouldRetry: true, shouldShowToast: true }
+    return {
+      type: 'network',
+      shouldRetry: true,
+      shouldShowToast: true,
+      provesBackendResponsive: false
+    }
   }
 
-  return { type: 'unknown', shouldRetry: true, shouldShowToast: true }
+  return {
+    type: 'unknown',
+    shouldRetry: true,
+    shouldShowToast: true,
+    provesBackendResponsive: false
+  }
 }

--- a/lightrag_webui/src/features/documentRefreshQueue.test.ts
+++ b/lightrag_webui/src/features/documentRefreshQueue.test.ts
@@ -35,7 +35,8 @@ const createHarness = (startAt = 1_000_000) => {
       const decision = admitCircuitBreakerRequest(breaker, now)
       breaker = decision.state
       return decision.admitted
-    }
+    },
+    priority: (request: Req) => (request.auto ? 0 : 1)
   }
 
   return {
@@ -118,6 +119,48 @@ describe('documentRefreshQueue', () => {
 
     // 'second' is superseded by 'third' in the single pending slot.
     expect(harness.ran).toEqual(['first', 'third'])
+  })
+
+  test('an automatic refresh cannot displace a queued user-intent one', async () => {
+    // The regression this pins: the pending slot took the newest request
+    // unconditionally, while admission moved to the point a request is issued.
+    // So an `auto` request landing behind a page change discarded it and was
+    // then refused by the open breaker — neither ran, and the caller saw no
+    // fetch and no error.
+    const harness = createHarness()
+    harness.openBreaker()
+
+    const active = harness.enqueue({ id: 'active', auto: false })
+    const pageChange = harness.enqueue({ id: 'page-change', auto: false })
+    const poll = harness.enqueue({ id: 'poll', auto: true })
+
+    await Promise.all([active, pageChange, poll])
+
+    expect(harness.ran).toEqual(['active', 'page-change'])
+  })
+
+  test('a user-intent refresh displaces a queued automatic one', async () => {
+    const harness = createHarness()
+
+    const active = harness.enqueue({ id: 'active', auto: false })
+    const poll = harness.enqueue({ id: 'poll', auto: true })
+    const manual = harness.enqueue({ id: 'manual', auto: false })
+
+    await Promise.all([active, poll, manual])
+
+    expect(harness.ran).toEqual(['active', 'manual'])
+  })
+
+  test('equal priority still means newest wins', async () => {
+    const harness = createHarness()
+
+    const active = harness.enqueue({ id: 'active', auto: true })
+    const first = harness.enqueue({ id: 'poll-1', auto: true })
+    const second = harness.enqueue({ id: 'poll-2', auto: true })
+
+    await Promise.all([active, first, second])
+
+    expect(harness.ran).toEqual(['active', 'poll-2'])
   })
 
   test('a dropped request does not stall the queue', async () => {

--- a/lightrag_webui/src/features/documentRefreshQueue.test.ts
+++ b/lightrag_webui/src/features/documentRefreshQueue.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+  admitCircuitBreakerRequest,
+  initialCircuitBreakerState,
+  recordCircuitBreakerFailure,
+  type CircuitBreakerState
+} from '@/features/documentRefreshCircuitBreaker'
+import { createRefreshQueue } from '@/features/documentRefreshQueue'
+
+type Req = { id: string; auto: boolean }
+
+/**
+ * Mirrors how DocumentManager wires the breaker into the queue: only `auto`
+ * requests (polling timer, activity probe, pipelineActive callback) ask for
+ * admission; manual refresh and page/filter changes always run.
+ */
+const createHarness = (startAt = 1_000_000) => {
+  let now = startAt
+  let breaker: CircuitBreakerState = initialCircuitBreakerState
+  const ran: string[] = []
+
+  const queue = createRefreshQueue<Req>()
+
+  const handlers = {
+    runRequest: async (request: Req) => {
+      ran.push(request.id)
+      // Yield so a caller enqueueing synchronously after this one lands in the
+      // pending slot, the way a real fetch would.
+      await Promise.resolve()
+    },
+    admit: (request: Req) => {
+      if (!request.auto) return true
+      const decision = admitCircuitBreakerRequest(breaker, now)
+      breaker = decision.state
+      return decision.admitted
+    }
+  }
+
+  return {
+    ran,
+    enqueue: (request: Req) => queue.enqueue(request, handlers),
+    openBreaker: () => {
+      for (let i = 0; i < CIRCUIT_BREAKER_FAILURE_THRESHOLD; i += 1) {
+        breaker = recordCircuitBreakerFailure(breaker, now)
+      }
+    },
+    advanceToRetryDeadline: () => {
+      now = breaker.nextRetryTime ?? now
+    },
+    breakerState: () => breaker
+  }
+}
+
+describe('documentRefreshQueue', () => {
+  test('an automatic refresh is dropped when the breaker is open and the queue is idle', async () => {
+    // The regression this pins: admission used to happen at the polling tick,
+    // so any entrance that found the queue idle — the throttle gate's trailing
+    // timer, the activity probe, the pipelineActive callback — ran its request
+    // as the loop's FIRST request, with nothing consulting the breaker.
+    const harness = createHarness()
+    harness.openBreaker()
+
+    await harness.enqueue({ id: 'poll-1', auto: true })
+
+    expect(harness.ran).toEqual([])
+  })
+
+  test('manual and user-driven refreshes still run while the breaker is open', async () => {
+    const harness = createHarness()
+    harness.openBreaker()
+
+    await harness.enqueue({ id: 'manual', auto: false })
+    await harness.enqueue({ id: 'page-change', auto: false })
+
+    expect(harness.ran).toEqual(['manual', 'page-change'])
+  })
+
+  test('half-open admits exactly one automatic request', async () => {
+    const harness = createHarness()
+    harness.openBreaker()
+    harness.advanceToRetryDeadline()
+
+    await harness.enqueue({ id: 'probe', auto: true })
+    await harness.enqueue({ id: 'follow-up', auto: true })
+
+    expect(harness.ran).toEqual(['probe'])
+    // The breaker is still open with the probe outstanding — only its
+    // settlement (success or failure) moves it on.
+    expect(harness.breakerState().isOpen).toBe(true)
+    expect(harness.breakerState().halfOpenSince).not.toBeNull()
+  })
+
+  test('a queued automatic refresh is re-checked before it runs', async () => {
+    const harness = createHarness()
+
+    // Closed breaker: the first request runs and, while it is in flight, a
+    // second one queues up behind it. The breaker opens in between (as it
+    // would when the first request fails), so the queued one must be dropped.
+    const first = harness.enqueue({ id: 'first', auto: true })
+    const queued = harness.enqueue({ id: 'queued', auto: true })
+    harness.openBreaker()
+
+    await Promise.all([first, queued])
+
+    expect(harness.ran).toEqual(['first'])
+  })
+
+  test('requests arriving during a run collapse into a single pending slot', async () => {
+    const harness = createHarness()
+
+    const first = harness.enqueue({ id: 'first', auto: false })
+    const second = harness.enqueue({ id: 'second', auto: false })
+    const third = harness.enqueue({ id: 'third', auto: false })
+
+    await Promise.all([first, second, third])
+
+    // 'second' is superseded by 'third' in the single pending slot.
+    expect(harness.ran).toEqual(['first', 'third'])
+  })
+
+  test('a dropped request does not stall the queue', async () => {
+    // A rejected request runs no async work, so the loop can complete without
+    // ever awaiting. The queue must not leave its busy marker behind in that
+    // window, or this manual refresh would attach to a finished loop and be
+    // discarded instead of running.
+    const harness = createHarness()
+    harness.openBreaker()
+
+    const dropped = harness.enqueue({ id: 'poll', auto: true })
+    const manual = harness.enqueue({ id: 'manual', auto: false })
+
+    await Promise.all([dropped, manual])
+
+    expect(harness.ran).toEqual(['manual'])
+  })
+})

--- a/lightrag_webui/src/features/documentRefreshQueue.ts
+++ b/lightrag_webui/src/features/documentRefreshQueue.ts
@@ -1,0 +1,92 @@
+/**
+ * Serializing queue for document list refreshes.
+ *
+ * At most one refresh runs at a time; anything arriving while one is in flight
+ * collapses into a single pending slot (the newest wins) and runs once the
+ * active one settles.
+ *
+ * `admit` is consulted immediately before a request would run — for the first
+ * request and for every queued one alike. That placement is the point of this
+ * module: the circuit breaker hands out a half-open probe to exactly one
+ * request, so the admission has to happen where the request is actually
+ * issued. Checking it at the call site instead leaves every entrance that can
+ * find the queue idle (the throttle gate's trailing timer, the activity probe,
+ * the pipelineActive callback) free to walk straight past an open breaker.
+ *
+ * Handlers ride along with each enqueue rather than being captured at
+ * construction, so the queue instance stays stable for the life of the
+ * component while still calling the current render's closures.
+ */
+export type RefreshQueueHandlers<T> = {
+  runRequest: (request: T) => Promise<void>
+  /** Return false to drop the request without running it. */
+  admit: (request: T) => boolean
+}
+
+export type RefreshQueue<T> = {
+  /**
+   * Run `request`, or collapse it into the pending slot when another refresh
+   * is already running. Resolves once the queue is idle again.
+   */
+  enqueue: (request: T, handlers: RefreshQueueHandlers<T>) => Promise<void>
+}
+
+export const createRefreshQueue = <T>(): RefreshQueue<T> => {
+  let activeLoop: Promise<void> | null = null
+  let pendingRequest: T | null = null
+  let currentHandlers: RefreshQueueHandlers<T> | null = null
+
+  const enqueue = async (
+    request: T,
+    handlers: RefreshQueueHandlers<T>
+  ): Promise<void> => {
+    currentHandlers = handlers
+
+    if (activeLoop) {
+      pendingRequest = request
+      await activeLoop
+      return
+    }
+
+    // The busy marker is published BEFORE the loop body and retired in its
+    // finally, both synchronously with respect to the loop. Publishing it
+    // afterwards (`const loop = (async () => {...})()` then assigning) leaves a
+    // window when the body completes without ever awaiting — which is exactly
+    // what a request `admit` rejects does: a caller enqueueing in that window
+    // would attach to a loop that has already finished, and its request would
+    // be cleared by the finally below instead of running.
+    let releaseLoop: () => void = () => {}
+    const loop = new Promise<void>((resolve) => {
+      releaseLoop = resolve
+    })
+    activeLoop = loop
+
+    try {
+      let nextRequest: T | null = request
+
+      while (nextRequest) {
+        // Clear before running: anything enqueued during the request belongs
+        // to the next iteration, not to this one.
+        pendingRequest = null
+
+        // Read per iteration — a request queued behind this one may have
+        // brought newer handlers with it.
+        const active = currentHandlers as RefreshQueueHandlers<T>
+
+        if (active.admit(nextRequest)) {
+          await active.runRequest(nextRequest)
+        }
+
+        nextRequest = pendingRequest
+      }
+    } finally {
+      if (activeLoop === loop) {
+        activeLoop = null
+      }
+      pendingRequest = null
+      releaseLoop()
+    }
+  }
+
+  return { enqueue }
+}

--- a/lightrag_webui/src/features/documentRefreshQueue.ts
+++ b/lightrag_webui/src/features/documentRefreshQueue.ts
@@ -2,8 +2,9 @@
  * Serializing queue for document list refreshes.
  *
  * At most one refresh runs at a time; anything arriving while one is in flight
- * collapses into a single pending slot (the newest wins) and runs once the
- * active one settles.
+ * collapses into a single pending slot and runs once the active one settles.
+ * The slot keeps the highest-priority request it has seen, newest first among
+ * equals — see `priority` for why "newest always wins" is not safe here.
  *
  * `admit` is consulted immediately before a request would run — for the first
  * request and for every queued one alike. That placement is the point of this
@@ -21,6 +22,21 @@ export type RefreshQueueHandlers<T> = {
   runRequest: (request: T) => Promise<void>
   /** Return false to drop the request without running it. */
   admit: (request: T) => boolean
+  /**
+   * Rank a request for the single pending slot. A queued request may only be
+   * displaced by one of EQUAL OR HIGHER priority.
+   *
+   * Entering the queue is not the same as running: `admit` is evaluated where
+   * the request is issued, so a request the breaker will refuse there must not
+   * be able to discard one that would have run. Without this, an automatic
+   * refresh landing behind a page change discards it and is then dropped
+   * itself — no fetch, no error, and the page number moves while the rows do
+   * not.
+   *
+   * Equal priority still means newest wins: two consecutive page changes must
+   * resolve to the second one.
+   */
+  priority: (request: T) => number
 }
 
 export type RefreshQueue<T> = {
@@ -43,7 +59,12 @@ export const createRefreshQueue = <T>(): RefreshQueue<T> => {
     currentHandlers = handlers
 
     if (activeLoop) {
-      pendingRequest = request
+      if (
+        pendingRequest === null ||
+        handlers.priority(request) >= handlers.priority(pendingRequest)
+      ) {
+        pendingRequest = request
+      }
       await activeLoop
       return
     }

--- a/lightrag_webui/src/lib/constants.ts
+++ b/lightrag_webui/src/lib/constants.ts
@@ -44,6 +44,10 @@ export const healthCheckInterval = 15 // seconds
 // /query and document uploads are legitimately long-running).
 export const healthCheckTimeout = 10 // seconds
 export const pipelineStatusTimeout = 10 // seconds
+// Message carried by the getDocumentsPaginatedWithTimeout timeout error.
+// Lives here so the refresh error classifier can recognise it without
+// importing the API module (which creates the axios instance on load).
+export const documentFetchTimeoutMessage = 'Document fetch timeout'
 
 export const defaultQueryLabel = '*'
 

--- a/lightrag_webui/src/lib/constants.ts
+++ b/lightrag_webui/src/lib/constants.ts
@@ -38,6 +38,12 @@ export const minNodeSize = 4
 export const maxNodeSize = 20
 
 export const healthCheckInterval = 15 // seconds
+// Request timeouts for the short polling endpoints. Kept below their own
+// polling interval so a stalled backend fails fast instead of leaving
+// requests hanging forever (the axios instance sets no global timeout —
+// /query and document uploads are legitimately long-running).
+export const healthCheckTimeout = 10 // seconds
+export const pipelineStatusTimeout = 10 // seconds
 
 export const defaultQueryLabel = '*'
 

--- a/lightrag_webui/src/stores/state.ts
+++ b/lightrag_webui/src/stores/state.ts
@@ -28,8 +28,8 @@ interface BackendState {
   // Resolve `apiDocsCapability` alone, without touching the shared backend
   // health state. Needed when periodic health checks are disabled: reusing
   // `check()` there would let a single failed probe latch `health: false`,
-  // which stops the document list polling for good and re-opens the API key
-  // alert on every dismissal (RFC #3671).
+  // which drops the document list to its idle polling cadence and re-opens the
+  // API key alert on every dismissal (RFC #3671).
   probeApiDocsCapability: () => Promise<void>
   clear: () => void
   setErrorMessage: (message: string, messageTitle: string) => void


### PR DESCRIPTION
## Summary

The WebUI circuit breaker guarding the document list poll never actually worked, and a slow backend could freeze the list entirely. This makes the breaker real and bounded, moves its admission to the point a request is issued, makes every outcome settle it, keeps permanent client errors from tripping it, gives the two short polling endpoints explicit timeouts, and stops a failed health check from silencing the list — without turning a dead backend into a toast flood.

## Motivation

Found while investigating a production stall where a `NanoVectorDBStorage` flush failed with `Embedding func: Worker execution timeout after 60s`. The backend side of that (storage saves blocking the event loop) is already fixed in #3740 / #3742; this PR covers what the frontend does while the backend is unresponsive, which is independent of that particular failure and applies to any backend slowdown.

## What's broken today

1. **The breaker can never open.** `recordSuccess()` was called on the polling tick itself, right after a fire-and-forget `refreshDocumentsThrottled()` that may not even have issued a request (the 2s throttle gate can turn it into a trailing timer). Since the polling interval (5s / 30s) is shorter than the request timeout (30s), every tick cleared the failure counter, so the `>= 3` threshold was effectively unreachable.

2. **If it did open, it self-locked, with unbounded backoff.** The only reset point sat behind the `return` in the open branch, so recovery depended entirely on the half-open window. Backoff was `Math.pow(2, failureCount) * 1000` with no cap on the exponent or on the counter (half-open only decrements by 1): ten consecutive failures meant ~17 minutes of silence, twelve meant ~68 minutes.

3. **`/health` had no timeout.** The axios instance sets none (default `0` = never), so a backend whose event loop is blocked left the probe hanging — the health state neither succeeded nor failed, and a fresh probe piled on every 15s. When a reverse proxy finally returned 504, `health: false` made the polling effect call `clearPollingInterval()` and `return`, so the document list stopped updating entirely until the next successful probe.

4. **`/documents/pipeline_status` had no timeout either**, and the dialog polls it every 2s with no in-flight guard, so a stalled backend produced one queued request and one error toast per tick.

5. **The admission ran at the polling tick, but the tick is not the only entrance.** Any caller that found the refresh loop idle — the throttle gate's trailing timer (armed before the breaker opened), the activity probe, the `pipelineActive` callback — became the loop's *first* request, and only *queued* requests were re-checked. So an automatic refresh could still be issued during backoff, pushing `failureCount` and `nextRetryTime` up further.

6. **Half-open let more than one request through.** Flipping `isOpen` to false at the backoff deadline simply closed the breaker again for as long as the probe took to settle — with a 5s poll cadence and a 30s request timeout that is several ticks, and the requests they queued bypassed the breaker entirely.

7. **A permanent 4xx counted as evidence that the backend was unreachable.** The response interceptor threw a bare `Error`, so callers could not tell a 404 from a network failure and every 4xx was treated as retryable. Harmless while the breaker was inert; with a working breaker, three consecutive 403/404/422 responses would open it.

The next five surfaced in review **because** the breaker started working, and are fixed in the same PR.

8. **A queued user-intent refresh could be discarded by an automatic one.** The queue's pending slot took the newest request unconditionally, while admission moved to the point a request is issued — so entering the queue stopped meaning "will run". An `auto` refresh landing behind a page change discarded it and was then refused itself: no fetch, no error, and `isRefreshing` never went true, so not even a loading indicator masked it. The page box moved to 3 while the table still showed page 2's rows, for up to the full 60s backoff window. The throttle gate had the same defect one layer up, where it simply dropped the call.

9. **A non-retryable outcome settled the half-open probe neither way.** `recordFailure()` was gated on `shouldRetry`, so a permanent 4xx or a cancellation consumed the probe slot and returned nothing. `halfOpenSince` stayed stamped and every automatic refresh was refused until the 45s probe timeout — repeatedly, indefinitely, bought by a request that may have returned in 50ms.

10. **The failure counter survived proof that the backend was alive.** It only ever resets on success, so `fail, fail, 403, fail` opened a breaker whose threshold is documented as *consecutive* failures.

11. **A dead backend produced one error toast per backoff window, forever.** Dropping the `!health` early return (item 3) is what keeps a transient 504 from freezing the list, but it also means the list is polled for as long as the tab is open. Each failure raised a fresh undeduped toast.

12. **Every caller of `refreshDocumentsThrottled()` was tagged `auto: true`**, including the post-upload, post-scan and post-delete refreshes — so a 200 from the upload endpoint neither refreshed the list nor reset the breaker.

## What's changed

### The breaker itself

- **New `lightrag_webui/src/features/documentRefreshCircuitBreaker.ts`** — the breaker as a pure state machine, following the existing `documentStatusFilters` / `documentRecoveryWarnings` pattern (the project has no React component test setup, so inline component state cannot be covered). Failure counter capped at 6, backoff capped at 60s.
- **Fed by real responses.** `runRefreshRequest` routes every paginated fetch through a local `fetchPage()` that records success once the response arrives (before the staleness check — a 200 proves the backend is reachable even if the payload is discarded). The polling tick records nothing.
- **Half-open admits exactly one probe.** `admitCircuitBreakerRequest` grants it by stamping `halfOpenSince` while *keeping* `isOpen: true`; only `recordSuccess` (clears everything) or `recordFailure` (re-arms the backoff) moves it on. Ticks arriving while a probe is unsettled are refused. `CIRCUIT_BREAKER_PROBE_TIMEOUT_MS` (45s, above the 30s request timeout) is the last-resort ceiling so an admission that never becomes a request cannot wedge the breaker.
- **Breaker state moved to a ref.** A `useState` write changed `startPollingInterval`'s identity, which made the polling effect tear down and recreate the interval on every failure.
- **Every outcome settles the probe — three, not two.** A retryable failure records a failure; a permanent 4xx records a *success*, because the application parsed and routed the request and answered, which is positive proof of health (deliberately **not** extended to 5xx: a 502/504 is the standard signal of a stalled backend or its proxy, exactly what this breaker detects); anything else goes through the new `settleCircuitBreakerProbe`, which returns the slot and re-stamps the backoff without moving the counter. The settle call sits in the `finally`, not a `catch` branch — the invariant is "every exit path returns the slot", and `finally` is the only construct that states it. It is idempotent, so it is also correct after a recorded outcome and on the unmount early return.

### Where the admission happens

- **New `lightrag_webui/src/features/documentRefreshQueue.ts`** — the serialize/collapse loop that was inline in `DocumentManager`, extracted with an `admit` hook consulted **immediately before each request runs**, for the first request and every queued one alike. That is the only placement where "the breaker admits exactly one probe" holds, and extracting it makes the scheduling layer testable.
- **Manual refresh and page/filter/sort changes stay untagged and always run** — explicit user intent is the escape hatch — and a success clears the breaker.
- **The pending slot is ranked.** A queued request may only be displaced by one of equal or higher priority, so an automatic refresh can no longer discard a page change it will not itself replace. Equal priority still means newest wins — two consecutive page changes must resolve to the second. The throttle gate's trailing timer follows the same rule by *upgrading* its intent tag instead of dropping the call.
- **`refreshDocumentsThrottled({ auto })`** takes the intent from its caller, defaulting to automatic. Post-upload, post-scan and post-delete refreshes are user intent; the activity probe's burst tags only its `t=0` refresh that way, since the rest polls speculatively and tagging all five would let one click bypass the breaker five times.

### What counts as a failure

- **New `lightrag_webui/src/features/documentRefreshErrors.ts`** — classifies a failed refresh into `cancelled` / `timeout` / `network` / `server` / `client` / `unknown`, where `shouldRetry` doubles as "counts against the breaker". Only 408 and 429 keep the retry treatment among 4xx codes.
- **`HttpRequestError` / `toHttpRequestError` in `api/lightrag.ts`** — the response interceptor now carries the status as a property, not only inside the message, so callers can branch on it.
- **`__setAxiosAdapterForTests`** so a test can drive a real HTTP failure through the actual interceptors.
- **`provesBackendResponsive`** on the classification, so the consumer can tell "the application answered" from "no answer arrived" — with `shouldRetry` outranking it, because a 429 does prove the backend answered but is also an instruction to slow down.
- **axios reports transport failures as `ERR_NETWORK`**, not the `NETWORK_ERROR` this checked; that branch was dead and the message fallback only fires when the browser's `ProgressEvent` carries no message of its own.

### Timeouts and polling cadence

- **Explicit timeouts** for `/health` and `/documents/pipeline_status` (10s each, below their own polling cadence). Deliberately **no global axios timeout**: `queryText` (non-streaming `/query`) and `uploadDocument` share the same instance and are legitimately long-running.
- **A failed health check drops the list to the 30s idle cadence** instead of stopping it. The breaker is what throttles a backend that is genuinely down.
- **`PipelineStatusDialog`** skips a tick while a request is in flight, and reports a fetch failure once instead of once per tick (reset on the next success).
- **One standing failure notice instead of a flood.** The `loadFailed` toast carries a stable id and, for any retryable failure, stays up until a successful response dismisses it. A stable id alone is not enough — it merges only into a toast that is still on screen, and the default 4s lifetime always expires before the next poll (5s at its fastest, 30s once health drops), so every failure would create a fresh toast. Persistence belongs to "this failure means the list is stale and staying stale", not to how many have accumulated. A permanent 4xx keeps the ordinary auto-dismissing toast: the backend answered, and the breaker has just been cleared. `StatusIndicator`'s red dot covers the plain unreachable-backend case but not this one — it tracks `/health`, so a backend answering `/health` while `/documents/paginated` keeps failing shows green over a frozen list, and it is not rendered at all when health checks are turned off.

### Hardening

- **The displayed page number is derived from the request**, not from `response.pagination`. Nothing can reach the old behaviour today — requests are serialized, late responses are swallowed, and `requestVersion` discards stale ones before any UI write — but it made the page a value a response could overwrite, and any future relaxation of those layers would surface as a page rolling backwards under the user.
- **`handlePageInputSubmit` honours `isLoading`** like the four paginator button handlers already did.

## Effect

| | Before | After |
|---|---|---|
| Breaker actually triggers | No — every tick cleared the counter | Yes — only a real 200 clears it |
| Max backoff | `2 ** n` s, uncapped (~17 min at n=10) | `min(2 ** n, 60)` s |
| Failure counter cap | none | 6 |
| Requests admitted during backoff | any entrance that found the loop idle | none |
| Requests during a half-open probe | every tick until the probe settled | none — one probe at a time |
| A permanent 403/404/422 | counted toward opening the breaker | closes the breaker — the app answered |
| Half-open probe after a 4xx | wedged for 45s, repeatedly | settled at once, backoff re-stamped |
| `fail, fail, 403, fail` | opens the breaker | does not — the 403 reset the count |
| Page change queued behind a poll tick | silently discarded, page/rows disagree | runs; automatic refreshes rank below it |
| Refresh after a successful upload | breaker could refuse it | user intent, always runs |
| Dead backend, tab left open | one new toast per backoff window | one standing notice, dismissed on recovery |
| Recovery after backend returns | wait out the backoff | first successful response clears it |
| `/health` while backend is blocked | hangs forever, probes pile up | fails at 10s |
| Document list on a 504 from `/health` | stops refreshing | keeps polling at 30s |
| Pipeline status dialog on a stall | one request + one toast every 2s | one request in flight, one toast |

## Testing

- `bun test` — 146 pass, 0 fail (35 new across `documentRefreshCircuitBreaker`, `documentRefreshQueue`, `documentRefreshErrors` and `api/lightrag`, covering the threshold, the backoff and counter caps, the half-open single-probe transition, probe settlement and backoff re-stamping, non-consecutive failures not accumulating, the queue's serialize/collapse/admit/priority behaviour, and the status classification through the real interceptors).
- `bun run lint` — clean.
- `bunx tsc --noEmit` — clean.

Not covered by automated tests: the component wiring (where `recordSuccess` / `recordFailure` / `settleProbe` are called, the throttle gate's intent upgrade, the polling cadence change) and the two new request timeouts — the repo has no React component test infrastructure and this PR does not add one. The equivalent invariants are pinned one layer down, in the pure modules. Manual verification:

These were driven end-to-end with Playwright against the packaged WebUI on a real `lightrag-server`, not by hand:

| scenario | toasts created | on screen | cleared on recovery |
|---|---|---|---|
| backend killed, 4 min | 1 | 1 throughout | yes, on the first 200 |
| backend `SIGSTOP`ped, 2 min | 1 | 1 throughout | yes, within 5s of `SIGCONT` |

For comparison, the same run against the first version of the toast fix produced 3 created / 2 removed over 90s before settling — which is what "the errors keep coming back" was.

A second run covers the escape hatch, clicking inside the backoff window (2.0s and 1.6s after a failed probe, with `nextRetryTime` 60s out) and using a no-click control to prove the breaker really was blocking at that moment:

| check | result |
|---|---|
| Refresh click while the breaker is open issues a request | 1 request |
| Page change while the breaker is open issues a request, page box advances | 1 request |
| Control: 12s quiet window with no click | 0 requests |
| Manual refresh after the backend returns recovers the list and clears the notice | 2 requests, 0 toasts |

The list also kept polling rather than freezing (probes at 46/76/106/136/166/226/316s), with the breaker widening the spacing to 60s and then 90s.

Details and full timelines: https://github.com/HKUDS/LightRAG/pull/3743#issuecomment-5459984503 and https://github.com/HKUDS/LightRAG/pull/3743#issuecomment-5460087128

## Review follow-ups

The five defects and one hardening item listed above as items 8-12 came from a follow-up review of the first three commits, plus one finding from Codex on the same catch block. Full analysis: https://github.com/HKUDS/LightRAG/pull/3743#issuecomment-5459499616 — all of it is fixed here.

Also verified in that review, and worth recording because it is easy to re-investigate: **out-of-order responses on `/documents/paginated` are structurally impossible**. The refresh queue never issues request N+1 until N settles, the timeout wrapper swallows a late response via its `timedOut` flag, and `requestVersion` discards a stale one before any UI write. Rapid page changes cannot show rows from the wrong page for that reason, and even a double-click resolves to the user's last intent. The paginator's `disabled={isLoading}` is defense-in-depth for UX, not the correctness guarantee — now stated on the prop.

## What's not changed

- The backend halt semantics after an `IndexFlushError` (`pipeline.py` internal-error abort) — halting on a broken storage backend is intentional; recovery still needs an explicit `/documents/scan`.
- No timeout on `/query`, uploads or `/graphs`.
- The graph fetch's bounded retry (3 attempts, 1/2/4s) — already correct.
- The 30s timeout on `/documents/paginated`.
- The in-flight request dedup in `subscribeToPaginatedDocumentsRequest` — pre-existing and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


