### PR TITLE
fix(extraction): read an empty JSON extraction as an answer, not a parse failure

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -902,51 +902,64 @@ def _looks_like_json_extraction_result(result: str) -> bool:
     return False
 
 
-async def _process_json_extraction_result(
-    result: str,
-    chunk_key: str,
-    timestamp: int,
-    file_path: str = "unknown_source",
-) -> tuple[dict, dict]:
-    """Process a JSON-formatted extraction result from LLM.
+def _load_json_extraction_payload(result: str, chunk_key: str) -> dict[str, Any] | None:
+    """Recover the JSON object from an extraction response, or None.
 
-    This function parses the LLM response as JSON and extracts entities and relationships.
-    It uses :func:`tolerant_load_json_dict` to recover JSON from fenced,
-    prose-wrapped, or slightly malformed responses from weaker models.
+    ``tolerant_load_json_dict`` strips fences, tolerates leading/trailing prose
+    (including trailing braces), and repairs the malformed-object slips
+    ``json_repair`` fixes. It never raises and returns ``{}`` for unparseable
+    input or a top-level array (callers require exactly one object). Note:
+    because the helper absorbs the underlying parse exception, only this single
+    "empty or unrecoverable" warning is logged — the low-level decode error is
+    no longer surfaced.
 
-    Args:
-        result: The JSON extraction result from LLM
-        chunk_key: The chunk key for source tracking
-        timestamp: The timestamp for the extraction
-        file_path: The file path for citation
-
-    Returns:
-        tuple: (nodes_dict, edges_dict) containing the extracted entities and relationships
+    ``None`` means the response was not recoverable as a single JSON object.
     """
-    maybe_nodes = defaultdict(list)
-    maybe_edges = defaultdict(list)
-
-    # tolerant_load_json_dict strips fences, tolerates leading/trailing prose
-    # (including trailing braces), and repairs the malformed-object slips
-    # json_repair fixes. It never raises and returns {} for unparseable input or
-    # a top-level array (callers require exactly one object). Note: because the
-    # helper absorbs the underlying parse exception, only this single "empty or
-    # unrecoverable" warning is logged — the low-level decode error is no longer
-    # surfaced.
     parsed = tolerant_load_json_dict(result)
     if not parsed:
         logger.warning(
             f"{chunk_key}: JSON extraction result is empty or unrecoverable"
             f"{_truncation_cause_suffix(result)}"
         )
-        return dict(maybe_nodes), dict(maybe_edges)
+        return None
 
     # Models quoting LaTeX in descriptions routinely under-escape backslashes
     # ("\frac" is valid JSON meaning form feed + "rac"); restore the zero-risk
     # cases before sanitization would otherwise delete the control characters
     # and leave a maimed formula. Covers initial extraction, gleaning, and
     # cache-rebuild — all three flow through this parser.
-    parsed = repair_vlm_json_escape_damage_nested(parsed, context=chunk_key)
+    return repair_vlm_json_escape_damage_nested(parsed, context=chunk_key)
+
+
+def _has_json_extraction_shape(payload: dict[str, Any]) -> bool:
+    """Whether a parsed object answered in the extraction schema.
+
+    Either list field being present and actually a list is enough. A chunk
+    that holds no reliable facts legitimately comes back as
+    ``{"entities": [], "relationships": []}``, so it is the presence of the
+    fields — never the presence of items in them — that says the model answered
+    in the schema rather than returning some unrelated object. The field names
+    are the ones :func:`_extract_from_json_payload` reads.
+    """
+    return any(
+        isinstance(payload.get(field), list) for field in ("entities", "relationships")
+    )
+
+
+def _extract_from_json_payload(
+    parsed: dict[str, Any],
+    chunk_key: str,
+    timestamp: int,
+    file_path: str = "unknown_source",
+) -> tuple[dict, dict]:
+    """Build the entity and relationship dicts from an already-parsed payload.
+
+    Split out of :func:`_process_json_extraction_result` so the cache-rebuild
+    path can decide whether the response parsed as JSON before it has any
+    entities to look at.
+    """
+    maybe_nodes = defaultdict(list)
+    maybe_edges = defaultdict(list)
 
     # Process entities
     entities_list = parsed.get("entities", [])
@@ -1086,6 +1099,33 @@ async def _process_json_extraction_result(
             continue
 
     return dict(maybe_nodes), dict(maybe_edges)
+
+
+async def _process_json_extraction_result(
+    result: str,
+    chunk_key: str,
+    timestamp: int,
+    file_path: str = "unknown_source",
+) -> tuple[dict, dict]:
+    """Process a JSON-formatted extraction result from LLM.
+
+    This function parses the LLM response as JSON and extracts entities and relationships.
+    It uses :func:`tolerant_load_json_dict` to recover JSON from fenced,
+    prose-wrapped, or slightly malformed responses from weaker models.
+
+    Args:
+        result: The JSON extraction result from LLM
+        chunk_key: The chunk key for source tracking
+        timestamp: The timestamp for the extraction
+        file_path: The file path for citation
+
+    Returns:
+        tuple: (nodes_dict, edges_dict) containing the extracted entities and relationships
+    """
+    payload = _load_json_extraction_payload(result, chunk_key)
+    if payload is None:
+        return {}, {}
+    return _extract_from_json_payload(payload, chunk_key, timestamp, file_path)
 
 
 async def rebuild_knowledge_from_chunks(
@@ -1635,8 +1675,10 @@ async def _rebuild_from_extraction_result(
     """Parse cached extraction result using the same logic as extract_entities.
 
     Supports both JSON and delimiter-based formats for backward compatibility.
