### PR TITLE
feat(query): expose LLM token usage through the /query REST API

### DIFF
--- a/lightrag/api/routers/query_routes.py
+++ b/lightrag/api/routers/query_routes.py
@@ -244,6 +244,17 @@ class ReferenceItem(BaseModel):
     )
 
 
+class TokenUsage(BaseModel):
+    prompt_tokens: int = Field(
+        description="Tokens consumed by the prompt(s) sent to the LLM"
+    )
+    completion_tokens: int = Field(
+        description="Tokens consumed by the LLM's generated output"
+    )
+    total_tokens: int = Field(description="prompt_tokens + completion_tokens")
+    call_count: int = Field(description="Number of LLM calls this figure aggregates")
+
+
 class QueryResponse(BaseModel):
     response: str = Field(
         description="The generated response",
@@ -264,6 +275,17 @@ class QueryResponse(BaseModel):
             "no-context reply, or the only_need_context / only_need_prompt debug "
             "output. Clients that label machine-written text cannot recover this "
             "from the response text alone."
+        ),
+    )
+    token_usage: Optional[TokenUsage] = Field(
+        default=None,
+        description=(
+            "LLM token usage for this query (keyword extraction plus the "
+            "answer-generation call, when the mode does both). Omitted "
+            "-- not zero -- when the answer was served entirely from cache, "
+            "when only_need_context/only_need_prompt short-circuited before "
+            "any LLM call, or when the configured LLM binding does not "
+            "report usage (currently: openai, gemini, ollama)."
         ),
     )
 
@@ -534,6 +556,9 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             QueryResponse: JSON response containing:
                 - **response**: The generated answer to your query
                 - **references**: Source citations (if include_references=True)
