### PR TITLE
docs: clarify file processing concurrency limits

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -334,8 +334,9 @@ VLM_LLM_MODEL=<your_vlm_model_name>
 
 大規模なドキュメント処理では、並行性を高める必要があります。ファイルの並行処理に関連する主要な環境変数は以下のとおりです:
 
-- **MAX_ASYNC_LLM/EXTRACT_ASYNC_LLM**: LLM モデルの最大並行数を制御します。
-- **MAX_PARALLEL_INSERT**: 並行処理されるファイルの最大数を制御します。1つのファイル内のテキスト・表・数式・画像の処理も並行して行われます。`MAX_PARALLEL_INSERT` は理想的には `MAX_ASYNC_LLM` の約1/3に設定すべきです。
+- **MAX_ASYNC_LLM**: LLM ロールの基本並行数を設定します（`MAX_ASYNC` は非推奨の互換エイリアスとして引き続き使用できます）。ファイル処理では、1 文書内の各チャンクに対するエンティティ/関係抽出 task 数もこれで上限が決まり、各エンティティ結合または関係結合フェーズはその 2 倍まで task を実行できます。
+- **EXTRACT_MAX_ASYNC_LLM**: 抽出および結合時の要約に対する、Extract ロールの実際の LLM リクエスト上限を任意で上書きします。未設定時は `MAX_ASYNC_LLM` を継承し、上記のパイプライン task 上限は変更しません。
+- **MAX_PARALLEL_INSERT**: 並行処理するファイル数を制御し、1 文書内の chunk やグラフ結合 task の上限は制御しません。`MAX_ASYNC_LLM` の約 1/3 を目安に設定してください。
 - **MAX_PARALLEL_PARSE_MINERU**: MinerU 解析で並行処理されるファイル数を制御します。
 - **MAX_PARALLEL_PARSE_DOCLING**: Docling 解析で並行処理されるファイル数を制御します。
 - **EMBEDDING_FUNC_MAX_ASYNC**: 埋め込みモデルの最大並行数を制御します。

--- a/README-zh.md
+++ b/README-zh.md
@@ -334,8 +334,9 @@ VLM_LLM_MODEL=<your_vlm_model_name>
 
 对于大规模的文档处理，需要提高文档处理的并发能力。几个涉及文件并发处理性能的关键环境变量包括：
 
-- **MAX_ASYNC_LLM/EXTRACT_ASYNC_LLM**：控制 LLM 模型的最大并发数。
-- **MAX_PARALLEL_INSERT**：控制并行处理文件的最大数量。单个文件内的文本、表格、公式、图片之间的处理也会并发进行。`MAX_PARALLEL_INSERT` 应该为 `MAX_ASYNC_LLM` 的 1/3 左右为宜。
+- **MAX_ASYNC_LLM**：设置 LLM 角色的基础并发数（`MAX_ASYNC` 仍作为兼容旧名保留）。文件处理时，它还限制单个文档内各文本块的实体/关系抽取 task 数；每个实体合并或关系合并阶段最多可运行其两倍数量的 task。
+- **EXTRACT_MAX_ASYNC_LLM**：可选地覆盖 Extract 角色的实际 LLM 请求并发数，适用于抽取和合并时的摘要请求。未设置时继承 `MAX_ASYNC_LLM`；它不会改变前述流水线 task 上限。
+- **MAX_PARALLEL_INSERT**：控制可并行处理的文件数量，而非单个文档内的 chunk 或图合并 task 上限。建议约为 `MAX_ASYNC_LLM` 的 1/3。
 - **MAX_PARALLEL_PARSE_MINERU**：控制 MinerU 文件解析的并发处理文件数。
 - **MAX_PARALLEL_PARSE_DOCLING**：控制 Docling 文件解析的并发处理文件数。
 - **EMBEDDING_FUNC_MAX_ASYNC**：控制嵌入模型的最大并发数。

--- a/README.md
+++ b/README.md
@@ -334,8 +334,9 @@ Since the cloud-based MinerU service has limitations on usage, file size, and pa
 
 For large-scale document processing, you need to improve concurrency. Key environment variables related to concurrent file processing include:
 
