### PR TITLE
feat(ollama): report token usage through the TokenTracker contract

### DIFF
--- a/lightrag/llm/ollama.py
+++ b/lightrag/llm/ollama.py
@@ -167,6 +167,38 @@ def _normalize_ollama_response_format(kwargs: dict) -> None:
     kwargs["format"] = response_format
 
 
+def _ollama_usage_counts(payload: Any) -> dict[str, int] | None:
+    """Map Ollama's eval counters onto the TokenTracker's key names, or None.
+
+    Ollama reports ``prompt_eval_count`` / ``eval_count`` and has no combined
+    total, so the total is their sum. ``.get`` works on both the raw dict
+    (ollama<0.4) and the ``SubscriptableBaseModel`` ChatResponse (ollama>=0.4)
+    -- the same accessor the truncation diagnostics below already rely on --
+    and a payload that has no ``.get`` at all degrades to ``None`` rather than
+    raising, for the reason :func:`_response_message_field` gives: a shape this
+    helper cannot read must not take down a response the caller could have used.
+
+    ``None`` means the payload reported no counters *at all*, which is an older
+    or non-conforming server rather than a call that consumed nothing. A
+    payload reporting one of the two is real usage, and the absent half counts
+    as zero.
+    """
+    get = getattr(payload, "get", None)
+    if not callable(get):
+        return None
+    prompt_tokens = get("prompt_eval_count")
+    completion_tokens = get("eval_count")
+    if prompt_tokens is None and completion_tokens is None:
+        return None
+    prompt_tokens = prompt_tokens or 0
+    completion_tokens = completion_tokens or 0
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": prompt_tokens + completion_tokens,
+    }
+
+
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=4, max=10),
@@ -181,9 +213,17 @@ async def _ollama_model_if_cache(
     history_messages=[],
     enable_cot: bool = False,
     image_inputs: list[Any] | None = None,
+    token_tracker: Any | None = None,
     **kwargs,
 ) -> Union[str, AsyncIterator[str]]:
     """Call Ollama chat API with OpenAI-style structured-output compatibility.
+
+    ``token_tracker`` matches the OpenAI binding's contract: an object with
+    ``add_usage(dict)``, called once per completed call with the counts Ollama
+    reports. It has to be an explicit parameter rather than a ``kwargs`` key,
+    because everything left in ``kwargs`` is forwarded verbatim to
+    ``AsyncClient.chat()``, which declares no ``**kwargs`` -- an unconsumed
+    ``token_tracker`` is a ``TypeError`` on the wire call, not a no-op.
 
     Structured output note:
     - This adapter accepts OpenAI-style ``response_format`` and translates it
@@ -287,9 +327,30 @@ async def _ollama_model_if_cache(
             """cannot cache stream response and process reasoning"""
 
             async def inner():
+                usage_counts = None
                 try:
                     async for chunk in response:
+                        if token_tracker:
+                            # The terminal chunk (done=true) is the one carrying
+                            # the counters; earlier chunks have none. Keep the
+                            # last set seen rather than assuming which chunk it
+                            # is. Guarded so an untracked stream does not pay
+                            # the lookup once per token.
+                            chunk_usage = _ollama_usage_counts(chunk)
+                            if chunk_usage is not None:
+                                usage_counts = chunk_usage
                         yield chunk["message"]["content"]
+                    # After the loop, inside the try: a consumer that
+                    # disconnects mid-stream (GeneratorExit) is not billed,
+                    # matching the OpenAI binding. The Gemini binding accounts
+                    # in a `finally` and does bill a disconnect; the two
+                    # upstream bindings already disagree, and this follows the
+                    # one whose usage semantics this file otherwise mirrors.
+                    if token_tracker and usage_counts is not None:
+                        token_tracker.add_usage(usage_counts)
+                        logger.debug(f"Streaming token usage: {usage_counts}")
+                    elif token_tracker:
+                        logger.debug("No usage information in Ollama stream response")
                 except Exception as e:
                     logger.error(f"Error in stream response: {str(e)}")
                     raise
@@ -303,6 +364,18 @@ async def _ollama_model_if_cache(
             return inner()
         else:
             model_response = response["message"]["content"]
+
+            # Account before the truncation checks below: the request burned
+            # its budget whether or not the output turned out to be usable, and
+            # the empty-and-cut-off case that raises is exactly the one that
+            # spent it. Matches the OpenAI binding, which counts usage before
+            # its own empty-response validation.
+            if token_tracker:
+                usage_counts = _ollama_usage_counts(response)
+                if usage_counts is not None:
+                    token_tracker.add_usage(usage_counts)
+                else:
+                    logger.debug("No usage information in Ollama response")
 
             """
             If the model also wraps its thoughts in a specific tag,
