### PR TITLE
fix(anthropic): mark token-limited responses

### DIFF
--- a/lightrag/llm/anthropic.py
+++ b/lightrag/llm/anthropic.py
@@ -30,6 +30,7 @@ from tenacity import (
 from lightrag.utils import (
     safe_unicode_decode,
     logger,
+    TruncatedResponse,
 )
 from lightrag.api import __api_version__
 
@@ -220,7 +221,10 @@ async def anthropic_complete_if_cache(
 
     if not stream:
         try:
-            return response.content[0].text
+            content = response.content[0].text
+            if getattr(response, "stop_reason", None) == "max_tokens":
+                content = TruncatedResponse(content)
+            return content
         finally:
             try:
                 await anthropic_async_client.close()

--- a/tests/llm/anthropic_impl/test_anthropic_truncation.py
+++ b/tests/llm/anthropic_impl/test_anthropic_truncation.py
@@ -1,0 +1,52 @@
+"""Offline tests for Anthropic token-limit truncation handling."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lightrag.llm.anthropic import anthropic_complete_if_cache
+from lightrag.utils import is_truncated_response
+
+pytestmark = pytest.mark.offline
+
+
+def _make_client(*, text: str, stop_reason: str) -> SimpleNamespace:
+    response = SimpleNamespace(
+        content=[SimpleNamespace(text=text)], stop_reason=stop_reason
+    )
+    return SimpleNamespace(
+        messages=SimpleNamespace(create=AsyncMock(return_value=response)),
+        close=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_max_tokens_stop_reason_marks_result_truncated():
+    partial = '{"entities":[{"name":"Ali'
+    client = _make_client(text=partial, stop_reason="max_tokens")
+
+    with patch("lightrag.llm.anthropic.AsyncAnthropic", return_value=client):
+        result = await anthropic_complete_if_cache.__wrapped__(
+            model="claude-test", prompt="Extract", api_key="test-key"
+        )
+
+    assert result == partial
+    assert is_truncated_response(result) is True
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_end_turn_stop_reason_remains_plain_string():
+    complete = '{"entities":[]}'
+    client = _make_client(text=complete, stop_reason="end_turn")
+
+    with patch("lightrag.llm.anthropic.AsyncAnthropic", return_value=client):
+        result = await anthropic_complete_if_cache.__wrapped__(
+            model="claude-test", prompt="Extract", api_key="test-key"
+        )
+
+    assert result == complete
+    assert type(result) is str
+    assert is_truncated_response(result) is False
+    client.close.assert_awaited_once()


### PR DESCRIPTION
## Description

Anthropic responses stopped by `max_tokens` were treated as complete and could be cached. This marks them as truncated using the existing `TruncatedResponse` handling.

## Related Issues

No related issue.

## Changes Made

* Handle Anthropic `max_tokens` stop reasons.
* Add tests for truncated and completed responses.

## Tests

* Anthropic tests: 14 passed
* Pre-commit: passed

## Checklist

* [x] Changes tested locally
* [x] Code reviewed
* [x] Documentation not required
* [x] Unit tests added

## Additional Notes

Normal `end_turn` responses remain unchanged. The change only affects non-streaming responses stopped by the token limit.
