### PR TITLE
Fix MinerU chart items dropped from IR

### DIFF
--- a/lightrag/parser/external/mineru/ir_builder.py
+++ b/lightrag/parser/external/mineru/ir_builder.py
@@ -27,8 +27,10 @@ Conversion rules (informed by spec §3-§六):
   is reserved for explicit 2D-array / non-HTML compatibility inputs. A real
   HTML ``<thead>`` populates ``table_header`` (per spec §5); otherwise the
   adapter does not guess a header row.
-- ``image`` / ``picture`` / ``drawing`` → IRDrawing + ``{{IMG:k}}`` placeholder.
-  Asset bytes are referenced via ``img_path`` relative to the raw dir.
+- ``image`` / ``picture`` / ``drawing`` / ``chart`` → IRDrawing + ``{{IMG:k}}``
+  placeholder. Asset bytes are referenced via ``img_path`` relative to the raw
+  dir. ``chart`` is a chart rendered as an image by MinerU, so it is treated as
+  a drawing.
 - ``equation`` → IREquation. ``is_block`` is decided by whether
   ``text_format=="block"`` (MinerU explicit flag) OR ``text_level==0`` with
   no inline neighbours; otherwise inline. The latex string is preserved
@@ -368,7 +370,7 @@ class MinerUIRBuilder:
                 _record_position(item)
                 continue
 
-            if item_type in {"image", "picture", "drawing"}:
+            if item_type in {"image", "picture", "drawing", "chart"}:
                 drawing, asset = self._build_ir_drawing(item, raw_dir, seen_assets)
                 placeholder = _next_key("im")
                 drawing.placeholder_key = placeholder

--- a/tests/parser/external/mineru/test_ir_builder.py
+++ b/tests/parser/external/mineru/test_ir_builder.py
@@ -179,6 +179,44 @@ def test_adapter_table_and_drawing_and_equation(tmp_path: Path) -> None:
 
 
 @pytest.mark.offline
+def test_adapter_chart_treated_as_drawing(tmp_path: Path) -> None:
+    """MinerU emits ``type="chart"`` items — a chart rendered as an image.
+
+    The adapter must treat them as drawings so the chart survives into the
+    sidecar (``blocks.jsonl`` / ``drawings.json``) instead of being silently
+    dropped by the plain-text fallback, which has no text field to read.
+    """
+    raw = _write_bundle(
+        tmp_path,
+        [
+            {"type": "text", "text": "Results", "text_level": 1},
+            {
+                "type": "chart",
+                "img_path": "images/chart_001.png",
+                "image_caption": ["Fig 1"],
+            },
+        ],
+    )
+    (raw / "images").mkdir()
+    (raw / "images" / "chart_001.png").write_bytes(b"\x89PNGchart")
+
+    ir = MinerUIRBuilder().normalize_from_workdir(raw, document_name="c.pdf")
+
+    assert len(ir.blocks) == 1
+    block = ir.blocks[0]
+    assert block.heading == "Results"
+    assert len(block.drawings) == 1
+    drawing = block.drawings[0]
+    assert drawing.fmt == "png"
+    assert drawing.caption == "Fig 1"
+    # The chart placeholder is rendered into the block content so the drawing
+    # survives into blocks.jsonl / drawings.json.
+    assert f"{{{{IMG:{drawing.placeholder_key}}}}}" in block.content_template
+    # The chart's image bytes are declared as an asset.
+    assert any(a.ref == "images/chart_001.png" for a in ir.assets)
+
+
+@pytest.mark.offline
 def test_adapter_page_idx_aggregated_and_deduped_when_no_bbox(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
MinerU emits type="chart" items for charts rendered as images, but _normalize_content_list only mapped image/picture/drawing to IRDrawing. chart fell through to the plain-text fallback, which reads no text field from an image-format item, so the chart silently vanished from the sidecar (blocks.jsonl / drawings.json).

Treat chart as a drawing so it survives into the IR and sidecar.

<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

 MinerU emits `type="chart"` items for charts rendered as images, but
  `MinerUIRBuilder._normalize_content_list` only mapped `image` / `picture` /
  `drawing` to `IRDrawing`. A `chart` item fell through to the plain-text
  fallback, which reads no text field from an image-format item, so the chart
  silently vanished from the sidecar (`blocks.jsonl` / `drawings.json`).

  This change treats `chart` as a drawing so charts survive into the IR and
  sidecar.

## Related Issues

None

## Changes Made

 - `lightrag/parser/external/mineru/ir_builder.py`: added `chart` to the
    drawing branch so chart items are routed through `_build_ir_drawing`
    (producing an `IRDrawing` + `AssetSpec` and a `{{IMG:k}}` placeholder), and
    updated the module docstring.
  - `tests/parser/external/mineru/test_ir_builder.py`: added
    `test_adapter_chart_treated_as_drawing` regression test.

## Checklist

  - [x] Changes tested locally
  - [x] Code reviewed
  - [x] Documentation updated (if necessary)
  - [x] Unit tests added (if applicable)

## Additional Notes

  `./scripts/test.sh tests/parser/external/mineru` → 103 passed; `ruff check`
  on both changed files passed.