-- **MAX_ASYNC_LLM/EXTRACT_ASYNC_LLM**: Controls the maximum concurrency for LLM models.
-- **MAX_PARALLEL_INSERT**: Controls the maximum number of files processed in parallel. Processing of text, tables, formulas, and images within a single file will also occur concurrently. `MAX_PARALLEL_INSERT` should ideally be set to about 1/3 of `MAX_ASYNC_LLM`.
+- **MAX_ASYNC_LLM**: Sets the base concurrency for LLM roles (`MAX_ASYNC` remains a deprecated alias). During file processing, it also caps entity/relation extraction tasks for the chunks of one document; each entity-merge or relation-merge phase can run up to twice this many tasks.
+- **EXTRACT_MAX_ASYNC_LLM**: Optionally overrides the Extract-role limit for actual extraction and merge-summary LLM requests. When unset, it inherits `MAX_ASYNC_LLM`; it does not change the pipeline task limits above.
+- **MAX_PARALLEL_INSERT**: Controls the maximum number of files processed in parallel, rather than the per-document chunk or graph-merge task limits. It should ideally be set to about 1/3 of `MAX_ASYNC_LLM`.
 - **MAX_PARALLEL_PARSE_MINERU**: Controls the number of parallel files processed for MinerU parsing.
 - **MAX_PARALLEL_PARSE_DOCLING**: Controls the number of parallel files processed for Docling parsing.
 - **EMBEDDING_FUNC_MAX_ASYNC**: Controls the maximum concurrency for embedding models.

--- a/docs/DockerDeployment.md
+++ b/docs/DockerDeployment.md
@@ -57,7 +57,7 @@ validation rules and provider-specific behavior.
 
 **RAG Configuration**
 
-- `MAX_ASYNC_LLM`: Maximum async operations (deprecated alias: `MAX_ASYNC`)
+- `MAX_ASYNC_LLM`: Base maximum LLM concurrency (deprecated alias: `MAX_ASYNC`). It also sets the per-document chunk-extraction task limit, while each entity/relation merge phase uses twice that task limit; see [File Processing Pipeline Specification](./FileProcessingPipeline.md) for the full pipeline and role-override rules.
 - `MAX_TOKENS`: Maximum token size
 - `EMBEDDING_DIM`: Embedding dimensions
 

--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -1093,7 +1093,8 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼�
 | `MAX_PARALLEL_PARSE_MINERU` | `1` | N2: MinerU 解析并发 worker 数 | MinerU 占用 GPU/CPU 显著，因此默认只启用一个 worker。本地部署且显存充足时可设 2-3；走 MinerU 官方云端服务时可适当提高（受云端配额限制） |
 | `MAX_PARALLEL_PARSE_DOCLING` | `1` | N3: Docling 解析并发 worker 数 | Docling 同样资源敏感，因此默认只启用一个 worker。本地部署且 CPU/GPU 充足时可设 2-3 |
 | `MAX_PARALLEL_ANALYZE` | `5` | N4: 多模态分析（VLM 图片 / 表格描述）并发 worker 数 | 直接消耗 VLM 配额。建议 ≤ VLM 服务并发上限 |
-| `MAX_PARALLEL_INSERT` | `3` | N5: 实体 / 关系抽取 + 入库阶段并发文档数 | 推荐 `MAX_ASYNC_LLM / 3`，区间 2~10。该阶段每个文档会触发多次 LLM 调用，过高会撞 LLM 限流。同时该值还作为 `asyncio.Semaphore` 用于二次约束（worker 数和信号量值一致） |
+| `MAX_ASYNC_LLM` | `4` | 基础 LLM 并发与 N5 的单文档 task 基数 | 对单个文档，文本块实体/关系抽取最多并发运行 `MAX_ASYNC_LLM` 个 task；每个实体合并或关系合并阶段最多运行 `2 × MAX_ASYNC_LLM` 个 task。设置 `EXTRACT_MAX_ASYNC_LLM` 后，它会独立限制实际 Extract 角色 LLM 请求，不改变这些 task 上限 |
+| `MAX_PARALLEL_INSERT` | `3` | N5: 实体 / 关系抽取 + 入库阶段并发文档数 | 推荐 `MAX_ASYNC_LLM / 3`，区间 2~10。它控制文档数量，不控制单个文档内的 chunk 或合并 task 上限。同时该值还作为 `asyncio.Semaphore` 用于二次约束（worker 数和信号量值一致） |
 | `QUEUE_SIZE_PARSE` | `20` | parse（native/MinerU/Docling）输入队列长度 | 一般无需调整。队列内仅为轻量 doc_id（大文档体在进入 analyze 前已剥离），仅限制 pipeline 一次预派发给 parse worker 的待处理文档数，调整影响很小 |
 | `QUEUE_SIZE_ANALYZE` | `100` | analyze 队列（parse → analyze 阶段）的有界容量 | 一般无需调整。极少量大批量任务（成千上万）可适当提高，避免 enqueue 端反压；内存紧张时可调低 |
 | `QUEUE_SIZE_INSERT` | `4` | analyze → process 阶段间的队列容量 | process 是流水线中最慢、最耗内存的阶段，队列特意做小，给上游提供反压防止内存堆积 |
