### PR TITLE
Fail legibly when bun test runs without the DOM preload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,9 +190,19 @@ lightrag-gunicorn                                         # Multi-worker (gunico
 ```
 
 ### WebUI
+
+Every command below is run **from `lightrag_webui/`**, not the repository root.
+`bun test` in particular resolves `bunfig.toml` — and the preload paths inside
+it — relative to the working directory, so running it from the root silently
+loads no DOM (see *React component tests*).
+
 ```bash
 cd lightrag_webui
-bun install --frozen-lockfile      # Install dependencies
+bun install --frozen-lockfile      # REQUIRED after any change to package.json /
+                                   # bun.lock, including a branch switch across
+                                   # one: `git checkout` does not update
+                                   # node_modules, and a stale tree surfaces as
+                                   # a wall of TS2307 "Cannot find module".
 bun run dev                        # Dev server (Node + Vite)
 bun run dev:bun                    # Dev server (Bun native)
 bun run build                      # Production build
@@ -215,7 +225,7 @@ bunx tsc --noEmit                  # Typecheck (`bun run build` does NOT typeche
 - Derive the subset from the mirror layout below: `lightrag/api/config.py` → `tests/api/config/`, `lightrag/kg/redis_impl.py` → `tests/kg/redis_impl/`, `lightrag/chunker/` → `tests/chunker/`. When a change spans several modules, run each of their directories rather than widening to `tests/`.
 - Run the full suite locally only at a milestone, or when the change is genuinely cross-cutting (`lightrag/base.py`, `lightrag/utils.py`, `lightrag/kg/shared_storage.py`, or anything every backend inherits).
 - Backend tests use pytest; frontend unit tests use Bun's built-in runner — see *WebUI* above and *React component tests* below.
-- **A WebUI change runs the WHOLE frontend check set**, from `lightrag_webui/`: `bun test`, `bunx tsc --noEmit`, and `bun run lint`. The subsetting rule above is a backend rule and does not apply — all three together take well under a minute (test ~2 s, typecheck ~14 s, lint ~21 s), so there is nothing to save by running less. Report the pass count. `bun run build` transpiles WITHOUT checking types, so skipping `tsc --noEmit` means nothing checks them.
+- **A WebUI change runs the WHOLE frontend check set**, from `lightrag_webui/`: `bun install --frozen-lockfile` (see *WebUI* above — skip it after a branch switch and every later step fails on missing modules), then `bun test`, `bunx tsc --noEmit`, and `bun run lint`. The subsetting rule above is a backend rule and does not apply — all three together take well under a minute (test ~2 s, typecheck ~14 s, lint ~21 s), so there is nothing to save by running less. Report the pass count. `bun run build` transpiles WITHOUT checking types, so skipping `tsc --noEmit` means nothing checks them.
 
 #### React component tests
 
