### PR TITLE
🐛 fix(webui): stop the conversation area from scrolling horizontally on phones

### DIFF
--- a/lightrag_webui/src/components/retrieval/ChatMessage.tsx
+++ b/lightrag_webui/src/components/retrieval/ChatMessage.tsx
@@ -41,6 +41,17 @@ export type { MessageWithError } from '@/types/retrieval'
 // full Mermaid support in both entries.
 const loadMermaid = () => import('mermaid').then((m) => m.default)
 
+/**
+ * Tables scroll INSIDE their own block. The message list scrolls vertically
+ * only (see MessageList), so a table wider than the conversation column would
+ * otherwise be clipped and unreachable on a narrow screen.
+ */
+const ScrollableTable = ({ children }: { children?: ReactNode }) => (
+  <div className="my-2 max-w-full overflow-x-auto">
+    <table>{children}</table>
+  </div>
+)
+
 // Restore original component definition and export
 export const ChatMessage = ({
   message,
@@ -148,11 +159,13 @@ export const ChatMessage = ({
     h4: ({ children }: { children?: ReactNode }) => <h4 className="text-base font-semibold mt-3 mb-2">{children}</h4>,
     ul: ({ children }: { children?: ReactNode }) => <ul className="list-disc pl-5 my-2">{children}</ul>,
     ol: ({ children }: { children?: ReactNode }) => <ol className="list-decimal pl-5 my-2">{children}</ol>,
-    li: ({ children }: { children?: ReactNode }) => <li className="my-1">{children}</li>
+    li: ({ children }: { children?: ReactNode }) => <li className="my-1">{children}</li>,
+    table: ScrollableTable
   }), [message.mermaidRendered, message.role]);
 
   const thinkingMarkdownComponents = useMemo(() => ({
-    code: (props: any) => (<CodeHighlight {...props} renderAsDiagram={message.mermaidRendered ?? false} messageRole={message.role} />)
+    code: (props: any) => (<CodeHighlight {...props} renderAsDiagram={message.mermaidRendered ?? false} messageRole={message.role} />),
+    table: ScrollableTable
   }), [message.mermaidRendered, message.role]);
 
   // Whether the assistant has begun emitting visible answer text. Drives both
@@ -188,6 +201,11 @@ export const ChatMessage = ({
       </div>
     ) : null
 
+  // The bubble shares its flex row with a fixed-width copy button (24px plus
+  // an 8px gap), and its percentage width knows nothing about that. `min-w-0`
+  // is therefore required, not cosmetic: without it the flex item's automatic
+  // minimum size pins the bubble at 95% and the row overflows by ~32px on a
+  // phone-width screen.
   return (
     <div
       className={`${
@@ -196,7 +214,7 @@ export const ChatMessage = ({
           : message.isError
             ? 'w-[95%] bg-red-100 text-red-600 dark:bg-red-950 dark:text-red-400'
             : 'w-[95%] bg-muted'
-      } rounded-lg px-4 py-2`}
+      } min-w-0 rounded-lg px-4 py-2`}
     >
       {/* Before any answer text: the timing row sits on top and the thinking
           hint appears beneath it, so the time doesn't jump when "Thinking..."

--- a/lightrag_webui/src/features/LoginPage.tsx
+++ b/lightrag_webui/src/features/LoginPage.tsx
@@ -164,7 +164,7 @@ const LoginPage = ({ autoActivateGuest = true }: LoginPageProps) => {
       // chrome in 100vh, which can push the form under the toolbar; dvh
       // tracks the actually visible viewport, and min- lets small screens
       // scroll instead of clipping.
-      className="flex min-h-dvh w-screen items-center justify-center bg-gradient-to-br from-emerald-50 to-teal-100 dark:from-gray-900 dark:to-gray-800"
+      className="flex min-h-dvh w-full items-center justify-center bg-gradient-to-br from-emerald-50 to-teal-100 dark:from-gray-900 dark:to-gray-800"
       style={{
         padding:
           'calc(env(safe-area-inset-top) + 1rem) calc(env(safe-area-inset-right) + 1rem) calc(env(safe-area-inset-bottom) + 1rem) calc(env(safe-area-inset-left) + 1rem)'
@@ -206,7 +206,7 @@ const LoginPage = ({ autoActivateGuest = true }: LoginPageProps) => {
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
                 required
-                className="h-11 flex-1"
+                className="h-11 min-w-0 flex-1"
               />
             </div>
             <div className="flex items-center gap-4">
@@ -220,7 +220,7 @@ const LoginPage = ({ autoActivateGuest = true }: LoginPageProps) => {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
-                className="h-11 flex-1"
+                className="h-11 min-w-0 flex-1"
               />
             </div>
             <Button

--- a/lightrag_webui/src/features/retrieval/MessageList.tsx
+++ b/lightrag_webui/src/features/retrieval/MessageList.tsx
@@ -290,7 +290,14 @@ export default function MessageList({
     <div className="relative grow">
       <div
         ref={messagesContainerRef}
-        className="bg-primary-foreground/60 absolute inset-0 flex flex-col overflow-auto rounded-lg border p-2"
+        // Vertical scrolling only. The list must NEVER scroll horizontally:
+        // its children legitimately paint outside the content box (the copy
+        // buttons' ::after touch targets extend 10px past the message row),
+        // and wide answer content scrolls INSIDE its own block (code, tables)
+        // rather than widening the conversation. Plain `overflow-auto` turned
+        // both into a horizontal scrollbar on narrow screens — visible from
+        // the very first short message.
+        className="bg-primary-foreground/60 absolute inset-0 flex flex-col overflow-y-auto overflow-x-hidden rounded-lg border p-2"
       >
         <div className="flex min-h-0 flex-1 flex-col gap-2">
           {messages.length === 0 ? (


### PR DESCRIPTION
## Description

The `/workspace` query page showed a horizontal scrollbar on phone-width screens as soon as the conversation contained any message — even a two-character one. The cause was not wide content: the message list used plain `overflow-auto`, so it took over horizontal scrolling as well, while two of its own children legitimately paint outside the content box.

Measured in Chrome against the production bundle at a 320px viewport, before the fix:

| Element | scrollWidth / clientWidth |
|---|---|
| message list (`overflow-auto`) | 322 / 302 |
| message row | 314 / 286 |
| document (login page) | 330 / 320 |

## Related Issues

None — reported directly against a local deployment.

## Changes Made

**1. `MessageList.tsx` — the conversation area scrolls vertically only**

`overflow-auto` → `overflow-y-auto overflow-x-hidden`. The copy buttons' touch targets (`after:-inset-2.5`, present so the 24px buttons reach the 44px minimum without moving layout) are absolutely positioned 10px outside the message row, and absolutely positioned descendants count toward the scrollable overflow area. That alone was enough to raise a horizontal scrollbar at every viewport width.

**2. `ChatMessage.tsx` — `min-w-0` on the message bubble**

The assistant bubble is `w-[95%]` and shares its flex row with a fixed 24px copy button plus an 8px gap; a percentage width knows nothing about that, and without `min-w-0` the flex item's automatic minimum size stopped it from shrinking. The row therefore overflowed by ~32px whenever 5% of the container was less than 32px — i.e. below ~640px.

**3. `ChatMessage.tsx` — markdown tables get their own scroll container**

Required by change 1, not cosmetic: with the list clipping horizontally, a table wider than the conversation column would have been silently cut off with no way to reach it. Tables now render inside a `max-w-full overflow-x-auto` wrapper and scroll within their own block, the same way code blocks already did.

**4. `LoginPage.tsx` — `min-w-0` on the credential inputs, `w-screen` → `w-full`**

The workspace entry's own sign-in step overflowed at 320px for the same class of reason: an `<input>` carries a ~200px intrinsic width, which is also its automatic minimum size as a flex item, so the `label + input` row could not shrink below ~280px. The page root also used `w-screen` on a `min-h-dvh` layout, where `100vw` includes the scrollbar gutter once the page actually scrolls.

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

**Verification.** Driven with Playwright against the built bundle served by the API server, at 320 / 375 / 414 / 500 / 768 / 1280 px, for short-message, code-block, table, long-URL and wide-table conversations. After the fix, neither the document nor the message list scrolls horizontally at any width, while a 518px table inside a 222px column and a 947px code block both remain reachable through their own in-block scrolling. `bun run lint`, `bun run build` (including the workspace first-load size audit) and `bun test` (372 passed) are green.

**No unit test.** Layout overflow is not observable in the bun + happy-dom stack this repo tests the WebUI with; a `className` assertion would fail on the old code only because the symbol is missing, never behaviourally, which does not meet the project's bar for a regression test. The verification above is the evidence.

**Admin page.** `MessageList` and `ChatMessage` are shared with `/webui`, which carried the same 6–10px touch-target overflow. That is fixed there too; the admin retrieval view was re-checked at 1280 and 768 with no visual change.

**Touch targets.** Clipping costs about 2px of the copy button's 44px hit area (8px of the 10px extension falls inside the container's own `p-2` padding), leaving ~42px. Restructuring the touch target for those 2px did not seem worth it.

**Left alone.** The remaining `w-screen` uses (`App.tsx`, `WorkspaceApp`, `WorkspaceWelcome`, `MigrationErrorScreen`) all sit in `h-dvh` / `overflow-hidden` contexts that never produce a vertical scrollbar, so the `100vw` problem cannot trigger there. They are untouched rather than swept along with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