@@ -1103,16 +1104,17 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼�
 1. **解析阶段按引擎隔离**，所以混用 native/mineru/docling 时不必担心一种引擎慢拖累另一种。
 2. **mineru / docling 默认 1**：两者资源占用高，因此默认避免多个解析任务并发（以及由此带来的 OOM、显存竞争和失败重试）；如果你部署了多 GPU 或专门的解析服务器，可手动调高。
 3. **`MAX_PARALLEL_INSERT` 兼任 worker 池大小和信号量上限**：流水线创建 `Semaphore(max_parallel_insert)`，每个 process worker 在抽取入库前还要拿一次信号量。所以哪怕你把 worker 数手动改大，实际并发上限仍由这个值决定——直接调它就够了。
-4. **queue size 与背压**：`QUEUE_SIZE_INSERT=4` 这个偏小的默认值是有意为之——process 阶段慢且占内存，让 analyze 阶段在队列写满时阻塞、再反压到 parse 阶段，避免一次性把成千上万份解析结果堆在内存里。
-5. **改后生效方式**：所有参数通过 `.env`（或环境变量）传入，仅在 `LightRAG` 实例构造时读取一次；改完需要重启服务。
-6. **分块不随并发增长**：分块在一个专用的单 worker 线程池里执行，目的是不阻塞事件循环，并发度不随 `MAX_PARALLEL_INSERT` 提高，调大并发不会让分块更快。自定义 `chunking_func` 仍在事件循环上执行（它的契约允许触碰运行中的事件循环），CPU 密集的实现应自行 `asyncio.to_thread`。
+4. **task 上限与请求上限不同**：`MAX_ASYNC_LLM` 设置 N5 单文档 chunk 抽取的 task 上限，以及其两倍的合并 task 上限。实际抽取和合并摘要请求使用 Extract 角色的上限：设置了 `EXTRACT_MAX_ASYNC_LLM` 时使用它，否则使用 `MAX_ASYNC_LLM`。缓存、图的 keyed lock 和角色上限都会让观测到的实际请求并发低于 task 并发。
+5. **queue size 与背压**：`QUEUE_SIZE_INSERT=4` 这个偏小的默认值是有意为之——process 阶段慢且占内存，让 analyze 阶段在队列写满时阻塞、再反压到 parse 阶段，避免一次性把成千上万份解析结果堆在内存里。
+6. **改后生效方式**：所有参数通过 `.env`（或环境变量）传入，仅在 `LightRAG` 实例构造时读取一次；改完需要重启服务。
+7. **分块不随并发增长**：分块在一个专用的单 worker 线程池里执行，目的是不阻塞事件循环，并发度不随 `MAX_PARALLEL_INSERT` 提高，调大并发不会让分块更快。自定义 `chunking_func` 仍在事件循环上执行（它的契约允许触碰运行中的事件循环），CPU 密集的实现应自行 `asyncio.to_thread`。
 
 **典型调优场景：**
 
 - 大量 PDF + 本地 MinerU 单 GPU：`MAX_PARALLEL_PARSE_MINERU=1`、`MAX_PARALLEL_ANALYZE=5`、`MAX_PARALLEL_INSERT=3`（默认即可；确认显存充足后再提高 MINERU）。
 - 大量 PDF + MinerU 云端服务：`MAX_PARALLEL_PARSE_MINERU=3~5`（视云端配额），其它保持默认。
 - 纯 docx / txt（仅走 native）：`MAX_PARALLEL_PARSE_NATIVE=10`、`MAX_PARALLEL_INSERT` 按 `MAX_ASYNC_LLM/3` 推算。
-- LLM 限流明显：先降 `MAX_PARALLEL_INSERT`（process 阶段每文档多次 LLM 调用），再降 `MAX_PARALLEL_ANALYZE`（VLM 是独立配额）。
+- Extract 角色 LLM 限流明显：先降 `EXTRACT_MAX_ASYNC_LLM`（未设置覆盖时降 `MAX_ASYNC_LLM`）以限制 provider 请求；如需减少在途文档数或内存，再同时降低 `MAX_PARALLEL_INSERT`。`MAX_PARALLEL_ANALYZE` 控制独立的 VLM 阶段。
 
 ### 8.7 准入与请求限制
 
@@ -1300,7 +1302,7 @@ per-file 个性化的典型场景：管理 UI 单独配置某个文件的 separa
 | 路由 | `LIGHTRAG_PARSER` | §2.3、§2.4、§2.5 |
 | 分块 | `CHUNK_SIZE`、`CHUNK_OVERLAP_SIZE`、`CHUNK_{F,R,V,P}_*` | §5.2 |
 | 多模态 | `VLM_PROCESS_ENABLE`、`VLM_MAX_IMAGE_BYTES`、`VLM_MIN_IMAGE_PIXEL`、`MAX_EXTRACT_INPUT_TOKENS`、`SURROUNDING_*_MAX_TOKENS`、`MM_EXTRACT_CONTENT_MIN_TOKENS` | §4 |
