### PR TITLE
Add local agent LLM fallback cascade

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Entries marked 🇨🇳 also ship a Chinese translation as `*-zh.md` in the same
 |---|---|
 | [RoleSpecificLLMConfiguration.md](./docs/RoleSpecificLLMConfiguration.md) [🇨🇳](./docs/RoleSpecificLLMConfiguration-zh.md) | Per-role (`EXTRACT` / `QUERY` / `KEYWORD` / `VLM`) LLM and VLM configuration |
 | [LLMProviderOptions.md](./docs/LLMProviderOptions.md) | Complete reference for provider generation options (`OPENAI_LLM_*`, `OLLAMA_LLM_*`, `GEMINI_LLM_*`, `BEDROCK_LLM_*`, `*_EMBEDDING_*`) |
+| [LLMAgentCascade.md](./docs/LLMAgentCascade.md) | Trusted local Claude Code → Codex CLI → OpenAI-compatible fallback for batch LLM calls |
 | [AsymmetricEmbedding.md](./docs/AsymmetricEmbedding.md) | Query/document asymmetric embedding (`EMBEDDING_ASYMMETRIC`) and per-model prefixes |
 | [MilvusConfigurationGuide.md](./docs/MilvusConfigurationGuide.md) | Tuning Milvus index parameters through `vector_db_storage_cls_kwargs` |
 

