### PR TITLE
refactor: remove the deprecated GET /documents listing and get_docs_by_status

### DIFF
--- a/examples/opensearch_storage_demo.py
+++ b/examples/opensearch_storage_demo.py
@@ -139,9 +139,11 @@ async def test_doc_status_storage():
             counts.get("processed") == 10, f"processed count: {counts.get('processed')}"
         )
 
-        # get_docs_by_status (uses PIT + search_after)
-        processed = await s.get_docs_by_status(DocStatus.PROCESSED)
-        check(len(processed) == 10, f"get_docs_by_status(processed): {len(processed)}")
+        # get_docs_by_statuses (uses PIT + search_after)
+        processed = await s.get_docs_by_statuses([DocStatus.PROCESSED])
+        check(
+            len(processed) == 10, f"get_docs_by_statuses(processed): {len(processed)}"
+        )
 
         # get_docs_by_track_id (uses PIT + search_after)
         await s.upsert(

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -63,7 +63,6 @@ from lightrag.base import (
     CURSOR_START,
     CursorAfter,
     CursorPosition,
-    DocProcessingStatus,
     DocStatus,
     SourceAbsent,
     SourceConflict,
@@ -1148,73 +1147,6 @@ class DocStatusResponse(BaseModel):
                 "error": None,
                 "metadata": {"author": "John Doe", "year": 2025},
                 "file_path": "research_paper.pdf",
-            }
-        }
-    )
-
-
-class DocsStatusesResponse(BaseModel):
-    """Response model for document statuses
-
-    Attributes:
-        statuses: Dictionary mapping document status to lists of document status responses
-    """
-
-    statuses: Dict[DocStatus, List[DocStatusResponse]] = Field(
-        default_factory=dict,
-        description="Dictionary mapping document status to lists of document status responses",
-    )
-
-    model_config = ConfigDict(
-        json_schema_extra={
-            "example": {
-                "statuses": {
-                    "PENDING": [
-                        {
-                            "id": "doc_123",
-                            "content_summary": "Pending document",
-                            "content_length": 5000,
-                            "status": "pending",
-                            "created_at": "2025-03-31T10:00:00",
-                            "updated_at": "2025-03-31T10:00:00",
-                            "track_id": "upload_20250331_100000_abc123",
-                            "chunks_count": None,
-                            "error": None,
-                            "metadata": None,
-                            "file_path": "pending_doc.pdf",
-                        }
-                    ],
-                    "PREPROCESSED": [
-                        {
-                            "id": "doc_789",
-                            "content_summary": "Document pending final indexing",
-                            "content_length": 7200,
-                            "status": "preprocessed",
-                            "created_at": "2025-03-31T09:30:00",
-                            "updated_at": "2025-03-31T09:35:00",
-                            "track_id": "upload_20250331_093000_xyz789",
-                            "chunks_count": 10,
-                            "error": None,
-                            "metadata": None,
-                            "file_path": "preprocessed_doc.pdf",
-                        }
-                    ],
-                    "PROCESSED": [
-                        {
-                            "id": "doc_456",
-                            "content_summary": "Processed document",
-                            "content_length": 8000,
-                            "status": "processed",
-                            "created_at": "2025-03-31T09:00:00",
-                            "updated_at": "2025-03-31T09:05:00",
-                            "track_id": "insert_20250331_090000_def456",
-                            "chunks_count": 8,
-                            "error": None,
-                            "metadata": {"author": "John Doe"},
-                            "file_path": "processed_doc.pdf",
-                        }
-                    ],
-                }
             }
         }
     )