@@ -228,6 +238,14 @@ file containing JSX must be named `.test.tsx`.
 happy-dom globally) and then `src/test/setup.ts` (jest-dom matchers plus
 Testing Library's `cleanup` in `afterEach`). Order is load-bearing — Testing
 Library binds to whatever `document` exists when it is first evaluated.
+
+That preload is found relative to the WORKING DIRECTORY, so `bun test` must be
+run from `lightrag_webui/`. From the repository root no preload loads at all
+and the failure is silent in the worst way: pure logic tests still pass and
+only the component tests break. `src/test/render.tsx` calls
+`assertDomAvailable()` at import time to turn that into a message naming the
+cause and the fix; `bun test --config <path>` does NOT work around it, because
+the preload paths inside the file are still resolved against the CWD.
 
 Rules for new tests:
 

--- a/lightrag_webui/src/test/domGlobals.test.ts
+++ b/lightrag_webui/src/test/domGlobals.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test'
+import { assertDomAvailable, restoreDomGlobals, withoutDomGlobals } from './domGlobals'
+
+describe('assertDomAvailable', () => {
+  test('says nothing when the preload installed a DOM', () => {
+    expect(() => assertDomAvailable()).not.toThrow()
+  })
+
+  test('names the cause and the fix when there is no DOM', () => {
+    withoutDomGlobals(() => {
+      // The whole point of the guard is that the message is actionable: the
+      // failure it replaces (`document[isPrepared]`, thrown from inside
+      // user-event) names neither the working directory nor the preload.
+      expect(() => assertDomAvailable()).toThrow(/lightrag_webui/)
+      expect(() => assertDomAvailable()).toThrow(/bunfig\.toml/)
+    })
+  })
+})
+
+describe('withoutDomGlobals', () => {
+  test('removes both globals by default and puts them back', () => {
+    withoutDomGlobals(() => {
+      expect(typeof globalThis.window).toBe('undefined')
+      expect(typeof globalThis.document).toBe('undefined')
+    })
+
+    expect(typeof globalThis.window).not.toBe('undefined')
+    expect(typeof globalThis.document).not.toBe('undefined')
+  })
+
+  test('removes only the named globals', () => {
+    withoutDomGlobals(() => {
+      expect(typeof globalThis.document).toBe('undefined')
+      // `window` survives, which is what lets a test exercise "resolved a
+      // title from the injected config, but has nowhere to write it".
+      expect(typeof globalThis.window).not.toBe('undefined')
+    }, ['document'])
+
+    expect(typeof globalThis.document).not.toBe('undefined')
+  })
+
+  test('restores the globals even when the body throws', () => {
+    expect(() =>
+      withoutDomGlobals(() => {
+        throw new Error('boom')
+      })
+    ).toThrow('boom')
+
+    expect(typeof globalThis.document).not.toBe('undefined')
+  })
+
+  test('returns whatever the body returned', () => {
+    expect(withoutDomGlobals(() => 42)).toBe(42)
+  })
+})
+
+describe('restoreDomGlobals', () => {
+  test('reinstates a stubbed global', () => {
+    const real = globalThis.window
+    Object.defineProperty(globalThis, 'window', {
+      value: { __LIGHTRAG_CONFIG__: { webuiTitle: 'stub' } },
+      configurable: true
+    })
+    expect(globalThis.window).not.toBe(real)
+
+    restoreDomGlobals()
+
+    expect(globalThis.window).toBe(real)
+  })
+})

--- a/lightrag_webui/src/test/domGlobals.ts
+++ b/lightrag_webui/src/test/domGlobals.ts
@@ -54,3 +54,33 @@ export const withoutDomGlobals = <T>(
     restoreDomGlobals()
   }
 }
+
+/**
+ * Fail fast, and legibly, when `bun test` ran without the DOM preload.
+ *
+ * Bun resolves `bunfig.toml` — and the preload paths inside it — relative to
+ * the CURRENT WORKING DIRECTORY. Running `bun test lightrag_webui/src/...`
+ * from the repository root therefore loads no preload at all, silently: pure
+ * logic tests still pass, and only the component tests fail, deep inside
+ * Testing Library, with
+ *
+ *     TypeError: undefined is not an object (evaluating 'document[isPrepared]')
+ *
+ * which names neither the cause nor the fix. `bun test --config <path>` does
+ * not help either, because the preload paths inside the file are still
+ * resolved against the CWD.
+ *
+ * Called at import time by `src/test/render.tsx`, so any test that renders a
+ * component reports this instead — before `userEvent.setup()` or `render()`
+ * gets the chance to fail obscurely.
+ */
+export const assertDomAvailable = (): void => {
+  if (typeof document !== 'undefined') return
+
+  throw new Error(
+    'No DOM: bun test started without the bunfig.toml preload. Run it from ' +
+      'the lightrag_webui/ directory (`cd lightrag_webui && bun test ...`) — ' +
+      'bun resolves bunfig.toml and its preload paths relative to the ' +
+      'working directory, so running from the repository root loads no DOM.'
+  )
+}

--- a/lightrag_webui/src/test/render.tsx
+++ b/lightrag_webui/src/test/render.tsx
@@ -16,6 +16,12 @@ import { createInstance, type i18n as I18n } from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
 import en from '@/locales/en.json'