+                - **token_usage**: LLM tokens spent on this query (omitted, not
+                  zero, on a cache hit, an only_need_context/only_need_prompt
+                  request, or a binding that doesn't report usage)
 
         Raises:
             HTTPException:
@@ -555,6 +580,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
             llm_response = result.get("llm_response", {})
             data = result.get("data", {})
             references = data.get("references", [])
+            token_usage = result.get("metadata", {}).get("token_usage")
 
             # Get the non-streaming response content
             response_content = llm_response.get("content", "")
@@ -596,6 +622,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
                     references=references,
                     response_time=response_time,
                     llm_generated=llm_generated,
+                    token_usage=token_usage,
                 )
             else:
                 return QueryResponse(
@@ -603,6 +630,7 @@ def create_query_routes(rag, api_key: Optional[str] = None, top_k: int = 60):
                     references=None,
                     response_time=response_time,
                     llm_generated=llm_generated,
+                    token_usage=token_usage,
                 )
         except Exception as e:
             logger.error(f"Error processing query: {str(e)}", exc_info=True)

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -137,6 +137,8 @@ from lightrag.namespace import NameSpace
 from lightrag.chunker import chunking_by_token_size
 from lightrag.operate import (
     KGRebuildReport,
+    _attach_token_usage,
+    _role_supports_token_tracker,
     _truncate_vdb_content,
     collect_kg_merge_candidates,
     extract_entities,
@@ -189,6 +191,7 @@ from lightrag.utils import (
     TokenLimitTruncationTally,
     LLM_TRUNCATION_METADATA_KEY,
     merge_truncation_metadata,
+    TokenTracker,
 )
 from lightrag.types import KnowledgeGraph
 from dotenv import load_dotenv
@@ -1204,6 +1207,16 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         states = getattr(self, "_role_llm_states", None) or {}
         global_config["role_llm_funcs"] = {
             spec.name: states[spec.name].wrapped if spec.name in states else None
+            for spec in ROLES
+        }
+        # Whether each role's bound LLM function accepts a ``token_tracker``
+        # kwarg at all -- see ``_wrap_llm_role_func`` in llm_roles.py for why
+        # this must be checked before ever passing that kwarg: most bindings
+        # forward unrecognized kwargs straight into their SDK client call.
+        global_config["role_supports_token_tracker"] = {
+            spec.name: bool(states[spec.name].metadata.get("supports_token_tracker"))
+            if spec.name in states
+            else False
             for spec in ROLES
         }
         global_config["llm_cache_identities"] = {
@@ -4241,15 +4254,20 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     global_config["role_llm_funcs"]["query"],
                     _priority=DEFAULT_SUMMARY_PRIORITY,
                 )
+                bypass_token_tracker = TokenTracker()
 
                 param.stream = True if param.stream is None else param.stream
-                response = await use_llm_func(
-                    query.strip(),
+                bypass_llm_kwargs: dict[str, Any] = dict(
                     system_prompt=system_prompt,
                     history_messages=param.conversation_history,
                     enable_cot=True,
                     stream=param.stream,
                 )
+                if _role_supports_token_tracker(global_config, "query"):
+                    bypass_llm_kwargs["token_tracker"] = bypass_token_tracker
+                response = await use_llm_func(query.strip(), **bypass_llm_kwargs)
+                bypass_metadata: dict[str, Any] = {}
+                _attach_token_usage({"metadata": bypass_metadata}, bypass_token_tracker)
                 # isinstance, not exact type: a truncated non-streaming
                 # response arrives as TruncatedResponse (a str subclass) and
                 # must not be misclassified as a streaming iterator.
@@ -4258,7 +4276,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         "status": "success",
                         "message": "Bypass mode LLM non streaming response",
                         "data": {},
-                        "metadata": {},
+                        "metadata": bypass_metadata,
                         "llm_response": {
                             "content": response,
                             "response_iterator": None,
@@ -4271,7 +4289,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         "status": "success",
                         "message": "Bypass mode LLM streaming response",
                         "data": {},
-                        "metadata": {},
+                        "metadata": bypass_metadata,
                         "llm_response": {
                             "content": None,
                             "response_iterator": response,

--- a/lightrag/llm_roles.py
+++ b/lightrag/llm_roles.py
@@ -159,6 +159,18 @@ class _RoleLLMMixin:
         """Read-only mapping of role name → effective LLM kwargs (None means inherit base)."""
         return {name: state.kwargs for name, state in self._role_llm_states.items()}
 
+    @property
+    def role_supports_token_tracker(self) -> Mapping[str, bool]:
+        """Read-only mapping of role name → whether its bound raw_func accepts
+        ``token_tracker``. Computed once per (re)build in
+        :meth:`_wrap_llm_role_func`; a role with no wrapped function yet
+        (not in ``_role_llm_states`` with metadata set) reads as ``False``.
+        """
+        return {
+            name: bool(state.metadata.get("supports_token_tracker"))
+            for name, state in self._role_llm_states.items()
+        }
+
     def _get_effective_role_llm_kwargs(self, role: str) -> dict[str, Any]:
         state = self._role_llm_states[self._normalize_llm_role(role)]
         if state.kwargs is not None:
@@ -186,6 +198,27 @@ class _RoleLLMMixin:
         model_kwargs: dict[str, Any],
     ) -> Callable[..., object]:
         spec = ROLES_BY_NAME[role_name]
+        # Recorded once per (re)build, not read from a live inspection on
+        # every call: whether raw_func accepts a ``token_tracker`` kwarg at
+        # all. Only openai/gemini/ollama declare it today; every other
+        # binding (anthropic, bedrock, hf, ...) forwards unrecognized kwargs
+        # verbatim into its SDK client call, so passing token_tracker= to one
+        # of those would raise a wire-level TypeError, not a harmless no-op.
+        # Callers must check this before adding the kwarg -- see
+        # ``role_supports_token_tracker`` and its use in operate.py.
+        try:
+            supports_token_tracker = (
+                "token_tracker" in inspect.signature(raw_func).parameters
+            )
+        except (TypeError, ValueError):
+            # A callable inspect.signature cannot introspect (some C-extension
+            # or exotic wrapper) is treated as not supporting it -- the safe
+            # default, matching every other binding that simply lacks the
+            # parameter.
+            supports_token_tracker = False
+        self.set_role_llm_metadata(
+            role_name, supports_token_tracker=supports_token_tracker
+        )
         return priority_limit_async_func_call(
             max_async,
             llm_timeout=timeout,

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -59,6 +59,7 @@ from lightrag.utils import (
     _cooperative_yield,
     wait_tasks_with_drain,
     performance_timing_log,
+    TokenTracker,
 )
 from lightrag.base import (
     BaseGraphStorage,
@@ -4538,6 +4539,41 @@ def _answer_cache_kv(
     return hashing_kv
 
 
+def _role_supports_token_tracker(global_config: dict[str, Any], role: str) -> bool:
+    """Whether ``role``'s bound LLM function accepts a ``token_tracker`` kwarg.
+
+    Only openai/gemini/ollama declare it today (see
+    ``lightrag/llm_roles.py::_wrap_llm_role_func``, which computes this once
+    per role rebuild from the raw provider function's real signature); every
+    other binding forwards unrecognized kwargs verbatim into its SDK client
+    call, so passing ``token_tracker=`` there raises a wire-level
+    ``TypeError`` rather than being silently ignored. Callers must check this
+    before adding the kwarg to a query-pipeline LLM call, and simply omit it
+    (not pass ``token_tracker=None``) when it comes back ``False`` -- the
+    unsupported bindings key on the kwarg's presence, not its value.
+    """
+    return bool(global_config.get("role_supports_token_tracker", {}).get(role, False))
+
+
+def _attach_token_usage(raw_data: dict[str, Any], token_tracker: TokenTracker) -> None:
+    """Record ``token_tracker``'s accumulated usage into ``raw_data['metadata']``.
+
+    A no-op while ``token_tracker`` has recorded no calls -- absent is not
+    zero, the same convention ``TokenTracker`` itself follows elsewhere
+    (see ``lightrag/llm/ollama.py``): a query path that never called the LLM
+    (an ``only_need_context``/``only_need_prompt`` short-circuit, or an
+    answer served entirely from cache) reports no ``token_usage`` at all,
+    rather than a misleading all-zero one. Mutates ``raw_data`` in place so
+    callers can invoke this at more than one return point on the same
+    ``raw_data`` object (e.g. once after keyword extraction, again after the
+    synthesis call) and each call layers in whatever was spent since the
+    tracker was created.
+    """
+    if token_tracker.call_count == 0:
+        return
+    raw_data.setdefault("metadata", {})["token_usage"] = token_tracker.get_usage()
+
+
 async def kg_query(
     query: str,
     knowledge_graph_inst: BaseGraphStorage,
@@ -4589,11 +4625,12 @@ async def kg_query(
         global_config["role_llm_funcs"]["query"], _priority=DEFAULT_QUERY_PRIORITY
     )
     llm_cache_identity = get_llm_cache_identity(global_config, "query")
+    token_tracker = TokenTracker()
 
     if progress_callback:
         await progress_callback(QueryProgress.EXTRACTING_KEYWORDS)
     hl_keywords, ll_keywords = await get_keywords_from_query(
-        query, query_param, global_config, hashing_kv
+        query, query_param, global_config, hashing_kv, token_tracker=token_tracker
     )
 
     logger.debug(f"High-level keywords: {hl_keywords}")
@@ -4609,7 +4646,15 @@ async def kg_query(
             logger.warning(f"Forced low_level_keywords to origin query: {query}")
             ll_keywords = [query]
         else:
-            return QueryResult(content=PROMPTS["fail_response"], llm_generated=False)
+            # Keyword extraction already ran and may have incurred real cost;
+            # record it before bailing out so it isn't silently dropped.
+            fail_raw_data: dict[str, Any] = {}
+            _attach_token_usage(fail_raw_data, token_tracker)
+            return QueryResult(
+                content=PROMPTS["fail_response"],
+                llm_generated=False,
+                raw_data=fail_raw_data,
+            )
 
     ll_keywords_str = ", ".join(ll_keywords) if ll_keywords else ""
     hl_keywords_str = ", ".join(hl_keywords) if hl_keywords else ""
@@ -4631,6 +4676,11 @@ async def kg_query(
     if context_result is None:
         logger.info("[kg_query] No query context could be built; returning no-result.")
         return None
+
+    # Keyword extraction is the only LLM call made so far on this path; record
+    # it now so a caller that stops here (only_need_context/only_need_prompt,
+    # just below) still sees what it actually cost.
+    _attach_token_usage(context_result.raw_data, token_tracker)
 
     # Return different content based on query parameters
     if query_param.only_need_context and not query_param.only_need_prompt:
@@ -4713,13 +4763,15 @@ async def kg_query(
     else:
         if progress_callback:
             await progress_callback(QueryProgress.GENERATING_RESPONSE)
-        response = await use_model_func(
-            user_query,
+        llm_call_kwargs: dict[str, Any] = dict(
             system_prompt=sys_prompt,
             history_messages=query_param.conversation_history,
             enable_cot=True,
             stream=query_param.stream,
         )
+        if _role_supports_token_tracker(global_config, "query"):
+            llm_call_kwargs["token_tracker"] = token_tracker
+        response = await use_model_func(user_query, **llm_call_kwargs)
 
         if (
             answer_cache_kv
@@ -4755,6 +4807,12 @@ async def kg_query(
                 ),
             )
 
+    # A cache hit skips the block above entirely -- token_tracker only gains
+    # the synthesis call's usage when one actually happened, so a cached
+    # answer still reports just the keyword-extraction cost attached earlier
+    # (or nothing, when keywords were also served from cache/pre-supplied).
+    _attach_token_usage(context_result.raw_data, token_tracker)
+
     # Return unified result based on actual response type
     if isinstance(response, str):
         # Non-streaming response (string)
@@ -4784,6 +4842,7 @@ async def get_keywords_from_query(
     query_param: QueryParam,
     global_config: dict[str, str],
     hashing_kv: BaseKVStorage | None = None,
+    token_tracker: TokenTracker | None = None,
 ) -> tuple[list[str], list[str]]:
     """
     Retrieves high-level and low-level keywords for RAG operations.
@@ -4796,6 +4855,9 @@ async def get_keywords_from_query(
         query_param: Query parameters that may contain pre-defined keywords
         global_config: Global configuration dictionary
         hashing_kv: Optional key-value storage for caching results
+        token_tracker: Optional tracker credited with the extraction call's
+            usage; untouched when keywords are pre-supplied or cached, since
+            no LLM call happens on either of those paths.
 
     Returns:
         A tuple containing (high_level_keywords, low_level_keywords)
@@ -4806,7 +4868,7 @@ async def get_keywords_from_query(
 
     # Extract keywords directly from the current query text.
     hl_keywords, ll_keywords = await extract_keywords_only(
-        query, query_param, global_config, hashing_kv
+        query, query_param, global_config, hashing_kv, token_tracker=token_tracker
     )
     return hl_keywords, ll_keywords
 
@@ -4921,6 +4983,7 @@ async def extract_keywords_only(
     param: QueryParam,
     global_config: dict[str, str],
     hashing_kv: BaseKVStorage | None = None,
+    token_tracker: TokenTracker | None = None,
 ) -> tuple[list[str], list[str]]:
     """
     Extract high-level and low-level keywords from the given 'text' using the LLM.
@@ -4982,7 +5045,12 @@ async def extract_keywords_only(
         global_config["role_llm_funcs"]["keyword"], _priority=DEFAULT_QUERY_PRIORITY
     )
 
-    result = await use_model_func(kw_prompt, response_format={"type": "json_object"})
+    keyword_call_kwargs: dict[str, Any] = dict(response_format={"type": "json_object"})
+    if token_tracker is not None and _role_supports_token_tracker(
+        global_config, "keyword"
+    ):
+        keyword_call_kwargs["token_tracker"] = token_tracker
+    result = await use_model_func(kw_prompt, **keyword_call_kwargs)
 
     # 5. Parse out JSON from the LLM response with tolerant provider normalization
     _, hl_keywords, ll_keywords = _parse_keywords_payload(result)
@@ -6562,6 +6630,7 @@ async def naive_query(
         global_config["role_llm_funcs"]["query"], _priority=DEFAULT_QUERY_PRIORITY
     )
     llm_cache_identity = get_llm_cache_identity(global_config, "query")
+    token_tracker = TokenTracker()
 
     tokenizer: Tokenizer = global_config["tokenizer"]
     if not tokenizer:
@@ -6721,13 +6790,15 @@ async def naive_query(
         )
         response = cached_response
     else:
-        response = await use_model_func(
-            user_query,
+        llm_call_kwargs: dict[str, Any] = dict(
             system_prompt=sys_prompt,
             history_messages=query_param.conversation_history,
             enable_cot=True,
             stream=query_param.stream,
         )
+        if _role_supports_token_tracker(global_config, "query"):
+            llm_call_kwargs["token_tracker"] = token_tracker
+        response = await use_model_func(user_query, **llm_call_kwargs)
 
         if (
             answer_cache_kv
@@ -6760,6 +6831,11 @@ async def naive_query(
                     queryparam=queryparam_dict,
                 ),
             )
+
+    # A cache hit skips the block above entirely, so this is a no-op then --
+    # naive mode has no keyword-extraction call, so a cache hit here means
+    # no token_usage at all, not just an unchanged one.
+    _attach_token_usage(raw_data, token_tracker)
 
     # Return unified result based on actual response type
     if isinstance(response, str):

--- a/tests/llm/test_query_token_usage.py
+++ b/tests/llm/test_query_token_usage.py
@@ -1,0 +1,528 @@
+"""Tests for REST-exposed LLM token usage on the query path (issue #2572).
+
+Three layers, each load-bearing on its own:
+
+1. **Capability detection** (``llm_roles.py::_wrap_llm_role_func`` /
+   ``role_supports_token_tracker``): only openai/gemini/ollama declare a
+   ``token_tracker`` parameter today. Every other binding forwards
+   unrecognized kwargs verbatim into its SDK client call, so passing
+   ``token_tracker=`` to one of those raises a wire-level ``TypeError``
+   rather than being silently ignored -- this is computed once per role
+   rebuild from the *real* bound function's signature, never assumed.
+
+2. **Attachment** (``operate.py::_attach_token_usage`` /
+   ``_role_supports_token_tracker``): ``kg_query``/``naive_query`` must
+   record usage into ``raw_data['metadata']['token_usage']`` only when an
+   LLM call actually happened (never on a cache hit, an
+   ``only_need_context``/``only_need_prompt`` short-circuit, or an
+   unsupported binding) -- "absent" must mean "we don't know", never "zero".
+
+3. **REST surface** (``query_routes.py``): ``QueryResponse.token_usage`` is
+   additive and optional, sourced from ``result['metadata']['token_usage']``.
+"""
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import QueryContextResult, QueryParam
+from lightrag.operate import (
+    _attach_token_usage,
+    _role_supports_token_tracker,
+    extract_keywords_only,
+    get_keywords_from_query,
+    kg_query,
+    naive_query,
+)
+from lightrag.utils import EmbeddingFunc, Tokenizer, TokenTracker
+
+pytestmark = pytest.mark.offline
+
+
+class _FakeTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(token) for token in tokens)
+
+
+def _fake_tokenizer() -> Tokenizer:
+    return Tokenizer("fake", _FakeTokenizerImpl())
+
+
+class _FakeKVStorage:
+    def __init__(self):
+        self.global_config = {"enable_llm_cache": True}
+        self._store = {}
+
+    async def get_by_id(self, key):
+        return self._store.get(key)
+
+    async def upsert(self, entries):
+        self._store.update(entries)
+
+
+class _FakeChunksVDB:
+    cosine_better_than_threshold = 0.0
+
+    async def query(self, *_args, **_kwargs):
+        return [
+            {
+                "id": "chunk-1",
+                "content": "Token usage test chunk about Alice the researcher.",
+                "file_path": "test.md",
+            }
+        ]
+
+
+def _naive_global_config(llm_func, *, role_supports=True) -> dict:
+    return {
+        "tokenizer": _fake_tokenizer(),
+        "role_llm_funcs": {"query": llm_func},
+        "role_supports_token_tracker": {"query": role_supports, "keyword": False},
+        "min_rerank_score": 0.0,
+        "max_total_tokens": 4096,
+    }
+
+
+def _naive_param(**overrides) -> QueryParam:
+    return QueryParam(mode="naive", enable_rerank=False, **overrides)
+
+
+# ---------------------------------------------------------------------------
+# 1. Capability detection (llm_roles.py)
+# ---------------------------------------------------------------------------
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.random.rand(len(texts), 16)
+
+
+async def _aware_base_llm(*args, token_tracker=None, **kwargs) -> str:
+    return "aware"
+
+
+async def _unaware_base_llm(*args, **kwargs) -> str:
+    return "unaware"
+
+
+def _make_rag(tmp_path, llm_func) -> LightRAG:
+    return LightRAG(
+        working_dir=str(tmp_path / "token-usage-role"),
+        workspace="token-usage-role",
+        llm_model_func=llm_func,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=16, max_token_size=4096, func=_mock_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+    )
+
+
+def test_role_supports_token_tracker_detects_the_real_signature(tmp_path):
+    aware_rag = _make_rag(tmp_path, _aware_base_llm)
+    unaware_rag = _make_rag(tmp_path, _unaware_base_llm)
+
+    # Every role inherits the base func here (no per-role override), so every
+    # role reflects the same base function's real signature.
+    assert all(aware_rag.role_supports_token_tracker.values())
+    assert not any(unaware_rag.role_supports_token_tracker.values())
+
+    # And it is threaded into global_config under the exact key operate.py reads.
+    aware_cfg = aware_rag._build_global_config()
+    unaware_cfg = unaware_rag._build_global_config()
+    assert aware_cfg["role_supports_token_tracker"]["query"] is True
+    assert unaware_cfg["role_supports_token_tracker"]["query"] is False
+
+
+def test_role_supports_token_tracker_helper_reads_the_global_config_key():
+    assert _role_supports_token_tracker(
+        {"role_supports_token_tracker": {"query": True}}, "query"
+    )
+    assert not _role_supports_token_tracker(
+        {"role_supports_token_tracker": {"query": False}}, "query"
+    )
+    # Missing role or missing key entirely defaults closed (unsupported),
+    # never open -- the safe default when nothing has been computed yet.
+    assert not _role_supports_token_tracker({}, "query")
+    assert not _role_supports_token_tracker(
+        {"role_supports_token_tracker": {}}, "query"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. _attach_token_usage
+# ---------------------------------------------------------------------------
+
+
+def test_attach_token_usage_is_a_no_op_for_an_untouched_tracker():
+    raw_data: dict = {}
+    _attach_token_usage(raw_data, TokenTracker())
+    assert raw_data == {}, "absent must mean unknown, not a zeroed-out usage dict"
+
+
+def test_attach_token_usage_writes_the_tracker_snapshot():
+    tracker = TokenTracker()
+    tracker.add_usage({"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15})
+    raw_data: dict = {}
+    _attach_token_usage(raw_data, tracker)
+    assert raw_data["metadata"]["token_usage"] == {
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "total_tokens": 15,
+        "call_count": 1,
+    }
+
+
+def test_attach_token_usage_preserves_existing_metadata_keys():
+    raw_data: dict = {"metadata": {"keywords": {"high_level": ["x"]}}}
+    tracker = TokenTracker()
+    tracker.add_usage({"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2})
+    _attach_token_usage(raw_data, tracker)
+    assert raw_data["metadata"]["keywords"] == {"high_level": ["x"]}
+    assert raw_data["metadata"]["token_usage"]["total_tokens"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 3. naive_query
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_naive_query_reports_token_usage_when_binding_supports_it():
+    async def aware_model(*_args, token_tracker=None, **_kwargs):
+        assert token_tracker is not None
+        token_tracker.add_usage(
+            {"prompt_tokens": 40, "completion_tokens": 10, "total_tokens": 50}
+        )
+        return "an answer"
+
+    cfg = _naive_global_config(aware_model, role_supports=True)
+    result = await naive_query(
+        "who is Alice?",
+        _FakeChunksVDB(),
+        _naive_param(),
+        cfg,
+        hashing_kv=_FakeKVStorage(),
+    )
+
+    usage = result.raw_data["metadata"]["token_usage"]
+    assert usage["total_tokens"] == 50
+    assert usage["call_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_naive_query_omits_token_usage_when_binding_unsupported():
+    call_kwargs_seen = {}
+
+    async def strict_model(*_args, **kwargs):
+        call_kwargs_seen.update(kwargs)
+        return "an answer"
+
+    cfg = _naive_global_config(strict_model, role_supports=False)
+    result = await naive_query(
+        "who is Alice?",
+        _FakeChunksVDB(),
+        _naive_param(),
+        cfg,
+        hashing_kv=_FakeKVStorage(),
+    )
+
+    assert "token_tracker" not in call_kwargs_seen, (
+        "the gate must keep token_tracker out of the call entirely, not pass "
+        "it as None -- an unsupported binding keys on the kwarg's presence"
+    )
+    assert "token_usage" not in result.raw_data.get("metadata", {})
+
+
+@pytest.mark.asyncio
+async def test_naive_query_omits_token_usage_on_cache_hit():
+    calls = 0
+
+    async def aware_model(*_args, token_tracker=None, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if token_tracker is not None:
+            token_tracker.add_usage(
+                {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+            )
+        return "an answer"
+
+    cfg = _naive_global_config(aware_model, role_supports=True)
+    cache = _FakeKVStorage()
+    param = _naive_param()
+
+    first = await naive_query(
+        "who is Alice?", _FakeChunksVDB(), param, cfg, hashing_kv=cache
+    )
+    assert first.raw_data["metadata"]["token_usage"]["total_tokens"] == 2
+    assert calls == 1
+
+    second = await naive_query(
+        "who is Alice?", _FakeChunksVDB(), param, cfg, hashing_kv=cache
+    )
+    assert calls == 1, "second call must be served from cache"
+    assert "token_usage" not in second.raw_data.get("metadata", {}), (
+        "a cached answer consumed no tokens on this call and must not report "
+        "the previous call's figure as if it were fresh"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. kg_query
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_query_context(monkeypatch):
+    """Skip retrieval: kg_query only forwards its storage args into this call."""
+
+    async def _fake_build_query_context(*_args, **_kwargs):
+        return QueryContextResult(context="KG CONTEXT", raw_data={})
+
+    monkeypatch.setattr(
+        "lightrag.operate._build_query_context", _fake_build_query_context
+    )
+
+
+def _kg_param(**overrides) -> QueryParam:
+    # Preset ll_keywords short-circuits keyword extraction so tests that
+    # don't care about it can ignore the keyword-role call entirely.
+    return QueryParam(
+        mode="local", enable_rerank=False, ll_keywords=["Alice"], **overrides
+    )
+
+
+def _kg_global_config(
+    query_func, *, query_supports=True, keyword_func=None, keyword_supports=False
+) -> dict:
+    role_llm_funcs = {"query": query_func}
+    if keyword_func is not None:
+        role_llm_funcs["keyword"] = keyword_func
+    return {
+        "tokenizer": _fake_tokenizer(),
+        "role_llm_funcs": role_llm_funcs,
+        "role_supports_token_tracker": {
+            "query": query_supports,
+            "keyword": keyword_supports,
+        },
+        "addon_params": {"language": "en"},
+        "min_rerank_score": 0.0,
+        "max_total_tokens": 4096,
+    }
+
+
+async def _run_kg_query(param, cfg, cache):
+    return await kg_query(
+        "who is Alice?", None, None, None, None, param, cfg, hashing_kv=cache
+    )
+
+
+@pytest.mark.asyncio
+async def test_kg_query_reports_synthesis_usage_with_preset_keywords(
+    stub_query_context,
+):
+    """No keyword-extraction call happens (ll_keywords preset), so the
+    reported usage is exactly the synthesis call's."""
+
+    async def aware_model(*_args, token_tracker=None, **_kwargs):
+        token_tracker.add_usage(
+            {"prompt_tokens": 80, "completion_tokens": 20, "total_tokens": 100}
+        )
+        return "an answer"
+
+    cfg = _kg_global_config(aware_model, query_supports=True)
+    result = await _run_kg_query(_kg_param(), cfg, _FakeKVStorage())
+
+    usage = result.raw_data["metadata"]["token_usage"]
+    assert usage["total_tokens"] == 100
+    assert usage["call_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_kg_query_aggregates_keyword_and_synthesis_usage(stub_query_context):
+    async def aware_query_model(*_args, token_tracker=None, **_kwargs):
+        token_tracker.add_usage(
+            {"prompt_tokens": 80, "completion_tokens": 20, "total_tokens": 100}
+        )
+        return "an answer"
+
+    async def aware_keyword_model(*_args, token_tracker=None, **_kwargs):
+        token_tracker.add_usage(
+            {"prompt_tokens": 30, "completion_tokens": 5, "total_tokens": 35}
+        )
+        return '{"high_level_keywords": ["physics"], "low_level_keywords": ["Alice"]}'
+
+    cfg = _kg_global_config(
+        aware_query_model,
+        query_supports=True,
+        keyword_func=aware_keyword_model,
+        keyword_supports=True,
+    )
+    # No preset keywords this time: force real extraction.
+    param = QueryParam(mode="local", enable_rerank=False)
+    result = await _run_kg_query(param, cfg, _FakeKVStorage())
+
+    usage = result.raw_data["metadata"]["token_usage"]
+    assert usage["total_tokens"] == 135
+    assert usage["call_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_kg_query_reports_keyword_only_usage_for_only_need_context(
+    stub_query_context,
+):
+    """only_need_context short-circuits before the synthesis call, so a
+    caller that stops there still sees exactly what it cost: the keyword
+    extraction, and nothing claimed for a synthesis call that never ran."""
+
+    async def keyword_model(*_args, token_tracker=None, **_kwargs):
+        token_tracker.add_usage(
+            {"prompt_tokens": 30, "completion_tokens": 5, "total_tokens": 35}
+        )
+        return '{"high_level_keywords": ["physics"], "low_level_keywords": ["Alice"]}'
+
+    async def synthesis_model(*_args, **_kwargs):
+        raise AssertionError("synthesis must not be called for only_need_context")
+
+    cfg = _kg_global_config(
+        synthesis_model,
+        query_supports=True,
+        keyword_func=keyword_model,
+        keyword_supports=True,
+    )
+    param = QueryParam(mode="local", enable_rerank=False, only_need_context=True)
+    result = await _run_kg_query(param, cfg, _FakeKVStorage())
+
+    usage = result.raw_data["metadata"]["token_usage"]
+    assert usage["total_tokens"] == 35
+    assert usage["call_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_kg_query_omits_token_usage_when_neither_role_supports_it(
+    stub_query_context,
+):
+    async def strict_query_model(*_args, **_kwargs):
+        return "an answer"
+
+    cfg = _kg_global_config(strict_query_model, query_supports=False)
+    result = await _run_kg_query(_kg_param(), cfg, _FakeKVStorage())
+
+    assert "token_usage" not in result.raw_data.get("metadata", {})
+
+
+@pytest.mark.asyncio
+async def test_kg_query_reports_keyword_usage_on_the_no_keywords_fail_path():
+    """Both keyword lists come back empty and the query is >=50 chars, so
+    kg_query bails out with the canned fail_response before ever reaching
+    _build_query_context. The keyword-extraction call still ran and spent
+    real tokens, so that cost must not be silently dropped."""
+
+    async def keyword_model(*_args, token_tracker=None, **_kwargs):
+        token_tracker.add_usage(
+            {"prompt_tokens": 12, "completion_tokens": 3, "total_tokens": 15}
+        )
+        return '{"high_level_keywords": [], "low_level_keywords": []}'
+
+    async def synthesis_model(*_args, **_kwargs):
+        raise AssertionError("synthesis must not be called on the fail path")
+
+    cfg = _kg_global_config(
+        synthesis_model,
+        query_supports=True,
+        keyword_func=keyword_model,
+        keyword_supports=True,
+    )
+    long_query = "x" * 60
+    param = QueryParam(mode="local", enable_rerank=False)
+    result = await kg_query(
+        long_query, None, None, None, None, param, cfg, hashing_kv=_FakeKVStorage()
+    )
+
+    assert result.llm_generated is False
+    usage = result.raw_data["metadata"]["token_usage"]
+    assert usage["total_tokens"] == 15
+    assert usage["call_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. extract_keywords_only / get_keywords_from_query
+# ---------------------------------------------------------------------------
+
+
+def _keyword_global_config(keyword_func, *, supports=True) -> dict:
+    return {
+        "tokenizer": _fake_tokenizer(),
+        "role_llm_funcs": {"keyword": keyword_func},
+        "role_supports_token_tracker": {"keyword": supports},
+        "addon_params": {"language": "en"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_extract_keywords_only_receives_token_tracker_when_supported():
+    async def aware_model(*_args, token_tracker=None, **_kwargs):
+        token_tracker.add_usage(
+            {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10}
+        )
+        return '{"high_level_keywords": ["a"], "low_level_keywords": ["b"]}'
+
+    tracker = TokenTracker()
+    cfg = _keyword_global_config(aware_model, supports=True)
+    hl, ll = await extract_keywords_only(
+        "some text",
+        QueryParam(mode="local"),
+        cfg,
+        hashing_kv=None,
+        token_tracker=tracker,
+    )
+    assert (hl, ll) == (["a"], ["b"])
+    assert tracker.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_extract_keywords_only_never_passes_token_tracker_when_unsupported():
+    seen_kwargs = {}
+
+    async def strict_model(*_args, **kwargs):
+        seen_kwargs.update(kwargs)
+        return '{"high_level_keywords": ["a"], "low_level_keywords": ["b"]}'
+
+    tracker = TokenTracker()
+    cfg = _keyword_global_config(strict_model, supports=False)
+    await extract_keywords_only(
+        "some text",
+        QueryParam(mode="local"),
+        cfg,
+        hashing_kv=None,
+        token_tracker=tracker,
+    )
+    assert "token_tracker" not in seen_kwargs
+    assert tracker.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_get_keywords_from_query_skips_llm_and_tracker_when_preset():
+    tracker = TokenTracker()
+
+    async def never_called(*_args, **_kwargs):
+        raise AssertionError("must not call the LLM when keywords are preset")
+
+    cfg = _keyword_global_config(never_called, supports=True)
+    param = QueryParam(
+        mode="local", hl_keywords=["preset-hl"], ll_keywords=["preset-ll"]
+    )
+    hl, ll = await get_keywords_from_query(
+        "some text", param, cfg, hashing_kv=None, token_tracker=tracker
+    )
+    assert (hl, ll) == (["preset-hl"], ["preset-ll"])
+    assert tracker.call_count == 0


### PR DESCRIPTION
## Summary

Closes #2572. Exposes LLM token usage through the `/query` REST endpoint.

`kg_query`/`naive_query` now accumulate a `TokenTracker` across the keyword-extraction and
synthesis LLM calls made on that request, and attach the total to
`QueryResult.raw_data['metadata']['token_usage']`. `QueryResponse` gains an additive, optional
`token_usage` field populated from that metadata.

## Why this needed a capability check, not a straight kwarg pass

Only `lightrag/llm/openai.py`, `gemini.py`, and `ollama.py` accept a `token_tracker` kwarg on
their `*_complete_if_cache` functions. Every other binding (anthropic, bedrock, hf, lmdeploy,
lollms, zhipu, jina, voyageai, azure_openai, nvidia_openai) does not declare it, and several
forward unrecognized kwargs straight into the underlying SDK client call — passing
`token_tracker=` unconditionally would raise `TypeError` at the wire level for those.

`llm_roles.py::_wrap_llm_role_func` now inspects each role's bound raw function's real signature
once per (re)build and records whether it accepts `token_tracker`, exposed as
`role_supports_token_tracker`. `operate.py`'s call sites only add the kwarg when the bound role
supports it — the key is omitted entirely when unsupported, never passed as `token_tracker=None`.

## What's included

- `llm_roles.py` — per-role capability detection (`role_supports_token_tracker`)
- `lightrag.py` — threads the capability map into `global_config`; bypass-mode query path gated
  the same way
- `operate.py` — `_role_supports_token_tracker`/`_attach_token_usage` helpers; `kg_query`,
  `naive_query`, `extract_keywords_only` build a `TokenTracker` and attach usage at every point a
  caller can legitimately stop early (`only_need_context`, a cache hit, the no-keywords fail
  path, synthesis complete) — absent always means "unknown", never a zeroed-out figure
- `api/routers/query_routes.py` — `TokenUsage` model, additive `QueryResponse.token_usage`,
  populated on `/query` (not `/query/stream` — left out of scope; the streaming bypass path
  can't observe usage until the generator is drained by the caller, after the response has
  already been returned)
- `tests/llm/test_query_token_usage.py` — capability detection against real provider
  signatures, the `_attach_token_usage` helper directly, and `naive_query`/`kg_query`/
  `extract_keywords_only` end to end (supported binding, unsupported binding safety, cache-hit
  omission, keyword+synthesis aggregation, and the no-keywords fail-path edge case)

## What's not in this PR

`/query/stream` does not get a `token_usage` line. The bypass-mode streaming path only knows
usage once the response generator is fully consumed by the caller, which happens after this
endpoint has already returned its NDJSON — there's nowhere left to attach it without changing
the streaming response shape. Left for a follow-up if wanted.

## Test plan

- `ruff check` / `ruff format` clean on all touched files
- `tests/llm/test_query_token_usage.py` (17 tests) plus the existing suites it borrows fixture
  conventions from and the REST route tests over the same `QueryResponse` model