-| VLM / 角色模型 | `VLM_LLM_*`、`VLM_MAX_ASYNC_LLM` | [RoleSpecificLLMConfiguration-zh.md](RoleSpecificLLMConfiguration-zh.md) |
+| LLM / VLM 角色模型 | `MAX_ASYNC_LLM`、`EXTRACT_LLM_*`、`EXTRACT_MAX_ASYNC_LLM`、`VLM_LLM_*`、`VLM_MAX_ASYNC_LLM` | [RoleSpecificLLMConfiguration-zh.md](RoleSpecificLLMConfiguration-zh.md) |
 | legacy 引擎 | `PDF_DECRYPT_PASSWORD` | §3.2 |
 | native 引擎 | `NATIVE_MD_IMAGE_*` | §3.3 |
 | native docx smart_heading | `DOCX_SMART_HEADING`、`DOCX_SMART_*` 调优项 | §3.3 与 `env.example` 的 smart_heading 注释块 |

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -1093,7 +1093,8 @@ Parse queues are **created dynamically from the registry's `ParserSpec.queue_gro
 | `MAX_PARALLEL_PARSE_MINERU` | `1` | N2: concurrent workers for MinerU parsing | MinerU is GPU/CPU heavy, so the default uses a single worker. Raise to 2-3 for a local deployment with enough VRAM, or higher against MinerU's official cloud service (subject to its quota) |
 | `MAX_PARALLEL_PARSE_DOCLING` | `1` | N3: concurrent workers for Docling parsing | Docling is equally resource-sensitive, so the default uses a single worker. Raise to 2-3 for a local deployment with enough CPU/GPU |
 | `MAX_PARALLEL_ANALYZE` | `5` | N4: concurrent workers for multimodal analysis (VLM image / table descriptions) | Consumes VLM quota directly. Keep ≤ the VLM service's concurrency limit |
-| `MAX_PARALLEL_INSERT` | `3` | N5: concurrent documents in the entity/relation extraction + ingestion stage | `MAX_ASYNC_LLM / 3` is a good rule of thumb, in the 2~10 range. Each document triggers many LLM calls here, so too high hits LLM rate limits. The same value also backs an `asyncio.Semaphore` as a second constraint (worker count equals the semaphore value) |
+| `MAX_ASYNC_LLM` | `4` | Base LLM concurrency and N5's per-document task basis | For one document, chunk entity/relation extraction runs at most `MAX_ASYNC_LLM` tasks concurrently; each entity-merge or relation-merge phase runs at most `2 × MAX_ASYNC_LLM` tasks. `EXTRACT_MAX_ASYNC_LLM`, when set, independently limits actual Extract-role LLM requests and does not change these task limits |
+| `MAX_PARALLEL_INSERT` | `3` | N5: concurrent documents in the entity/relation extraction + ingestion stage | `MAX_ASYNC_LLM / 3` is a good rule of thumb, in the 2~10 range. It controls the number of documents, not the per-document chunk or merge task limits. The same value also backs an `asyncio.Semaphore` as a second constraint (worker count equals the semaphore value) |
 | `QUEUE_SIZE_PARSE` | `20` | Input queue length for parse (native/MinerU/Docling) | Rarely needs tuning. The queue holds only lightweight doc_ids (large document bodies are stripped before analyze), and it just bounds how many documents the pipeline pre-dispatches to parse workers |
 | `QUEUE_SIZE_ANALYZE` | `100` | Bounded capacity of the analyze queue (parse → analyze) | Rarely needs tuning. Raise it slightly for very large batches (tens of thousands) to avoid back-pressure at the enqueue side; lower it when memory is tight |
 | `QUEUE_SIZE_INSERT` | `4` | Queue capacity between the analyze and process stages | process is the slowest and most memory-hungry stage, so this queue is deliberately small, giving upstream back-pressure |
@@ -1103,16 +1104,17 @@ Parse queues are **created dynamically from the registry's `ParserSpec.queue_gro
 1. **The parse stage is isolated per engine**, so mixing native/mineru/docling never lets one slow engine drag another down.
 2. **mineru / docling default to 1**: both are resource-heavy, so the default avoids concurrent parser jobs (and the resulting OOM / VRAM contention / failure retries). Raise it by hand if you have multiple GPUs or a dedicated parsing server.
 3. **`MAX_PARALLEL_INSERT` is both pool size and semaphore ceiling**: the pipeline creates `Semaphore(max_parallel_insert)` and every process worker takes it before extracting and ingesting. So even if you raise the worker count by hand, this value still caps real concurrency — just tune it directly.