@@ -6239,110 +6171,6 @@ def create_document_routes(
             return PipelineStatusResponse(**status_dict)
         except Exception as e:
             logger.error(f"Error getting pipeline status: {str(e)}")
-            logger.error(traceback.format_exc())
-            raise internal_server_error(e)
-
-    # TODO: Deprecated, use /documents/paginated instead
-    @router.get(
-        "", response_model=DocsStatusesResponse, dependencies=[Depends(combined_auth)]
-    )
-    async def documents() -> DocsStatusesResponse:
-        """
-        Get the status of all documents in the system. This endpoint is deprecated; use /documents/paginated instead.
-        To prevent excessive resource consumption, a maximum of 1,000 records is returned.
-
-        This endpoint retrieves the current status of all documents, grouped by their
-        processing status (PENDING, PROCESSING, PREPROCESSED, PROCESSED, FAILED). The results are
-        limited to 1000 total documents with fair distribution across all statuses.
-
-        Returns:
-            DocsStatusesResponse: A response object containing a dictionary where keys are
-                                DocStatus values and values are lists of DocStatusResponse
-                                objects representing documents in each status category.
-                                Maximum 1000 documents total will be returned.
-
-        Raises:
-            HTTPException: If an error occurs while retrieving document statuses (500).
-        """
-        try:
-            statuses = (
-                DocStatus.PENDING,
-                DocStatus.PARSING,
-                DocStatus.ANALYZING,
-                DocStatus.PROCESSING,
-                DocStatus.PREPROCESSED,
-                DocStatus.PROCESSED,
-                DocStatus.FAILED,
-            )
-
-            tasks = [rag.get_docs_by_status(status) for status in statuses]
-            results: List[Dict[str, DocProcessingStatus]] = await asyncio.gather(*tasks)
-
-            response = DocsStatusesResponse()
-            total_documents = 0
-            max_documents = 1000
-
-            # Convert results to lists for easier processing
-            status_documents = []
-            for idx, result in enumerate(results):
-                status = statuses[idx]
-                docs_list = []
-                for doc_id, doc_status in result.items():
-                    docs_list.append((doc_id, doc_status))
-                status_documents.append((status, docs_list))
-
-            # Fair distribution: round-robin across statuses
-            status_indices = [0] * len(
-                status_documents
-            )  # Track current index for each status
-            current_status_idx = 0
-
-            while total_documents < max_documents:
-                # Check if we have any documents left to process
-                has_remaining = False
-                for status_idx, (status, docs_list) in enumerate(status_documents):
-                    if status_indices[status_idx] < len(docs_list):
-                        has_remaining = True
-                        break
-
-                if not has_remaining:
-                    break
-
-                # Try to get a document from the current status
-                status, docs_list = status_documents[current_status_idx]
-                current_index = status_indices[current_status_idx]
-
-                if current_index < len(docs_list):
-                    doc_id, doc_status = docs_list[current_index]
-
-                    if status not in response.statuses:
-                        response.statuses[status] = []
-
-                    response.statuses[status].append(
-                        DocStatusResponse(
-                            id=doc_id,
-                            content_summary=doc_status.content_summary,
-                            content_length=doc_status.content_length,
-                            status=doc_status.status,
-                            created_at=format_datetime(doc_status.created_at),
-                            updated_at=format_datetime(doc_status.updated_at),
-                            track_id=doc_status.track_id,
-                            chunks_count=doc_status.chunks_count,
-                            error_msg=doc_status.error_msg,
-                            metadata=doc_status.metadata,
-                            file_path=normalize_file_path(doc_status.file_path),
-                        )
-                    )
-
-                    status_indices[current_status_idx] += 1
-                    total_documents += 1
-
-                # Move to next status (round-robin)
-                current_status_idx = (current_status_idx + 1) % len(status_documents)
-
-            return response
-        except Exception as e:
-            logger.error(f"Error GET /documents: {str(e)}")
             logger.error(traceback.format_exc())
             raise internal_server_error(e)
 

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -1297,12 +1297,6 @@ class DocStatusStorage(BaseKVStorage, ABC):
         """Get counts of documents in each status"""
 
     @abstractmethod
-    async def get_docs_by_status(
-        self, status: DocStatus
-    ) -> dict[str, DocProcessingStatus]:
-        """Get all documents with a specific status"""
-
-    @abstractmethod
     async def get_docs_by_statuses(
         self, statuses: list[DocStatus], strict: bool = False
     ) -> dict[str, DocProcessingStatus]:

--- a/lightrag/kg/__init__.py
+++ b/lightrag/kg/__init__.py
@@ -43,7 +43,7 @@ STORAGE_IMPLEMENTATIONS = {
             "MongoDocStatusStorage",
             "OpenSearchDocStatusStorage",
         ],
-        "required_methods": ["get_docs_by_status"],
+        "required_methods": ["get_docs_by_statuses"],
     },
 }
 

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -87,7 +87,7 @@ class JsonDocStatusStorage(DocStatusStorage):
         * Pre-upsert preparation (``chunks_list`` default) runs
           *outside* the lock because it only mutates the caller-
           supplied dict, not the shared store.