-    Attempts JSON parsing first; if the cached result looks like JSON (starts with '{'),
-    uses the JSON parser. Otherwise, falls back to the traditional delimiter-based parser.
+    A result carrying the extraction schema is answered from JSON however empty
+    it turns out to be; the delimiter parser is the fallback for a result that
+    is not recoverable as an extraction object, or that appends delimiter
+    records to one (see the call site).
 
     Args:
         text_chunks_storage: Text chunks storage to get chunk data
@@ -1659,15 +1701,28 @@ async def _rebuild_from_extraction_result(
     # Auto-detect format: try JSON first if the result looks like JSON
     if _looks_like_json_extraction_result(extraction_result):
         # Likely JSON format (from entity_extraction_use_json mode)
-        nodes, edges = await _process_json_extraction_result(
-            extraction_result,
-            chunk_id,
-            timestamp,
-            file_path,
-        )
-        # If JSON parsing yielded results, use them
-        if nodes or edges:
-            return nodes, edges
+        payload = _load_json_extraction_payload(extraction_result, chunk_id)
+        if payload is not None and _has_json_extraction_shape(payload):
+            nodes, edges = _extract_from_json_payload(
+                payload, chunk_id, timestamp, file_path
+            )
+            # A response in the extraction schema is authoritative even when
+            # both arrays are empty — the chunk held no reliable facts, which
+            # is a normal answer. Deciding that on the entity count instead
+            # sent every such cache entry through the delimiter parser, whose
+            # only output was a misleading "Complete delimiter can not be
+            # found" warning (issue #3744).
+            #
+            # The one shape the old test rescued is a JSON object with
+            # delimiter records appended, which the JSON prompt never asks for
+            # but tolerant_load_json_dict accepts as trailing prose. Its
+            # terminator is what says so, and a response carrying one reaches
+            # the delimiter parser without the spurious warning, so the rescue
+            # costs nothing to keep.
+            if nodes or edges:
+                return nodes, edges
+            if PROMPTS["DEFAULT_COMPLETION_DELIMITER"] not in extraction_result:
+                return nodes, edges
         # Otherwise fall through to text-based parsing
 
     # Fall back to traditional delimiter-based parsing

--- a/tests/extraction/test_empty_json_extraction_rebuild.py
+++ b/tests/extraction/test_empty_json_extraction_rebuild.py
@@ -1,0 +1,178 @@
+"""An empty JSON extraction is an answer, not a parse failure.
+
+``{"entities": [], "relationships": []}`` is what a chunk holding no reliable
+facts legitimately produces in ``ENTITY_EXTRACTION_USE_JSON`` mode. The
+cache-rebuild path used to decide "did the JSON parse work?" from the entity
+count, so every such cache entry fell through to the delimiter parser — which
+found no ``<|COMPLETE|>`` in a JSON document and warned about it, once per
+chunk, for the whole rebuild.
+
+The fallback now turns on the response's own format rather than on how much it
+yielded: a result carrying the extraction schema is answered from JSON however
+empty it turns out to be, unless it also carries the delimiter terminator that
+says records were appended to it.
+
+See issue #3744.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from lightrag import operate
+from lightrag.prompt import PROMPTS
+
+pytestmark = pytest.mark.offline
+
+_EMPTY_JSON = '{"entities": [], "relationships": []}'
+
+_POPULATED_JSON = (
+    '{"entities":[{"name":"Alice","type":"person","description":"an engineer"}],'
+    '"relationships":[{"source":"Alice","target":"Acme",'
+    '"keywords":"works at","description":"Alice works at Acme"}]}'
+)
+
+# Parses as an object but answers a different question, so it is not an
+# extraction result and the delimiter parser is still the right fallback.
+_NON_EXTRACTION_JSON = '{"summary": "no entities here"}'
+
+_TUPLE = PROMPTS["DEFAULT_TUPLE_DELIMITER"]
+_COMPLETE = PROMPTS["DEFAULT_COMPLETION_DELIMITER"]
+
+# The shape the old entity-count test rescued: an empty JSON object with
+# delimiter records appended. The JSON prompt never asks for it, but
+# tolerant_load_json_dict accepts the records as trailing prose.
+_EMPTY_JSON_WITH_APPENDED_RECORDS = (
+    f"{_EMPTY_JSON}\nentity{_TUPLE}Alice{_TUPLE}person{_TUPLE}an engineer\n{_COMPLETE}"
+)
+
+
+class _DummyTextChunksStorage:
+    async def get_by_id(self, chunk_id: str):
+        return {"file_path": "test.md"}
+
+
+async def _rebuild(extraction_result: str):
+    return await operate._rebuild_from_extraction_result(
+        text_chunks_storage=_DummyTextChunksStorage(),
+        extraction_result=extraction_result,
+        chunk_id="chunk-001",
+        timestamp=123,
+    )
+
+
+def _delimiter_parser_must_not_run():
+    return patch(
+        "lightrag.operate._process_extraction_result",
+        side_effect=AssertionError(
+            "delimiter parser reached for a valid JSON extraction result"
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "cached",
+    [_EMPTY_JSON, f"```json\n{_EMPTY_JSON}\n```"],
+    ids=["raw", "fenced"],
+)
+@pytest.mark.asyncio
+async def test_empty_json_extraction_does_not_reach_the_delimiter_parser(cached):
+    with _delimiter_parser_must_not_run():
+        nodes, edges = await _rebuild(cached)
+
+    assert nodes == {}, "empty extraction must not invent entities"
+    assert edges == {}, "empty extraction must not invent relationships"
+
+
+@pytest.mark.asyncio
+async def test_empty_json_extraction_is_logged_as_nothing_at_all():
+    """The symptom the issue reports: one misleading warning per rebuilt chunk.
+
+    Neither warning belongs here — not the delimiter parser's, and not the
+    JSON parser's own "empty or unrecoverable", which would be just as wrong
+    about a response that parsed perfectly well.
+    """
+    with patch("lightrag.operate.logger") as mock_logger:
+        await _rebuild(_EMPTY_JSON)
+
+    warnings = [str(call.args[0]) for call in mock_logger.warning.call_args_list]
+    assert warnings == [], warnings
+
+
+@pytest.mark.asyncio
+async def test_json_whose_records_are_all_skipped_is_still_a_json_answer():
+    """Records dropped by validation leave the same empty result as an empty
+    array, and must be read the same way — the schema is what decides."""
+    all_records_dropped = (
+        '{"entities":[{"name":"Alice","type":"person","description":"  "}],'
+        '"relationships":[]}'
+    )
+
+    with _delimiter_parser_must_not_run():
+        nodes, edges = await _rebuild(all_records_dropped)
+
+    assert nodes == {}, "an entity with no description is dropped, not rescued"
+    assert edges == {}
+
+
+@pytest.mark.asyncio
+async def test_populated_json_extraction_still_parses_as_json():
+    with _delimiter_parser_must_not_run():
+        nodes, edges = await _rebuild(_POPULATED_JSON)
+
+    assert set(nodes) == {"Alice"}, "entity dropped — JSON answer not used"
+    assert ("Alice", "Acme") in edges
+    assert nodes["Alice"][0]["file_path"] == "test.md"
+
+
+@pytest.mark.asyncio
+async def test_object_without_the_extraction_schema_still_falls_back():
+    """The fallback is narrowed, not removed: an object that is not an
+    extraction result keeps reaching the delimiter parser."""
+    with patch(
+        "lightrag.operate._process_extraction_result",
+        return_value=({"FromDelimiter": []}, {}),
+    ) as delimiter_parser:
+        nodes, _edges = await _rebuild(_NON_EXTRACTION_JSON)
+
+    assert delimiter_parser.await_count == 1, "non-extraction JSON must fall back"
+    assert nodes == {"FromDelimiter": []}
+
+
+@pytest.mark.asyncio
+async def test_unparseable_json_still_falls_back():
+    with patch(
+        "lightrag.operate._process_extraction_result",
+        return_value=({"FromDelimiter": []}, {}),
+    ) as delimiter_parser:
+        nodes, _edges = await _rebuild("{ not json at all")
+
+    assert delimiter_parser.await_count == 1, "unparseable JSON must fall back"
+    assert nodes == {"FromDelimiter": []}
+
+
+@pytest.mark.asyncio
+async def test_records_appended_to_an_empty_object_are_still_recovered():
+    """Narrowing the fallback must not drop what the old entity-count test
+    rescued. The appended terminator is what says the response is also in
+    delimiter format, so it reaches the delimiter parser — which finds its
+    terminator there and emits no warning about it."""
+    with patch("lightrag.operate.logger") as mock_logger:
+        nodes, _edges = await _rebuild(_EMPTY_JSON_WITH_APPENDED_RECORDS)
+
+    assert "Alice" in nodes, "appended delimiter records were dropped"
+    warnings = [str(call.args[0]) for call in mock_logger.warning.call_args_list]
+    assert not any("Complete delimiter" in warning for warning in warnings), warnings
+
+
+def test_extraction_shape_is_decided_by_the_fields_not_their_contents():
+    assert operate._has_json_extraction_shape({"entities": [], "relationships": []})
+    assert operate._has_json_extraction_shape({"entities": [{"name": "Alice"}]})
+    # One field is enough: models routinely omit the empty one.
+    assert operate._has_json_extraction_shape({"relationships": []})
+
+    assert not operate._has_json_extraction_shape({"summary": "no entities here"})
+    # Present but not a list: the builder cannot read it, so it is not the shape.
+    assert not operate._has_json_extraction_shape({"entities": "none"})


### PR DESCRIPTION
## Description

In `ENTITY_EXTRACTION_USE_JSON` mode a chunk that holds no reliable facts legitimately returns `{"entities": [], "relationships": []}`. During an extraction-cache rebuild, `_rebuild_from_extraction_result` decided whether the JSON parse had worked from the entity count:

```python
nodes, edges = await _process_json_extraction_result(...)
if nodes or edges:
    return nodes, edges
# Otherwise fall through to text-based parsing
```

So every empty-but-valid cached entry fell through to the delimiter parser, which found no `<|COMPLETE|>` in a JSON document and warned about it — once per chunk, for the whole rebuild. The warning does not, by itself, indicate malformed JSON, truncation, or lost extraction data, which is exactly what an operator reads it as.

The fallback now turns on the response's own format rather than on how much it yielded.

## Related Issues

Closes #3744.

## Changes Made

`_process_json_extraction_result` splits into two halves so the rebuild path can ask "did this parse as an extraction response?" before it has any entities to look at:

- `_load_json_extraction_payload` — the `tolerant_load_json_dict` call plus the LaTeX escape repair. Returns `None` when the response is not recoverable as a single JSON object.
- `_extract_from_json_payload` — the entity and relationship record loops, unchanged.
- `_has_json_extraction_shape` — whether a parsed object answered in the extraction schema, decided by the presence of the `entities` / `relationships` list fields and never by their contents. That distinction is the fix.

`_process_json_extraction_result` keeps its signature and semantics and is now those two halves in sequence, so initial extraction and gleaning are untouched. Neither has a fallback anyway — they know which format they asked for, and the empty-vs-failure question exists only in the rebuild dispatcher, which has to auto-detect the format of each cached entry.

### The fallback is narrowed, not removed

Delimiter parsing is still reached by a result that does not parse as an extraction object: a top-level array, unparseable text that happens to start with a brace, or an object answering some other question. Those all behave exactly as before.

One further shape kept working deliberately. A response that is an empty JSON object with delimiter records appended is not something the JSON prompt asks for, but `tolerant_load_json_dict` accepts the records as trailing prose, so the shape gate passes and a strict "JSON wins" rule would drop them. Its terminator is what identifies it, and a response carrying one reaches the delimiter parser *without* the spurious warning — the parser finds the terminator it was looking for. So the rescue costs nothing to keep, and the narrowing loses no cached shape at all rather than only no shape I could think of.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

New `tests/extraction/test_empty_json_extraction_rebuild.py` drives `_rebuild_from_extraction_result` end to end. It pins the reported case raw and fenced, asserts the rebuild logs *nothing* for it — not the delimiter warning and not the JSON parser's own "empty or unrecoverable", which would be just as wrong about a response that parsed perfectly well — and covers a payload whose records are all dropped by validation, which lands in the same place as an empty array and must be read the same way. Three tests pin the surviving fallback paths and one pins the appended-records rescue; those four pass on `main` as well, which is the point of them.

Run subset per AGENTS.md: `tests/extraction`.
