### PR TITLE
feat(api): add GET /graph/export to download the full knowledge graph

### DIFF
--- a/lightrag/api/routers/graph_routes.py
+++ b/lightrag/api/routers/graph_routes.py
@@ -2,10 +2,15 @@
 This module contains all graph-related routes for the LightRAG API.
 """
 
-from typing import Optional, Dict, Any
+import os
+import tempfile
 import traceback
+from pathlib import Path
+from typing import Optional, Dict, Any, Literal
 from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
+from starlette.background import BackgroundTask
 
 from lightrag.base import DeletionResult
 from lightrag.utils import logger
@@ -851,5 +856,75 @@ def create_graph_routes(rag, api_key: Optional[str] = None):
             logger.error(error_msg)
             logger.error(traceback.format_exc())
             raise internal_server_error(e)
+
+    _EXPORT_SUFFIXES: dict[str, str] = {
+        "csv": ".csv",
+        "excel": ".xlsx",
+        "md": ".md",
+        "txt": ".txt",
+    }
+    _EXPORT_MEDIA_TYPES: dict[str, str] = {
+        "csv": "text/csv",
+        "excel": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "md": "text/markdown",
+        "txt": "text/plain",
+    }
+
+    @router.get("/graph/export", dependencies=[Depends(combined_auth)])
+    async def export_graph(
+        file_format: Literal["csv", "excel", "md", "txt"] = Query(
+            "csv", description="Export file format"
+        ),
+        include_vector_data: bool = Query(
+            False, description="Include vector database data in the export"
+        ),
+    ) -> FileResponse:
+        """
+        Export the full knowledge graph (all entities, relations, and
+        relationships) as a downloadable file.
+
+        Unlike ``GET /graphs``, which returns a bounded, connected subgraph
+        for interactive viewing, this dumps the entire graph -- intended for
+        offline review, backup, or manual editing outside the running
+        instance. Delegates to :meth:`LightRAG.aexport_data`, writing to a
+        server-managed temporary file (never a client-supplied path) that is
+        removed once the response has been fully sent.
+
+        Args:
+            file_format: Output format -- csv, excel, md, or txt.
+            include_vector_data: Whether to include embedding-vector
+                metadata alongside each entity/relation.
+
+        Returns:
+            FileResponse: The export file as a binary attachment.
+
+        Raises:
+            HTTPException: On an unexpected error while building or writing
+                the export (500).
+        """
+        suffix = _EXPORT_SUFFIXES[file_format]
+        fd, tmp_path_str = tempfile.mkstemp(
+            suffix=suffix, prefix="lightrag_graph_export_"
+        )
+        os.close(fd)
+        tmp_path = Path(tmp_path_str)
+        try:
+            await rag.aexport_data(
+                str(tmp_path),
+                file_format=file_format,
+                include_vector_data=include_vector_data,
+            )
+        except Exception as e:
+            tmp_path.unlink(missing_ok=True)
+            logger.error(f"Error exporting graph as '{file_format}': {str(e)}")
+            logger.error(traceback.format_exc())
+            raise internal_server_error(e)
+
+        return FileResponse(
+            path=tmp_path,
+            filename=f"lightrag_graph_export{suffix}",
+            media_type=_EXPORT_MEDIA_TYPES[file_format],
+            background=BackgroundTask(tmp_path.unlink, missing_ok=True),
+        )
 
     return router

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -4166,13 +4166,41 @@ async def aexport_data(
                 relations_data.append(relation_row)
 
     # --- Relationships (from VectorDB) ---
-    all_relationships = await relationships_vdb.client_storage
-    for rel in all_relationships["data"]:
-        relationships_data.append(
-            {
-                "relationship_id": rel["__id__"],
-                "data": str(rel),  # Convert to string for compatibility
-            }
+    # ``client_storage`` is a debug/snapshot escape hatch, not part of the
+    # BaseVectorStorage contract: only NanoVectorDBStorage (async property)
+    # and FaissVectorDBStorage (sync property) implement it. Every other
+    # backend (Milvus, Qdrant, Postgres, Redis, MongoDB, OpenSearch) has no
+    # such attribute at all. This section is a supplementary raw-record
+    # dump; the entity/relation data above already carries the authoritative
+    # graph content, so skip it rather than fail the whole export on a
+    # backend that doesn't support it.
+    #
+    # Check the class, not the instance, for attribute presence:
+    # ``hasattr(relationships_vdb, ...)`` would call the getter to answer
+    # the question, and for NanoVectorDB's *async* property that getter
+    # returns a coroutine that ``hasattr`` immediately discards --
+    # "coroutine was never awaited" plus doing the (wasted) work twice.
+    # Attribute access on the class itself returns the property descriptor
+    # without invoking it.
+    if hasattr(type(relationships_vdb), "client_storage"):
+        # The two implementations disagree on sync vs. async (NanoVectorDB's
+        # is async, Faiss's is a plain sync property), so the value itself
+        # decides whether to await -- a fixed isinstance/backend-name check
+        # would silently break the moment either changes.
+        client_storage = relationships_vdb.client_storage
+        if inspect.isawaitable(client_storage):
+            client_storage = await client_storage
+        for rel in client_storage["data"]:
+            relationships_data.append(
+                {
+                    "relationship_id": rel["__id__"],
+                    "data": str(rel),  # Convert to string for compatibility
+                }
+            )
+    else:
+        logger.debug(
+            f"{type(relationships_vdb).__name__} does not expose client_storage; "
+            "skipping the raw VectorDB relationships dump in the export."
         )
 
     # Export based on format

--- a/tests/api/routes/test_graph_export_route.py
+++ b/tests/api/routes/test_graph_export_route.py
@@ -1,0 +1,137 @@
+"""Tests for GET /graph/export.
+
+Unlike ``GET /graphs`` (a bounded, connected subgraph for the interactive
+viewer), this dumps the whole graph via ``LightRAG.aexport_data`` for
+offline review/backup. The route's own job -- writing to a server-managed
+temp file rather than a client-supplied path, streaming it back, and
+cleaning up afterward -- is what's under test here; ``aexport_data``'s own
+export logic is covered separately in
+``tests/utils/test_aexport_data_portable_relationships.py``.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_graph_routes = importlib.import_module("lightrag.api.routers.graph_routes")
+sys.argv = _original_argv
+
+create_graph_routes = _graph_routes.create_graph_routes
+
+pytestmark = pytest.mark.offline
+
+_API_KEY = "test-key"
+_HEADERS = {"X-API-Key": _API_KEY}
+
+
+def _write_fixed_content(path: str, file_format: str, include_vector_data: bool):
+    Path(path).write_text(
+        f"format={file_format} include_vector_data={include_vector_data}",
+        encoding="utf-8",
+    )
+
+
+def _build_client() -> TestClient:
+    rag = SimpleNamespace(
+        aexport_data=AsyncMock(side_effect=_write_fixed_content),
+    )
+    app = FastAPI()
+    app.include_router(create_graph_routes(rag, api_key=_API_KEY))
+    return TestClient(app), rag
+
+
+def test_export_returns_the_generated_file_as_an_attachment():
+    client, rag = _build_client()
+
+    response = client.get("/graph/export", headers=_HEADERS)
+
+    assert response.status_code == 200
+    assert response.content == b"format=csv include_vector_data=False"
+    assert "lightrag_graph_export.csv" in response.headers["content-disposition"]
+    assert response.headers["content-type"].startswith("text/csv")
+    rag.aexport_data.assert_awaited_once()
+    _, kwargs = rag.aexport_data.await_args
+    assert kwargs["file_format"] == "csv"
+    assert kwargs["include_vector_data"] is False
+
+
+def test_export_forwards_format_and_include_vector_data():
+    client, rag = _build_client()
+
+    response = client.get(
+        "/graph/export?file_format=excel&include_vector_data=true",
+        headers=_HEADERS,
+    )
+
+    assert response.status_code == 200
+    assert response.content == b"format=excel include_vector_data=True"
+    assert "lightrag_graph_export.xlsx" in response.headers["content-disposition"]
+    _, kwargs = rag.aexport_data.await_args
+    assert kwargs["file_format"] == "excel"
+    assert kwargs["include_vector_data"] is True
+
+
+def test_export_rejects_an_unsupported_format():
+    client, _rag = _build_client()
+
+    response = client.get("/graph/export?file_format=pdf", headers=_HEADERS)
+
+    assert response.status_code == 422
+
+
+def test_export_requires_auth():
+    client, _rag = _build_client()
+
+    response = client.get("/graph/export")
+
+    assert response.status_code in (401, 403)
+
+
+def test_export_cleans_up_the_temp_file_after_the_response(tmp_path):
+    captured_path: dict[str, str] = {}
+
+    async def _capture_and_write(path, file_format, include_vector_data):
+        captured_path["path"] = path
+        Path(path).write_text("content", encoding="utf-8")
+
+    rag = SimpleNamespace(aexport_data=AsyncMock(side_effect=_capture_and_write))
+    app = FastAPI()
+    app.include_router(create_graph_routes(rag, api_key=_API_KEY))
+    client = TestClient(app)
+
+    response = client.get("/graph/export", headers=_HEADERS)
+
+    assert response.status_code == 200
+    assert "path" in captured_path
+    # TestClient's background-task execution runs the FileResponse's cleanup
+    # synchronously before returning, so the temp file is gone by the time
+    # the request completes.
+    assert not Path(captured_path["path"]).exists()
+
+
+def test_export_500s_and_removes_the_temp_file_when_aexport_data_fails():
+    captured_path: dict[str, str] = {}
+
+    async def _capture_then_fail(path, file_format, include_vector_data):
+        captured_path["path"] = path
+        Path(path).write_text("partial", encoding="utf-8")
+        raise RuntimeError("boom")
+
+    rag = SimpleNamespace(aexport_data=AsyncMock(side_effect=_capture_then_fail))
+    app = FastAPI()
+    app.include_router(create_graph_routes(rag, api_key=_API_KEY))
+    client = TestClient(app)
+
+    response = client.get("/graph/export", headers=_HEADERS)
+
+    assert response.status_code == 500
+    assert "path" in captured_path
+    assert not Path(captured_path["path"]).exists()