--- a/docs/LLMAgentCascade.md
+++ b/docs/LLMAgentCascade.md
@@ -1,0 +1,188 @@
+# Local Agent LLM Cascade
+
+`lightrag.llm.agent_cascade` provides a bounded text-call interface for trusted
+local workloads that want this provider order:
+
+1. Claude Code through its local login or `CLAUDE_CODE_OAUTH_TOKEN`.
+2. Codex CLI through its cached ChatGPT/API-key login.
+3. An MCPHub OpenAI-compatible chat completion.
+
+The cascade can be passed directly as a LightRAG `llm_model_func`, or called
+with an output parser for large extraction and transformation jobs. A fallback
+success is marked `degraded=True`, and every prior attempt is retained as
+structured, credential-redacted metadata.
+
+This adapter is for trusted local batch workers. It is not an API-server
+authentication mechanism and must not be exposed to untrusted prompts or
+public users.
+
+## Prerequisites and authentication
+
+Install the two agent CLIs and authenticate them before starting the worker:
+
+```bash
+claude --version
+codex --version
+codex login status
+```
+
+Codex officially supports ChatGPT login and API-key login for local workflows,
+caches the login in `~/.codex/auth.json` or the operating-system credential
+store, and refreshes active ChatGPT sessions during use. For unattended
+enterprise automation, use a Codex access token or workload identity when your
+workspace supports it. General OpenAI API services should continue to use a
+Platform API key. See the [official Codex authentication
+documentation](https://developers.openai.com/codex/auth/).
+
+Claude can use its existing local login. A worker can instead provide one or
+more OAuth environment variables:
+
+```bash
+export CLAUDE_CODE_OAUTH_TOKEN=...
+export CLAUDE_CODE_OAUTH_TOKEN_1=...  # optional round-robin pool
+export CLAUDE_CODE_OAUTH_TOKEN_2=...
+```
+
+When an OAuth token is selected, the Claude child process receives only that
+token under the canonical name and does not inherit `ANTHROPIC_API_KEY`. Token
+values are never placed in result metadata or attempt errors.
+
+The final provider uses LightRAG's existing OpenAI-compatible binding:
+
+```bash
+uv sync --extra offline-llm
+export MCPHUB_API_KEY=...
+export MCPHUB_BASE_URL=https://api.mcphub.com/v1
+```
+
+`MCP_KEY` is accepted as a legacy key alias. Never commit any credential.
+
+## Use with LightRAG
+
+```python
+from lightrag import LightRAG
+from lightrag.llm.agent_cascade import LLMAgentCascade
+
+cascade = LLMAgentCascade()
+
+rag = LightRAG(
+    working_dir="./rag_storage",
+    llm_model_func=cascade,
+    embedding_func=your_embedding_func,
+)
+
+await rag.initialize_storages()
+try:
+    await rag.ainsert("Text to index")
+finally:
+    await rag.finalize_storages()
+```
+
+The provider CLIs return final responses rather than token deltas. When
+LightRAG calls the function with `stream=True`, the adapter returns a valid
+async iterator containing one final chunk.
+
+The cascade is text-only. It rejects `image_inputs`; use a vision-capable
+LightRAG provider for the VLM role.
+
+## Use for validated extraction
+
+The parser is the acceptance gate. A provider that returns empty or
+schema-invalid output is recorded as `invalid_output`, then the next provider
+is attempted.
+
+```python
+import json
+
+from lightrag.llm.agent_cascade import LLMAgentCascade, LLMTask
+
+cascade = LLMAgentCascade()
+result = await cascade.acall(
+    LLMTask(
+        prompt="Return one JSON object for this source record: ...",
+        system_prompt="Extract observed fields only. Do not infer missing values.",
+        task_type="catalog_record_extraction",
+        idempotency_key="source-123",
+    ),
+    parser=json.loads,
+)
+
+print(result.value)
+print(result.provider, result.degraded)
+for attempt in result.attempts:
+    print(attempt.provider, attempt.status, attempt.error_kind)
+```
+
+Synchronous scripts can use `cascade.call(task, parser=...)`. Inside notebooks,
+services, or any running event loop, use `await cascade.acall(...)` instead.
+
+For production structured output, pass a strict Pydantic
+`model_validate_json` function or an equivalent schema parser.
+
+## Fallback behavior
+
+The default policy falls through on:
+
+- a missing CLI, credential, or optional OpenAI dependency;
+- authentication, quota, rate-limit, timeout, transport, and server failures;
+- empty or parser-invalid output;
+- a provider without a required capability.
+
+It stops on request/programming errors and safety refusals. This prevents a bad
+request from being hidden by another billable call and prevents fallback from
+becoming a safety-policy bypass.
+
+After three availability failures, the default circuit breaker skips that
+provider for five minutes. Reuse one `LLMAgentCascade` across a batch so the
+breaker state remains useful.
+
+## Tool and process boundary
+
+- Claude runs with an empty tool list, no session persistence, and slash
+  commands disabled.
+- Codex runs ephemerally in a new empty temporary directory with a read-only
+  sandbox, user configuration and repository rules disabled. Codex remains an
+  agent runtime; use this adapter only on a trusted machine and trusted input.
+- MCPHub is one chat completion and has no agent tool loop.
+- `requires_tools=True` is rejected by every default provider. Inject a custom
+  provider instead of silently granting broader capabilities.
+
+Each CLI gets a per-call child environment. Concurrent calls therefore do not
+mutate process-global OAuth variables. Each call still starts a subprocess, so
+batch controllers should enforce provider-specific concurrency and account
+limits.
+
+## Batch execution
+
+For large jobs:
+
+- reuse one cascade instance;
+- checkpoint every record using `idempotency_key`;
+- retry a record rather than an entire batch;
+- persist `attempts` beside the accepted parsed output;
+- use an external `asyncio.Semaphore` for provider/account concurrency;
+- keep prompts idempotent because fallback replays the logical task;
+- do not log raw prompts if records contain sensitive data.
+
+The cascade does not persist trajectories or prompts itself. Claude is invoked
+with `--no-session-persistence`, and Codex with `--ephemeral`.
+
+## Environment variables
+
+| Variable | Default | Meaning |
+|---|---:|---|
+| `LIGHTRAG_AGENT_PROVIDER_ORDER` | `claude,codex,mcphub` | Ordered, comma-separated providers. |
+| `LIGHTRAG_AGENT_CLAUDE_MODEL` | `claude-sonnet-4-6` | Model passed to Claude Code. |
+| `LIGHTRAG_AGENT_CODEX_MODEL` | `gpt-5.6-luna` | Model passed to `codex exec`. |
+| `LIGHTRAG_AGENT_MCPHUB_MODEL` | `gpt-5.6-luna` | OpenAI-compatible fallback model. |
+| `LIGHTRAG_AGENT_CODEX_HOME` | Codex default | Optional credential/config directory. |
+| `LIGHTRAG_AGENT_MAX_TOKENS` | `8192` | MCPHub output-token ceiling. |
+| `LIGHTRAG_AGENT_COMMAND_TIMEOUT_SECONDS` | `900` | Per-provider wall-clock timeout. |
+| `LIGHTRAG_AGENT_CIRCUIT_FAILURE_THRESHOLD` | `3` | Failures before opening a provider circuit. |
+| `LIGHTRAG_AGENT_CIRCUIT_COOLDOWN_SECONDS` | `300` | Open-circuit cooldown. |
+| `MCPHUB_BASE_URL` | `https://api.mcphub.com/v1` | OpenAI-compatible fallback endpoint. |
+| `MCPHUB_API_KEY` | none | MCPHub bearer credential. |
+| `CLAUDE_CODE_OAUTH_TOKEN(_1.._5)` | local login | Optional Claude OAuth token pool. |
+
+Callers can also construct `CascadeConfig` directly or inject provider
+implementations for tests and custom runtimes.

--- a/lightrag/llm/agent_cascade.py
+++ b/lightrag/llm/agent_cascade.py
@@ -1,0 +1,884 @@
+"""Fail over bounded text tasks across local agent logins and an API gateway.
+
+This module is intentionally separate from the regular API-key bindings.  It is
+for trusted local batch jobs that already use Claude Code or Codex CLI login
+state and want a final OpenAI-compatible gateway fallback.  Every provider is
+lazy: importing :mod:`lightrag` does not require either CLI or the OpenAI SDK.
+
+The cascade is also a LightRAG ``llm_model_func``.  It returns a string for a
+normal call and a one-chunk async iterator when ``stream=True``.  Call
+``acall()`` directly when structured attempt metadata or parser validation is
+needed by an extraction pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import tempfile
+import threading
+import time
+from typing import Any, Generic, Literal, Protocol, TypeVar
+
+from lightrag.utils import logger
+
+
+ProviderName = Literal["claude", "codex", "mcphub"]
+ErrorKind = Literal[
+    "unavailable",
+    "authentication",
+    "quota",
+    "rate_limit",
+    "timeout",
+    "transport",
+    "server",
+    "invalid_output",
+    "capability",
+    "safety",
+    "request",
+    "internal",
+    "circuit_open",
+]
+
+DEFAULT_PROVIDER_ORDER: tuple[ProviderName, ...] = ("claude", "codex", "mcphub")
+DEFAULT_FALLBACK_KINDS: frozenset[ErrorKind] = frozenset(
+    {
+        "unavailable",
+        "authentication",
+        "quota",
+        "rate_limit",
+        "timeout",
+        "transport",
+        "server",
+        "invalid_output",
+        "capability",
+        "circuit_open",
+    }
+)
+_CIRCUIT_FAILURE_KINDS: frozenset[ErrorKind] = frozenset(
+    {
+        "unavailable",
+        "authentication",
+        "quota",
+        "rate_limit",
+        "timeout",
+        "transport",
+        "server",
+    }
+)
+
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)(authorization\s*[:=]\s*bearer\s+)[^\s,;]+"),
+    re.compile(r"(?i)\b(?:mcp|sk-ant|sk-proj|sk)-[A-Za-z0-9._-]+"),
+    re.compile(
+        r"(?i)((?:access|refresh|oauth|api)[_-]?token|api[_-]?key)"
+        r"\s*[:=]\s*['\"]?[^\s,'\"]+"
+    ),
+)
+_SAFETY_REFUSAL_RE = re.compile(
+    r"(?i)^\s*(?:"
+    r"i (?:cannot|can't) (?:help|assist) with|"
+    r"i(?:'m| am) unable to (?:help|assist)|"
+    r"i must refuse|"
+    r"cannot comply with (?:that|this|the) request|"
+    r"against my safety policy|"
+    r"not able to provide (?:that |this )?assistance"
+    r")"
+)
+
+ParsedT = TypeVar("ParsedT")
+
+
+def _redact_error(value: object, *, limit: int = 800) -> str:
+    text = str(value).strip() or type(value).__name__
+    for pattern in _SECRET_PATTERNS:
+        if pattern.groups:
+            text = pattern.sub(lambda match: f"{match.group(1)}[REDACTED]", text)
+        else:
+            text = pattern.sub("[REDACTED]", text)
+    return text[:limit]
+
+
+def _positive_int(name: str, value: object) -> int:
+    if type(value) is not int or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _positive_float(name: str, value: object) -> float:
+    if type(value) not in {int, float} or value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return float(value)
+
+
+@dataclass(frozen=True)
+class CascadeConfig:
+    """Provider order, models, and failure policy for one reusable cascade."""
+
+    provider_order: tuple[ProviderName, ...] = DEFAULT_PROVIDER_ORDER
+    claude_model: str = "claude-sonnet-4-6"
+    codex_model: str = "gpt-5.6-luna"
+    mcphub_model: str = "gpt-5.6-luna"
+    mcphub_base_url: str = "https://api.mcphub.com/v1"
+    max_tokens: int = 8192
+    command_timeout_seconds: float = 900.0
+    circuit_failure_threshold: int = 3
+    circuit_cooldown_seconds: float = 300.0
+    codex_home: str | None = None
+    fallback_kinds: frozenset[ErrorKind] = DEFAULT_FALLBACK_KINDS
+
+    def __post_init__(self) -> None:
+        if not self.provider_order:
+            raise ValueError("provider_order must not be empty")
+        if len(set(self.provider_order)) != len(self.provider_order):
+            raise ValueError("provider_order must not contain duplicates")
+        unknown = set(self.provider_order) - set(DEFAULT_PROVIDER_ORDER)
+        if unknown:
+            raise ValueError(f"unknown providers: {', '.join(sorted(unknown))}")
+        for name in ("claude_model", "codex_model", "mcphub_model"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{name} must be a nonblank string")
+        if (
+            not isinstance(self.mcphub_base_url, str)
+            or not self.mcphub_base_url.strip()
+        ):
+            raise ValueError("mcphub_base_url must be a nonblank string")
+        _positive_int("max_tokens", self.max_tokens)
+        _positive_float("command_timeout_seconds", self.command_timeout_seconds)
+        _positive_int("circuit_failure_threshold", self.circuit_failure_threshold)
+        _positive_float("circuit_cooldown_seconds", self.circuit_cooldown_seconds)
+
+    @classmethod
+    def from_env(cls, environment: Mapping[str, str] | None = None) -> "CascadeConfig":
+        if environment is None:
+            try:
+                from dotenv import load_dotenv
+
+                load_dotenv(dotenv_path=".env", override=False)
+            except ImportError:
+                pass
+        env = environment if environment is not None else os.environ
+        order = tuple(
+            name.strip().casefold()
+            for name in env.get(
+                "LIGHTRAG_AGENT_PROVIDER_ORDER", "claude,codex,mcphub"
+            ).split(",")
+            if name.strip()
+        )
+        return cls(
+            provider_order=order,  # type: ignore[arg-type]
+            claude_model=env.get("LIGHTRAG_AGENT_CLAUDE_MODEL", "claude-sonnet-4-6"),
+            codex_model=env.get("LIGHTRAG_AGENT_CODEX_MODEL", "gpt-5.6-luna"),
+            mcphub_model=env.get("LIGHTRAG_AGENT_MCPHUB_MODEL", "gpt-5.6-luna"),
+            mcphub_base_url=env.get("MCPHUB_BASE_URL", "https://api.mcphub.com/v1"),
+            max_tokens=int(env.get("LIGHTRAG_AGENT_MAX_TOKENS", "8192")),
+            command_timeout_seconds=float(
+                env.get("LIGHTRAG_AGENT_COMMAND_TIMEOUT_SECONDS", "900")
+            ),
+            circuit_failure_threshold=int(
+                env.get("LIGHTRAG_AGENT_CIRCUIT_FAILURE_THRESHOLD", "3")
+            ),
+            circuit_cooldown_seconds=float(
+                env.get("LIGHTRAG_AGENT_CIRCUIT_COOLDOWN_SECONDS", "300")
+            ),
+            codex_home=env.get("LIGHTRAG_AGENT_CODEX_HOME") or None,
+        )
+
+
+@dataclass(frozen=True)
+class LLMTask:
+    prompt: str
+    system_prompt: str = "You extract and transform data accurately."
+    history_messages: tuple[Mapping[str, Any], ...] = ()
+    task_type: str = "llm_data_task"
+    idempotency_key: str | None = None
+    requires_tools: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.prompt, str) or not self.prompt.strip():
+            raise ValueError("prompt must be a nonblank string")
+        if not isinstance(self.system_prompt, str) or not self.system_prompt.strip():
+            raise ValueError("system_prompt must be a nonblank string")
+        if not isinstance(self.task_type, str) or not self.task_type.strip():
+            raise ValueError("task_type must be a nonblank string")
+        if self.idempotency_key is not None and (
+            not isinstance(self.idempotency_key, str)
+            or not self.idempotency_key.strip()
+        ):
+            raise ValueError("idempotency_key must be a nonblank string when set")
+        if type(self.requires_tools) is not bool:
+            raise TypeError("requires_tools must be a boolean")
+        for message in self.history_messages:
+            if not isinstance(message, Mapping):
+                raise TypeError("history_messages entries must be mappings")
+
+    def rendered_prompt(self, *, include_system: bool = True) -> str:
+        sections = []
+        if include_system:
+            sections.append(f"System instructions:\n{self.system_prompt.strip()}")
+        if self.history_messages:
+            history = json.dumps(
+                list(self.history_messages), ensure_ascii=False, default=str
+            )
+            sections.append(f"Conversation history (JSON):\n{history}")
+        sections.append(f"Task:\n{self.prompt.strip()}")
+        return "\n\n".join(sections)
+
+
+@dataclass(frozen=True)
+class ProviderOutput:
+    content: str
+    provider: ProviderName
+    model: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProviderAttempt:
+    provider: ProviderName
+    model: str
+    status: Literal["succeeded", "failed", "skipped"]
+    elapsed_ms: int
+    error_kind: ErrorKind | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class LLMResult(Generic[ParsedT]):
+    value: ParsedT
+    content: str
+    provider: ProviderName
+    model: str
+    attempts: tuple[ProviderAttempt, ...]
+    task_type: str
+    idempotency_key: str | None = None
+    provider_metadata: dict[str, Any] = field(default_factory=dict)
+    degraded: bool = False
+
+
+class ProviderCallError(RuntimeError):
+    def __init__(self, kind: ErrorKind, message: str) -> None:
+        self.kind = kind
+        super().__init__(_redact_error(message))
+
+
+class AllProvidersFailed(RuntimeError):
+    def __init__(self, attempts: Sequence[ProviderAttempt]) -> None:
+        self.attempts = tuple(attempts)
+        summary = "; ".join(
+            f"{attempt.provider}:{attempt.error_kind or attempt.status}"
+            for attempt in self.attempts
+        )
+        super().__init__(f"all configured LLM providers failed ({summary})")
+
+
+class LLMProvider(Protocol):
+    name: ProviderName
+    model: str
+
+    async def invoke(self, task: LLMTask) -> ProviderOutput: ...
+
+
+def _classify_error(error: object) -> ErrorKind:
+    text = str(error).casefold()
+    if any(token in text for token in ("safety", "content policy", "refusal")):
+        return "safety"
+    if any(
+        token in text
+        for token in (
+            "unauthorized",
+            "authentication",
+            "not logged in",
+            "invalid api key",
+            "invalid_grant",
+            "401",
+            "403",
+        )
+    ):
+        return "authentication"
+    if any(
+        token in text
+        for token in (
+            "quota",
+            "usage limit",
+            "credit exhausted",
+            "payment required",
+            "402",
+        )
+    ):
+        return "quota"
+    if any(token in text for token in ("rate limit", "too many requests", "429")):
+        return "rate_limit"
+    if any(token in text for token in ("timed out", "timeout")):
+        return "timeout"
+    if any(token in text for token in ("connection", "network", "transport", "dns")):
+        return "transport"
+    if re.search(r"\b5\d\d\b", text):
+        return "server"
+    if any(
+        token in text
+        for token in ("not configured", "not set", "not installed", "not found")
+    ):
+        return "unavailable"
+    if any(token in text for token in ("bad request", "invalid request", "400")):
+        return "request"
+    return "internal"
+
+
+def _looks_like_safety_refusal(content: str) -> bool:
+    return _SAFETY_REFUSAL_RE.search(content[:2000]) is not None
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+CommandRunner = Callable[..., Awaitable[CommandResult]]
+
+
+async def _run_command(
+    command: Sequence[str],
+    *,
+    input_text: str,
+    timeout_seconds: float,
+    cwd: str,
+    environment: Mapping[str, str],
+) -> CommandResult:
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
+            env=dict(environment),
+        )
+    except FileNotFoundError as exc:
+        raise ProviderCallError(
+            "unavailable", f"agent executable not found: {command[0]}"
+        ) from exc
+
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            process.communicate(input_text.encode("utf-8")),
+            timeout=timeout_seconds,
+        )
+    except asyncio.TimeoutError as exc:
+        if process.returncode is None:
+            process.kill()
+        await process.communicate()
+        raise ProviderCallError(
+            "timeout", f"agent command timed out after {timeout_seconds:g}s"
+        ) from exc
+    except BaseException:
+        if process.returncode is None:
+            process.kill()
+        await process.communicate()
+        raise
+
+    return CommandResult(
+        returncode=process.returncode or 0,
+        stdout=stdout.decode("utf-8", errors="replace"),
+        stderr=stderr.decode("utf-8", errors="replace"),
+    )
+
+
+class ClaudeCodeProvider:
+    """Run one tool-free Claude Code turn using local login or OAuth env state."""
+
+    name: ProviderName = "claude"
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        timeout_seconds: float,
+        executable: str = "claude",
+        command_runner: CommandRunner | None = None,
+        environment: Mapping[str, str] | None = None,
+    ) -> None:
+        self.model = model
+        self.timeout_seconds = timeout_seconds
+        self.executable = executable
+        self._command_runner = command_runner
+        self._environment = environment
+        self._token_lock = threading.Lock()
+        self._next_token = 0
+
+    def _child_environment(self) -> tuple[dict[str, str], str | None]:
+        env = dict(self._environment if self._environment is not None else os.environ)
+        # This adapter is for Claude Code login/OAuth use. Never let a caller's
+        # unrelated API key silently change the billing/authentication path.
+        env.pop("ANTHROPIC_API_KEY", None)
+        token_names = ("CLAUDE_CODE_OAUTH_TOKEN",) + tuple(
+            f"CLAUDE_CODE_OAUTH_TOKEN_{index}" for index in range(1, 6)
+        )
+        available = [(name, env.get(name, "")) for name in token_names if env.get(name)]
+        selected_name: str | None = None
+        if available:
+            with self._token_lock:
+                selected_name, token = available[self._next_token % len(available)]
+                self._next_token += 1
+            env["CLAUDE_CODE_OAUTH_TOKEN"] = token
+            for name in token_names[1:]:
+                env.pop(name, None)
+        return env, selected_name
+
+    async def invoke(self, task: LLMTask) -> ProviderOutput:
+        if task.requires_tools:
+            raise ProviderCallError(
+                "capability", "the Claude cascade adapter intentionally disables tools"
+            )
+        runner = self._command_runner or _run_command
+        if self._command_runner is None and shutil.which(self.executable) is None:
+            raise ProviderCallError("unavailable", "Claude Code CLI is not installed")
+        environment, selected_token = self._child_environment()
+        command = [
+            self.executable,
+            "--print",
+            "--output-format",
+            "text",
+            "--model",
+            self.model,
+            "--permission-mode",
+            "dontAsk",
+            "--tools",
+            "",
+            "--no-session-persistence",
+            "--disable-slash-commands",
+            "--system-prompt",
+            task.system_prompt,
+        ]
+        with tempfile.TemporaryDirectory(prefix="lightrag-claude-") as workdir:
+            try:
+                result = await runner(
+                    command,
+                    input_text=task.rendered_prompt(include_system=False),
+                    timeout_seconds=self.timeout_seconds,
+                    cwd=workdir,
+                    environment=environment,
+                )
+            except ProviderCallError:
+                raise
+            except Exception as exc:
+                raise ProviderCallError(
+                    _classify_error(exc),
+                    f"Claude command failed: {type(exc).__name__}",
+                ) from exc
+        if result.returncode:
+            detail = result.stderr or result.stdout or f"exit code {result.returncode}"
+            raise ProviderCallError(
+                _classify_error(detail),
+                f"Claude command failed (exit code {result.returncode})",
+            )
+        content = result.stdout.strip()
+        if not content:
+            raise ProviderCallError("invalid_output", "Claude returned an empty output")
+        metadata = {"auth": "local_login"}
+        if selected_token:
+            metadata["auth"] = "oauth_environment"
+            metadata["token_slot"] = selected_token
+        return ProviderOutput(content, self.name, self.model, metadata)
+
+
+class CodexCLIProvider:
+    """Run one ephemeral Codex CLI turn with its normal cached authentication."""
+
+    name: ProviderName = "codex"
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        timeout_seconds: float,
+        codex_home: str | None = None,
+        executable: str = "codex",
+        command_runner: CommandRunner | None = None,
+        environment: Mapping[str, str] | None = None,
+    ) -> None:
+        self.model = model
+        self.timeout_seconds = timeout_seconds
+        self.codex_home = codex_home
+        self.executable = executable
+        self._command_runner = command_runner
+        self._environment = environment
+
+    async def invoke(self, task: LLMTask) -> ProviderOutput:
+        if task.requires_tools:
+            raise ProviderCallError(
+                "capability", "the Codex cascade adapter does not enable task tools"
+            )
+        runner = self._command_runner or _run_command
+        if self._command_runner is None and shutil.which(self.executable) is None:
+            raise ProviderCallError("unavailable", "Codex CLI is not installed")
+        environment = dict(
+            self._environment if self._environment is not None else os.environ
+        )
+        if self.codex_home:
+            environment["CODEX_HOME"] = str(Path(self.codex_home).expanduser())
+
+        with tempfile.TemporaryDirectory(prefix="lightrag-codex-") as workdir:
+            output_path = Path(workdir) / "last-message.txt"
+            command = [
+                self.executable,
+                "exec",
+                "--model",
+                self.model,
+                "--sandbox",
+                "read-only",
+                "--cd",
+                workdir,
+                "--skip-git-repo-check",
+                "--ephemeral",
+                "--ignore-user-config",
+                "--ignore-rules",
+                "--color",
+                "never",
+                "--output-last-message",
+                str(output_path),
+                "-",
+            ]
+            try:
+                result = await runner(
+                    command,
+                    input_text=task.rendered_prompt(),
+                    timeout_seconds=self.timeout_seconds,
+                    cwd=workdir,
+                    environment=environment,
+                )
+            except ProviderCallError:
+                raise
+            except Exception as exc:
+                raise ProviderCallError(
+                    _classify_error(exc),
+                    f"Codex command failed: {type(exc).__name__}",
+                ) from exc
+            if result.returncode:
+                detail = (
+                    result.stderr or result.stdout or f"exit code {result.returncode}"
+                )
+                raise ProviderCallError(
+                    _classify_error(detail),
+                    f"Codex command failed (exit code {result.returncode})",
+                )
+            content = (
+                output_path.read_text(encoding="utf-8").strip()
+                if output_path.exists()
+                else ""
+            )
+        if not content:
+            raise ProviderCallError("invalid_output", "Codex returned an empty output")
+        return ProviderOutput(
+            content,
+            self.name,
+            self.model,
+            {"auth": "codex_cli", "ephemeral": True, "sandbox": "read-only"},
+        )
+
+
+class McpHubProvider:
+    """Use LightRAG's OpenAI-compatible binding against an MCPHub endpoint."""
+
+    name: ProviderName = "mcphub"
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        base_url: str,
+        max_tokens: int,
+        timeout_seconds: float,
+        api_key: str | None = None,
+        completion_func: Callable[..., Awaitable[Any]] | None = None,
+        environment: Mapping[str, str] | None = None,
+    ) -> None:
+        self.model = model
+        self.base_url = base_url.rstrip("/")
+        self.max_tokens = max_tokens
+        self.timeout_seconds = timeout_seconds
+        self.api_key = api_key
+        self._completion_func = completion_func
+        self._environment = environment
+
+    async def invoke(self, task: LLMTask) -> ProviderOutput:
+        if task.requires_tools:
+            raise ProviderCallError(
+                "capability", "MCPHub chat completion has no agent tool loop"
+            )
+        env = self._environment if self._environment is not None else os.environ
+        api_key = self.api_key or env.get("MCPHUB_API_KEY") or env.get("MCP_KEY")
+        if not api_key:
+            raise ProviderCallError("unavailable", "MCPHUB_API_KEY is not configured")
+        completion_func = self._completion_func
+        if completion_func is None:
+            try:
+                from lightrag.llm.openai import openai_complete_if_cache
+            except ImportError as exc:
+                raise ProviderCallError(
+                    "unavailable", "OpenAI provider dependencies are not installed"
+                ) from exc
+            completion_func = openai_complete_if_cache
+        try:
+            content = await completion_func(
+                model=self.model,
+                prompt=task.prompt,
+                system_prompt=task.system_prompt,
+                history_messages=list(task.history_messages),
+                base_url=self.base_url,
+                api_key=api_key,
+                stream=False,
+                timeout=int(self.timeout_seconds),
+                max_completion_tokens=self.max_tokens,
+            )
+        except ProviderCallError:
+            raise
+        except Exception as exc:
+            raise ProviderCallError(
+                _classify_error(exc),
+                f"MCPHub call failed: {type(exc).__name__}",
+            ) from exc
+        if not isinstance(content, str) or not content.strip():
+            raise ProviderCallError("invalid_output", "MCPHub returned an empty output")
+        return ProviderOutput(content.strip(), self.name, self.model)
+
+
+@dataclass
+class _CircuitState:
+    failures: int = 0
+    open_until: float = 0.0
+
+
+class LLMAgentCascade:
+    """Try configured providers in order and return the first accepted output."""
+
+    def __init__(
+        self,
+        config: CascadeConfig | None = None,
+        *,
+        providers: Mapping[ProviderName, LLMProvider] | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.config = config or CascadeConfig.from_env()
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._circuits = {name: _CircuitState() for name in self.config.provider_order}
+        self._providers = (
+            dict(providers)
+            if providers is not None
+            else {
+                "claude": ClaudeCodeProvider(
+                    model=self.config.claude_model,
+                    timeout_seconds=self.config.command_timeout_seconds,
+                ),
+                "codex": CodexCLIProvider(
+                    model=self.config.codex_model,
+                    timeout_seconds=self.config.command_timeout_seconds,
+                    codex_home=self.config.codex_home,
+                ),
+                "mcphub": McpHubProvider(
+                    model=self.config.mcphub_model,
+                    base_url=self.config.mcphub_base_url,
+                    max_tokens=self.config.max_tokens,
+                    timeout_seconds=self.config.command_timeout_seconds,
+                ),
+            }
+        )
+
+    def _circuit_is_open(self, provider: ProviderName) -> bool:
+        with self._lock:
+            state = self._circuits[provider]
+            if state.open_until <= self._clock():
+                if state.open_until:
+                    state.failures = 0
+                    state.open_until = 0.0
+                return False
+            return True
+
+    def _record_success(self, provider: ProviderName) -> None:
+        with self._lock:
+            self._circuits[provider] = _CircuitState()
+
+    def _record_failure(self, provider: ProviderName, kind: ErrorKind) -> None:
+        if kind not in _CIRCUIT_FAILURE_KINDS:
+            return
+        with self._lock:
+            state = self._circuits[provider]
+            state.failures += 1
+            if state.failures >= self.config.circuit_failure_threshold:
+                state.open_until = self._clock() + self.config.circuit_cooldown_seconds
+
+    async def acall(
+        self,
+        task: LLMTask,
+        *,
+        parser: Callable[[str], ParsedT] | None = None,
+    ) -> LLMResult[ParsedT | str]:
+        if not isinstance(task, LLMTask):
+            raise TypeError("task must be an LLMTask")
+        attempts: list[ProviderAttempt] = []
+        for index, provider_name in enumerate(self.config.provider_order):
+            provider = self._providers.get(provider_name)
+            if provider is None:
+                raise ValueError(f"provider implementation missing: {provider_name}")
+            if self._circuit_is_open(provider_name):
+                attempts.append(
+                    ProviderAttempt(
+                        provider=provider_name,
+                        model=provider.model,
+                        status="skipped",
+                        elapsed_ms=0,
+                        error_kind="circuit_open",
+                        error="provider circuit is open",
+                    )
+                )
+                continue
+            started = self._clock()
+            try:
+                output = await provider.invoke(task)
+                if not isinstance(output.content, str) or not output.content.strip():
+                    raise ProviderCallError(
+                        "invalid_output", f"{provider_name} returned an empty output"
+                    )
+                if _looks_like_safety_refusal(output.content):
+                    raise ProviderCallError(
+                        "safety", f"{provider_name} returned a safety refusal"
+                    )
+                try:
+                    value = parser(output.content) if parser else output.content
+                except Exception as exc:
+                    raise ProviderCallError(
+                        "invalid_output",
+                        f"output validation failed: {type(exc).__name__}",
+                    ) from exc
+            except ProviderCallError as exc:
+                elapsed_ms = max(0, int((self._clock() - started) * 1000))
+                attempts.append(
+                    ProviderAttempt(
+                        provider=provider_name,
+                        model=provider.model,
+                        status="failed",
+                        elapsed_ms=elapsed_ms,
+                        error_kind=exc.kind,
+                        error=_redact_error(exc),
+                    )
+                )
+                self._record_failure(provider_name, exc.kind)
+                if exc.kind not in self.config.fallback_kinds:
+                    raise AllProvidersFailed(attempts) from exc
+                continue
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                attempts.append(
+                    ProviderAttempt(
+                        provider=provider_name,
+                        model=provider.model,
+                        status="failed",
+                        elapsed_ms=max(0, int((self._clock() - started) * 1000)),
+                        error_kind="internal",
+                        error=_redact_error(exc),
+                    )
+                )
+                raise AllProvidersFailed(attempts) from exc
+            self._record_success(provider_name)
+            attempts.append(
+                ProviderAttempt(
+                    provider=provider_name,
+                    model=provider.model,
+                    status="succeeded",
+                    elapsed_ms=max(0, int((self._clock() - started) * 1000)),
+                )
+            )
+            return LLMResult(
+                value=value,
+                content=output.content,
+                provider=provider_name,
+                model=output.model,
+                attempts=tuple(attempts),
+                task_type=task.task_type,
+                idempotency_key=task.idempotency_key,
+                provider_metadata=dict(output.metadata),
+                degraded=index > 0,
+            )
+        raise AllProvidersFailed(attempts)
+
+    def call(
+        self,
+        task: LLMTask,
+        *,
+        parser: Callable[[str], ParsedT] | None = None,
+    ) -> LLMResult[ParsedT | str]:
+        """Synchronous convenience wrapper for scripts without an event loop."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.acall(task, parser=parser))
+        raise RuntimeError(
+            "LLMAgentCascade.call() cannot run inside an event loop; use acall()"
+        )
+
+    async def __call__(
+        self,
+        prompt: str,
+        system_prompt: str | None = None,
+        history_messages: list[dict[str, Any]] | None = None,
+        stream: bool | None = None,
+        **kwargs: Any,
+    ) -> str | AsyncIterator[str]:
+        """LightRAG ``llm_model_func`` compatibility entrypoint.
+
+        Agent CLIs are final-response transports, so streaming is represented
+        as one final chunk.  Image inputs and arbitrary tools are deliberately
+        unsupported by this text-only batch adapter.
+        """
+        if kwargs.get("image_inputs"):
+            raise ValueError("LLMAgentCascade is text-only and rejects image_inputs")
+        task = LLMTask(
+            prompt=prompt,
+            system_prompt=system_prompt
+            or "You are a helpful assistant. Follow the requested output format exactly.",
+            history_messages=tuple(history_messages or ()),
+            task_type=kwargs.get("task_type", "lightrag_llm_call"),
+            idempotency_key=kwargs.get("idempotency_key"),
+            requires_tools=kwargs.get("requires_tools", False),
+        )
+        result = await self.acall(task)
+        if result.degraded:
+            logger.warning(
+                "LLM agent cascade degraded to %s after %d failed/skipped provider(s)",
+                result.provider,
+                len(result.attempts) - 1,
+            )
+        if stream:
+            return _single_chunk(result.content)
+        return result.content
+
+
+async def _single_chunk(content: str) -> AsyncIterator[str]:
+    yield content
+
+
+__all__ = [
+    "AllProvidersFailed",
+    "CascadeConfig",
+    "ClaudeCodeProvider",
+    "CodexCLIProvider",
+    "CommandResult",
+    "LLMAgentCascade",
+    "LLMResult",
+    "LLMTask",
+    "McpHubProvider",
+    "ProviderAttempt",
+    "ProviderCallError",
+    "ProviderOutput",
+]

--- a/tests/llm/agent_cascade_impl/test_agent_cascade.py
+++ b/tests/llm/agent_cascade_impl/test_agent_cascade.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+import json
+from pathlib import Path
+
+import pytest
+
+from lightrag.llm.agent_cascade import (
+    AllProvidersFailed,
+    CascadeConfig,
+    ClaudeCodeProvider,
+    CodexCLIProvider,
+    CommandResult,
+    LLMAgentCascade,
+    LLMTask,
+    McpHubProvider,
+    ProviderCallError,
+    ProviderOutput,
+)
+
+
+class ScriptedProvider:
+    def __init__(self, name, *outcomes, model="test-model"):
+        self.name = name
+        self.model = model
+        self.outcomes = list(outcomes)
+        self.calls = 0
+
+    async def invoke(self, _task):
+        self.calls += 1
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return ProviderOutput(outcome, self.name, self.model)
+
+
+def _config(*providers, threshold=3):
+    return CascadeConfig(
+        provider_order=providers,
+        circuit_failure_threshold=threshold,
+    )
+
+
+@pytest.mark.asyncio
+async def test_falls_back_and_validates_with_parser():
+    claude = ScriptedProvider("claude", ProviderCallError("quota", "limit"))
+    codex = ScriptedProvider("codex", "not json")
+    mcphub = ScriptedProvider("mcphub", '{"value": 3}')
+    cascade = LLMAgentCascade(
+        _config("claude", "codex", "mcphub"),
+        providers={"claude": claude, "codex": codex, "mcphub": mcphub},
+    )
+
+    result = await cascade.acall(
+        LLMTask("extract", idempotency_key="row-1"), parser=json.loads
+    )
+
+    assert result.value == {"value": 3}
+    assert result.provider == "mcphub"
+    assert result.idempotency_key == "row-1"
+    assert result.degraded is True
+    assert [attempt.error_kind for attempt in result.attempts] == [
+        "quota",
+        "invalid_output",
+        None,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_safety_refusal_stops_without_fallback():
+    claude = ScriptedProvider("claude", "I cannot assist with that request.")
+    codex = ScriptedProvider("codex", "must not run")
+    cascade = LLMAgentCascade(
+        _config("claude", "codex"),
+        providers={"claude": claude, "codex": codex},
+    )
+
+    with pytest.raises(AllProvidersFailed) as caught:
+        await cascade.acall(LLMTask("extract"))
+
+    assert caught.value.attempts[0].error_kind == "safety"
+    assert codex.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_refusal_text_inside_structured_data_is_not_a_safety_signal():
+    content = '{"source_text": "I cannot assist with that request."}'
+    claude = ScriptedProvider("claude", content)
+    cascade = LLMAgentCascade(_config("claude"), providers={"claude": claude})
+
+    result = await cascade.acall(LLMTask("extract"), parser=json.loads)
+
+    assert result.value["source_text"].startswith("I cannot")
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_skips_repeated_auth_failure():
+    claude = ScriptedProvider(
+        "claude",
+        ProviderCallError("authentication", "bad login"),
+        ProviderCallError("authentication", "bad login"),
+    )
+    codex = ScriptedProvider("codex", "one", "two", "three")
+    cascade = LLMAgentCascade(
+        _config("claude", "codex", threshold=2),
+        providers={"claude": claude, "codex": codex},
+    )
+
+    await cascade.acall(LLMTask("first"))
+    await cascade.acall(LLMTask("second"))
+    third = await cascade.acall(LLMTask("third"))
+
+    assert claude.calls == 2
+    assert third.attempts[0].error_kind == "circuit_open"
+    assert third.provider == "codex"
+
+
+@pytest.mark.asyncio
+async def test_attempt_error_redacts_openai_style_secret():
+    claude = ScriptedProvider(
+        "claude",
+        ProviderCallError("authentication", "credential sk-example-secret-value"),
+    )
+    cascade = LLMAgentCascade(_config("claude"), providers={"claude": claude})
+
+    with pytest.raises(AllProvidersFailed) as caught:
+        await cascade.acall(LLMTask("extract"))
+
+    assert caught.value.attempts[0].error == "credential [REDACTED]"
+
+
+def test_config_from_env_controls_models_and_limits():
+    config = CascadeConfig.from_env(
+        {
+            "LIGHTRAG_AGENT_PROVIDER_ORDER": "codex,mcphub",
+            "LIGHTRAG_AGENT_CODEX_MODEL": "codex-model",
+            "LIGHTRAG_AGENT_MCPHUB_MODEL": "gateway-model",
+            "MCPHUB_BASE_URL": "https://gateway.example/v1/",
+            "LIGHTRAG_AGENT_MAX_TOKENS": "2048",
+            "LIGHTRAG_AGENT_COMMAND_TIMEOUT_SECONDS": "45",
+            "LIGHTRAG_AGENT_CIRCUIT_FAILURE_THRESHOLD": "4",
+            "LIGHTRAG_AGENT_CIRCUIT_COOLDOWN_SECONDS": "90",
+            "LIGHTRAG_AGENT_CODEX_HOME": "/tmp/codex-home",
+        }
+    )
+
+    assert config.provider_order == ("codex", "mcphub")
+    assert config.codex_model == "codex-model"
+    assert config.mcphub_model == "gateway-model"
+    assert config.mcphub_base_url == "https://gateway.example/v1/"
+    assert config.max_tokens == 2048
+    assert config.command_timeout_seconds == 45.0
+    assert config.circuit_failure_threshold == 4
+    assert config.circuit_cooldown_seconds == 90.0
+    assert config.codex_home == "/tmp/codex-home"
+
+
+@pytest.mark.parametrize(
+    "kwargs,error",
+    [
+        ({"idempotency_key": ""}, "idempotency_key"),
+        ({"requires_tools": 1}, "requires_tools"),
+        ({"history_messages": ("bad",)}, "history_messages"),
+    ],
+)
+def test_task_rejects_invalid_control_metadata(kwargs, error):
+    with pytest.raises((TypeError, ValueError), match=error):
+        LLMTask("extract", **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_claude_cli_is_tool_free_and_uses_isolated_oauth_environment():
+    calls = []
+
+    async def runner(command, **kwargs):
+        calls.append((command, kwargs))
+        return CommandResult(0, '{"ok": true}\n', "")
+
+    provider = ClaudeCodeProvider(
+        model="sonnet",
+        timeout_seconds=30,
+        command_runner=runner,
+        environment={
+            "CLAUDE_CODE_OAUTH_TOKEN_1": "test-token",
+            "ANTHROPIC_API_KEY": "must-not-shadow-oauth",
+            "PATH": "/usr/bin",
+        },
+    )
+
+    result = await provider.invoke(LLMTask("extract"))
+
+    command, kwargs = calls[0]
+    tools_index = command.index("--tools")
+    assert command[tools_index + 1] == ""
+    assert "--no-session-persistence" in command
+    assert kwargs["environment"]["CLAUDE_CODE_OAUTH_TOKEN"] == "test-token"
+    assert "CLAUDE_CODE_OAUTH_TOKEN_1" not in kwargs["environment"]
+    assert "ANTHROPIC_API_KEY" not in kwargs["environment"]
+    assert result.content == '{"ok": true}'
+    assert result.metadata["token_slot"] == "CLAUDE_CODE_OAUTH_TOKEN_1"
+
+
+@pytest.mark.asyncio
+async def test_claude_cli_rotates_named_oauth_token_pool():
+    selected = []
+
+    async def runner(_command, **kwargs):
+        selected.append(kwargs["environment"]["CLAUDE_CODE_OAUTH_TOKEN"])
+        return CommandResult(0, "ok", "")
+
+    provider = ClaudeCodeProvider(
+        model="sonnet",
+        timeout_seconds=30,
+        command_runner=runner,
+        environment={
+            "CLAUDE_CODE_OAUTH_TOKEN": "token-0",
+            "CLAUDE_CODE_OAUTH_TOKEN_1": "token-1",
+        },
+    )
+
+    await provider.invoke(LLMTask("one"))
+    await provider.invoke(LLMTask("two"))
+
+    assert selected == ["token-0", "token-1"]
+
+
+@pytest.mark.asyncio
+async def test_claude_local_login_does_not_inherit_anthropic_api_key():
+    environments = []
+
+    async def runner(_command, **kwargs):
+        environments.append(kwargs["environment"])
+        return CommandResult(0, "ok", "")
+
+    provider = ClaudeCodeProvider(
+        model="sonnet",
+        timeout_seconds=30,
+        command_runner=runner,
+        environment={"ANTHROPIC_API_KEY": "must-not-use", "PATH": "/usr/bin"},
+    )
+
+    result = await provider.invoke(LLMTask("one"))
+
+    assert "ANTHROPIC_API_KEY" not in environments[0]
+    assert result.metadata["auth"] == "local_login"
+
+
+@pytest.mark.asyncio
+async def test_codex_cli_uses_ephemeral_read_only_execution_and_codex_home(
+    tmp_path: Path,
+):
+    calls = []
+
+    async def runner(command, **kwargs):
+        calls.append((command, kwargs))
+        output_path = Path(command[command.index("--output-last-message") + 1])
+        output_path.write_text("codex answer\n", encoding="utf-8")
+        return CommandResult(0, "events are ignored", "")
+
+    provider = CodexCLIProvider(
+        model="codex-model",
+        timeout_seconds=30,
+        codex_home=str(tmp_path / "codex-home"),
+        command_runner=runner,
+        environment={"PATH": "/usr/bin"},
+    )
+
+    result = await provider.invoke(LLMTask("transform"))
+
+    command, kwargs = calls[0]
+    assert command[:2] == ["codex", "exec"]
+    assert command[-1] == "-"
+    assert "--ephemeral" in command
+    assert "--ignore-user-config" in command
+    assert command[command.index("--sandbox") + 1] == "read-only"
+    assert kwargs["environment"]["CODEX_HOME"] == str(tmp_path / "codex-home")
+    assert result.content == "codex answer"
+    assert result.metadata["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_cli_error_is_classified_for_fallback():
+    async def runner(_command, **_kwargs):
+        return CommandResult(1, "", "429 too many requests")
+
+    provider = CodexCLIProvider(
+        model="codex-model",
+        timeout_seconds=30,
+        command_runner=runner,
+    )
+
+    with pytest.raises(ProviderCallError) as caught:
+        await provider.invoke(LLMTask("transform"))
+
+    assert caught.value.kind == "rate_limit"
+    assert "too many requests" not in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_mcphub_uses_lightrag_openai_compatible_call_shape():
+    calls = []
+
+    async def completion_func(**kwargs):
+        calls.append(kwargs)
+        return "gateway answer"
+
+    provider = McpHubProvider(
+        model="gateway-model",
+        base_url="https://gateway.example/v1/",
+        max_tokens=123,
+        timeout_seconds=30,
+        completion_func=completion_func,
+        environment={"MCPHUB_API_KEY": "test-key"},
+    )
+
+    result = await provider.invoke(
+        LLMTask(
+            "extract",
+            system_prompt="schema only",
+            history_messages=({"role": "assistant", "content": "prior"},),
+        )
+    )
+
+    assert result.content == "gateway answer"
+    assert calls[0]["base_url"] == "https://gateway.example/v1"
+    assert calls[0]["api_key"] == "test-key"
+    assert calls[0]["max_completion_tokens"] == 123
+    assert calls[0]["history_messages"][0]["content"] == "prior"
+
+
+@pytest.mark.asyncio
+async def test_light_rag_callable_returns_text_or_one_chunk_stream():
+    provider = ScriptedProvider("claude", "plain", "streamed")
+    cascade = LLMAgentCascade(_config("claude"), providers={"claude": provider})
+
+    text = await cascade("question", system_prompt="system")
+    stream = await cascade("question", stream=True)
+
+    assert text == "plain"
+    assert isinstance(stream, AsyncIterator)
+    assert [chunk async for chunk in stream] == ["streamed"]
+
+
+@pytest.mark.asyncio
+async def test_light_rag_callable_rejects_images_before_provider_call():
+    provider = ScriptedProvider("claude", "must not run")
+    cascade = LLMAgentCascade(_config("claude"), providers={"claude": provider})
+
+    with pytest.raises(ValueError, match="text-only"):
+        await cascade("question", image_inputs=[{"data": "..."}])
+
+    assert provider.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_light_rag_callable_does_not_coerce_requires_tools_strings():
+    provider = ScriptedProvider("claude", "must not run")
+    cascade = LLMAgentCascade(_config("claude"), providers={"claude": provider})
+
+    with pytest.raises(TypeError, match="requires_tools"):
+        await cascade("question", requires_tools="false")
+
+    assert provider.calls == 0
+
+
+def test_sync_call_runs_without_an_event_loop():
+    provider = ScriptedProvider("claude", '{"ok": true}')
+    cascade = LLMAgentCascade(_config("claude"), providers={"claude": provider})
+
+    result = cascade.call(LLMTask("extract"), parser=json.loads)
+
+    assert result.value == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_sync_call_rejects_an_existing_event_loop():
+    provider = ScriptedProvider("claude", "must not run")
+    cascade = LLMAgentCascade(_config("claude"), providers={"claude": provider})
+
+    with pytest.raises(RuntimeError, match="use acall"):
+        cascade.call(LLMTask("extract"))
+
+    assert provider.calls == 0


### PR DESCRIPTION
## Summary

- add a reusable `LLMAgentCascade` that tries Claude Code, Codex CLI, then an MCPHub OpenAI-compatible completion
- expose the cascade as a native LightRAG `llm_model_func` and as a validated `acall()` / `call()` interface for batch extraction
- retain structured, redacted provider attempts, parser-gated output acceptance, safety-aware fallback, and per-provider circuit breaking
- document authentication, environment variables, process/tool boundaries, and batch checkpointing

## Motivation

Large local extraction and transformation jobs often have access to existing Claude Code or Codex login state but still need deterministic degradation when a login, quota, transport, or output-schema failure occurs. This adds one bounded orchestration layer without changing LightRAG's existing API-key bindings or API-server binding selection.

## What changed

- Claude runs in a fresh temporary directory with an empty tool list, no session persistence, and isolated OAuth-token child environments. `ANTHROPIC_API_KEY` is removed so it cannot silently replace Claude Code login/OAuth billing.
- Codex runs through `codex exec` in an empty temporary directory with `--ephemeral`, a read-only sandbox, and user configuration/repository rules disabled. Authentication remains owned by the Codex CLI and optional `CODEX_HOME`.
- MCPHub reuses LightRAG's existing OpenAI-compatible completion implementation and is skipped for tool-dependent tasks.
- Missing runtimes, auth/quota/rate-limit/timeout/transport/server errors, empty output, and parser failures can fall through. Request errors and safety refusals stop the chain.
- CLI stdout/stderr and prompts are not copied into attempt errors; common credential forms are redacted defensively.
- Streaming callers receive a valid one-chunk async iterator because both agent CLIs return final responses.

## Limitations

- intended only for trusted local text workloads; it is not an API-server authentication mechanism
- text-only; `image_inputs` are rejected
- Codex remains an agent runtime even with an empty temporary workspace and read-only sandbox
- each Claude/Codex attempt starts a subprocess, so batch owners should enforce provider-specific concurrency
- no live provider request was made as part of validation

## Validation

- `20 passed`: `tests/llm/agent_cascade_impl`
- `53 passed`: existing role runtime, query history/cache, image-binding, and cache-identity contract tests
- Ruff check and format check passed
- pre-commit hooks passed for all changed files
- isolated `uv --extra test` import smoke passed
- installed Claude/Codex CLI option surfaces accepted the generated flags without making a model call
