### PR TITLE
test(extraction): pin the gleaning guard arithmetic and lazy invariant precompute

### DIFF
--- a/tests/extraction/test_extract_entities.py
+++ b/tests/extraction/test_extract_entities.py
@@ -1,6 +1,8 @@
 """Tests for entity extraction gleaning token limit guard."""
 
+import json
 import logging
+import re
 from unittest.mock import AsyncMock
 
 import pytest
@@ -255,3 +257,203 @@ async def test_gleaning_json_mode_binds_continue_prompt(monkeypatch):
 
     # Both rounds ran: initial extraction + one gleaning pass.
     assert llm_func.await_count == 2
+
+
+# --- Additional coverage for the invariant-hoisting optimization ------------
+#
+# The tests above pin that the system prompt is encoded once per run (text
+# mode) and that JSON mode reaches the gleaning call at all. The three below
+# pin the two properties nothing else asserts: that hoisting MOVED the
+# continue prompt's tokens into the invariant rather than dropping them from
+# the guard, and that the precompute stays behind the guard's own condition.
+
+
+def _make_counting_config(
+    entity_extract_max_gleaning: int = 1,
+    use_json: bool = False,
+) -> tuple[dict, CountingTokenizer]:
+    """global_config whose tokenizer records every encoded string."""
+    inner = CountingTokenizer()
+    global_config = _make_global_config(
+        entity_extract_max_gleaning=entity_extract_max_gleaning
+    )
+    global_config["tokenizer"] = Tokenizer("counting", inner)
+    global_config["entity_extraction_use_json"] = use_json
+    return global_config, inner
+
+
+def _make_multi_chunks(count: int = 3) -> dict[str, dict]:
+    return {
+        f"chunk-{i:03d}": {
+            "tokens": 16,
+            "content": f"Test content number {i}.",
+            "full_doc_id": "doc-001",
+            "chunk_order_index": i - 1,
+        }
+        for i in range(1, count + 1)
+    }
+
+
+# Minimal valid JSON-mode extraction result that
+# _process_json_extraction_result can parse.
+_JSON_EXTRACTION_RESULT = json.dumps(
+    {
+        "entities": [
+            {
+                "name": "TEST_ENTITY",
+                "type": "CONCEPT",
+                "description": "A test entity",
+            }
+        ],
+        "relationships": [],
+    }
+)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_json_mode_encodes_both_invariants_once_per_run(monkeypatch):
+    """In JSON mode BOTH hoisted strings are chunk-invariant — the system
+    prompt and the continue prompt — so each is encoded once for the whole
+    run regardless of chunk count."""
+    from lightrag.operate import extract_entities
+    from lightrag.prompt import PROMPTS
+
+    monkeypatch.setenv("MAX_EXTRACT_INPUT_TOKENS", "999999")
+
+    global_config, inner = _make_counting_config(
+        entity_extract_max_gleaning=1, use_json=True
+    )
+    llm_func = global_config["llm_model_func"]
+    llm_func.return_value = _JSON_EXTRACTION_RESULT
+
+    await extract_entities(
+        chunks=_make_multi_chunks(3),
+        global_config=global_config,
+    )
+
+    # All 3 chunks ran initial extraction + gleaning.
+    assert llm_func.await_count == 6
+
+    for template_key in (
+        "entity_extraction_json_system_prompt",
+        "entity_continue_extraction_json_user_prompt",
+    ):
+        # Match on the template's leading literal text so the assertion does
+        # not depend on how the prompt is rendered.
+        prefix = PROMPTS[template_key].split("{", 1)[0]
+        assert prefix, f"{template_key} must start with literal text"
+        matches = [s for s in inner.encoded if s.startswith(prefix)]
+        assert len(matches) == 1, (
+            f"{template_key} was encoded {len(matches)} times for a 3-chunk "
+            "run; it is chunk-invariant and must be encoded once"
+        )
+
+
+async def _projected_gleaning_tokens(
+    monkeypatch, caplog, use_json: bool, continue_prompt_padding: str = ""
+) -> int:
+    """Run extraction under a cap of 10 tokens (which no realistic prompt
+    fits) and return the token count the guard reported in its WARNING.
+    ``continue_prompt_padding`` is appended verbatim to the mode's continue
+    prompt template, so a caller can measure how the projection responds to a
+    known change in that prompt's length."""
+    from lightrag.operate import extract_entities
+    from lightrag.prompt import PROMPTS
+
+    monkeypatch.setenv("MAX_EXTRACT_INPUT_TOKENS", "10")
+    continue_key = (
+        "entity_continue_extraction_json_user_prompt"
+        if use_json
+        else "entity_continue_extraction_user_prompt"
+    )
+    if continue_prompt_padding:
+        monkeypatch.setitem(
+            PROMPTS,
+            continue_key,
+            PROMPTS[continue_key] + continue_prompt_padding,
+        )
+
+    global_config, _ = _make_counting_config(
+        entity_extract_max_gleaning=1, use_json=use_json
+    )
+    llm_func = global_config["llm_model_func"]
+    llm_func.return_value = _JSON_EXTRACTION_RESULT if use_json else _EXTRACTION_RESULT
+
+    caplog.clear()
+    with caplog.at_level("WARNING", logger="lightrag"):
+        await extract_entities(
+            chunks=_make_chunks(),
+            global_config=global_config,
+        )
+
+    # Only the initial extraction round ran; gleaning was skipped.
+    assert llm_func.await_count == 1
+
+    reported = [
+        re.search(r"Input tokens \((\d+)\)", rec.getMessage())
+        for rec in caplog.records
+        if rec.getMessage().startswith("Gleaning stopped for chunk chunk-001:")
+    ]
+    assert reported and reported[0], (
+        "expected a gleaning-stopped WARNING carrying the projected token "
+        f"count; got: {[r.getMessage() for r in caplog.records]}"
+    )
+    return int(reported[0].group(1))
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_json", [False, True], ids=["text_mode", "json_mode"])
+async def test_guard_still_counts_the_continue_prompt(
+    monkeypatch, caplog, _propagate_lightrag_logger, use_json
+):
+    """The guard must keep counting the continue prompt in both modes.
+
+    Hoisting moved the JSON continue prompt's tokens from a per-chunk encode
+    into the precomputed invariant, and left the text-mode one per-chunk.  If
+    either were dropped rather than moved, the guard would under-count and
+    let an oversized gleaning payload reach the provider.  Lengthening the
+    continue prompt by a known amount must move the projection by exactly
+    that amount (the test tokenizer maps one character to one token).
+    """
+    baseline = await _projected_gleaning_tokens(monkeypatch, caplog, use_json)
+    padding = "X" * 64
+    padded = await _projected_gleaning_tokens(
+        monkeypatch, caplog, use_json, continue_prompt_padding=padding
+    )
+
+    assert padded - baseline == len(padding), (
+        f"projected gleaning input moved by {padded - baseline} tokens when "
+        f"the continue prompt grew by {len(padding)}; the guard is no longer "
+        "counting the continue prompt"
+    )
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_invariant_tokens_not_encoded_when_guard_inactive(monkeypatch):
+    """Precomputing the invariant token count must stay behind the same
+    condition that gates the guard, so a run that never consults it does not
+    pay for the encode.  With gleaning off, the system prompt is never fed to
+    the tokenizer."""
+    from lightrag.operate import extract_entities
+    from lightrag.prompt import PROMPTS
+
+    monkeypatch.setenv("MAX_EXTRACT_INPUT_TOKENS", "999999")
+
+    global_config, inner = _make_counting_config(entity_extract_max_gleaning=0)
+    llm_func = global_config["llm_model_func"]
+    llm_func.return_value = _EXTRACTION_RESULT
+
+    await extract_entities(
+        chunks=_make_chunks(),
+        global_config=global_config,
+    )
+
+    assert llm_func.await_count == 1
+
+    prefix = PROMPTS["entity_extraction_system_prompt"].split("{", 1)[0]
+    assert not [s for s in inner.encoded if s.startswith(prefix)], (
+        "system prompt was encoded even though the gleaning guard never runs"
+    )


