### PR TITLE
Use custom logo and deployment title on login page

### DIFF
--- a/docs/UserDefinedUI-zh.md
+++ b/docs/UserDefinedUI-zh.md
@@ -20,7 +20,7 @@ LightRAG 支持用**你自己的**欢迎页、登录页文案、用户协议、�
 
 Bundle **不能**设置的内容：
 
-- 浏览器标签标题，以及登录卡片自身的 `LightRAG` 标题与副标题。与登录卡片的 Logo 不同，这些内容都**硬编码在前端**—— `index.html` 与 `workspace.html` 里的 `<title>Lightrag</title>`，以及 `LoginPage.tsx` 里的标题和走 i18n 的 `login.description`。Bundle 和任何环境变量都改不了它们，只能修改前端源码并重新构建。
+- 浏览器标签标题，以及登录卡片的标题和副标题。manifest 不能设置这些内容：`WEBUI_TITLE` 同时控制浏览器标签标题和登录页标题（未提供时回退为 `LightRAG`），副标题仍为 `LoginPage.tsx` 中走 i18n 的 `login.description`。
 - **登录之后**显示的应用头部（`/webui` 的 `SiteHeader`、`/workspace` 的工作区头部）。这一处由 `WEBUI_TITLE` / `WEBUI_DESCRIPTION` 环境变量设置，manifest 有意不允许覆盖。
 - 内容周围的按钮、菜单和设置项——参见 [§5.3 界面语言与 Bundle 语言](#53-界面语言与-bundle-语言)。
 - 文字方向。方向由 locale 推导（见 [§5.2](#52-文字方向rtl)），绝不取自 Bundle 中的标记。

--- a/docs/UserDefinedUI-zh.md
+++ b/docs/UserDefinedUI-zh.md
@@ -16,11 +16,11 @@ LightRAG 支持用**你自己的**欢迎页、登录页文案、用户协议、�
 | **查询空白页** | `/workspace` 查询页，对话为空时（点击 *Clear* 后会再次出现） | `query_empty`（必填） |
 | **登录页文案** | 用户名/密码表单上方，**两个入口都生效**（`/webui/#/login` 与 `/workspace/#/login`） | `login`（可选） |
 | **用户协议 + 同意勾选框** | 登录页上的勾选框，其链接以弹窗打开协议文档；未勾选时前端登录按钮保持禁用——这是前端提示，不是服务端强制（见 [§6](#6-登录同意门禁)） | `agreements`（可选，与 `login` 成对生效） |
-| **品牌 Logo** | 欢迎页与查询空白页 | `brand.logo`、locale 级 `logo`、`logo_alt` |
+| **品牌 Logo** | 欢迎页、查询空白页与登录页 | `brand.logo`、locale 级 `logo`、`logo_alt` |
 
 Bundle **不能**设置的内容：
 
-- 浏览器标签标题，以及登录卡片自身的 `LightRAG` 标题与副标题。这些都**硬编码在前端**—— `index.html` 与 `workspace.html` 里的 `<title>Lightrag</title>`，以及 `LoginPage.tsx` 里的标题和走 i18n 的 `login.description`。Bundle 和任何环境变量都改不了它们，只能修改前端源码并重新构建。
+- 浏览器标签标题，以及登录卡片自身的 `LightRAG` 标题与副标题。与登录卡片的 Logo 不同，这些内容都**硬编码在前端**—— `index.html` 与 `workspace.html` 里的 `<title>Lightrag</title>`，以及 `LoginPage.tsx` 里的标题和走 i18n 的 `login.description`。Bundle 和任何环境变量都改不了它们，只能修改前端源码并重新构建。
 - **登录之后**显示的应用头部（`/webui` 的 `SiteHeader`、`/workspace` 的工作区头部）。这一处由 `WEBUI_TITLE` / `WEBUI_DESCRIPTION` 环境变量设置，manifest 有意不允许覆盖。
 - 内容周围的按钮、菜单和设置项——参见 [§5.3 界面语言与 Bundle 语言](#53-界面语言与-bundle-语言)。
 - 文字方向。方向由 locale 推导（见 [§5.2](#52-文字方向rtl)），绝不取自 Bundle 中的标记。

--- a/docs/UserDefinedUI.md
+++ b/docs/UserDefinedUI.md
@@ -20,7 +20,7 @@ A ready-to-copy bundle lives in [`docs/ui_templates_example/`](./ui_templates_ex
 
 What you **cannot** set from the bundle:
 
-- The browser tab title and the login card's own `LightRAG` heading and subtitle. Unlike the login card's logo, these are **hardcoded in the frontend** — `<title>Lightrag</title>` in `index.html` and `workspace.html`, and the heading plus the localized `login.description` in `LoginPage.tsx`. Neither the bundle nor any environment variable changes them; that needs a WebUI edit and rebuild.
+- The browser tab title and the login card's heading and subtitle. The manifest cannot set them: `WEBUI_TITLE` supplies both the browser tab title and login heading (falling back to `LightRAG`), while the subtitle remains the localized `login.description` in `LoginPage.tsx`.
 - The in-app header shown **after sign-in** (`SiteHeader` on `/webui`, the workspace header on `/workspace`). That one is set by the `WEBUI_TITLE` / `WEBUI_DESCRIPTION` environment variables, and the manifest deliberately cannot override them.
 - The buttons, menus and settings around your content — see [§5.3 Interface languages](#53-interface-languages-vs-bundle-locales).
 - Text direction. It is derived from the locale (see [§5.2](#52-text-direction-rtl)), never taken from bundle markup.

--- a/docs/UserDefinedUI.md
+++ b/docs/UserDefinedUI.md
@@ -16,11 +16,11 @@ A ready-to-copy bundle lives in [`docs/ui_templates_example/`](./ui_templates_ex
 | **Query empty state** | `/workspace` query page, while the conversation is empty (and again after *Clear*) | `query_empty` (required) |
 | **Login page text** | Above the username/password form, on **both** entries (`/webui/#/login` and `/workspace/#/login`) | `login` (optional) |
 | **User agreement + consent checkbox** | A checkbox on the login page, whose link opens the document in a dialog; the WebUI's Login button stays disabled until it is ticked — a WebUI prompt, not server-side enforcement ([§6](#6-the-login-consent-gate)) | `agreements` (optional, pairs with `login`) |
-| **Brand logo** | Welcome page and query empty state | `brand.logo`, per-locale `logo`, `logo_alt` |
+| **Brand logo** | Welcome page, query empty state and login page | `brand.logo`, per-locale `logo`, `logo_alt` |
 
 What you **cannot** set from the bundle:
 
-- The browser tab title and the login card's own `LightRAG` heading and subtitle. These are **hardcoded in the frontend** — `<title>Lightrag</title>` in `index.html` and `workspace.html`, and the heading plus the localized `login.description` in `LoginPage.tsx`. Neither the bundle nor any environment variable changes them; that needs a WebUI edit and rebuild.
+- The browser tab title and the login card's own `LightRAG` heading and subtitle. Unlike the login card's logo, these are **hardcoded in the frontend** — `<title>Lightrag</title>` in `index.html` and `workspace.html`, and the heading plus the localized `login.description` in `LoginPage.tsx`. Neither the bundle nor any environment variable changes them; that needs a WebUI edit and rebuild.
 - The in-app header shown **after sign-in** (`SiteHeader` on `/webui`, the workspace header on `/workspace`). That one is set by the `WEBUI_TITLE` / `WEBUI_DESCRIPTION` environment variables, and the manifest deliberately cannot override them.
 - The buttons, menus and settings around your content — see [§5.3 Interface languages](#53-interface-languages-vs-bundle-locales).
 - Text direction. It is derived from the locale (see [§5.2](#52-text-direction-rtl)), never taken from bundle markup.

--- a/env.example
+++ b/env.example
@@ -68,15 +68,6 @@ WEBUI_DESCRIPTION='Simple and Fast Graph Based RAG System'
 ### refuses to start. Changes require a restart of all workers. See
 ### docs/UserDefinedUI.md for the full guide, and docs/ui_templates_example/
 ### for a ready-to-copy example bundle.
-### Recommended: mount the directory read-only in containers.
-### docker-compose.yml and docker-compose-full.yml already mount
-### ./data/ui_templates at the container path below, so enabling the variable
-### is all that is needed there. docker-compose.podman.yml keeps that mount
-### commented out (Podman is stricter about a bind mount whose host source is
-### missing): create ./data/ui_templates and uncomment the mount as well, or
-### the server starts against a path that is not there and refuses to run.
-### The default below is for running from the repository root. Container
-### deployments should override it in compose with /app/data/ui_templates.
 # UI_TEMPLATES_DIR=./lightrag_webui/ui_templates
 
 ### Optional SSL Configuration

--- a/env.example
+++ b/env.example
@@ -14,7 +14,7 @@
 ### and knowledge graph. Bind to 127.0.0.1 for local-only access.
 HOST=0.0.0.0
 PORT=9621
-### Deployment name shown in the WebUI header AND as the browser tab title.
+### Deployment name shown in WebUI headers, on the login page, and as the browser tab title.
 ### Leave unset to keep the default 'LightRAG'.
 WEBUI_TITLE='My Graph KB'
 WEBUI_DESCRIPTION='Simple and Fast Graph Based RAG System'

--- a/lightrag_webui/src/components/customization/brandTitle.test.ts
+++ b/lightrag_webui/src/components/customization/brandTitle.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { resolveBrandTitle } from './brandTitle'
+
+type GlobalWithWindow = typeof globalThis & {
+  window?: { __LIGHTRAG_CONFIG__?: { webuiTitle?: string | null } }
+}
+
+const globalWithWindow = globalThis as GlobalWithWindow
+const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window')
+
+const setRuntimeTitle = (webuiTitle: string | null | undefined): void => {
+  Object.defineProperty(globalThis, 'window', {
+    value: { __LIGHTRAG_CONFIG__: { webuiTitle } },
+    configurable: true
+  })
+}
+
+afterEach(() => {
+  if (previousWindow) {
+    Object.defineProperty(globalThis, 'window', previousWindow)
+  } else {
+    delete globalWithWindow.window
+  }
+})
+
+describe('resolveBrandTitle', () => {
+  test('prefers the successful customization snapshot', () => {
+    setRuntimeTitle('Injected title')
+    expect(resolveBrandTitle('Bundle title', 'Auth title')).toBe('Bundle title')
+  })
+
+  test('preserves the fresh auth-status title when customization fails', () => {
+    setRuntimeTitle('Injected title')
+    expect(resolveBrandTitle(null, 'Acme Safety')).toBe('Acme Safety')
+  })
+
+  test('falls back to the injected deployment title when both API sources fail', () => {
+    setRuntimeTitle('Injected title')
+    expect(resolveBrandTitle(null, null)).toBe('Injected title')
+  })
+
+  test('ignores blank sources and ultimately uses the product default', () => {
+    setRuntimeTitle('   ')
+    expect(resolveBrandTitle(' ', '\t')).toBe('LightRAG')
+  })
+})

--- a/lightrag_webui/src/components/customization/brandTitle.ts
+++ b/lightrag_webui/src/components/customization/brandTitle.ts
@@ -1,0 +1,28 @@
+import { getRuntimeWebuiTitle } from '@/lib/runtimeConfig'
+
+const normalizedTitle = (title: string | null | undefined): string | null => {
+  const trimmed = title?.trim()
+  return trimmed ? trimmed : null
+}
+
+/**
+ * Resolves the deployment title without consulting persisted auth state.
+ *
+ * A successful customization response is authoritative. If that optional
+ * endpoint is unavailable, the current /auth-status response is the next
+ * freshest source; the title injected into index.html covers deployments
+ * where a reverse proxy cannot reach either API route. Local-storage auth
+ * state is intentionally excluded because it may belong to an older server
+ * configuration.
+ */
+export function resolveBrandTitle(
+  snapshotTitle: string | null | undefined,
+  authStatusTitle: string | null | undefined
+): string {
+  return (
+    normalizedTitle(snapshotTitle) ??
+    normalizedTitle(authStatusTitle) ??
+    normalizedTitle(getRuntimeWebuiTitle()) ??
+    'LightRAG'
+  )
+}

--- a/lightrag_webui/src/components/customization/useCustomizedContent.ts
+++ b/lightrag_webui/src/components/customization/useCustomizedContent.ts
@@ -8,6 +8,7 @@ import {
 } from '@/stores/customization'
 import { resolveUiLanguage } from '@/lib/browserLanguage'
 import defaultLogoUrl from '@/assets/logo.svg'
+import { resolveBrandTitle } from '@/components/customization/brandTitle'
 
 /**
  * Resolves the branding content the WebUI shows (welcome page, query empty
@@ -65,7 +66,9 @@ export interface CustomizedContent {
   consentPending: boolean
 }
 
-export function useCustomizedContent(): CustomizedContent {
+export function useCustomizedContent(
+  authStatusTitle?: string | null
+): CustomizedContent {
   const { t } = useTranslation()
   const language = useSettingsStore.use.language()
   const languageUserSelected = useSettingsStore.use.languageUserSelected()
@@ -133,7 +136,7 @@ export function useCustomizedContent(): CustomizedContent {
       logoAlt: snapshot.brand.logo_alt ?? '',
       welcomeMarkdown: snapshot.welcome?.content ?? '',
       queryEmptyMarkdown: snapshot.query_empty?.content ?? '',
-      brandTitle: snapshot.brand.title || 'LightRAG',
+      brandTitle: resolveBrandTitle(snapshot.brand.title, authStatusTitle),
       brandDescription: snapshot.brand.description ?? null,
       loginMarkdown: snapshot.login?.content ?? '',
       agreementsMarkdown: snapshot.agreements?.content ?? null,
@@ -151,7 +154,7 @@ export function useCustomizedContent(): CustomizedContent {
     logoAlt: 'LightRAG',
     welcomeMarkdown: t('workspace.welcome.defaultMarkdown'),
     queryEmptyMarkdown: t('workspace.queryEmpty.defaultMarkdown'),
-    brandTitle: snapshot?.brand?.title || 'LightRAG',
+    brandTitle: resolveBrandTitle(snapshot?.brand?.title, authStatusTitle),
     brandDescription: snapshot?.brand?.description ?? null,
     // No bundle, or a hard failure: no deployment-specific agreement text
     // exists to consent TO, so the gate stays off. Fail-open is the only

--- a/lightrag_webui/src/features/LoginPage.tsx
+++ b/lightrag_webui/src/features/LoginPage.tsx
@@ -48,6 +48,7 @@ const LoginPage = ({ autoActivateGuest = true }: LoginPageProps) => {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [checkingAuth, setCheckingAuth] = useState(true)
+  const [authStatusTitle, setAuthStatusTitle] = useState<string | null>(null)
   // The tick is stored WITH the document it was given for; a language switch
   // replaces that document, and consent must not survive the swap.
   const [consentTick, setConsentTick] = useState<LoginConsentTick>({
@@ -62,7 +63,7 @@ const LoginPage = ({ autoActivateGuest = true }: LoginPageProps) => {
 
   // Fired in PARALLEL with the /auth-status probe below (both are effects of
   // this same mount), so the consent gate costs no serial round trip.
-  const content = useCustomizedContent()
+  const content = useCustomizedContent(authStatusTitle)
   const consentAgreed = isAgreedTo(consentTick, content.agreementsMarkdown)
   const consentState = {
     // NOT content.loading: on a language switch the store keeps the previous
@@ -102,6 +103,7 @@ const LoginPage = ({ autoActivateGuest = true }: LoginPageProps) => {
 
         // Check auth status
         const status = await getAuthStatus()
+        setAuthStatusTitle(status.webui_title || null)
 
         // Set session flag for version check to avoid duplicate checks in App component
         if (status.core_version || status.api_version) {

--- a/lightrag_webui/src/features/LoginPage.tsx
+++ b/lightrag_webui/src/features/LoginPage.tsx
@@ -17,7 +17,6 @@ import {
   DialogTitle
 } from '@/components/ui/Dialog'
 import { ScrollArea } from '@/components/ui/ScrollArea'
-import { ZapIcon } from 'lucide-react'
 import AppSettings from '@/components/AppSettings'
 import CustomizedMarkdown from '@/components/customization/CustomizedMarkdown'
 import { useCustomizedContent } from '@/components/customization/useCustomizedContent'
@@ -252,17 +251,14 @@ const LoginPage = ({ autoActivateGuest = true }: LoginPageProps) => {
       <Card className="w-full max-w-[480px] shadow-lg mx-4">
         <CardHeader className="flex items-center justify-center space-y-2 pb-8 pt-6">
           <div className="flex flex-col items-center space-y-4">
-            <div className="flex items-center gap-3">
-              {content.logoUrl && failedLogoUrl !== content.logoUrl && (
-                <img
-                  src={content.logoUrl}
-                  alt={content.logoAlt}
-                  className="h-12 w-12 object-contain"
-                  onError={() => setFailedLogoUrl(content.logoUrl)}
-                />
-              )}
-              <ZapIcon className="size-10 text-emerald-400" aria-hidden="true" />
-            </div>
+            {content.logoUrl && failedLogoUrl !== content.logoUrl && (
+              <img
+                src={content.logoUrl}
+                alt={content.logoAlt}
+                className="h-12 w-12 object-contain"
+                onError={() => setFailedLogoUrl(content.logoUrl)}
+              />
+            )}
             <div className="text-center space-y-2">
               <h1 className="text-3xl font-bold tracking-tight">LightRAG</h1>
               <p className="text-muted-foreground text-sm">

--- a/lightrag_webui/src/features/LoginPage.tsx
+++ b/lightrag_webui/src/features/LoginPage.tsx
@@ -4,7 +4,6 @@ import { useAuthStore } from '@/stores/state'
 import { activateLoginIdentityFromToken } from '@/lib/loginIdentity'
 import { markVersionCheckedFromLogin } from '@/lib/versionCheckCache'
 import { loginToServer, getAuthStatus } from '@/api/lightrag'
-import logoUrl from '@/assets/logo.svg'
 import { toast } from 'sonner'
 import { useTranslation } from 'react-i18next'
 import { Card, CardContent, CardHeader } from '@/components/ui/Card'
@@ -57,6 +56,9 @@ const LoginPage = ({ autoActivateGuest = true }: LoginPageProps) => {
     agreed: false
   })
   const [agreementsOpen, setAgreementsOpen] = useState(false)
+  // Latch the URL that failed, not a boolean: a language switch may supply
+  // a different logo URL that should get its own load attempt.
+  const [failedLogoUrl, setFailedLogoUrl] = useState<string | null>(null)
   const authCheckRef = useRef(false); // Prevent duplicate calls in Vite dev mode
 
   // Fired in PARALLEL with the /auth-status probe below (both are effects of
@@ -251,7 +253,14 @@ const LoginPage = ({ autoActivateGuest = true }: LoginPageProps) => {
         <CardHeader className="flex items-center justify-center space-y-2 pb-8 pt-6">
           <div className="flex flex-col items-center space-y-4">
             <div className="flex items-center gap-3">
-              <img src={logoUrl} alt="LightRAG Logo" className="h-12 w-12" />
+              {content.logoUrl && failedLogoUrl !== content.logoUrl && (
+                <img
+                  src={content.logoUrl}
+                  alt={content.logoAlt}
+                  className="h-12 w-12 object-contain"
+                  onError={() => setFailedLogoUrl(content.logoUrl)}
+                />
+              )}
               <ZapIcon className="size-10 text-emerald-400" aria-hidden="true" />
             </div>
             <div className="text-center space-y-2">

--- a/lightrag_webui/src/features/LoginPage.tsx
+++ b/lightrag_webui/src/features/LoginPage.tsx
@@ -260,7 +260,7 @@ const LoginPage = ({ autoActivateGuest = true }: LoginPageProps) => {
               />
             )}
             <div className="text-center space-y-2">
-              <h1 className="text-3xl font-bold tracking-tight">LightRAG</h1>
+              <h1 className="text-3xl font-bold tracking-tight">{content.brandTitle}</h1>
               <p className="text-muted-foreground text-sm">
                 {t('login.description')}
               </p>

--- a/lightrag_webui/src/features/loginLogo.test.ts
+++ b/lightrag_webui/src/features/loginLogo.test.ts
@@ -10,6 +10,8 @@ describe('login logo customization wiring', () => {
     expect(source).toContain('content.logoUrl && failedLogoUrl !== content.logoUrl')
     expect(source).toContain('src={content.logoUrl}')
     expect(source).toContain('alt={content.logoAlt}')
+    expect(source).not.toContain('import { ZapIcon } from \'lucide-react\'')
+    expect(source).not.toContain('<ZapIcon')
   })
 
   test('latches a failed URL without blocking a later locale logo', () => {

--- a/lightrag_webui/src/features/loginLogo.test.ts
+++ b/lightrag_webui/src/features/loginLogo.test.ts
@@ -3,6 +3,10 @@ import { readFileSync } from 'fs'
 import { join } from 'path'
 
 const source = readFileSync(join(import.meta.dir, 'LoginPage.tsx'), 'utf8')
+const welcomeSource = readFileSync(
+  join(import.meta.dir, 'workspace', 'WorkspaceWelcome.tsx'),
+  'utf8'
+)
 
 describe('login logo customization wiring', () => {
   test('uses the resolved bundle logo instead of importing the built-in asset', () => {
@@ -19,5 +23,11 @@ describe('login logo customization wiring', () => {
       'const [failedLogoUrl, setFailedLogoUrl] = useState<string | null>(null)'
     )
     expect(source).toContain('onError={() => setFailedLogoUrl(content.logoUrl)}')
+  })
+
+  test('uses the same resolved deployment title as the welcome page', () => {
+    expect(source).toContain('{content.brandTitle}</h1>')
+    expect(welcomeSource).toContain('{content.brandTitle}</h1>')
+    expect(source).not.toContain('>LightRAG</h1>')
   })
 })

--- a/lightrag_webui/src/features/loginLogo.test.ts
+++ b/lightrag_webui/src/features/loginLogo.test.ts
@@ -30,4 +30,12 @@ describe('login logo customization wiring', () => {
     expect(welcomeSource).toContain('{content.brandTitle}</h1>')
     expect(source).not.toContain('>LightRAG</h1>')
   })
+
+  test('passes the fresh auth-status title into the customization fallback', () => {
+    expect(source).toContain(
+      'const [authStatusTitle, setAuthStatusTitle] = useState<string | null>(null)'
+    )
+    expect(source).toContain('setAuthStatusTitle(status.webui_title || null)')
+    expect(source).toContain('useCustomizedContent(authStatusTitle)')
+  })
 })

--- a/lightrag_webui/src/features/loginLogo.test.ts
+++ b/lightrag_webui/src/features/loginLogo.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const source = readFileSync(join(import.meta.dir, 'LoginPage.tsx'), 'utf8')
+
+describe('login logo customization wiring', () => {
+  test('uses the resolved bundle logo instead of importing the built-in asset', () => {
+    expect(source).not.toContain('import logoUrl from \'@/assets/logo.svg\'')
+    expect(source).toContain('content.logoUrl && failedLogoUrl !== content.logoUrl')
+    expect(source).toContain('src={content.logoUrl}')
+    expect(source).toContain('alt={content.logoAlt}')
+  })
+
+  test('latches a failed URL without blocking a later locale logo', () => {
+    expect(source).toContain(
+      'const [failedLogoUrl, setFailedLogoUrl] = useState<string | null>(null)'
+    )
+    expect(source).toContain('onError={() => setFailedLogoUrl(content.logoUrl)}')
+  })
+})


### PR DESCRIPTION
## Description

Make both login routes use the branding resolved from the active UI customization response instead of hardcoded login-card branding. The login page now follows the same logo and deployment-title behavior as the workspace welcome surface, including degraded operation when the optional customization endpoint is unavailable.

## Related Issues

N/A — small follow-up bug found while validating UI customization.

## Changes Made

- Render `content.logoUrl` and `content.logoAlt` on the shared login page.
- Use `content.brandTitle` so `WEBUI_TITLE` controls the login heading with the existing `LightRAG` fallback.
- Preserve the deployment title when `/ui/customization` fails, with the precedence customization snapshot → fresh `/auth-status` title → injected runtime title → `LightRAG`.
- Avoid persisted auth-state titles in the fallback because they may belong to an older server configuration.
- Remove the decorative `ZapIcon` so the configured logo is the only image above the login heading.
- Avoid flashing the built-in logo while customization is loading and honor an explicit no-logo configuration.
- Latch only the URL that failed so a language switch can retry a different locale logo.
- Add regression coverage for the login logo, icon removal, deployment-title fallback, and failed-URL behavior.
- Update `env.example` and the English and Chinese UI customization guides while preserving line-for-line alignment.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local validation:

- `bun test src/components/customization/brandTitle.test.ts src/features/loginLogo.test.ts src/features/loginConsent.test.ts src/stores/customization.test.ts src/api/customization.test.ts` — 50 passed.
- `bunx eslint src/components/customization/brandTitle.ts src/components/customization/brandTitle.test.ts src/components/customization/useCustomizedContent.ts src/features/LoginPage.tsx src/features/loginLogo.test.ts` — passed.
- `bun run build` — passed, including the workspace bundle-size audit.
- English/Chinese guide line count and structural alignment check — 529 lines each, no mismatches.
- `git diff --check` — passed.

Browser E2E was not run because no browser instance was available in the review environment.
