### PR TITLE
fix: accept valid empty JSON extraction results in cache rebuild

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -1665,8 +1665,9 @@ async def _rebuild_from_extraction_result(
             timestamp,
             file_path,
         )
-        # If JSON parsing yielded results, use them
-        if nodes or edges:
+        # A successful parse (tolerant_load_json_dict's own non-empty-dict
+        # signal) is accepted even when it legitimately yields no nodes/edges.
+        if nodes or edges or tolerant_load_json_dict(extraction_result):
             return nodes, edges
         # Otherwise fall through to text-based parsing
 

--- a/tests/extraction/test_rebuild_json_empty_fallback.py
+++ b/tests/extraction/test_rebuild_json_empty_fallback.py
@@ -1,0 +1,76 @@
+"""A cached extraction result that is valid, empty JSON must not fall through
+to the delimiter parser: that parser has no chance of finding a
+"<|COMPLETE|>" marker in a JSON payload and would log a misleading warning
+about it, even though the JSON was parsed successfully and simply carried no
+entities or relationships.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lightrag.operate import _rebuild_from_extraction_result
+
+pytestmark = pytest.mark.offline
+
+
+class DummyKV:
+    async def get_by_id(self, key):
+        return {"file_path": "doc.pdf"}
+
+
+@pytest.fixture
+def _propagate_lightrag_logger(monkeypatch):
+    """``lightrag.utils.logger`` sets ``propagate = False``; restore
+    propagation locally so ``caplog`` can capture WARNING records."""
+    monkeypatch.setattr(logging.getLogger("lightrag"), "propagate", True)
+
+
+@pytest.mark.asyncio
+async def test_rebuild_accepts_valid_empty_json_without_delimiter_warning(
+    caplog, _propagate_lightrag_logger
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="lightrag"):
+        nodes, edges = await _rebuild_from_extraction_result(
+            DummyKV(),
+            '{"entities": [], "relationships": []}',
+            chunk_id="chunk-1",
+            timestamp=1,
+        )
+    assert nodes == {}
+    assert edges == {}
+    assert "Complete delimiter can not be found" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_rebuild_still_returns_entities_from_nonempty_json() -> None:
+    nodes, edges = await _rebuild_from_extraction_result(
+        DummyKV(),
+        '{"entities":[{"name":"Alice","type":"person",'
+        '"description":"an engineer"}],"relationships":[]}',
+        chunk_id="chunk-2",
+        timestamp=1,
+    )
+    assert "Alice" in nodes
+
+
+@pytest.mark.asyncio
+async def test_rebuild_still_falls_back_on_unparseable_json_looking_text(
+    caplog, _propagate_lightrag_logger
+) -> None:
+    """Text that starts with '{' but is not recoverable JSON, and also has no
+    completion marker, is the pre-existing garbage-input case: falling
+    through to the delimiter parser (and its warning) is correct there,
+    unlike the valid-empty-JSON case above."""
+    with caplog.at_level(logging.WARNING, logger="lightrag"):
+        nodes, edges = await _rebuild_from_extraction_result(
+            DummyKV(),
+            "{not json at all, no delimiter either",
+            chunk_id="chunk-3",
+            timestamp=1,
+        )
+    assert nodes == {}
+    assert edges == {}
+    assert "Complete delimiter can not be found" in caplog.text


### PR DESCRIPTION
`_rebuild_from_extraction_result` (lightrag/operate.py) only accepts a JSON-parsed extraction result when `nodes or edges` is truthy. A syntactically valid extraction that legitimately found nothing, `{"entities": [], "relationships": []}`, yields two empty (falsy) dicts, so the code falls through to the delimiter-based parser on the same JSON string. That string was never going to contain the `<|COMPLETE|>` marker, so the fallback logs a warning that reads like the extraction failed when it actually succeeded.

`tolerant_load_json_dict`, which the JSON branch already calls internally, documents a non-empty dict as its own signal that parsing succeeded, independent of what the extracted entities/relationships turn out to be. This PR gates the fallback on that signal instead of on the emptiness of the results, so a genuinely empty extraction is accepted and a genuinely unparseable one still falls back exactly as before.

Scope: this path is only reachable from cache rebuild. The live extraction path (`use_json_extraction` branch a few hundred lines up) picks a parser once by mode and never falls back between them, so it is unaffected.

Verification:
- New test `tests/extraction/test_rebuild_json_empty_fallback.py`: fails on `main` with the exact misleading warning, passes on this branch; also pins that a non-empty JSON result and a genuinely unparseable one keep behaving as before.
- Full offline suite (`pytest tests/ -m offline`): 5991 passed, 45 skipped (pre-existing spaCy model gaps), 0 failed.
- `pre-commit run --files lightrag/operate.py tests/extraction/test_rebuild_json_empty_fallback.py`: clean.
- Not verified: the live (non-cached) extraction path, since it does not exercise this fallback at all.

Fixes #3744