### PR DESCRIPTION
## Description

Follow-up test coverage for #3760, which is now merged. This PR was previously stacked on it and carried @hata33's two commits so the diff would apply; with #3760 in `main` those became duplicates and conflicted, so the branch was rebased onto `main` and now holds **one commit touching one file** — `tests/extraction/test_extract_entities.py`, additions only. No production code, no existing test modified.

#3760's implementation is correct as merged. This PR only closes gaps in what the suite *proves*.

## Related Issues

- Follow-up test coverage for #3759 / #3760

## Changes Made

Two properties of the invariant-hoisting optimization were unpinned. I verified that by mutating `lightrag/operate.py` **as merged on `main`** and watching the existing suite stay green:

| Mutation of the merged implementation | Suite on `main` | With this PR |
|---|---|---|
| JSON continue prompt dropped from `gleaning_invariant_tokens` | 🟢 passes | 🔴 2 failed |
| `gleaning_precheck` reverted to unconditional | 🟢 passes | 🔴 1 failed |
| Text-mode continue prompt dropped from the guard | 🟢 passes | 🔴 1 failed |

The first and third matter because a guard that under-counts lets an oversized gleaning payload reach the provider — the `context_length_exceeded` error the guard exists to prevent. The second silently reintroduces a per-call encode of the ~2k-token system prompt on runs with gleaning off.

A cap-based skip assertion cannot detect any of them: at a 10-token cap the system prompt alone busts the budget, so the guard trips regardless of what else is counted. (My own first draft of these tests had exactly that flaw, and two mutations survived it.) The tests therefore measure a **delta** — lengthening a continue prompt template by a known number of characters must move the projected token count the guard reports by exactly that many, since the test tokenizer maps one character to one token. That isolates the prompt's contribution in each mode.

Added:

- **`test_json_mode_encodes_both_invariants_once_per_run`** — in JSON mode *both* hoisted strings are chunk-invariant, so each is encoded once across a 3-chunk run. Matches on each template's leading literal text rather than on rendered output, so it does not restate the rendering logic. Also catches the `UnboundLocalError` case that `test_gleaning_json_mode_binds_continue_prompt` covers.
- **`test_guard_still_counts_the_continue_prompt[text_mode, json_mode]`** — the delta measurement, covering the hoisted JSON prompt and the still-per-chunk text-mode one.
- **`test_invariant_tokens_not_encoded_when_guard_inactive`** — with gleaning off, the system prompt never reaches the tokenizer, so the lazy gate cannot silently regress.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary) — test-only change
- [x] Unit tests added (if applicable)

## Additional Notes

Against the rebased head:

- `tests/extraction/test_extract_entities.py` → 10 passed
- `tests/extraction` (excluding `test_keyword_extraction_drivers.py`, uncollectable here without the `ollama` package) → 271 passed, 7 failed. Those 7 fail identically on clean `main`: my sandbox cannot reach the tiktoken BPE vocab download. Unrelated to this diff, and green in CI.
- `ruff check .` and `ruff format --check` clean
- All three mutations above re-verified against the merged `main` implementation after the rebase.

Every added test was confirmed to fail against the mutation it targets before being called done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5U8CojutuGG5PB5U7hX2d