+import { assertDomAvailable } from '@/test/domGlobals'
+
+// At import time, so a component test that calls `userEvent.setup()` before
+// it renders anything still gets this message rather than an obscure failure
+// from inside Testing Library.
+assertDomAvailable()
 
 const createTestI18n = (): I18n => {
   const instance = createInstance()


### PR DESCRIPTION
## Description

Follow-up to #3783. That PR gave `bun test` a DOM through a `bunfig.toml` preload; this one closes the two ways that setup wastes someone's time, both hit in practice right after it merged.

**1. Running `bun test` from the repository root silently loads no DOM.** Bun resolves `bunfig.toml` — and the preload paths inside it — against the working directory, so `bun test lightrag_webui/src/...` from the root gets no preload. Nothing reports that. Pure logic tests still pass; only the component tests break, deep inside user-event:

```
TypeError: undefined is not an object (evaluating 'document[isPrepared]')
    at prepareDocument (@testing-library/user-event/.../prepareDocument.js:10:9)
```

which names neither the cause nor the fix, and reads like a broken dependency. Passing a path to `bun test --config` does not work around it either — verified — because the preload paths inside the file are still resolved against the CWD.

**2. A branch switch across a `package.json` change leaves `node_modules` stale.** #3783 was the first change ever to add WebUI dependencies, so `git checkout` followed by `bunx tsc --noEmit` produced 10 errors that look like broken code:

```
error TS2307: Cannot find module '@testing-library/react' or its corresponding type declarations.
error TS2339: Property 'toBeInTheDocument' does not exist on type 'Matchers'.
...
```

Only 4 are the real symptom. The other 6 are downstream: `src/test/matchers.d.ts` merges jest-dom's matchers into `bun:test` through an `import type`, which resolves to nothing when the package is absent, so the declaration merge silently fails and every matcher reports as missing. `bun install --frozen-lockfile` clears all 10 at once.

## Related Issues

Follow-up to #3783 (merged). No open issue.

## Changes Made

- **`src/test/domGlobals.ts`**: adds `assertDomAvailable()`, which throws an error naming both the cause and the fix when no DOM is present.
- **`src/test/render.tsx`**: calls it at import time. Import time rather than inside `renderWithProviders` because a test may call `userEvent.setup()` before it renders anything — `TouchDescriptionPopover.test.tsx` does exactly that, and a guard inside the render helper would fire too late for it.
- **`src/test/domGlobals.test.ts`** (new): the tests this helper never had — the guard in both directions, plus `withoutDomGlobals`' restore-on-throw, its `keys` narrowing, and its return value.
- **`AGENTS.md`**: states that every WebUI command runs from `lightrag_webui/` and why; marks `bun install --frozen-lockfile` REQUIRED after a branch switch across a `package.json` change; documents the CWD-sensitivity of the preload under *React component tests*.

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Test Plan

Run from `lightrag_webui/`:

- `bun test` — **560 pass / 0 fail** across 62 files (was 553/61 on main; +7 from the new `domGlobals.test.ts`)
- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- `bun run build` — succeeds, first-load budget `2380078 bytes` unchanged

The guard was verified against the real failure, not just in a unit test. From the repository root, before this change the run failed at test 4 with `document[isPrepared]`; after it, the message arrives at module load, before any test body:

```
# Unhandled error between tests
error: No DOM: bun test started without the bunfig.toml preload. Run it from the
lightrag_webui/ directory (`cd lightrag_webui && bun test ...`) — bun resolves
bunfig.toml and its preload paths relative to the working directory, so running
from the repository root loads no DOM.
    at assertDomAvailable (src/test/domGlobals.ts:80:13)
    at src/test/render.tsx:24:1
```

Each new test was mutation-checked — a test that has not been seen to fail proves nothing:

| Mutation | Result |
|---|---|
| guard body replaced with `return` | 6 pass / **1 fail** |
| `withoutDomGlobals`' `finally` restore removed | 3 pass / **4 fail** |
| `keys` parameter ignored, always removes both | 6 pass / **1 fail** |
| (restored) | 7 pass / 0 fail |

## Additional Notes

Both problems are documentation-and-diagnostics only — no production module changes, and the build output is unaffected.

The branch reuses the name from #3783, restarted from `main` after that PR merged (its remote branch was deleted on merge); this is a new pull request, not a reopening.

One deliberate omission: the repository still has 17 tests that `readFileSync` a `.tsx` and assert on substrings. Converting them to real renders is worth doing now that the harness exists, but it is a separate change of a different size and is not bundled here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCWY6MFANEXGX2h7JzUgDX)_
