### PR TITLE
fix(reproduce): batch_eval.py always exits with TypeError — give it a CLI

### DIFF
--- a/reproduce/batch_eval.py
+++ b/reproduce/batch_eval.py
@@ -1,5 +1,6 @@
 import re
 import json
+import argparse
 import jsonlines
 
 from openai import OpenAI
@@ -109,4 +110,41 @@ def batch_eval(query_file, result1_file, result2_file, output_file_path):
 
 
 if __name__ == "__main__":
-    batch_eval()
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build an OpenAI Batch API request file that compares the answers of "
+            "two RAG systems on the same questions."
+        )
+    )
+    parser.add_argument(
+        "-q",
+        "--query_file",
+        type=str,
+        required=True,
+        help="Questions file produced by Step_2.py.",
+    )
+    parser.add_argument(
+        "-r1",
+        "--result1_file",
+        type=str,
+        required=True,
+        help="First system's answers, as produced by Step_3.py.",
+    )
+    parser.add_argument(
+        "-r2",
+        "--result2_file",
+        type=str,
+        required=True,
+        help="Second system's answers, as produced by Step_3.py.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output_file",
+        type=str,
+        default="batch_eval_requests.jsonl",
+        help="Where to write the Batch API request file.",
+    )
+
+    args = parser.parse_args()
+
+    batch_eval(args.query_file, args.result1_file, args.result2_file, args.output_file)


### PR DESCRIPTION
## Problem

`reproduce/batch_eval.py` cannot be run. Its `__main__` block calls the function
with no arguments, but the function requires four:

```python
def batch_eval(query_file, result1_file, result2_file, output_file_path):
...
if __name__ == "__main__":
    batch_eval()
```

On current `main`:

```console
$ python batch_eval.py
Traceback (most recent call last):
  File ".../reproduce/batch_eval.py", line 112, in <module>
    batch_eval()
TypeError: batch_eval() missing 4 required positional arguments: 'query_file',
'result1_file', 'result2_file', and 'output_file_path'
```

This is a documented entry point — `docs/Reproduce.md` sends readers to it:

> To evaluate the performance of two RAG systems on high-level queries, LightRAG uses the following prompt, with the specific code available in `reproduce/batch_eval.py`.

## Fix

Parse the four paths with `argparse`, following the convention `Step_0.py` in the
same directory already uses (parse in `__main__`, hand the values to the function):

```python
args = parser.parse_args()
batch_eval(args.query_file, args.result1_file, args.result2_file, args.output_file)
```

The three input paths are `required` rather than defaulted, because there is no
way to guess which two systems a user is comparing; only `--output_file` gets a
default. Happy to switch them to pipeline-shaped defaults
(`../datasets/questions/{cls}_questions.txt`, `{cls}_result.json`) closer to
`Step_3.py`'s style if you'd prefer that.

## Verification

Ran the real script before and after (no mocks):

```console
# before — current main
$ python batch_eval.py
TypeError: batch_eval() missing 4 required positional arguments: ...

# after — this PR
$ python batch_eval.py
usage: batch_eval.py [-h] -q QUERY_FILE -r1 RESULT1_FILE -r2 RESULT2_FILE [-o OUTPUT_FILE]
batch_eval.py: error: the following arguments are required: -q/--query_file, -r1/--result1_file, -r2/--result2_file
```

End-to-end with fixture files, to confirm all four parsed values actually reach
the function body (2 questions, 2 answer files, real `jsonlines`/`openai` installed):

```console
$ python batch_eval.py -q q.txt -r1 r1.json -r2 r2.json -o out.jsonl
Batch API requests written to out.jsonl
openai.AuthenticationError: Error code: 401 - Incorrect API key provided: sk-dummy...
```

`out.jsonl` was written with both requests correctly assembled (`request-1`,
`request-2`, each with the comparison prompt and both answers). The only failure
is the OpenAI auth step, which is expected with a dummy key and is past everything
this PR touches.

Lint with the pinned `ruff v0.15.17` from `.pre-commit-config.yaml`, run from the
repo root so `pyproject.toml` applies:

```console
$ ruff check --ignore=E402 reproduce/batch_eval.py
All checks passed!
$ ruff format --diff reproduce/batch_eval.py
1 file already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
