### PR TITLE
fix(extraction): report an unparseable rebuild payload once, not twice

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -907,6 +907,7 @@ async def _process_json_extraction_result(
     chunk_key: str,
     timestamp: int,
     file_path: str = "unknown_source",
+    parsed: dict[str, Any] | None = None,
 ) -> tuple[dict, dict]:
     """Process a JSON-formatted extraction result from LLM.
 
@@ -919,6 +920,13 @@ async def _process_json_extraction_result(
         chunk_key: The chunk key for source tracking
         timestamp: The timestamp for the extraction
         file_path: The file path for citation
+        parsed: Payload already recovered by :func:`tolerant_load_json_dict`,
+            for callers that need the parse outcome themselves rather than
+            only the extracted entities -- an empty result does not say
+            whether the payload was unrecoverable or merely carried nothing,
+            and cache rebuild has to tell those apart. ``None`` means "not
+            supplied" and is unambiguous: the helper always returns a dict,
+            so an unrecoverable payload still arrives here as ``{}``.
 
     Returns:
         tuple: (nodes_dict, edges_dict) containing the extracted entities and relationships
@@ -933,7 +941,8 @@ async def _process_json_extraction_result(
     # helper absorbs the underlying parse exception, only this single "empty or
     # unrecoverable" warning is logged — the low-level decode error is no longer
     # surfaced.
-    parsed = tolerant_load_json_dict(result)
+    if parsed is None:
+        parsed = tolerant_load_json_dict(result)
     if not parsed:
         logger.warning(
             f"{chunk_key}: JSON extraction result is empty or unrecoverable"
@@ -1669,22 +1678,31 @@ async def _rebuild_from_extraction_result(
     # Auto-detect format: try JSON first if the result looks like JSON
     json_parse_reported_failure = False
     if _looks_like_json_extraction_result(extraction_result):
+        # Parse here and hand the payload down, so the parse outcome -- not the
+        # emptiness of what was extracted from it -- decides whether the failure
+        # below was already reported. The two differ: a payload that parses but
+        # carries the wrong schema ({"answer": "none found"}) extracts nothing
+        # while _process_json_extraction_result stays silent about it.
+        parsed = tolerant_load_json_dict(extraction_result)
         # Likely JSON format (from entity_extraction_use_json mode)
         nodes, edges = await _process_json_extraction_result(
             extraction_result,
             chunk_id,
             timestamp,
             file_path,
+            parsed=parsed,
         )
         # If JSON parsing yielded results, use them
         if nodes or edges:
             return nodes, edges
-        # Otherwise fall through to text-based parsing. _process_json_extraction_result
-        # has already logged the parse failure, and the delimiter parser below is a
-        # speculative rescue for a payload that only looked like JSON -- its own
-        # "no completion delimiter" complaint would report that same single failure a
-        # second time, so it is demoted to DEBUG for this call only.
-        json_parse_reported_failure = True
+        # Otherwise fall through to text-based parsing. When the payload was
+        # unrecoverable, _process_json_extraction_result has already logged that
+        # failure and the delimiter parser below is only a speculative rescue --
+        # its own "no completion delimiter" complaint would report the same
+        # single failure a second time, so it is demoted to DEBUG for this call.
+        # When the payload parsed, nothing has been reported yet and the
+        # delimiter parser keeps its warning.
+        json_parse_reported_failure = not parsed
 
     # Fall back to traditional delimiter-based parsing
     return await _process_extraction_result(

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -1501,6 +1501,7 @@ async def _process_extraction_result(
     file_path: str = "unknown_source",
     tuple_delimiter: str = "<|#|>",
     completion_delimiter: str = "<|COMPLETE|>",
+    warn_on_missing_completion_delimiter: bool = True,
 ) -> tuple[dict, dict]:
     """Process a single extraction result (either initial or gleaning)
     Args:
