### PR TITLE
test(webui): stop replacing the window global in the workspace entry test

### DIFF
--- a/lightrag_webui/src/bootstrap/workspaceEntry.test.ts
+++ b/lightrag_webui/src/bootstrap/workspaceEntry.test.ts
@@ -1,7 +1,6 @@
 import { afterAll, beforeAll, describe, expect, spyOn, test } from 'bun:test'
 import { QUERY_SETTINGS_STORAGE_KEY, WEBUI_RETRIEVAL_HISTORY_KEY } from '@/lib/storageKeys'
 import type { navigationService as NavigationServiceType } from '@/services/navigation'
-import { restoreDomGlobals } from '@/test/domGlobals'
 
 /**
  * Workspace entry bootstrap: configures the navigation singleton for THIS
@@ -10,6 +9,17 @@ import { restoreDomGlobals } from '@/test/domGlobals'
  * effect from the next query without a reload.
  *
  * Isolation rules this file follows (learned the hard way):
+ * - NEVER replace the `window` GLOBAL, not even with a stub carrying just
+ *   the one method the bootstrap calls. The preloaded happy-dom window is
+ *   process-wide, and the import graph reached from `./workspaceEntry` pulls
+ *   in axios, which reads `window.location.href` while its platform module
+ *   is being evaluated. A stub without `location` therefore threw here — but
+ *   only when this file happened to run before whichever other file
+ *   evaluates axios first, which left `@/api/lightrag` half-evaluated in the
+ *   registry and cascaded into TDZ errors across ten unrelated files. The
+ *   bootstrap's listener registration is observed with a call-through spy on
+ *   the REAL window instead, and the captured listeners are removed again in
+ *   afterAll so nothing survives this file.
  * - NO `mock.module` on shared singletons: bun's module mocks live in the
  *   process-wide registry for the rest of the run and would hand every later
  *   test file a gutted navigationService. The bootstrap's configureEntry call
@@ -46,6 +56,7 @@ const storageListeners: StorageListener[] = []
 
 let navigationService: typeof NavigationServiceType
 let configureSpy: ReturnType<typeof spyOn> | undefined
+let addEventListenerSpy: ReturnType<typeof spyOn> | undefined
 let querySettingsModule: typeof import('@/stores/querySettings')
 let workspaceHistoryModule: typeof import('@/stores/workspaceRetrievalHistory')
 
@@ -62,14 +73,10 @@ beforeAll(async () => {
       configurable: true
     })
   }
-  Object.defineProperty(globalThis, 'window', {
-    value: {
-      addEventListener: (type: string, listener: StorageListener) => {
-        if (type === 'storage') storageListeners.push(listener)
-      }
-    },
-    configurable: true
-  })
+  // Call-through spy on the real window: records what the bootstrap
+  // registers AND still registers it, so no window property goes missing
+  // from the modules imported below. See the isolation rules above.
+  addEventListenerSpy = spyOn(window, 'addEventListener')
 
   navigationService = (await import('@/services/navigation')).navigationService
   // Call-through spy: records the bootstrap's configuration AND still applies
@@ -79,12 +86,21 @@ beforeAll(async () => {
   querySettingsModule = await import('@/stores/querySettings')
   workspaceHistoryModule = await import('@/stores/workspaceRetrievalHistory')
   await import('./workspaceEntry')
+
+  for (const [type, listener] of addEventListenerSpy.mock.calls) {
+    if (type === 'storage') storageListeners.push(listener as StorageListener)
+  }
 })
 
 afterAll(() => {
+  // The listeners went onto the process-wide window, so they would answer a
+  // real `storage` event dispatched by any later test file.
+  for (const listener of storageListeners) {
+    window.removeEventListener('storage', listener as never)
+  }
+  addEventListenerSpy?.mockRestore()
   configureSpy?.mockRestore()
   navigationService.resetForTests()
-  restoreDomGlobals()
 })
 
 const recordedConfig = () => {


### PR DESCRIPTION
## Summary

One test file was replacing the process-wide `window` global with a stub, which broke ten unrelated test files depending on execution order. Fixing that file takes the local `bun test` run from **41 failures across 11 files to 0**.

## The bug

`src/bootstrap/workspaceEntry.test.ts` needed to capture the `storage` listeners its bootstrap registers, and did it by installing a stub window:

```ts
Object.defineProperty(globalThis, 'window', {
  value: { addEventListener: (type, listener) => { … } },
  configurable: true
})
```

The import graph reached from `./workspaceEntry` (`@/services/navigation` → … → `@/api/lightrag`) pulls in **axios**, whose platform module reads `window.location.href` *while it is being evaluated*. The stub has no `location`, so that read throws `TypeError: undefined is not an object`.

Whether it threw was pure luck of file order:

- If any earlier test file had already evaluated axios, the cached module never touched the stub and this file passed.
- If this file ran first, the throw escaped `beforeAll`, which left `@/api/lightrag` **half-evaluated in the process-wide module registry**. Every later file that imports it then died on a TDZ error — `ReferenceError: Cannot access 'verifyCredentials' before initialization`, `… 'InvalidApiKeyError' …` — inside its own `beforeAll`, taking that whole file's tests with it.

This is the failure mode `src/test/domGlobals.ts` and the *"The DOM is process-wide"* rule in `AGENTS.md` exist to prevent; the guard in `harnessIsolation.test.ts` catches a bare `delete` of the globals, but not a *replacement*.

## Blast radius

On this branch's base, with the stub restored:

```
433 pass / 41 fail — Ran 474 tests across 62 files
```

100 tests never ran at all: a file whose `beforeAll` throws contributes phantom failures instead of its test bodies. The 11 affected files were `bootstrap/workspaceEntry`, `stores/{tokenValidation,documentTitleSync,healthCheckRace,state}`, `lib/loginIdentity`, `api/{lightrag,lightrag-stream}`, `services/navigation`, `features/workspace/{authBootstrap,credentialProbe}` — every one of them a cascade victim, not an independent bug. All 10 downstream files pass in isolation.

## The fix

Keep the real preloaded happy-dom window and observe the registrations with a call-through spy:

```ts
addEventListenerSpy = spyOn(window, 'addEventListener')
…
for (const [type, listener] of addEventListenerSpy.mock.calls) {
  if (type === 'storage') storageListeners.push(listener as StorageListener)
}
```

Because the listeners now land on the **process-wide** window rather than a throwaway stub, `afterAll` removes each captured one — otherwise a later file dispatching a real `storage` event would drive this bootstrap's `persist.rehydrate()` and the cross-tab identity watcher. `restoreDomGlobals()` goes with the stub it existed to undo, and the new rule is recorded in the file's "isolation rules" header block, beside the `mock.module` rule it belongs next to.

The conditional `localStorage` / `sessionStorage` stubs stay: they never fire under the preload and only guard the no-preload case.

## Why CI never caught it

CI is green today because its bun happens to schedule an axios-loading file first. The workflow pins `bun-version: latest` (bun 1.4.0 as of this run; local reproduction was on 1.3.11), so the order that hides this is not a property anyone controls — a future bun release could surface the same 41 failures in CI. Flagging rather than changing: whether to pin a bun version in `webui-tests.yml` is a separate call.

Also worth noting the local symptom was misleading: because `bun test` on 1.3.11 prints no `(pass)` lines, the run looked like "28 pre-existing environment failures" rather than one file's bug. It is not environmental.

## Verification

Fix-proof, same commit, same bun, only the one file swapped:

| `src/bootstrap/workspaceEntry.test.ts` | `bun test` (whole suite) |
| --- | --- |
| pre-fix (stub window) | 433 pass / **41 fail** — 474 tests, 62 files |
| post-fix (this PR) | **574 pass / 0 fail** — 574 tests, 62 files |

574/0/62 is exactly what CI reports for `main` at `241c06a`, so local and CI now agree test-for-test. The file alone goes from 0 pass / 2 fail (its 6 tests never reached) to 6 pass / 0 fail.

Full WebUI check set from `lightrag_webui/`: `bun install --frozen-lockfile`, `bun test` (574 pass / 0 fail), `bunx tsc --noEmit` clean, `bun run lint` clean.

## What's broken

Nothing. No production code changes — one test file.