@@ -384,6 +457,7 @@ async def ollama_model_complete(
     enable_cot: bool = False,
     keyword_extraction=False,
     entity_extraction=False,
+    token_tracker: Any | None = None,
     **kwargs,
 ) -> Union[str, AsyncIterator[str]]:
     # Forward legacy extraction flags as kwargs so _ollama_model_if_cache can
@@ -393,12 +467,17 @@ async def ollama_model_complete(
     if entity_extraction:
         kwargs.setdefault("entity_extraction", True)
     model_name = kwargs["hashing_kv"].global_config["llm_model_name"]
+    # Declared and forwarded by name rather than left to ride in **kwargs: this
+    # is the entry point the API server binds and the one library users read,
+    # so the parameter has to be visible in its signature. The OpenAI binding's
+    # wrappers do the same.
     return await _ollama_model_if_cache(
         model_name,
         prompt,
         system_prompt=system_prompt,
         history_messages=history_messages,
         enable_cot=enable_cot,
+        token_tracker=token_tracker,
         **kwargs,
     )
 
@@ -417,6 +496,7 @@ async def ollama_embed(
     query_prefix: str | None = None,
     document_prefix: str | None = None,
     embedding_dim: int | None = None,
+    token_tracker: Any | None = None,
     **kwargs,
 ) -> np.ndarray:
     """Generate embeddings using Ollama's API.
@@ -435,9 +515,13 @@ async def ollama_embed(
         query_prefix: Optional prefix to prepend to texts when context="query" (e.g., "search_query: ").
         document_prefix: Optional prefix to prepend to texts when context="document" (e.g., "search_document: ").
         embedding_dim: Optional target dimension. When set, forwarded to Ollama's
-            embed API so the model actually returns a vector of that size. Kept as
-            the last named parameter (before **kwargs) so existing positional
-            callers of the pre-existing parameters are unaffected.
+            embed API so the model actually returns a vector of that size. New
+            named parameters are appended after the existing ones rather than
+            inserted among them, so positional callers stay unaffected.
+        token_tracker: Optional token usage tracker, as on the LLM path. Ollama
+            reports ``prompt_eval_count`` for an embed call and no
+            ``eval_count``, so a tracked embedding contributes prompt tokens
+            only.
         **kwargs: Additional arguments passed to the Ollama client.
 
     Returns:
@@ -479,6 +563,10 @@ async def ollama_embed(
         if embedding_dim is not None:
             embed_kwargs["dimensions"] = embedding_dim
         data = await ollama_client.embed(**embed_kwargs)
+        if token_tracker:
+            usage_counts = _ollama_usage_counts(data)
+            if usage_counts is not None:
+                token_tracker.add_usage(usage_counts)
         return np.array(data["embeddings"])
     except Exception as e:
         logger.error(f"Error in ollama_embed: {str(e)}")

--- a/tests/llm/ollama_impl/test_ollama_token_usage.py
+++ b/tests/llm/ollama_impl/test_ollama_token_usage.py
@@ -1,0 +1,289 @@
+"""Offline tests: the Ollama binding reports token usage.
+
+Ollama returns ``prompt_eval_count`` / ``eval_count`` on every completed call,
+and this module already read them -- but only to decorate a truncation error
+message. Nothing surfaced them as usage, so the ``TokenTracker`` contract the
+OpenAI and Gemini bindings honour was unimplemented here.
+
+On the chat path, passing ``token_tracker`` was not merely ignored before this:
+everything left in ``**kwargs`` is forwarded verbatim to
+``AsyncClient.chat()``, which declares no ``**kwargs``, so it raised
+``TypeError`` on every call. (``ollama_embed`` builds its client arguments
+explicitly, so there the same kwarg was silently dropped instead.) The
+parameter is explicit now, and the forwarding test below is what keeps it out
+of the wire call.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import numpy as np
+import pytest
+
+from lightrag.llm.ollama import (
+    _ollama_model_if_cache,
+    _ollama_usage_counts,
+    ollama_embed,
+)
+from lightrag.utils import TokenTracker
+
+pytestmark = pytest.mark.offline
+
+
+def _make_fake_client(response):
+    return SimpleNamespace(
+        chat=AsyncMock(return_value=response),
+        _client=SimpleNamespace(aclose=AsyncMock()),
+    )
+
+
+def _chat_response(content="answer", **extra):
+    return {"message": {"content": content}, "done_reason": "stop", **extra}
+
+
+async def _call(response, **kwargs):
+    fake_client = _make_fake_client(response)
+    with patch("lightrag.llm.ollama.ollama.AsyncClient", return_value=fake_client):
+        result = await _ollama_model_if_cache(model="test-model", prompt="Q", **kwargs)
+    return result, fake_client
+
+
+# -- non-streaming ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completion_records_prompt_and_eval_counts():
+    tracker = TokenTracker()
+
+    result, _ = await _call(
+        _chat_response(prompt_eval_count=31, eval_count=11),
+        token_tracker=tracker,
+    )
+
+    assert result == "answer"
+    assert tracker.get_usage() == {
+        "prompt_tokens": 31,
+        "completion_tokens": 11,
+        "total_tokens": 42,
+        "call_count": 1,
+    }, "Ollama's eval counters were not recorded as usage"
+
+
+@pytest.mark.asyncio
+async def test_token_tracker_is_not_forwarded_to_the_wire_call():
+    """`AsyncClient.chat` declares no **kwargs, so a `token_tracker` left in
+    kwargs is a TypeError on every call rather than a no-op. It must be
+    consumed by the binding."""
+    _, fake_client = await _call(
+        _chat_response(prompt_eval_count=1, eval_count=1),
+        token_tracker=TokenTracker(),
+    )
+
+    assert "token_tracker" not in fake_client.chat.await_args.kwargs, (
+        "token_tracker reached AsyncClient.chat(), which declares no **kwargs"
+    )
+
+
+@pytest.mark.asyncio
+async def test_usage_is_counted_before_the_empty_truncation_raise():
+    """The budget was spent whether or not the output was usable, and the
+    empty-and-cut-off case is exactly the one that spent it."""
+    from lightrag.llm.ollama import InvalidResponseError
+
+    tracker = TokenTracker()
+
+    with pytest.raises(InvalidResponseError):
+        await _call(
+            {
+                "message": {"content": "", "thinking": "thought for a while"},
+                "done_reason": "length",
+                "prompt_eval_count": 12,
+                "eval_count": 400,
+            },
+            token_tracker=tracker,
+        )
+
+    assert tracker.get_usage()["total_tokens"] == 412, (
+        "a call that burned its whole budget on the reasoning trace must "
+        "still be billed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_response_without_counters_records_nothing():
+    """Older servers omit the counters; a missing count is not a zero count."""
+    tracker = TokenTracker()
+
+    await _call(_chat_response(), token_tracker=tracker)
+
+    assert tracker.get_usage()["call_count"] == 0, (
+        "a response reporting no counters was billed as a zero-token call"
+    )
+
+
+def test_the_retry_policy_still_guards_the_call():
+    """The `@retry` block sits immediately above `_ollama_model_if_cache`, so a
+    helper defined between the two silently steals it and leaves every Ollama
+    call unretried. Nothing else in this directory pins it."""
+    assert hasattr(_ollama_model_if_cache, "retry"), (
+        "_ollama_model_if_cache lost its tenacity @retry decorator"
+    )
+    assert not hasattr(_ollama_usage_counts, "retry"), (
+        "the @retry block slid onto _ollama_usage_counts"
+    )
+
+
+# -- streaming -------------------------------------------------------------
+
+
+class _FakeStream:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __aiter__(self):
+        async def gen():
+            for chunk in self._chunks:
+                yield chunk
+
+        return gen()
+
+
+@pytest.mark.asyncio
+async def test_streaming_records_usage_from_the_terminal_chunk():
+    tracker = TokenTracker()
+    stream = _FakeStream(
+        [
+            {"message": {"content": "hel"}},
+            {"message": {"content": "lo"}},
+            # Terminal chunk: empty content, counters attached.
+            {
+                "message": {"content": ""},
+                "done": True,
+                "prompt_eval_count": 7,
+                "eval_count": 2,
+            },
+        ]
+    )
+
+    result, _ = await _call(stream, stream=True, token_tracker=tracker)
+    collected = "".join([chunk async for chunk in result])
+
+    assert collected == "hello"
+    assert tracker.get_usage() == {
+        "prompt_tokens": 7,
+        "completion_tokens": 2,
+        "total_tokens": 9,
+        "call_count": 1,
+    }, "the terminal chunk's counters were not recorded"
+
+
+@pytest.mark.asyncio
+async def test_streaming_without_counters_records_nothing():
+    tracker = TokenTracker()
+    stream = _FakeStream([{"message": {"content": "hi"}}])
+
+    result, _ = await _call(stream, stream=True, token_tracker=tracker)
+    assert "".join([chunk async for chunk in result]) == "hi"
+
+    assert tracker.get_usage()["call_count"] == 0, (
+        "a stream reporting no counters was billed as a zero-token call"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_disconnected_stream_is_not_billed():
+    """Accounting sits after the loop and inside the try, so GeneratorExit on
+    consumer disconnect skips it -- the OpenAI binding's choice. Gemini bills a
+    disconnect from a `finally`; this file follows OpenAI."""
+    tracker = TokenTracker()
+    stream = _FakeStream(
+        [
+            {"message": {"content": "hel"}},
+            {"message": {"content": "lo"}},
+            {"message": {"content": ""}, "done": True, "eval_count": 2},
+        ]
+    )
+
+    result, _ = await _call(stream, stream=True, token_tracker=tracker)
+    agen = result.__aiter__()
+    assert await agen.__anext__() == "hel"
+    await agen.aclose()
+
+    assert tracker.get_usage()["call_count"] == 0, (
+        "a stream the consumer abandoned was billed"
+    )
+
+
+# -- embeddings ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embed_records_prompt_tokens_only():
+    """An embed call has no generation, so Ollama reports no `eval_count`."""
+    tracker = TokenTracker()
+    fake_client = SimpleNamespace(
+        embed=AsyncMock(
+            return_value={"embeddings": [[0.1, 0.2]], "prompt_eval_count": 6}
+        ),
+        _client=SimpleNamespace(aclose=AsyncMock()),
+    )
+
+    with patch("lightrag.llm.ollama.ollama.AsyncClient", return_value=fake_client):
+        vectors = await ollama_embed.func(["hello"], token_tracker=tracker)
+
+    assert isinstance(vectors, np.ndarray)
+    assert tracker.get_usage() == {
+        "prompt_tokens": 6,
+        "completion_tokens": 0,
+        "total_tokens": 6,
+        "call_count": 1,
+    }, "embed usage was not recorded, or invented completion tokens"
+
+
+# -- the mapping itself ----------------------------------------------------
+
+
+def test_usage_counts_sums_a_total_ollama_does_not_report():
+    assert _ollama_usage_counts({"prompt_eval_count": 4, "eval_count": 6}) == {
+        "prompt_tokens": 4,
+        "completion_tokens": 6,
+        "total_tokens": 10,
+    }
+
+
+def test_usage_counts_distinguishes_absent_from_zero():
+    # Neither counter: an older or non-conforming server, not a call that
+    # consumed nothing.
+    assert _ollama_usage_counts({}) is None
+    assert _ollama_usage_counts({"message": {"content": "x"}}) is None
+    # One counter present is real usage; the absent half counts as zero.
+    assert _ollama_usage_counts({"eval_count": 3}) == {
+        "prompt_tokens": 0,
+        "completion_tokens": 3,
+        "total_tokens": 3,
+    }
+
+
+def test_usage_counts_reads_an_ollama_0_4_chat_response():
+    """The raw-dict fixtures above stand in for ollama<0.4. Pin the >=0.4
+    object shape too, since `SubscriptableBaseModel.get` is what makes that
+    dict-style access work against a real client."""
+    from ollama import ChatResponse
+
+    response = ChatResponse(
+        model="test-model",
+        message={"role": "assistant", "content": "hi"},
+        prompt_eval_count=8,
+        eval_count=4,
+    )
+
+    assert _ollama_usage_counts(response) == {
+        "prompt_tokens": 8,
+        "completion_tokens": 4,
+        "total_tokens": 12,
+    }
+
+
+def test_usage_counts_degrades_on_a_payload_it_cannot_read():
+    """A shape without `.get` must not take down a usable response."""
+    assert _ollama_usage_counts(object()) is None


### PR DESCRIPTION
## Description

`TokenTracker` (`lightrag/utils.py`) is the binding-facing usage contract, but only `lightrag/llm/openai.py` and `lightrag/llm/gemini.py` implement it. Ollama — the most common local deployment in this tracker — reported nothing, even though the server returns `prompt_eval_count` / `eval_count` on every completed call and this module already reads both to decorate a truncation error message:

```python
diagnostics = format_response_diagnostics(
    done_reason="length",
    eval_count=response.get("eval_count"),
    prompt_eval_count=response.get("prompt_eval_count"),
    ...
)
```

The numbers were already in hand and already accessible; nothing surfaced them as usage.

On the chat path this was worse than a no-op. Everything left in `**kwargs` is forwarded verbatim to `AsyncClient.chat()`, which declares no `**kwargs`:

```
AsyncClient.chat(self, model='', messages=None, *, tools=None, stream=False,
                 think=None, logprobs=None, top_logprobs=None, format=None,
                 options=None, keep_alive=None)
```

So `LightRAG(llm_model_kwargs={"token_tracker": tracker})` — which works on the OpenAI binding, since `llm_model_kwargs` is splatted into the bound role function in `lightrag/llm_roles.py` — raised `TypeError` on every Ollama call. `ollama_embed` builds its client arguments explicitly rather than forwarding `**kwargs`, so there the same kwarg was silently dropped instead.

## Related Issues

Refs #2572, which asks for token usage on the REST surface. This is the layer under that: usage cannot be exposed for a binding that never reports it. It does not close the issue.

## Changes Made

- `token_tracker` is an explicit parameter on `_ollama_model_if_cache`, `ollama_model_complete` and `ollama_embed`. Explicit rather than a `kwargs` key because on the chat path an unconsumed one reaches the wire call. Appended after the existing parameters, so positional callers are unaffected.
- `_ollama_usage_counts()` maps Ollama's counters onto the tracker's key names and sums the total Ollama does not report. It reads through `.get`, which covers both the raw dict of ollama<0.4 and the `SubscriptableBaseModel` `ChatResponse` of >=0.4 — the accessor the truncation diagnostics already rely on — and returns `None` for a payload with no `.get` rather than raising, for the reason `_response_message_field` gives next door: a shape this helper cannot read must not take down a response the caller could have used.
- Non-streaming, streaming and embedding paths all account.

### Two decisions worth a reviewer's eye

**Absent is not zero.** A payload reporting neither counter records nothing. An older or non-conforming server that reports no numbers is not evidence of a zero-token call, and recording it as a genuine zero would make a tracked total silently under-count instead of visibly skipping. A payload reporting one of the two is real usage, and the missing half counts as zero.

**Streaming accounts after the loop and inside the `try`**, so a consumer that disconnects mid-stream is not billed. That is the OpenAI binding's behaviour; Gemini accounts from a `finally` and does bill a disconnect. The two upstream bindings already disagree, so this follows the one whose usage semantics the rest of this file mirrors, and says so in a comment rather than leaving the next reader to discover the split. Happy to flip it if you would rather the bindings converge the other way.

Non-streaming accounts before the empty-truncation check raises: the request burned its budget whether or not the output was usable, and a thinking model that spent the whole `num_predict` on its reasoning trace is exactly the case that raises there. This matches the OpenAI binding, which counts usage before its own empty-response validation.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

New `tests/llm/ollama_impl/test_ollama_token_usage.py`. Beyond the happy paths it pins the decisions above: usage counted before the truncation raise, a counter-less response and a counter-less stream recording nothing, an abandoned stream not billed, `token_tracker` never reaching `AsyncClient.chat()`, and the mapper against a real `ChatResponse` so the ollama>=0.4 claim is not left to the raw-dict fixtures.

One test is not about this feature. `tests/llm/ollama_impl/` pins no retry policy, and the `@retry(...)` block sits immediately above `async def _ollama_model_if_cache` — so a helper defined between the two silently takes the decorator and leaves every Ollama call unretried, with both lines showing as context in the diff. I did exactly that in an earlier revision of this branch and caught it in review, so `test_the_retry_policy_still_guards_the_call` now asserts the decorator is where it belongs.

The change is additive: 0 deleted lines in `lightrag/llm/ollama.py`. Run subset per AGENTS.md: `tests/llm/ollama_impl`.