@@ -1509,6 +1510,11 @@ async def _process_extraction_result(
         file_path (str): The file path for citation
         tuple_delimiter (str): Delimiter for tuple fields
         completion_delimiter (str): Delimiter for completion
+        warn_on_missing_completion_delimiter (bool): Whether a missing
+            completion delimiter is worth a WARNING. Callers that already
+            reported the failure they are recovering from pass False so the
+            same failure is not announced twice; the missing delimiter is
+            still logged at DEBUG level for diagnosis.
     Returns:
         tuple: (nodes_dict, edges_dict) containing the extracted entities and relationships
     """
@@ -1516,10 +1522,14 @@ async def _process_extraction_result(
     maybe_edges = defaultdict(list)
 
     if completion_delimiter not in result:
-        logger.warning(
+        message = (
             f"{chunk_key}: Complete delimiter can not be found in extraction result"
             f"{_truncation_cause_suffix(result)}"
         )
+        if warn_on_missing_completion_delimiter:
+            logger.warning(message)
+        else:
+            logger.debug(message)
 
     # Split LLL output result to records by "\n"
     records = split_string_by_multi_markers(
@@ -1657,6 +1667,7 @@ async def _rebuild_from_extraction_result(
     )
 
     # Auto-detect format: try JSON first if the result looks like JSON
+    json_parse_reported_failure = False
     if _looks_like_json_extraction_result(extraction_result):
         # Likely JSON format (from entity_extraction_use_json mode)
         nodes, edges = await _process_json_extraction_result(
@@ -1668,7 +1679,12 @@ async def _rebuild_from_extraction_result(
         # If JSON parsing yielded results, use them
         if nodes or edges:
             return nodes, edges
-        # Otherwise fall through to text-based parsing
+        # Otherwise fall through to text-based parsing. _process_json_extraction_result
+        # has already logged the parse failure, and the delimiter parser below is a
+        # speculative rescue for a payload that only looked like JSON -- its own
+        # "no completion delimiter" complaint would report that same single failure a
+        # second time, so it is demoted to DEBUG for this call only.
+        json_parse_reported_failure = True
 
     # Fall back to traditional delimiter-based parsing
     return await _process_extraction_result(
@@ -1678,6 +1694,7 @@ async def _rebuild_from_extraction_result(
         file_path,
         tuple_delimiter=PROMPTS["DEFAULT_TUPLE_DELIMITER"],
         completion_delimiter=PROMPTS["DEFAULT_COMPLETION_DELIMITER"],
+        warn_on_missing_completion_delimiter=not json_parse_reported_failure,
     )
 
 

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -1678,11 +1678,11 @@ async def _rebuild_from_extraction_result(
     # Auto-detect format: try JSON first if the result looks like JSON
     json_parse_reported_failure = False
     if _looks_like_json_extraction_result(extraction_result):
-        # Parse here and hand the payload down, so the parse outcome -- not the
-        # emptiness of what was extracted from it -- decides whether the failure
-        # below was already reported. The two differ: a payload that parses but
-        # carries the wrong schema ({"answer": "none found"}) extracts nothing
-        # while _process_json_extraction_result stays silent about it.
+        # Parse once here and hand the payload down. The parse outcome, not the
+        # emptiness of what was extracted from it, is what decides below whether
+        # the failure being recovered from was already reported -- the two are
+        # different things, and a payload carrying the wrong schema
+        # ({"answer": "none found"}) extracts nothing while parsing perfectly.
         parsed = tolerant_load_json_dict(extraction_result)
         # Likely JSON format (from entity_extraction_use_json mode)
         nodes, edges = await _process_json_extraction_result(
@@ -1694,16 +1694,15 @@ async def _rebuild_from_extraction_result(
         )
         # A successful parse (tolerant_load_json_dict's own non-empty-dict
         # signal) is accepted even when it legitimately yields no nodes/edges.
-        if nodes or edges or tolerant_load_json_dict(extraction_result):
+        if nodes or edges or parsed:
             return nodes, edges
-        # Otherwise fall through to text-based parsing. When the payload was
-        # unrecoverable, _process_json_extraction_result has already logged that
-        # failure and the delimiter parser below is only a speculative rescue --
-        # its own "no completion delimiter" complaint would report the same
-        # single failure a second time, so it is demoted to DEBUG for this call.
-        # When the payload parsed, nothing has been reported yet and the
-        # delimiter parser keeps its warning.
-        json_parse_reported_failure = not parsed
+        # Only an unrecoverable payload can reach here, and
+        # _process_json_extraction_result has already logged that failure. The
+        # delimiter parser below is a speculative rescue for a payload that
+        # merely looked like JSON, so its own "no completion delimiter"
+        # complaint would report that same single failure a second time; it is
+        # demoted to DEBUG for this call.
+        json_parse_reported_failure = True
 
     # Fall back to traditional delimiter-based parsing
     return await _process_extraction_result(

--- a/tests/extraction/test_rebuild_fallback_warning_dedup.py
+++ b/tests/extraction/test_rebuild_fallback_warning_dedup.py
@@ -109,14 +109,29 @@ async def test_json_payload_rescued_by_the_delimiter_parser_keeps_its_records(
 
 
 @pytest.mark.asyncio
-async def test_wrong_schema_json_payload_keeps_the_fallback_warning(
-    caplog, _propagate_lightrag_logger
+async def test_wrong_schema_json_payload_never_reaches_the_fallback(
+    monkeypatch, caplog, _propagate_lightrag_logger
 ) -> None:
-    """A payload that parses but has none of the extraction fields extracts
+    """A payload that parses but carries none of the extraction fields extracts
     nothing, and ``_process_json_extraction_result`` reports nothing about it.
-    Demotion keys off the parse outcome rather than off the empty result, so
-    this chunk keeps the one warning it has -- inferring "already reported"
-    from emptiness would silence it entirely."""
+
+    This is what makes the demotion above safe to apply unconditionally: such a
+    payload is accepted as a successful parse and returns early, so the
+    delimiter parser is never invoked and there is no warning to lose. Keying
+    the demotion off the empty extraction result instead of off the parse
+    outcome would silence this chunk's only warning the moment that early
+    return went away, so pin the early return itself.
+    """
+    from lightrag import operate
+
+    calls: list[str] = []
+
+    async def _spy(result, chunk_key, *args, **kwargs):
+        calls.append(chunk_key)
+        return {}, {}
+
+    monkeypatch.setattr(operate, "_process_extraction_result", _spy)
+
     with caplog.at_level(logging.WARNING, logger="lightrag"):
         nodes, edges = await _rebuild_from_extraction_result(
             DummyKV(),
@@ -127,7 +142,5 @@ async def test_wrong_schema_json_payload_keeps_the_fallback_warning(
 
     assert nodes == {}
     assert edges == {}
-
-    warnings = _warnings(caplog)
-    assert any(_DELIMITER_WARNING in message for message in warnings), warnings
-    assert not any(_JSON_WARNING in message for message in warnings), warnings
+    assert calls == [], calls
+    assert _warnings(caplog) == []

--- a/tests/extraction/test_rebuild_fallback_warning_dedup.py
+++ b/tests/extraction/test_rebuild_fallback_warning_dedup.py
@@ -9,7 +9,10 @@ delimiter is missing because the payload was never delimiter-formatted, which
 is a consequence of the already-reported failure rather than a new finding.
 
 A genuinely delimiter-formatted payload that is missing its terminator is a
-different matter -- nothing else reported it, so that WARNING stays.
+different matter -- nothing else reported it, so that WARNING stays. So is a
+payload that parses cleanly but carries the wrong schema: the JSON parser
+accepts it and says nothing, so demoting there would leave the chunk with no
+parse-level warning at all.
 """
 
 from __future__ import annotations
@@ -103,3 +106,28 @@ async def test_json_payload_rescued_by_the_delimiter_parser_keeps_its_records(
         )
 
     assert "Alice" in nodes
+
+
+@pytest.mark.asyncio
+async def test_wrong_schema_json_payload_keeps_the_fallback_warning(
+    caplog, _propagate_lightrag_logger
+) -> None:
+    """A payload that parses but has none of the extraction fields extracts
+    nothing, and ``_process_json_extraction_result`` reports nothing about it.
+    Demotion keys off the parse outcome rather than off the empty result, so
+    this chunk keeps the one warning it has -- inferring "already reported"
+    from emptiness would silence it entirely."""
+    with caplog.at_level(logging.WARNING, logger="lightrag"):
+        nodes, edges = await _rebuild_from_extraction_result(
+            DummyKV(),
+            '{"answer": "no entities found"}',
+            chunk_id="chunk-4",
+            timestamp=1,
+        )
+
+    assert nodes == {}
+    assert edges == {}
+
+    warnings = _warnings(caplog)
+    assert any(_DELIMITER_WARNING in message for message in warnings), warnings
+    assert not any(_JSON_WARNING in message for message in warnings), warnings

--- a/tests/extraction/test_rebuild_fallback_warning_dedup.py
+++ b/tests/extraction/test_rebuild_fallback_warning_dedup.py
@@ -1,0 +1,105 @@
+"""One failure must be reported once.
+
+When a cache-rebuild payload looks like JSON but cannot be parsed,
+``_process_json_extraction_result`` logs the failure and
+``_rebuild_from_extraction_result`` then tries the delimiter parser as a
+speculative rescue. That rescue attempt must not announce the same failure a
+second time with its own "Complete delimiter can not be found" WARNING: the
+delimiter is missing because the payload was never delimiter-formatted, which
+is a consequence of the already-reported failure rather than a new finding.
+
+A genuinely delimiter-formatted payload that is missing its terminator is a
+different matter -- nothing else reported it, so that WARNING stays.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from lightrag.operate import _rebuild_from_extraction_result
+
+pytestmark = pytest.mark.offline
+
+_DELIMITER_WARNING = "Complete delimiter can not be found"
+_JSON_WARNING = "JSON extraction result is empty or unrecoverable"
+
+
+class DummyKV:
+    async def get_by_id(self, key):
+        return {"file_path": "doc.pdf"}
+
+
+@pytest.fixture
+def _propagate_lightrag_logger(monkeypatch):
+    """``lightrag.utils.logger`` sets ``propagate = False``; restore
+    propagation locally so ``caplog`` can capture records."""
+    monkeypatch.setattr(logging.getLogger("lightrag"), "propagate", True)
+
+
+def _warnings(caplog) -> list[str]:
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unparseable_json_payload_reports_the_failure_exactly_once(
+    caplog, _propagate_lightrag_logger
+) -> None:
+    with caplog.at_level(logging.DEBUG, logger="lightrag"):
+        nodes, edges = await _rebuild_from_extraction_result(
+            DummyKV(),
+            "{not json at all, no delimiter either",
+            chunk_id="chunk-1",
+            timestamp=1,
+        )
+
+    assert nodes == {}
+    assert edges == {}
+
+    warnings = _warnings(caplog)
+    assert len(warnings) == 1, warnings
+    assert _JSON_WARNING in warnings[0]
+
+    # The rescue attempt's own finding is kept for diagnosis, just not at a
+    # level that reads as a second, independent failure.
+    assert _DELIMITER_WARNING in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_delimiter_payload_missing_its_terminator_still_warns(
+    caplog, _propagate_lightrag_logger
+) -> None:
+    """The payload never looked like JSON, so no one else reported anything and
+    the delimiter parser's warning is the only signal there is."""
+    with caplog.at_level(logging.WARNING, logger="lightrag"):
+        await _rebuild_from_extraction_result(
+            DummyKV(),
+            '("entity"<|#|>Alice<|#|>person<|#|>an engineer)',
+            chunk_id="chunk-2",
+            timestamp=1,
+        )
+
+    warnings = _warnings(caplog)
+    assert any(_DELIMITER_WARNING in message for message in warnings), warnings
+
+
+@pytest.mark.asyncio
+async def test_json_payload_rescued_by_the_delimiter_parser_keeps_its_records(
+    caplog, _propagate_lightrag_logger
+) -> None:
+    """Demoting the warning must not disturb the rescue itself: an empty JSON
+    object with delimiter records appended still yields those records."""
+    with caplog.at_level(logging.WARNING, logger="lightrag"):
+        nodes, _edges = await _rebuild_from_extraction_result(
+            DummyKV(),
+            '{}\n("entity"<|#|>Alice<|#|>person<|#|>an engineer)\n<|COMPLETE|>',
+            chunk_id="chunk-3",
+            timestamp=1,
+        )
+
+    assert "Alice" in nodes

--- a/tests/extraction/test_rebuild_json_empty_fallback.py
+++ b/tests/extraction/test_rebuild_json_empty_fallback.py
@@ -62,9 +62,15 @@ async def test_rebuild_still_falls_back_on_unparseable_json_looking_text(
 ) -> None:
     """Text that starts with '{' but is not recoverable JSON, and also has no
     completion marker, is the pre-existing garbage-input case: falling
-    through to the delimiter parser (and its warning) is correct there,
-    unlike the valid-empty-JSON case above."""
-    with caplog.at_level(logging.WARNING, logger="lightrag"):
+    through to the delimiter parser is correct there, unlike the
+    valid-empty-JSON case above.
+
+    The delimiter parser's finding is recorded at DEBUG rather than WARNING on
+    this path: the JSON parser has already reported the failure at WARNING, and
+    repeating it would make one bad chunk read as two problems. See
+    ``test_rebuild_fallback_warning_dedup.py``.
+    """
+    with caplog.at_level(logging.DEBUG, logger="lightrag"):
         nodes, edges = await _rebuild_from_extraction_result(
             DummyKV(),
             "{not json at all, no delimiter either",


### PR DESCRIPTION
## Description

During cache rebuild, a payload that looks like JSON but cannot be parsed is reported **twice** for a single failure:

1. `_process_json_extraction_result` logs `"<chunk>: JSON extraction result is empty or unrecoverable"`.
2. `_rebuild_from_extraction_result` then falls through to the delimiter parser, which logs `"<chunk>: Complete delimiter can not be found in extraction result"`.

The second message is not an independent finding. The delimiter is missing because the payload was never delimiter-formatted, which is a direct consequence of the failure already reported one line up. At WARNING level it makes one bad chunk look like two distinct problems, and points at a delimiter-format issue that does not exist.

This demotes that second message to DEBUG on that one path. The delimiter parser is unchanged for every other caller, and the rescue it performs is untouched — an empty JSON object with delimiter records appended still yields those records.

## Related Issues

Follows #3745 (merged), which fixed a different warning on the same function: a *valid* empty JSON extraction being misread as a parse failure. This PR has been merged up to it and reconciled — see the last commit and the note below.

## Changes Made

- `lightrag/operate.py`
  - `_process_extraction_result` takes `warn_on_missing_completion_delimiter: bool = True`. When False the missing-completion-delimiter finding goes to DEBUG instead of WARNING, so nothing is lost for diagnosis.
  - `_process_json_extraction_result` takes `parsed: dict | None = None`, letting a caller that has already recovered the payload hand it in instead of having it re-parsed. `None` is unambiguous as "not supplied" because `tolerant_load_json_dict` always returns a dict, so an unrecoverable payload still arrives as `{}`.
  - `_rebuild_from_extraction_result` parses once, uses that payload both for the #3745 acceptance test and for the demotion decision, and demotes only on the fall-through — which after #3745 only an unrecoverable payload can reach.
  - Net effect on the parse count for this path: `main` parses the payload twice (once inside the parser, once in #3745's acceptance condition); this PR parses it once.
  - The defaults keep the live extraction path (`operate.py:4134` and `4200`) and genuine delimiter payloads behaving exactly as before.
- `tests/extraction/test_rebuild_fallback_warning_dedup.py` (new, 4 tests)
  - An unparseable JSON-looking payload produces exactly one WARNING (the JSON one), with the delimiter finding still present at DEBUG.
  - A delimiter-formatted payload missing its terminator still WARNs — nothing else reported it, so it is the only signal there is.
  - A wrong-schema JSON payload never reaches the fallback at all, spying on `_process_extraction_result` to prove it. This is what makes the demotion safe to apply unconditionally, and is the thing that would have to be revisited if that early return were removed.
  - The rescue path still recovers delimiter records appended after an empty JSON object.
- `tests/extraction/test_rebuild_json_empty_fallback.py` (from #3745)
  - `test_rebuild_still_falls_back_on_unparseable_json_looking_text` asserted the delimiter finding at WARNING, which is exactly the message this PR moves. It keeps every assertion it made — the fall-through, the empty result, and the presence of the finding — and captures at DEBUG instead.

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

**What's broken and how the fix works:** the two log sites have no knowledge of each other, so the fallback parser cannot tell "I am the first one to look at this payload" from "I am a rescue attempt after someone already reported a failure". The caller knows, so the decision is passed down from there rather than inferred at the log site.

**Review history worth reading:** the first version keyed the demotion off empty extraction results. Codex correctly pointed out that emptiness does not imply the JSON parser said anything — a payload that parses but carries the wrong schema (`{"answer": "no entities found"}`) extracts nothing in silence, so the demotion removed that chunk's *only* warning instead of deduplicating two. Fixed in 0b0c8b4 by tracking the parse outcome, and #3745 landing has since made that case return early anyway; the test now pins the early return.

**What this deliberately leaves alone:** #3745 already decided that a JSON payload accepted as a valid parse gets no delimiter warning. This PR does not revisit that; it only removes the doubled report on the unparseable path.

**Verification**

- `tests/extraction`: 265 passed, 7 failed. The 7 failures are identical on `main` (261 passed, 7 failed — the delta is exactly the 4 new tests) and come from missing spaCy models in this environment; `test_keyword_extraction_drivers.py` fails to collect for the same reason on both sides and was excluded.
- `tests/pipeline` and `tests/llm/test_vlm_json_escape_repair.py`: 694 passed. Together with `tests/extraction` this covers every test file referencing the changed symbols or log strings.
- `ruff check` and `ruff format --check` clean.

**Not verified:** the live (non-cached) extraction path, which does not reach this fallback and is unaffected by the default arguments.