-4. **Queue size and back-pressure**: the small `QUEUE_SIZE_INSERT=4` default is deliberate — process is slow and memory-hungry, so a full queue blocks the analyze stage and back-pressures parse, instead of piling tens of thousands of parse results into memory at once.
-5. **How changes take effect**: every parameter comes from `.env` (or the environment) and is read once when the `LightRAG` instance is constructed; restart the service after changing one.
-6. **Chunking does not scale with concurrency**: chunking runs in a dedicated single-worker thread pool so it does not block the event loop, and its concurrency does not grow with `MAX_PARALLEL_INSERT` — raising that will not make chunking faster. A custom `chunking_func` still runs on the event loop (its contract allows touching the running loop), so CPU-heavy implementations should call `asyncio.to_thread` themselves.
+4. **Task limits and request limits are distinct**: `MAX_ASYNC_LLM` sets N5's per-document chunk-extraction task limit and its `2 ×` merge-task limit. Actual extraction and merge-summary requests use the Extract role's limit, `EXTRACT_MAX_ASYNC_LLM` when set or `MAX_ASYNC_LLM` otherwise. Caches, keyed graph locks, and a role limit can make observed request concurrency lower than task concurrency.
+5. **Queue size and back-pressure**: the small `QUEUE_SIZE_INSERT=4` default is deliberate — process is slow and memory-hungry, so a full queue blocks the analyze stage and back-pressures parse, instead of piling tens of thousands of parse results into memory at once.
+6. **How changes take effect**: every parameter comes from `.env` (or the environment) and is read once when the `LightRAG` instance is constructed; restart the service after changing one.
+7. **Chunking does not scale with concurrency**: chunking runs in a dedicated single-worker thread pool so it does not block the event loop, and its concurrency does not grow with `MAX_PARALLEL_INSERT` — raising that will not make chunking faster. A custom `chunking_func` still runs on the event loop (its contract allows touching the running loop), so CPU-heavy implementations should call `asyncio.to_thread` themselves.
 
 **Typical tuning scenarios:**
 
 - Many PDFs + local MinerU on a single GPU: `MAX_PARALLEL_PARSE_MINERU=1`, `MAX_PARALLEL_ANALYZE=5`, `MAX_PARALLEL_INSERT=3` (the defaults; raise MINERU only after verifying available VRAM).
 - Many PDFs + MinerU's cloud service: `MAX_PARALLEL_PARSE_MINERU=3~5` (per your cloud quota), everything else default.
 - Pure docx / txt (native only): `MAX_PARALLEL_PARSE_NATIVE=10`, with `MAX_PARALLEL_INSERT` derived from `MAX_ASYNC_LLM/3`.
-- Visible LLM rate limiting: lower `MAX_PARALLEL_INSERT` first (the process stage makes many LLM calls per document), then `MAX_PARALLEL_ANALYZE` (VLM has its own quota).
+- Visible Extract-role LLM rate limiting: lower `EXTRACT_MAX_ASYNC_LLM` (or `MAX_ASYNC_LLM` when no override is set) to cap provider requests; lower `MAX_PARALLEL_INSERT` as well if fewer in-flight documents or lower memory use is needed. `MAX_PARALLEL_ANALYZE` controls the separate VLM stage.
 
 ### 8.7 Admission and Request Limits
 
@@ -1300,7 +1302,7 @@ Where to find each family of file-processing variables. This is an index, not a 
 | Routing | `LIGHTRAG_PARSER` | §2.3, §2.4, §2.5 |
 | Chunking | `CHUNK_SIZE`, `CHUNK_OVERLAP_SIZE`, `CHUNK_{F,R,V,P}_*` | §5.2 |
 | Multimodal | `VLM_PROCESS_ENABLE`, `VLM_MAX_IMAGE_BYTES`, `VLM_MIN_IMAGE_PIXEL`, `MAX_EXTRACT_INPUT_TOKENS`, `SURROUNDING_*_MAX_TOKENS`, `MM_EXTRACT_CONTENT_MIN_TOKENS` | §4 |
-| VLM / role models | `VLM_LLM_*`, `VLM_MAX_ASYNC_LLM` | [RoleSpecificLLMConfiguration.md](RoleSpecificLLMConfiguration.md) |
+| LLM / VLM role models | `MAX_ASYNC_LLM`, `EXTRACT_LLM_*`, `EXTRACT_MAX_ASYNC_LLM`, `VLM_LLM_*`, `VLM_MAX_ASYNC_LLM` | [RoleSpecificLLMConfiguration.md](RoleSpecificLLMConfiguration.md) |
 | legacy engine | `PDF_DECRYPT_PASSWORD` | §3.2 |
 | native engine | `NATIVE_MD_IMAGE_*` | §3.3 |
 | native docx smart_heading | `DOCX_SMART_HEADING`, `DOCX_SMART_*` tuning | §3.3 and the smart_heading block of `env.example` |

--- a/docs/LightRAG-API-Server-zh.md
+++ b/docs/LightRAG-API-Server-zh.md
@@ -568,7 +568,8 @@ LightRAG 服务器可以在 `Gunicorn + Uvicorn` 预加载模式下运行。Guni
 WORKERS=2
 ### 一批中并行处理的文件数
 MAX_PARALLEL_INSERT=3