--- a/tests/utils/test_aexport_data_portable_relationships.py
+++ b/tests/utils/test_aexport_data_portable_relationships.py
@@ -1,0 +1,121 @@
+"""Tests for aexport_data's handling of vector storage backends.
+
+``client_storage`` is a debug/snapshot escape hatch, not part of the
+BaseVectorStorage contract. Two backends implement it, disagreeing on sync
+vs. async: ``NanoVectorDBStorage`` (an *async* property) and
+``FaissVectorDBStorage`` (a plain *sync* property) -- verified against every
+``lightrag/kg/*_impl.py``; no other backend (Milvus, Qdrant, Postgres, Redis,
+MongoDB, OpenSearch) defines it at all.
+
+Before this fix, ``aexport_data`` did ``await relationships_vdb.client_storage``
+unconditionally while building the supplementary "Relationships (from
+VectorDB)" dump. That failed two different ways depending on backend:
+``AttributeError`` on every backend without the attribute, and
+``TypeError: object dict can't be used in 'await' expression`` on Faiss,
+whose property returns a plain dict rather than a coroutine. Both crashed the
+whole export, even though the entity/relation data -- the export's primary
+content -- never touches that attribute.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lightrag.utils import aexport_data
+
+pytestmark = pytest.mark.offline
+
+
+class _FakeGraphStorage:
+    """Minimal graph with one edge, enough to exercise entities + relations."""
+
+    async def get_all_labels(self):
+        return ["Alice", "Bob"]
+
+    async def get_node(self, entity_name):
+        return {"description": f"{entity_name} node", "source_id": "chunk-1"}
+
+    async def has_edge(self, src, tgt):
+        return {src, tgt} == {"Alice", "Bob"} and src == "Alice"
+
+    async def get_edge(self, src, tgt):
+        return {"description": "knows", "source_id": "chunk-1"}
+
+
+class _VdbWithoutClientStorage:
+    """Stands in for every backend except NanoVectorDB."""
+
+    async def get_by_id(self, id):
+        return None
+
+
+class _VdbWithAsyncClientStorage:
+    """Stands in for NanoVectorDBStorage: client_storage is an async property."""
+
+    async def get_by_id(self, id):
+        return None
+
+    @property
+    async def client_storage(self):
+        return {"data": [{"__id__": "rel-1", "weight": 1.0}]}
+
+
+class _VdbWithSyncClientStorage:
+    """Stands in for FaissVectorDBStorage: client_storage is a plain sync property."""
+
+    async def get_by_id(self, id):
+        return None
+
+    @property
+    def client_storage(self):
+        return {"data": [{"__id__": "rel-2", "weight": 2.0}]}
+
+
+async def _run_export(tmp_path: Path, relationships_vdb) -> str:
+    output_path = tmp_path / "export.csv"
+    await aexport_data(
+        _FakeGraphStorage(),
+        _VdbWithoutClientStorage(),
+        relationships_vdb,
+        str(output_path),
+        file_format="csv",
+    )
+    return output_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_export_does_not_crash_without_client_storage(tmp_path):
+    content = await _run_export(tmp_path, _VdbWithoutClientStorage())
+
+    # Entities and relations -- the export's primary content -- still land.
+    assert "# ENTITIES" in content
+    assert "Alice" in content
+    assert "# RELATIONS" in content
+    # No raw-VDB section: the backend has nothing to supply it from.
+    assert "# RELATIONSHIPS" not in content
+
+
+@pytest.mark.asyncio
+async def test_export_includes_relationships_dump_for_async_client_storage(tmp_path):
+    content = await _run_export(tmp_path, _VdbWithAsyncClientStorage())
+
+    assert "# ENTITIES" in content
+    assert "# RELATIONS" in content
+    assert "# RELATIONSHIPS" in content
+    assert "rel-1" in content
+
+
+@pytest.mark.asyncio
+async def test_export_includes_relationships_dump_for_sync_client_storage(tmp_path):
+    # Faiss's client_storage is a plain sync property (returns a dict, not a
+    # coroutine); awaiting it unconditionally raises TypeError. This pins
+    # that the fix inspects the value rather than assuming every
+    # client_storage is awaitable.
+    content = await _run_export(tmp_path, _VdbWithSyncClientStorage())
+
+    assert "# ENTITIES" in content
+    assert "# RELATIONS" in content
+    assert "# RELATIONSHIPS" in content
+    assert "rel-2" in content


### PR DESCRIPTION
## Description

Adds `GET /graph/export` so the full knowledge graph (entities, relations, relationships) can be
downloaded through the REST API. Previously the only way to get this data out of a running
instance was direct filesystem access to internal storage files.

This is the **export half only**. Import (writing into the graph) and a WebUI button are
deliberately out of scope -- see *Additional Notes*.

## Related Issues

Fixes #1937

## Changes Made

- New route `GET /graph/export` in `lightrag/api/routers/graph_routes.py`, guarded by the same
  `combined_auth` dependency as every other route in the file. Accepts `file_format`
  (csv/excel/md/txt) and `include_vector_data` query params and wires up the existing
  `LightRAG.aexport_data()`, which already builds this export but was never exposed over HTTP.
- Writes to a server-managed temp file via `tempfile.mkstemp` (never a client-supplied path),
  streams it back as a `FileResponse` attachment, and removes the temp file once the response has
  been fully sent (via a `BackgroundTask`), or immediately on error.
- Fixes a portability bug in `lightrag/utils.py::aexport_data` found while wiring this up: the
  "Relationships (from VectorDB)" section unconditionally accessed
  `relationships_vdb.client_storage`. That attribute is a debug/snapshot escape hatch implemented
  by exactly two backends, which disagree on sync vs. async (`NanoVectorDBStorage`: async
  property; `FaissVectorDBStorage`: plain sync property) -- every other backend (Milvus, Qdrant,
  Postgres, Redis, MongoDB, OpenSearch) has no such attribute at all. Left as-is, exporting a
  graph on any of those backends would have crashed the whole export. The fix checks for the
  attribute on the class (so testing for it doesn't trigger an async property's getter) and
  inspects the value itself before deciding whether to await it, so unsupported backends now just
  skip that one supplementary section instead of failing outright.
- Tests: `tests/api/routes/test_graph_export_route.py` (auth, format validation via FastAPI's
  `Literal` query-param typing, temp-file cleanup on both success and failure, forwarding of
  `file_format`/`include_vector_data`) and
  `tests/utils/test_aexport_data_portable_relationships.py` (pins the portability fix for both the
  async-property and sync-property backend shapes, plus the no-`client_storage` case).

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Import and a WebUI download button are intentionally not part of this PR. Import means writing
into the graph -- validation, conflict handling, pipeline coordination -- which is a materially
larger and separate piece of work better reviewed on its own; a WebUI button is a natural,
additive follow-up once the endpoint exists. Noted on the issue as deliberate scoping, not an
oversight.

`pre-commit run --all-files` and the full `pytest` suite were run locally; the only failures are
pre-existing and environment-specific to this Windows dev machine (symlink tests requiring admin,
`psutil`/`fcntl`-dependent process checks, missing `libcairo` for SVG rasterization, gunicorn not
running on Windows), unrelated to this change.