-        * Read methods are richer (``get_docs_by_status`` /
+        * Read methods are richer (``get_docs_by_statuses`` /
           ``get_docs_by_track_id`` / ``get_docs_paginated`` /
           ``get_doc_by_file_path`` / etc.), but they all follow the
           same "acquire ``_storage_lock``, scan ``self._data``, copy
@@ -195,12 +195,6 @@ class JsonDocStatusStorage(DocStatusStorage):
                 counts[doc["status"]] += 1
         return counts
 
-    async def get_docs_by_status(
-        self, status: DocStatus
-    ) -> dict[str, DocProcessingStatus]:
-        """Get all documents with a specific status"""
-        return await self.get_docs_by_statuses([status])
-
     async def get_docs_by_statuses(
         self, statuses: list[DocStatus], strict: bool = False
     ) -> dict[str, DocProcessingStatus]:
@@ -208,8 +202,8 @@ class JsonDocStatusStorage(DocStatusStorage):
 
         Acquires the storage lock once and scans the in-memory dict once,
         filtering against a set of status values.  More efficient than N separate
-        get_docs_by_status() calls, which would acquire the lock N times and scan
-        the data N times.  ``strict=True`` raises on any record that cannot be
+        per-status reads, which would acquire the lock N times and scan the data
+        N times.  ``strict=True`` raises on any record that cannot be
         converted (complete-or-raise scheduling contract, see base class).
         """
         if not statuses:

--- a/lightrag/kg/mongo_impl.py
+++ b/lightrag/kg/mongo_impl.py
@@ -765,12 +765,6 @@ class MongoDocStatusStorage(DocStatusStorage):
             counts[doc["_id"]] = doc["count"]
         return counts
 
-    async def get_docs_by_status(
-        self, status: DocStatus
-    ) -> dict[str, DocProcessingStatus]:
-        """Get all documents with a specific status"""
-        return await self.get_docs_by_statuses([status])
-
     async def get_docs_by_statuses(
         self, statuses: list[DocStatus], strict: bool = False
     ) -> dict[str, DocProcessingStatus]:

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -1868,7 +1868,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             )
             await _cooperative_yield(i)
         try:
-            # DocStatus needs refresh="wait_for" because get_docs_by_status
+            # DocStatus needs refresh="wait_for" because get_docs_by_statuses
             # (search-based) is called immediately after enqueue upserts.
             _, failed = await _run_chunked_async_bulk(
                 self.client,
@@ -1989,12 +1989,6 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             if strict:
                 raise
         return result
-
-    async def get_docs_by_status(
-        self, status: DocStatus
-    ) -> dict[str, DocProcessingStatus]:
-        """Get all documents matching a specific processing status."""
-        return await self.get_docs_by_statuses([status])
 
     async def get_docs_by_statuses(
         self, statuses: list[DocStatus], strict: bool = False
@@ -3089,7 +3083,7 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
             ids = list(ids)
         try:
             # DocStatus needs refresh="wait_for" because downstream readers
-            # (get_docs_by_status, get_docs_paginated, etc.) are search-based
+            # (get_docs_by_statuses, get_docs_paginated, etc.) are search-based
             # and callers like _validate_and_fix_document_consistency() may
             # query immediately after deletion without index_done_callback().
             actions = [

--- a/lightrag/kg/postgres_impl.py
+++ b/lightrag/kg/postgres_impl.py
@@ -6474,61 +6474,6 @@ class PGDocStatusStorage(DocStatusStorage):
             counts[doc["status"]] = doc["count"]
         return counts
 
-    async def get_docs_by_status(
-        self, status: DocStatus
-    ) -> dict[str, DocProcessingStatus]:
-        """all documents with a specific status"""
-        sql = "select * from LIGHTRAG_DOC_STATUS where workspace=$1 and status=$2"
-        params = {"workspace": self.workspace, "status": status.value}
-        result = await self.db.query(sql, list(params.values()), True)
-
-        docs_by_status = {}
-        for element in result:
-            # Parse chunks_list JSON string back to list
-            chunks_list = element.get("chunks_list", [])
-            if isinstance(chunks_list, str):
-                try:
-                    chunks_list = json.loads(chunks_list)
-                except json.JSONDecodeError:
-                    chunks_list = []
-
-            # Parse metadata JSON string back to dict
-            metadata = element.get("metadata", {})
-            if isinstance(metadata, str):
-                try:
-                    metadata = json.loads(metadata)
-                except json.JSONDecodeError:
-                    metadata = {}
-            # Ensure metadata is a dict
-            if not isinstance(metadata, dict):
-                metadata = {}
-
-            # Safe handling for file_path
-            file_path = element.get("file_path")
-            if file_path is None:
-                file_path = "no-file-path"
-
-            # Convert datetime objects to ISO format strings with timezone info
-            created_at = self._format_datetime_with_timezone(element["created_at"])
-            updated_at = self._format_datetime_with_timezone(element["updated_at"])
-
-            docs_by_status[element["id"]] = DocProcessingStatus(
-                content_summary=element["content_summary"],
-                content_length=element["content_length"],
-                status=element["status"],
-                created_at=created_at,
-                updated_at=updated_at,
-                chunks_count=element["chunks_count"],
-                file_path=file_path,
-                chunks_list=chunks_list,
-                metadata=metadata,
-                error_msg=element.get("error_msg"),
-                track_id=element.get("track_id"),
-                content_hash=element.get("content_hash"),
-            )
-
-        return docs_by_status
-
     def _pg_doc_processing_status_from_row(
         self, element: dict[str, Any]
     ) -> DocProcessingStatus:
@@ -6578,7 +6523,7 @@ class PGDocStatusStorage(DocStatusStorage):
     ) -> dict[str, DocProcessingStatus]:
         """Fetch documents matching any of the given statuses in a single query.
 
-        Replaces multiple sequential/parallel get_docs_by_status() calls when the
+        Replaces multiple sequential/parallel per-status reads when the
         caller needs documents across several statuses (e.g. PROCESSING + FAILED + PENDING).
         Uses a single ANY($2) query instead of N separate round-trips.  Query
         errors always propagate; ``strict=True`` additionally raises on any row

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -1043,12 +1043,6 @@ class RedisDocStatusStorage(DocStatusStorage):
 
         return counts
 
-    async def get_docs_by_status(
-        self, status: DocStatus
-    ) -> dict[str, DocProcessingStatus]:
-        """Get all documents with a specific status"""
-        return await self.get_docs_by_statuses([status])
-
     @staticmethod
     def _redis_doc_processing_status_from_data(
         data: dict[str, Any],
@@ -1081,8 +1075,8 @@ class RedisDocStatusStorage(DocStatusStorage):
         Redis has no server-side multi-value filter, so documents must be fetched
         and filtered in Python.  This override performs a single SCAN + pipeline
         GET over the keyspace, filtering against a set of status values.  The
-        previous pattern of N separate get_docs_by_status() calls would do N full
-        SCANs (one per status), so this reduces keyspace traversal from N passes to one.
+        alternative of N separate per-status reads would do N full SCANs (one per
+        status), so this reduces keyspace traversal from N passes to one.
         Transport errors always propagate (SCAN interruption re-raises below);
         ``strict=True`` additionally raises on any record that cannot be parsed
         (complete-or-raise scheduling contract, see base class).

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -4540,16 +4540,6 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             owning_loop=self._owning_loop,
         )
 
-    async def get_docs_by_status(
-        self, status: DocStatus
-    ) -> dict[str, DocProcessingStatus]:
-        """Get documents by status
-
-        Returns:
-            Dict with document id is keys and document status is values
-        """
-        return await self.doc_status.get_docs_by_status(status)
-
     async def aget_docs_by_ids(
         self, ids: str | list[str]
     ) -> dict[str, DocProcessingStatus]:

--- a/lightrag/storage_migrations.py
+++ b/lightrag/storage_migrations.py
@@ -54,8 +54,16 @@ class _StorageMigrationMixin:
                 # Check if full_entities and full_relations are empty
                 # Get all processed documents to check their entity/relation data
                 try:
+                    # strict=True: this mapping is the ONLY input that decides
+                    # which documents get recovery anchors written. A row that
+                    # cannot be parsed must abort the migration, not be skipped
+                    # — a partial mapping writes anchors for its siblings, after
+                    # which the "anchors already exist" check above short-
+                    # circuits every later startup, so the omitted document
+                    # never gets anchors and every purge of it fails closed
+                    # (409) for good. See the purge recovery contract.
                     processed_docs = await self.doc_status.get_docs_by_statuses(
-                        [DocStatus.PROCESSED]
+                        [DocStatus.PROCESSED], strict=True
                     )
 
                     if not processed_docs:

--- a/lightrag/storage_migrations.py
+++ b/lightrag/storage_migrations.py
@@ -54,8 +54,8 @@ class _StorageMigrationMixin:
                 # Check if full_entities and full_relations are empty
                 # Get all processed documents to check their entity/relation data
                 try:
-                    processed_docs = await self.doc_status.get_docs_by_status(
-                        DocStatus.PROCESSED
+                    processed_docs = await self.doc_status.get_docs_by_statuses(
+                        [DocStatus.PROCESSED]
                     )
 
                     if not processed_docs:

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -503,7 +503,6 @@ class LightragPathFilter(logging.Filter):
         super().__init__()
         # Define paths to be filtered
         self.filtered_paths = [
-            "/documents",
             "/documents/paginated",
             "/health",
             "/webui/",

--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -346,10 +346,6 @@ export type PaginatedDocsResponse = {
   status_counts: Record<string, number>
 }
 
-export type StatusCountsResponse = {
-  status_counts: Record<string, number>
-}
-
 export type AuthStatusResponse = {
   auth_configured: boolean
   access_token?: string
@@ -658,11 +654,6 @@ export const checkHealth = async (): Promise<
  */
 export const verifyCredentials = async (): Promise<void> => {
   await axiosInstance.get('/auth/verify')
-}
-
-export const getDocuments = async (): Promise<DocsStatusesResponse> => {
-  const response = await axiosInstance.get('/documents')
-  return response.data
 }
 
 export const getSupportedFileTypes = async (signal?: AbortSignal): Promise<SupportedFileTypes> => {
@@ -1413,13 +1404,4 @@ export const getDocumentsPaginatedWithTimeout = (
         reject(error)
       })
   })
-}
-
-/**
- * Get counts of documents by status
- * @returns Promise with status counts response
- */
-export const getDocumentStatusCounts = async (): Promise<StatusCountsResponse> => {
-  const response = await axiosInstance.get('/documents/status_counts')
-  return response.data
 }

--- a/tests/api/test_path_prefixes.py
+++ b/tests/api/test_path_prefixes.py
@@ -739,7 +739,6 @@ class TestWhitelistUnderApiPrefix:
             prefix = "" if mode == "strip" else "/api/v1"
 
             assert client.delete(f"{prefix}/documents").status_code == 401
-            assert client.get(f"{prefix}/documents").status_code == 401
 
     @pytest.mark.parametrize("mode", ["verbatim", "strip"])
     def test_whitelisted_routes_stay_open_under_a_prefix(

--- a/tests/kg/noop_impl/test_noop_vector_storage.py
+++ b/tests/kg/noop_impl/test_noop_vector_storage.py
@@ -181,8 +181,8 @@ async def test_graph_only_normal_ingestion_rebuilds_into_nano_vector_storage(
     await graph_only_rag.initialize_storages()
     await graph_only_rag.ainsert("Alice knows Bob.", file_paths="example.txt")
 
-    processed_docs = await graph_only_rag.doc_status.get_docs_by_status(
-        DocStatus.PROCESSED
+    processed_docs = await graph_only_rag.doc_status.get_docs_by_statuses(
+        [DocStatus.PROCESSED]
     )
     assert len(processed_docs) == 1
     doc_id, doc_status = next(iter(processed_docs.items()))
@@ -229,7 +229,9 @@ async def test_graph_only_normal_ingestion_rebuilds_into_nano_vector_storage(
         compute_mdhash_id("Bob", prefix="ent-"),
     ]
     relationship_id = compute_mdhash_id("AliceBob", prefix="rel-")
-    reopened_docs = await indexed_rag.doc_status.get_docs_by_status(DocStatus.PROCESSED)
+    reopened_docs = await indexed_rag.doc_status.get_docs_by_statuses(
+        [DocStatus.PROCESSED]
+    )
 
     assert doc_id in reopened_docs
     assert reopened_docs[doc_id].chunks_list == chunk_ids

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -1549,7 +1549,7 @@ class TestDocStatusStorage:
             assert counts["processed"] == 5
 
     @pytest.mark.asyncio
-    async def test_get_docs_by_status(self, global_config, embed_func, mock_client):
+    async def test_get_docs_by_statuses(self, global_config, embed_func, mock_client):
         mock_client.search = AsyncMock(
             return_value={
                 "hits": {
@@ -1575,7 +1575,7 @@ class TestDocStatusStorage:
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
-            result = await s.get_docs_by_status(DocStatus.PROCESSED)
+            result = await s.get_docs_by_statuses([DocStatus.PROCESSED])
             assert "d1" in result
             assert isinstance(result["d1"], DocProcessingStatus)
 
@@ -2057,7 +2057,7 @@ class TestDocStatusStorage:
             assert await s.get_all_status_counts() == {}
             assert await s.get_docs_paginated(page=1, page_size=10) == ([], 0)
             assert await s.get_doc_by_file_path("/a.txt") is None
-            assert await s.get_docs_by_status(DocStatus.PROCESSED) == {}
+            assert await s.get_docs_by_statuses([DocStatus.PROCESSED]) == {}
 
             mock_client.count.assert_not_awaited()
             mock_client.search.assert_not_awaited()

--- a/tests/kg/test_scheduling_base_defaults.py
+++ b/tests/kg/test_scheduling_base_defaults.py
@@ -96,11 +96,6 @@ class _MinimalDocStatusStorage(DocStatusStorage):
     async def get_status_counts(self) -> dict[str, int]:  # pragma: no cover
         return {}
 
-    async def get_docs_by_status(
-        self, status: DocStatus
-    ) -> dict[str, DocProcessingStatus]:  # pragma: no cover - unused
-        return {}
-
     async def get_docs_by_statuses(
         self, statuses: list[DocStatus], strict: bool = False
     ) -> dict[str, DocProcessingStatus]:  # pragma: no cover - unused

--- a/tests/pipeline/test_doc_status_chunk_preservation.py
+++ b/tests/pipeline/test_doc_status_chunk_preservation.py
@@ -1212,8 +1212,10 @@ async def test_validate_and_fix_consistency_preserves_chunks_on_reset(tmp_path):
             }
         )
 
-        failed_docs = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
-        processing_docs = await rag.doc_status.get_docs_by_status(DocStatus.PROCESSING)
+        failed_docs = await rag.doc_status.get_docs_by_statuses([DocStatus.FAILED])
+        processing_docs = await rag.doc_status.get_docs_by_statuses(
+            [DocStatus.PROCESSING]
+        )
         to_process_docs = {**failed_docs, **processing_docs}
 
         pipeline_status = {"latest_message": "", "history_messages": []}
@@ -1278,7 +1280,7 @@ async def test_validate_and_fix_consistency_repairs_unknown_file_path_from_full_
             }
         )
 
-        failed_docs = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+        failed_docs = await rag.doc_status.get_docs_by_statuses([DocStatus.FAILED])
         pipeline_status = {"latest_message": "", "history_messages": []}
         await rag._validate_and_fix_document_consistency(
             to_process_docs=failed_docs,

--- a/tests/pipeline/test_doc_status_reset_metadata.py
+++ b/tests/pipeline/test_doc_status_reset_metadata.py
@@ -282,7 +282,9 @@ async def test_interrupted_reset_clears_attempt_metadata_in_storage_and_memory(
             }
         )
 
-        to_process_docs = await rag.doc_status.get_docs_by_status(DocStatus.PROCESSING)
+        to_process_docs = await rag.doc_status.get_docs_by_statuses(
+            [DocStatus.PROCESSING]
+        )
         pipeline_status = {"latest_message": "", "history_messages": []}
         await rag._validate_and_fix_document_consistency(
             to_process_docs=to_process_docs,
@@ -359,7 +361,7 @@ async def test_stale_pending_normalized_clean_pending_untouched(tmp_path):
             }
         )
 
-        to_process_docs = await rag.doc_status.get_docs_by_status(DocStatus.PENDING)
+        to_process_docs = await rag.doc_status.get_docs_by_statuses([DocStatus.PENDING])
         pipeline_status = {"latest_message": "", "history_messages": []}
         await rag._validate_and_fix_document_consistency(
             to_process_docs=to_process_docs,
@@ -437,7 +439,7 @@ async def test_pending_custom_metadata_semantic_lock(tmp_path):
             }
         )
 
-        to_process_docs = await rag.doc_status.get_docs_by_status(DocStatus.PENDING)
+        to_process_docs = await rag.doc_status.get_docs_by_statuses([DocStatus.PENDING])
         pipeline_status = {"latest_message": "", "history_messages": []}
         await rag._validate_and_fix_document_consistency(
             to_process_docs=to_process_docs,
@@ -467,7 +469,7 @@ async def test_reset_and_normalize_with_string_status(tmp_path):
     ``str`` base) cannot silently stop string-status docs from being cleaned.
 
     Builds the ``to_process_docs`` objects directly with string statuses to
-    exercise the string path (``get_docs_by_status`` would return enum-valued
+    exercise the string path (``get_docs_by_statuses`` would return enum-valued
     members from the in-memory store).
     """
     rag = await _build_rag(tmp_path, "reset_string_status")

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -2097,7 +2097,7 @@ def test_enqueue_dedupes_by_filename_and_content_hash(tmp_path):
             third_id = compute_mdhash_id("third.txt", prefix="doc-")
             assert await rag.full_docs.get_by_id(third_id) is None
 
-            failed_docs = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+            failed_docs = await rag.doc_status.get_docs_by_statuses([DocStatus.FAILED])
             kinds = {
                 getattr(doc, "metadata", {}).get("duplicate_kind")
                 for doc in failed_docs.values()
@@ -2137,7 +2137,7 @@ def test_enqueue_dedupes_parser_hinted_filename_variants(tmp_path):
             )
             assert (await rag.full_docs.get_by_id(first_id))["content"] == "alpha body"
 
-            failed_docs = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+            failed_docs = await rag.doc_status.get_docs_by_statuses([DocStatus.FAILED])
             # The duplicate record stores the canonical basename — hint is
             # not preserved anywhere in the new schema.
             assert any(
@@ -2201,7 +2201,7 @@ def test_enqueue_without_file_paths_uses_content_ids(tmp_path):
                 assert full_doc.get("content_hash")
                 assert status.get("content_hash") == full_doc.get("content_hash")
 
-            failed_docs = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+            failed_docs = await rag.doc_status.get_docs_by_statuses([DocStatus.FAILED])
             duplicate_failures = [
                 doc
                 for doc in failed_docs.values()
@@ -2364,7 +2364,7 @@ def test_enqueue_rejects_removed_or_unknown_docs_format(tmp_path):
                     lightrag_document_paths="__parsed__/doc.blocks.jsonl",
                 )
             # Nothing was enqueued by the rejected calls.
-            failed = await rag.doc_status.get_docs_by_status(DocStatus.FAILED)
+            failed = await rag.doc_status.get_docs_by_statuses([DocStatus.FAILED])
             assert failed == {}
         finally:
             await rag.finalize_storages()
@@ -2497,9 +2497,9 @@ def test_state_machine_upsert_preserves_content_hash(tmp_path):
 
             # Simulate the production state-machine upsert pattern: read
             # status_doc, then write a new payload that includes content_hash.
-            status_doc = (await rag.doc_status.get_docs_by_status(DocStatus.PENDING))[
-                doc_id
-            ]
+            status_doc = (
+                await rag.doc_status.get_docs_by_statuses([DocStatus.PENDING])
+            )[doc_id]
             for next_status in (
                 DocStatus.PARSING,
                 DocStatus.ANALYZING,

--- a/tests/test_storage_migrations_strict_read.py
+++ b/tests/test_storage_migrations_strict_read.py
@@ -1,0 +1,140 @@
+"""The entity/relation migration must read doc_status COMPLETE-or-raise.
+
+WHY: ``processed_docs`` is the ONLY input that decides which documents get
+``full_entities`` / ``full_relations`` recovery anchors written.  A relaxed
+read (``strict=False``) skips-and-logs an unparseable row, and the migration
+then happily writes anchors for that row's siblings.  From the next startup
+on, the "anchors already exist" sample check short-circuits before the
+migration ever runs again, so the omitted document never gets anchors — and
+per the purge recovery contract, every later purge of it fails closed (409)
+with nothing able to repair it but an offline ``audit_kg_integrity``.
+
+A malformed row must therefore abort startup, not be silently dropped.
+Before this was pinned, four of the five doc-status backends read relaxed
+here (their ``get_docs_by_status`` delegated to ``get_docs_by_statuses``
+with the default ``strict=False``), so the hazard was live on all of them.
+"""
+
+import pytest
+
+from lightrag.base import DocProcessingStatus, DocStatus
+from lightrag.kg.shared_storage import initialize_share_data
+from lightrag.storage_migrations import _StorageMigrationMixin
+
+pytestmark = pytest.mark.offline
+
+
+class _CorruptRowDocStatus:
+    """One healthy PROCESSED doc plus one row that cannot be parsed.
+
+    Mirrors what every real backend does: log the bad row, then re-raise it
+    only when the caller asked for the strict (complete-or-raise) contract.
+    """
+
+    def __init__(self):
+        self.calls: list[bool] = []
+        self.healthy = {
+            "doc-ok": DocProcessingStatus(
+                content_summary="ok",
+                content_length=10,
+                file_path="ok.pdf",
+                status=DocStatus.PROCESSED,
+                created_at="2024-01-01T00:00:00+00:00",
+                updated_at="2024-01-01T00:00:00+00:00",
+                chunks_list=["chunk-ok"],
+                metadata={},
+            )
+        }
+
+    async def get_docs_by_statuses(self, statuses, strict: bool = False):
+        self.calls.append(strict)
+        if strict:
+            raise KeyError("content_summary")
+        return dict(self.healthy)
+
+
+class _FakeKV:
+    def __init__(self):
+        self.data: dict = {}
+
+    async def get_by_id(self, key):
+        return self.data.get(key)
+
+    async def upsert(self, payload):
+        self.data.update(payload)
+
+    async def index_done_callback(self):
+        return None
+
+
+class _FakeGraph:
+    """A legacy graph: one entity attributed to the CORRUPT document's chunk."""
+
+    async def get_all_labels(self):
+        return ["E1"]
+
+    async def get_all_nodes(self):
+        return [{"entity_id": "E1", "source_id": "chunk-corrupt"}]
+
+    async def get_all_edges(self):
+        return []
+
+
+class _Migrator(_StorageMigrationMixin):
+    def __init__(self, doc_status):
+        self.doc_status = doc_status
+        self.chunk_entity_relation_graph = _FakeGraph()
+        self.full_entities = _FakeKV()
+        self.full_relations = _FakeKV()
+        self.entity_chunks = None
+        self.relation_chunks = None
+
+    async def _migrate_chunk_tracking_storage(self) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _shared_storage():
+    initialize_share_data(workers=1)
+
+
+@pytest.mark.asyncio
+async def test_unparseable_doc_status_row_aborts_the_migration():
+    """FIX-PROOF: with a relaxed read this completed and persisted nothing for
+    the corrupt document, leaving it permanently anchor-less."""
+    doc_status = _CorruptRowDocStatus()
+    migrator = _Migrator(doc_status)
+
+    with pytest.raises(KeyError):
+        await migrator.check_and_migrate_data()
+
+    # The read asked for the strict contract...
+    assert doc_status.calls == [True]
+    # ...and nothing was persisted, so a later run can still migrate the whole
+    # corpus once the bad row is repaired. A relaxed read would have written
+    # anchors here and made that repair unreachable.
+    assert migrator.full_entities.data == {}
+    assert migrator.full_relations.data == {}
+
+
+@pytest.mark.asyncio
+async def test_healthy_corpus_still_migrates():
+    """STABILITY: the strict read must not break the normal migration path."""
+
+    class _HealthyDocStatus(_CorruptRowDocStatus):
+        async def get_docs_by_statuses(self, statuses, strict: bool = False):
+            self.calls.append(strict)
+            return dict(self.healthy)
+
+    class _MatchingGraph(_FakeGraph):
+        async def get_all_nodes(self):
+            return [{"entity_id": "E1", "source_id": "chunk-ok"}]
+
+    doc_status = _HealthyDocStatus()
+    migrator = _Migrator(doc_status)
+    migrator.chunk_entity_relation_graph = _MatchingGraph()
+
+    await migrator.check_and_migrate_data()
+
+    assert doc_status.calls == [True]
+    assert migrator.full_entities.data["doc-ok"]["entity_names"] == ["E1"]


### PR DESCRIPTION
## Summary

Removes the deprecated `GET /documents` full-listing endpoint and the now-unused `get_docs_by_status` read that backed it, plus the frontend's dead client functions.

The WebUI moved its document list to `POST /documents/paginated` and reads status counts from that same response, so nothing in the repo called the full-listing endpoint any more. It was still served, still marked `# TODO: Deprecated, use /documents/paginated instead`, and still scanned the whole doc-status store on every request. Optimizing that scan (#3762) buys nothing for a path with no callers — removing it is the actual fix.

Closes #3761. Supersedes #3762 (thanks @hata33 for the analysis that surfaced this).

## Motivation

Evidence the listing path is dead:

- `DocumentManager.tsx` fetches only through `getDocumentsPaginatedWithTimeout`, on both the manual-refresh and the polling branch, and takes status counts from `response.status_counts`.
- `getDocuments()` and `getDocumentStatusCounts()` in `src/api/lightrag.ts` had zero call sites in `src/`.
- `rag.get_docs_by_status`'s only in-repo caller was the deleted endpoint.
- `api/utils_api.py`'s token-renewal skip list (documented as "client polls this frequently") already lists only `/documents/paginated` and `/documents/pipeline_status`.
- No `docs/*.md` documents the endpoint, and it had no functional test coverage.

## What's changed

**API**

- Deleted `GET /documents` and its `DocsStatusesResponse` response model. `DELETE /documents` (clear) is untouched — still used by `ClearDocumentsDialog`.
- Removed `LightragPathFilter`'s `"/documents"` entry. `filter()` matches GET and POST only, so this entry only ever muted the deleted GET; DELETE was never filtered and its access logging is unchanged.

**Core / storage**

- Removed `DocStatusStorage.get_docs_by_status` (abstract) and its five backend implementations. Four (JSON, Redis, Mongo, OpenSearch) were one-line delegations to `get_docs_by_statuses`; PostgreSQL carried a 55-line duplicate of the batched query's row parsing, which the batched path already covers via `_pg_doc_processing_status_from_row`.
- Removed `LightRAG.get_docs_by_status`.
- `storage_migrations` and the OpenSearch demo now call `get_docs_by_statuses([...])` (default `strict=False`, so the relaxed read contract and the returned shape are unchanged).
- `kg/__init__.py`'s declared `required_methods` for `DOC_STATUS_STORAGE` and the docstrings/comments that named the removed method are updated.

**Frontend**

- Dropped the dead `getDocuments` and `getDocumentStatusCounts` exports and the now-unused `StatusCountsResponse` type. The backend `GET /documents/status_counts` endpoint is kept — only its unused client is removed.
- `DocsStatusesResponse` (TS) stays: it is DocumentManager's internal bucket shape, built locally from the paginated response, not a wire type.

**Tests**

- Pipeline / noop / OpenSearch call sites moved to `get_docs_by_statuses`; the OpenSearch `test_get_docs_by_status` cases (including the post-`drop()` missing-index assertion) were converted rather than deleted, so that coverage now pins the batched read.
- `tests/kg/test_scheduling_base_defaults.py`'s stub drops the method the abstract no longer requires.
- `tests/api/test_path_prefixes.py` loses its `GET /documents` assertion. With the route gone the path matches only DELETE, so a GET returns 405 before route dependencies run and `== 401` cannot hold; DELETE (the test's stated subject) still asserts 401.

## Breaking change

`LightRAG.get_docs_by_status(status)` and the `DocStatusStorage` abstract method are removed with no deprecation shim. The exact replacement is `get_docs_by_statuses([status])` — implemented by every doc-status backend, already the read path used by the pipeline and the paginated endpoint, and what the four delegating backends were calling anyway.

Any third-party client still calling `GET /documents` must move to `POST /documents/paginated`.

## Tests

- Full backend suite (`./scripts/test.sh tests`): **7753 passed**, 200 skipped, 6 failed — the same 6 `test_ai_content_notice` / `test_api_docs_toggle` failures reproduce identically on clean `main` in this environment (local `.env` / WebUI-mount artifacts), unrelated to this change.
- Frontend from `lightrag_webui/`: `bun test` **447 pass / 28 fail**, byte-identical to clean `main`; `bunx tsc --noEmit` clean; `bun run lint` clean.
- `ruff check .` clean; `pre-commit run` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