-# LLM 的最大并发请求数(MAX_ASYNC 作为兼容旧名仍可用)
+### 基础 LLM 并发与单文档 chunk 抽取 task 上限
+### （MAX_ASYNC 作为兼容旧名仍可用）
 MAX_ASYNC_LLM=4
 ```
 
@@ -977,7 +978,7 @@ python -m lightrag.tools.migrate_graph_storage --apply
 | `--working-dir` | `./rag_storage` | RAG 存储工作目录 |
 | `--input-dir` | `./inputs` | 上传/输入文档目录 |
 | `--timeout` | `150` | Gunicorn worker timeout 以及 fallback 请求超时 |
-| `--max-async` | `4` | 最大并发 LLM 操作数 |
+| `--max-async` | `4` | 基础 LLM 最大并发；也是单文档 chunk 抽取的 task 上限（每个实体/关系合并阶段使用其两倍的 task 上限） |
 | `--log-level` | `INFO` | 日志级别（`DEBUG`、`INFO`、`WARNING`、`ERROR`、`CRITICAL`） |
 | `--verbose` | `False` | 详细调试输出，配合 debug 日志生效 |
 | `--key` | `None` | 用于认证的 API key |
@@ -1253,7 +1254,7 @@ notes.[-R].md
 
 ### 流水线并发
 
-`MAX_PARALLEL_INSERT` 控制并行处理的文件数量。`MAX_ASYNC_LLM`(兼容旧名:`MAX_ASYNC`)控制并发 LLM 调用，包括抽取、合并、查询关键词生成和最终回答生成。解析压力较大的部署可以使用可选的分阶段流水线变量，例如 `MAX_PARALLEL_PARSE_NATIVE`、`MAX_PARALLEL_PARSE_MINERU`、`MAX_PARALLEL_PARSE_DOCLING` 和 `MAX_PARALLEL_ANALYZE`。
+`MAX_PARALLEL_INSERT` 控制并行处理的文件数量，不控制单个文档内的 chunk 或图合并 task 上限。`MAX_ASYNC_LLM`（兼容旧名：`MAX_ASYNC`）是基础 LLM 并发；对每个文档，它将 chunk 的实体/关系抽取 task 限制为 `MAX_ASYNC_LLM` 个，并将每个实体合并或关系合并阶段限制为 `2 × MAX_ASYNC_LLM` 个 task。实际 Extract 角色 LLM 请求在设置了 `EXTRACT_MAX_ASYNC_LLM` 时使用该值，否则使用 `MAX_ASYNC_LLM`；该角色覆盖不会改变流水线 task 上限。解析压力较大的部署可以使用可选的分阶段流水线变量，例如 `MAX_PARALLEL_PARSE_NATIVE`、`MAX_PARALLEL_PARSE_MINERU`、`MAX_PARALLEL_PARSE_DOCLING` 和 `MAX_PARALLEL_ANALYZE`。完整拓扑见[文件处理流水线规格](./FileProcessingPipeline-zh.md#86-流水线并发参数)。
 
 当处理循环 busy 时，上传和文本插入仍可被接受；运行中的循环会被通知并拾取新 pending 文档。`/documents/clear`、单文档删除等破坏性任务，以及 `/documents/scan` 的分类阶段仍会拒绝并发入队，以保护存储一致性。失败文件可通过 WebUI 重新处理，也可以触发 `/documents/scan`。
 

--- a/docs/LightRAG-API-Server.md
+++ b/docs/LightRAG-API-Server.md
@@ -568,7 +568,8 @@ Though LightRAG Server uses one worker to process the document indexing pipeline
 WORKERS=2
 ### Number of parallel files to process in one batch
 MAX_PARALLEL_INSERT=3
-### Max concurrent requests to the LLM (MAX_ASYNC is still accepted as a deprecated alias)
+### Base LLM concurrency and the per-document chunk-extraction task limit
+### (MAX_ASYNC is still accepted as a deprecated alias)
 MAX_ASYNC_LLM=4
 ```
 
@@ -977,7 +978,7 @@ Only the graph moves; vector and KV data are untouched and stay valid, because t
 | `--working-dir` | `./rag_storage` | Working directory for RAG storage |
 | `--input-dir` | `./inputs` | Directory containing uploaded/input documents |
 | `--timeout` | `150` | Gunicorn worker timeout and fallback request timeout |
-| `--max-async` | `4` | Maximum concurrent LLM operations |
+| `--max-async` | `4` | Base maximum LLM concurrency; also the per-document chunk-extraction task limit (each entity/relation merge phase uses twice this task limit) |
 | `--log-level` | `INFO` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`) |
 | `--verbose` | `False` | Verbose debug output, effective with debug logging |
 | `--key` | `None` | API key for authentication |
@@ -1253,7 +1254,7 @@ For the full routing syntax, supported extensions, parser cache behavior, chunke
 
 ### Pipeline Concurrency
 
-`MAX_PARALLEL_INSERT` controls how many files are processed in parallel. `MAX_ASYNC_LLM` (deprecated alias: `MAX_ASYNC`) controls concurrent LLM calls, including extraction, merging, query keyword generation, and final answer generation. Optional staged-pipeline variables such as `MAX_PARALLEL_PARSE_NATIVE`, `MAX_PARALLEL_PARSE_MINERU`, `MAX_PARALLEL_PARSE_DOCLING`, and `MAX_PARALLEL_ANALYZE` can be used for parser-heavy deployments.
+`MAX_PARALLEL_INSERT` controls how many files are processed in parallel; it does not set the per-document chunk or graph-merge task limit. `MAX_ASYNC_LLM` (deprecated alias: `MAX_ASYNC`) is the base LLM concurrency and, for each document, caps chunk entity/relation extraction tasks at `MAX_ASYNC_LLM` and each entity-merge or relation-merge phase at `2 × MAX_ASYNC_LLM` tasks. The Extract role's actual LLM requests use `EXTRACT_MAX_ASYNC_LLM` when configured, otherwise `MAX_ASYNC_LLM`; this role override does not change the pipeline task limits. Optional staged-pipeline variables such as `MAX_PARALLEL_PARSE_NATIVE`, `MAX_PARALLEL_PARSE_MINERU`, `MAX_PARALLEL_PARSE_DOCLING`, and `MAX_PARALLEL_ANALYZE` can be used for parser-heavy deployments. See [File Processing Pipeline Specification](./FileProcessingPipeline.md#86-pipeline-concurrency-parameters) for the complete topology.
 
 Uploads and text inserts can be accepted while the processing loop is busy; the running loop is nudged to pick up the new pending work. Destructive jobs such as document clear/delete and the classification phase of `/documents/scan` still reject concurrent enqueues to protect storage consistency. Failed files can be reprocessed from the WebUI or by triggering `/documents/scan`.
 

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -88,7 +88,7 @@ Notes:
 | **llm_model_name** | `str` | LLM model name for generation | `gpt-4o-mini` |
 | **summary_context_size** | `int` | Maximum tokens send to LLM to generate summaries for entity relation merging | `10000`（configured by env var SUMMARY_CONTEXT_SIZE) |
 | **summary_max_tokens** | `int` | Maximum token size for entity/relation description | `500`（configured by env var SUMMARY_MAX_TOKENS) |
-| **llm_model_max_async** | `int` | Maximum number of concurrent asynchronous LLM processes | `4`（default value changed by env var MAX_ASYNC_LLM; MAX_ASYNC is still accepted as a deprecated alias) |
+| **llm_model_max_async** | `int` | Base maximum LLM concurrency; also caps per-document chunk extraction tasks, while each entity/relation merge phase uses twice this task limit | `4`（default value changed by env var MAX_ASYNC_LLM; MAX_ASYNC is still accepted as a deprecated alias; `EXTRACT_MAX_ASYNC_LLM` can independently limit actual Extract-role requests) |
 | **llm_model_kwargs** | `dict` | Additional parameters for LLM generation | |
 | **vector_db_storage_cls_kwargs** | `dict` | Additional parameters for vector database, like setting the threshold for nodes and relations retrieval | cosine_better_than_threshold: 0.2（default value changed by env var COSINE_THRESHOLD) |
 | **enable_llm_cache** | `bool` | If `TRUE`, stores LLM results in cache; repeated prompts return cached responses | `TRUE` |

--- a/docs/RoleSpecificLLMConfiguration-zh.md
+++ b/docs/RoleSpecificLLMConfiguration-zh.md
@@ -43,6 +43,12 @@ MAX_ASYNC_LLM=4
 | `LLM_TIMEOUT` | 基础 LLM timeout。角色未设置 timeout 时继承它。 |
 | `MAX_ASYNC_LLM` | 基础 LLM 最大并发。角色未设置 `{ROLE}_MAX_ASYNC_LLM` 时继承它。`MAX_ASYNC` 作为兼容旧名仍可用。 |
 
+### 与文件处理的关系
+
+`MAX_ASYNC_LLM` 还是文件处理调度器使用的基础值：对单个文档，文本块的实体/关系抽取最多并发运行这么多 task；每个实体合并或关系合并阶段最多运行其两倍数量的 task。这些是流水线 task 上限，不会替代角色级请求限流。
+
+Extract 角色既处理文本块抽取，也在图合并时生成描述摘要。设置 `EXTRACT_MAX_ASYNC_LLM` 后，它会限制该角色实际发出的 LLM 请求；未设置时继承 `MAX_ASYNC_LLM`。调整此角色覆盖值不会改变调度器的单文档 task 上限。完整 worker 拓扑见[文件处理流水线规格](FileProcessingPipeline-zh.md#86-流水线并发参数)。
+
 ## 角色覆盖变量
 
 每个角色都可以覆盖 binding、模型、endpoint、API key、并发和 timeout：

--- a/docs/RoleSpecificLLMConfiguration.md
+++ b/docs/RoleSpecificLLMConfiguration.md
@@ -43,6 +43,12 @@ Common fields:
 | `LLM_TIMEOUT` | Base LLM timeout. A role inherits it when no role timeout is set. |
 | `MAX_ASYNC_LLM` | Base maximum LLM concurrency. A role inherits it when `{ROLE}_MAX_ASYNC_LLM` is not set. `MAX_ASYNC` is still accepted as a deprecated alias. |
 
+### File-processing interaction
+
+`MAX_ASYNC_LLM` is also the base value used by the file-processing scheduler: for one document, chunk entity/relation extraction runs at most this many tasks concurrently, and each entity-merge or relation-merge phase runs at most twice this many tasks. These are pipeline task limits, not a replacement for role-level request limiting.
+
+The Extract role performs both chunk extraction and description summaries during graph merging. `EXTRACT_MAX_ASYNC_LLM`, when set, limits its actual LLM requests; otherwise it inherits `MAX_ASYNC_LLM`. Changing this role override does not change the scheduler's per-document task limits. See [File Processing Pipeline Specification](FileProcessingPipeline.md#86-pipeline-concurrency-parameters) for the complete worker topology.
+
 ## Role Override Variables
 
 Each role can override the binding, model, endpoint, API key, concurrency, and timeout:

--- a/env.example
+++ b/env.example
@@ -915,8 +915,13 @@ DOCLING_DO_FORMULA_ENRICHMENT=false
 ########################################
 ### Pipeline Concurrency Configuration
 ########################################
-### Number of parallel processing documents(between 2~10, MAX_ASYNC_LLM/3 is recommended)
+### Number of parallel processing documents (between 2~10, MAX_ASYNC_LLM/3 is recommended).
+### This does not set per-document chunk extraction or graph-merge task limits.
 MAX_PARALLEL_INSERT=3
+### For each document, MAX_ASYNC_LLM caps chunk entity/relation extraction tasks;
+### each entity-merge or relation-merge phase caps tasks at 2 * MAX_ASYNC_LLM.
+### EXTRACT_MAX_ASYNC_LLM limits the actual Extract-role LLM requests and does
+### not change those pipeline task limits.
 ### Optional per-stage document pipeline concurrency
 # MAX_PARALLEL_PARSE_NATIVE=5
 # MAX_PARALLEL_PARSE_MINERU=1
@@ -1003,7 +1008,10 @@ LLM_BINDING_HOST=https://api.openai.com/v1
 LLM_BINDING_API_KEY=your_api_key
 LLM_MODEL=gpt-5.4-mini
 
-### Max concurrency requests of LLM
+### Base maximum concurrency for LLM roles and file-pipeline task scheduling.
+### Per document, it caps chunk entity/relation extraction tasks; each entity
+### or relation merge phase uses twice this task limit. EXTRACT_MAX_ASYNC_LLM
+### can separately limit actual Extract-role requests without changing them.
 ### MAX_ASYNC is still accepted as a deprecated alias
 ### NOTE: with gunicorn multi-worker (lightrag-gunicorn --workers N) every
 ###       MAX_ASYNC_* / *_MAX_ASYNC_* setting (LLM roles, embedding, rerank)
@@ -1029,6 +1037,8 @@ MAX_ASYNC_LLM=4
 ###   docs/RoleSpecificLLMConfiguration-zh.md
 ###########################################################################
 # EXTRACT_LLM_MODEL=gpt-5.4-mini
+### Overrides only the actual Extract-role LLM request limit; file-pipeline
+### chunk and merge task limits above still use MAX_ASYNC_LLM.
 # EXTRACT_MAX_ASYNC_LLM=4
 # EXTRACT_LLM_TIMEOUT=240
 # EXTRACT_LLM_BINDING=openai


### PR DESCRIPTION
## Description

Clarify how the base LLM concurrency setting affects file-processing work, so operators can tune document throughput without confusing per-file task limits, actual Extract-role requests, and parallel-file workers.

## Related Issues

N/A

## Changes Made

- Documented `MAX_ASYNC_LLM` as the per-document chunk-extraction task limit and the basis for the `2 ×` entity/relation merge-task limit.
- Distinguished `MAX_PARALLEL_INSERT` (parallel documents) from those per-document task limits.
- Documented `EXTRACT_MAX_ASYNC_LLM` as the optional limit for actual Extract-role LLM requests, and corrected the obsolete `EXTRACT_ASYNC_LLM` name.
- Synchronized the README translations, environment example, pipeline, role, API, Docker, and SDK configuration documentation.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

Validation: `pre-commit run --files ...` and `git diff --check` passed. This is documentation-only; no unit test is applicable.
