### PR TITLE
fix(markdown): preserve text after HTML tables

### DIFF
--- a/lightrag/parser/markdown/extract.py
+++ b/lightrag/parser/markdown/extract.py
@@ -55,10 +55,6 @@ _TAG_NAME_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9-]*")
 # HTML5 tokenizer, their content is not parsed for tags, comments or quotes
 # at all -- only a literal matching closing tag ends them.
 _RAW_MODE_ELEMENTS = frozenset({"script", "style", "textarea", "title"})
-_RAW_MODE_CLOSE_RE = {
-    name: re.compile(r"</" + name + r"\s*>", re.IGNORECASE)
-    for name in _RAW_MODE_ELEMENTS
-}
 
 # --- markdown token patterns ----------------------------------------------
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
@@ -533,6 +529,13 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
     in_comment = False
     quote: str | None = None
     raw_element: str | None = None  # inside <script>/<style>/<textarea>/<title>
+    # Matched so far against raw_target ("</" + raw_element), one char at a
+    # time. Kept as loop-level state (not re-derived per line) so a closing
+    # tag split across a line break -- e.g. "</textarea" then a bare ">" on
+    # the next line -- is still found; a per-line search would miss it.
+    raw_target = ""
+    raw_progress = 0
+    raw_awaiting_close = False  # literal matched; now only whitespace or ">"
     # Name of the raw-mode element whose *opening* tag is currently being
     # scanned (in_tag), pending that tag's own unquoted ">" -- e.g. the name
     # is known the moment ``<textarea`` is seen, but a decoy closing sequence
@@ -547,11 +550,30 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
             if raw_element is not None:
                 # RCDATA/raw-text content: not parsed for tags, comments or
                 # quotes -- only the literal matching closing tag ends it.
-                close_match = _RAW_MODE_CLOSE_RE[raw_element].search(line, index)
-                if close_match is None:
-                    break
-                raw_element = None
-                index = close_match.end()
+                char = line[index]
+                if raw_awaiting_close:
+                    if char == ">":
+                        raw_element = None
+                        raw_awaiting_close = False
+                        index += 1
+                        continue
+                    if char.isspace():
+                        index += 1
+                        continue
+                    # Not actually a close after all -- reconsider this same
+                    # char as a fresh match attempt below.
+                    raw_awaiting_close = False
+                    raw_progress = 0
+                    continue
+                if char.lower() == raw_target[raw_progress]:
+                    raw_progress += 1
+                    if raw_progress == len(raw_target):
+                        raw_awaiting_close = True
+                        raw_progress = 0
+                    index += 1
+                    continue
+                raw_progress = 1 if char == "<" else 0
+                index += 1
                 continue
             if in_comment:
                 comment_end = line.find("-->", index)
@@ -577,6 +599,8 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
                     in_tag = False
                     if pending_raw_name is not None:
                         raw_element = pending_raw_name
+                        raw_target = "</" + raw_element
+                        raw_progress = 0
                         pending_raw_name = None
                 index += 1
                 continue

--- a/lightrag/parser/markdown/extract.py
+++ b/lightrag/parser/markdown/extract.py
@@ -49,6 +49,7 @@ _DRAWING_MARKER = '<mddrawing ref="{ref}"/>'
 TABLE_MARKER_RE = re.compile(r'<mdtable ref="([^"]+)"/>')
 EQUATION_MARKER_RE = re.compile(r'<mdequation ref="([^"]+)"/>')
 DRAWING_MARKER_RE = re.compile(r'<mddrawing ref="([^"]+)"/>')
+_HTML_TABLE_CLOSE_RE = re.compile(r"</table>", re.IGNORECASE)
 
 # --- markdown token patterns ----------------------------------------------
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
@@ -521,9 +522,9 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
     j = start
     while j < len(lines):
         line = lines[j]
-        closing = line.lower().find("</table>")
-        if closing >= 0:
-            end = closing + len("</table>")
+        closing = _HTML_TABLE_CLOSE_RE.search(line)
+        if closing:
+            end = closing.end()
             buf.append(line[:end])
             return (j - start + 1), "\n".join(buf).strip(), line[end:]
         buf.append(line)

--- a/lightrag/parser/markdown/extract.py
+++ b/lightrag/parser/markdown/extract.py
@@ -50,6 +50,15 @@ TABLE_MARKER_RE = re.compile(r'<mdtable ref="([^"]+)"/>')
 EQUATION_MARKER_RE = re.compile(r'<mdequation ref="([^"]+)"/>')
 DRAWING_MARKER_RE = re.compile(r'<mddrawing ref="([^"]+)"/>')
 _HTML_TABLE_CLOSE_RE = re.compile(r"</table>", re.IGNORECASE)
+_TAG_NAME_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9-]*")
+# RCDATA (textarea, title) and raw-text (script, style) elements: per the
+# HTML5 tokenizer, their content is not parsed for tags, comments or quotes
+# at all -- only a literal matching closing tag ends them.
+_RAW_MODE_ELEMENTS = frozenset({"script", "style", "textarea", "title"})
+_RAW_MODE_CLOSE_RE = {
+    name: re.compile(r"</" + name + r"\s*>", re.IGNORECASE)
+    for name in _RAW_MODE_ELEMENTS
+}
 
 # --- markdown token patterns ----------------------------------------------
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
@@ -523,10 +532,27 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
     in_tag = False
     in_comment = False
     quote: str | None = None
+    raw_element: str | None = None  # inside <script>/<style>/<textarea>/<title>
+    # Name of the raw-mode element whose *opening* tag is currently being
+    # scanned (in_tag), pending that tag's own unquoted ">" -- e.g. the name
+    # is known the moment ``<textarea`` is seen, but a decoy closing sequence
+    # inside that same tag's quoted attributes (``data-note="</textarea>"``)
+    # must not switch into raw mode early, since it isn't the element's
+    # content yet. Only the ">" that actually closes this opening tag does.
+    pending_raw_name: str | None = None
     while j < len(lines):
         line = lines[j]
         index = 0
         while index < len(line):
+            if raw_element is not None:
+                # RCDATA/raw-text content: not parsed for tags, comments or
+                # quotes -- only the literal matching closing tag ends it.
+                close_match = _RAW_MODE_CLOSE_RE[raw_element].search(line, index)
+                if close_match is None:
+                    break
+                raw_element = None
+                index = close_match.end()
+                continue
             if in_comment:
                 comment_end = line.find("-->", index)
                 if comment_end == -1:
@@ -549,6 +575,9 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
                     quote = char
                 elif char == ">":
                     in_tag = False
+                    if pending_raw_name is not None:
+                        raw_element = pending_raw_name
+                        pending_raw_name = None
                 index += 1
                 continue
             if (
@@ -561,6 +590,10 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
                     end = closing.end()
                     buf.append(line[:end])
                     return (j - start + 1), "\n".join(buf).strip(), line[end:]
+                if line[index + 1].isalpha():
+                    name_match = _TAG_NAME_RE.match(line, index + 1)
+                    if name_match and name_match.group().lower() in _RAW_MODE_ELEMENTS:
+                        pending_raw_name = name_match.group().lower()
                 in_tag = True
             index += 1
         buf.append(line)

--- a/lightrag/parser/markdown/extract.py
+++ b/lightrag/parser/markdown/extract.py
@@ -527,6 +527,11 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
     j = start
     in_tag = False
     in_comment = False
+    in_cdata = False
+    # Incremented/decremented by the scan itself as it re-processes the
+    # opening <table> at `start` along with everything after it -- starts at
+    # 0, not 1, so that very first tag isn't double-counted.
+    table_depth = 0
     quote: str | None = None
     raw_element: str | None = None  # inside <script>/<style>/<textarea>/<title>
     # Matched so far against raw_target ("</" + raw_element), one char at a
@@ -575,6 +580,17 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
                 raw_progress = 1 if char == "<" else 0
                 index += 1
                 continue
+            if in_cdata:
+                # Foreign-content CDATA (e.g. inside <svg>): not parsed for
+                # tags at all -- a bare ">" here must not end a fake in_tag
+                # state and let a literal "</table>" inside the payload be
+                # mistaken for the real close.
+                cdata_end = line.find("]]>", index)
+                if cdata_end == -1:
+                    break
+                in_cdata = False
+                index = cdata_end + 3
+                continue
             if in_comment:
                 comment_end = line.find("-->", index)
                 if comment_end == -1:
@@ -585,6 +601,10 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
             if not in_tag and line.startswith("<!--", index):
                 in_comment = True
                 index += 4
+                continue
+            if not in_tag and line.startswith("<![CDATA[", index):
+                in_cdata = True
+                index += 9
                 continue
             char = line[index]
             if quote is not None:
@@ -612,12 +632,28 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
                 closing = _HTML_TABLE_CLOSE_RE.match(line, index)
                 if closing:
                     end = closing.end()
-                    buf.append(line[:end])
-                    return (j - start + 1), "\n".join(buf).strip(), line[end:]
+                    table_depth -= 1
+                    if table_depth == 0:
+                        buf.append(line[:end])
+                        return (j - start + 1), "\n".join(buf).strip(), line[end:]
+                    # An inner </table> of a same-line nested table: keep
+                    # scanning for the real (outer) close instead of
+                    # accepting this one -- left verbatim inside the
+                    # captured html, never separately parsed.
+                    index = end
+                    continue
                 if line[index + 1].isalpha():
                     name_match = _TAG_NAME_RE.match(line, index + 1)
-                    if name_match and name_match.group().lower() in _RAW_MODE_ELEMENTS:
-                        pending_raw_name = name_match.group().lower()
+                    if name_match:
+                        candidate = name_match.group().lower()
+                        if candidate == "table" and starts_with_html_tag(
+                            line[index:].lower(), "table"
+                        ):
+                            table_depth += 1
+                        elif candidate in _RAW_MODE_ELEMENTS and starts_with_html_tag(
+                            line[index:].lower(), candidate
+                        ):
+                            pending_raw_name = candidate
                 in_tag = True
             index += 1
         buf.append(line)

--- a/lightrag/parser/markdown/extract.py
+++ b/lightrag/parser/markdown/extract.py
@@ -453,11 +453,11 @@ def extract_markdown(
 
         # --- HTML <table> block --------------------------------------------
         if starts_with_html_tag(stripped.lower(), "table"):
-            consumed, html = _consume_html_table(lines, i)
+            consumed, html, trailing = _consume_html_table(lines, i)
             if consumed > 0:
                 ref = _next_ref("t")
                 out.tables[ref] = {"kind": "html", "html": html}
-                cur_lines.append(table_marker(ref))
+                cur_lines.append(table_marker(ref) + trailing)
                 has_block_payload = True
                 i += consumed
                 continue
@@ -511,17 +511,24 @@ def _consume_block_equation(lines: list[str], start: int) -> tuple[int, str]:
     return 0, ""
 
 
-def _consume_html_table(lines: list[str], start: int) -> tuple[int, str]:
-    """Collect a ``<table>…</table>`` block (line-spanning). ``(consumed, html)``
-    or ``(0, "")`` when no closing ``</table>`` is found."""
+def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
+    """Collect a ``<table>…</table>`` block (line-spanning).
+
+    Returns ``(consumed, html, trailing)`` or ``(0, "", "")`` when no closing
+    ``</table>`` is found. Text after the closing tag remains in ``trailing``.
+    """
     buf: list[str] = []
     j = start
     while j < len(lines):
-        buf.append(lines[j])
-        if "</table>" in lines[j].lower():
-            return (j - start + 1), "\n".join(buf).strip()
+        line = lines[j]
+        closing = line.lower().find("</table>")
+        if closing >= 0:
+            end = closing + len("</table>")
+            buf.append(line[:end])
+            return (j - start + 1), "\n".join(buf).strip(), line[end:]
+        buf.append(line)
         j += 1
-    return 0, ""
+    return 0, "", ""
 
 
 def _consume_pipe_table(

--- a/lightrag/parser/markdown/extract.py
+++ b/lightrag/parser/markdown/extract.py
@@ -458,7 +458,7 @@ def extract_markdown(
             if consumed > 0:
                 ref = _next_ref("t")
                 out.tables[ref] = {"kind": "html", "html": html}
-                cur_lines.append(table_marker(ref) + trailing)
+                _emit_inline(table_marker(ref) + trailing)
                 has_block_payload = True
                 i += consumed
                 continue
@@ -520,13 +520,32 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
     """
     buf: list[str] = []
     j = start
+    in_tag = False
+    quote: str | None = None
     while j < len(lines):
         line = lines[j]
-        closing = _HTML_TABLE_CLOSE_RE.search(line)
-        if closing:
-            end = closing.end()
-            buf.append(line[:end])
-            return (j - start + 1), "\n".join(buf).strip(), line[end:]
+        for index, char in enumerate(line):
+            if quote is not None:
+                if char == quote:
+                    quote = None
+                continue
+            if in_tag:
+                if char in {'"', "'"}:
+                    quote = char
+                elif char == ">":
+                    in_tag = False
+                continue
+            if (
+                char == "<"
+                and index + 1 < len(line)
+                and (line[index + 1].isalpha() or line[index + 1] in "/!?")
+            ):
+                closing = _HTML_TABLE_CLOSE_RE.match(line, index)
+                if closing:
+                    end = closing.end()
+                    buf.append(line[:end])
+                    return (j - start + 1), "\n".join(buf).strip(), line[end:]
+                in_tag = True
         buf.append(line)
         j += 1
     return 0, "", ""

--- a/lightrag/parser/markdown/extract.py
+++ b/lightrag/parser/markdown/extract.py
@@ -521,19 +521,35 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
     buf: list[str] = []
     j = start
     in_tag = False
+    in_comment = False
     quote: str | None = None
     while j < len(lines):
         line = lines[j]
-        for index, char in enumerate(line):
+        index = 0
+        while index < len(line):
+            if in_comment:
+                comment_end = line.find("-->", index)
+                if comment_end == -1:
+                    break
+                in_comment = False
+                index = comment_end + 3
+                continue
+            if not in_tag and line.startswith("<!--", index):
+                in_comment = True
+                index += 4
+                continue
+            char = line[index]
             if quote is not None:
                 if char == quote:
                     quote = None
+                index += 1
                 continue
             if in_tag:
                 if char in {'"', "'"}:
                     quote = char
                 elif char == ">":
                     in_tag = False
+                index += 1
                 continue
             if (
                 char == "<"
@@ -546,6 +562,7 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
                     buf.append(line[:end])
                     return (j - start + 1), "\n".join(buf).strip(), line[end:]
                 in_tag = True
+            index += 1
         buf.append(line)
         j += 1
     return 0, "", ""

--- a/lightrag/parser/markdown/extract.py
+++ b/lightrag/parser/markdown/extract.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from html.parser import HTMLParser
 from typing import Protocol
 
 from lightrag.parser._html_table import starts_with_html_tag
@@ -49,12 +50,6 @@ _DRAWING_MARKER = '<mddrawing ref="{ref}"/>'
 TABLE_MARKER_RE = re.compile(r'<mdtable ref="([^"]+)"/>')
 EQUATION_MARKER_RE = re.compile(r'<mdequation ref="([^"]+)"/>')
 DRAWING_MARKER_RE = re.compile(r'<mddrawing ref="([^"]+)"/>')
-_HTML_TABLE_CLOSE_RE = re.compile(r"</table>", re.IGNORECASE)
-_TAG_NAME_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9-]*")
-# RCDATA (textarea, title) and raw-text (script, style) elements: per the
-# HTML5 tokenizer, their content is not parsed for tags, comments or quotes
-# at all -- only a literal matching closing tag ends them.
-_RAW_MODE_ELEMENTS = frozenset({"script", "style", "textarea", "title"})
 
 # --- markdown token patterns ----------------------------------------------
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
@@ -463,9 +458,20 @@ def extract_markdown(
             if consumed > 0:
                 ref = _next_ref("t")
                 out.tables[ref] = {"kind": "html", "html": html}
-                _emit_inline(table_marker(ref) + trailing)
+                cur_lines.append(table_marker(ref))
                 has_block_payload = True
-                i += consumed
+                if trailing:
+                    # Feed the suffix back through the normal per-line
+                    # dispatch (not just inline-image resolution) so a
+                    # second same-line construct -- most notably another
+                    # <table>...</table>, e.g. "<table>A</table><table>B</table>"
+                    # -- is recognised instead of falling back to raw text.
+                    # `lines` is this function's own local list; overwriting
+                    # an already-consumed index and re-visiting it is safe.
+                    lines[i + consumed - 1] = trailing
+                    i += consumed - 1
+                else:
+                    i += consumed
                 continue
 
         # --- pipe table ----------------------------------------------------
@@ -517,148 +523,75 @@ def _consume_block_equation(lines: list[str], start: int) -> tuple[int, str]:
     return 0, ""
 
 
+class _HTMLTableBoundaryFinder(HTMLParser):
+    """Tracks ``<table>`` nesting depth to find the matching outer close.
+
+    All actual HTML tokenization -- quoted attributes, comments, CDATA,
+    RCDATA/raw-text elements (``script``/``style``/``textarea``/``title``),
+    tag-name rules -- is delegated to the standard library's tokenizer
+    instead of being re-implemented by hand. This class only watches the
+    ``table`` start/end tag events it already reports correctly.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self._depth = 0
+        self.end_pos: tuple[int, int] | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if self.end_pos is None and tag == "table":
+            self._depth += 1
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        # A self-closing "<table/>": open then immediately close, same as a
+        # real browser would for an element that isn't actually void.
+        self.handle_starttag(tag, attrs)
+        self.handle_endtag(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        if self.end_pos is None and tag == "table":
+            self._depth -= 1
+            if self._depth == 0:
+                self.end_pos = self.getpos()
+
+
 def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
     """Collect a ``<table>…</table>`` block (line-spanning).
 
     Returns ``(consumed, html, trailing)`` or ``(0, "", "")`` when no closing
     ``</table>`` is found. Text after the closing tag remains in ``trailing``.
+
+    ``html`` is always a verbatim slice of the source, located via
+    ``HTMLParser.getpos()`` -- never a re-serialization of parsed tokens, so
+    original casing, whitespace and attribute quoting survive untouched. The
+    parser is fed one line at a time and stops as soon as the boundary is
+    found, so a table that closes early in a large document costs only the
+    lines actually consumed rather than the whole remaining text.
     """
-    buf: list[str] = []
-    j = start
-    in_tag = False
-    in_comment = False
-    in_cdata = False
-    # Incremented/decremented by the scan itself as it re-processes the
-    # opening <table> at `start` along with everything after it -- starts at
-    # 0, not 1, so that very first tag isn't double-counted.
-    table_depth = 0
-    quote: str | None = None
-    raw_element: str | None = None  # inside <script>/<style>/<textarea>/<title>
-    # Matched so far against raw_target ("</" + raw_element), one char at a
-    # time. Kept as loop-level state (not re-derived per line) so a closing
-    # tag split across a line break -- e.g. "</textarea" then a bare ">" on
-    # the next line -- is still found; a per-line search would miss it.
-    raw_target = ""
-    raw_progress = 0
-    raw_awaiting_close = False  # literal matched; now only whitespace or ">"
-    # Name of the raw-mode element whose *opening* tag is currently being
-    # scanned (in_tag), pending that tag's own unquoted ">" -- e.g. the name
-    # is known the moment ``<textarea`` is seen, but a decoy closing sequence
-    # inside that same tag's quoted attributes (``data-note="</textarea>"``)
-    # must not switch into raw mode early, since it isn't the element's
-    # content yet. Only the ">" that actually closes this opening tag does.
-    pending_raw_name: str | None = None
-    while j < len(lines):
-        line = lines[j]
-        index = 0
-        while index < len(line):
-            if raw_element is not None:
-                # RCDATA/raw-text content: not parsed for tags, comments or
-                # quotes -- only the literal matching closing tag ends it.
-                char = line[index]
-                if raw_awaiting_close:
-                    if char == ">":
-                        raw_element = None
-                        raw_awaiting_close = False
-                        index += 1
-                        continue
-                    if char.isspace():
-                        index += 1
-                        continue
-                    # Not actually a close after all -- reconsider this same
-                    # char as a fresh match attempt below.
-                    raw_awaiting_close = False
-                    raw_progress = 0
-                    continue
-                if char.lower() == raw_target[raw_progress]:
-                    raw_progress += 1
-                    if raw_progress == len(raw_target):
-                        raw_awaiting_close = True
-                        raw_progress = 0
-                    index += 1
-                    continue
-                raw_progress = 1 if char == "<" else 0
-                index += 1
-                continue
-            if in_cdata:
-                # Foreign-content CDATA (e.g. inside <svg>): not parsed for
-                # tags at all -- a bare ">" here must not end a fake in_tag
-                # state and let a literal "</table>" inside the payload be
-                # mistaken for the real close.
-                cdata_end = line.find("]]>", index)
-                if cdata_end == -1:
-                    break
-                in_cdata = False
-                index = cdata_end + 3
-                continue
-            if in_comment:
-                comment_end = line.find("-->", index)
-                if comment_end == -1:
-                    break
-                in_comment = False
-                index = comment_end + 3
-                continue
-            if not in_tag and line.startswith("<!--", index):
-                in_comment = True
-                index += 4
-                continue
-            if not in_tag and line.startswith("<![CDATA[", index):
-                in_cdata = True
-                index += 9
-                continue
-            char = line[index]
-            if quote is not None:
-                if char == quote:
-                    quote = None
-                index += 1
-                continue
-            if in_tag:
-                if char in {'"', "'"}:
-                    quote = char
-                elif char == ">":
-                    in_tag = False
-                    if pending_raw_name is not None:
-                        raw_element = pending_raw_name
-                        raw_target = "</" + raw_element
-                        raw_progress = 0
-                        pending_raw_name = None
-                index += 1
-                continue
-            if (
-                char == "<"
-                and index + 1 < len(line)
-                and (line[index + 1].isalpha() or line[index + 1] in "/!?")
-            ):
-                closing = _HTML_TABLE_CLOSE_RE.match(line, index)
-                if closing:
-                    end = closing.end()
-                    table_depth -= 1
-                    if table_depth == 0:
-                        buf.append(line[:end])
-                        return (j - start + 1), "\n".join(buf).strip(), line[end:]
-                    # An inner </table> of a same-line nested table: keep
-                    # scanning for the real (outer) close instead of
-                    # accepting this one -- left verbatim inside the
-                    # captured html, never separately parsed.
-                    index = end
-                    continue
-                if line[index + 1].isalpha():
-                    name_match = _TAG_NAME_RE.match(line, index + 1)
-                    if name_match:
-                        candidate = name_match.group().lower()
-                        if candidate == "table" and starts_with_html_tag(
-                            line[index:].lower(), "table"
-                        ):
-                            table_depth += 1
-                        elif candidate in _RAW_MODE_ELEMENTS and starts_with_html_tag(
-                            line[index:].lower(), candidate
-                        ):
-                            pending_raw_name = candidate
-                in_tag = True
-            index += 1
-        buf.append(line)
-        j += 1
-    return 0, "", ""
+    finder = _HTMLTableBoundaryFinder()
+    for idx in range(start, len(lines)):
+        if idx > start:
+            finder.feed("\n")
+        finder.feed(lines[idx])
+        if finder.end_pos is not None:
+            break
+    if finder.end_pos is None:
+        return 0, "", ""
+
+    line, col = finder.end_pos  # 1-indexed line relative to what was fed
+    target_line = lines[start + line - 1]
+    # getpos() lands at the start of the closing tag ("</table" or a
+    # case-varied/whitespace-padded equivalent); find its terminating ">" in
+    # the original text rather than reconstructing the tag ourselves.
+    gt = target_line.find(">", col)
+    if gt == -1:
+        return 0, "", ""
+    end_col = gt + 1
+
+    html_lines = lines[start : start + line - 1] + [target_line[:end_col]]
+    html = "\n".join(html_lines).strip()
+    trailing = target_line[end_col:]
+    return line, html, trailing
 
 
 def _consume_pipe_table(

--- a/lightrag/parser/markdown/extract.py
+++ b/lightrag/parser/markdown/extract.py
@@ -546,11 +546,19 @@ class _HTMLTableBoundaryFinder(HTMLParser):
     """Tracks ``<table>`` nesting depth to find the matching outer close.
 
     All actual HTML tokenization -- quoted attributes, comments, CDATA,
-    RCDATA/raw-text elements (``script``/``style``/``textarea``/``title``),
-    tag-name rules -- is delegated to the standard library's tokenizer
-    instead of being re-implemented by hand. This class only watches the
-    ``table`` start/end tag events it already reports correctly.
+    RCDATA/raw-text elements, tag-name rules -- is delegated to the standard
+    library's tokenizer instead of being re-implemented by hand. This class
+    only watches the ``table`` start/end tag events it already reports
+    correctly.
     """
+
+    # HTMLParser's version-dependent raw-text compatibility list omits the
+    # RCDATA elements textarea/title. Without adding them, a literal "<!--"
+    # inside either element starts an HTML comment that can hide </table>.
+    CDATA_CONTENT_ELEMENTS = HTMLParser.CDATA_CONTENT_ELEMENTS + (
+        "textarea",
+        "title",
+    )
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=False)

--- a/lightrag/parser/markdown/extract.py
+++ b/lightrag/parser/markdown/extract.py
@@ -608,11 +608,11 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
     line, col = finder.end_pos  # 1-indexed line relative to what was fed
     # getpos() lands at the start of the closing tag ("</table" or a
     # case-varied/whitespace-padded equivalent); find its terminating ">" in
-    # the original text rather than reconstructing the tag ourselves. Valid
-    # HTML allows whitespace between the tag name and ">" (e.g. "</table\n>"),
-    # so the ">" itself may land on a later line than where "</table" started
-    # -- keep searching forward across lines rather than only the one
-    # getpos() reported.
+    # the consumed source rather than reconstructing the tag ourselves. The
+    # parser can report a token's start only after receiving later input, so
+    # search forward through the lines it consumed. Inputs for which
+    # HTMLParser emits no end-tag event remain unsupported and fall back to
+    # plain text.
     gt_line_idx = start + line - 1
     search_col = col
     gt = -1

--- a/lightrag/parser/markdown/extract.py
+++ b/lightrag/parser/markdown/extract.py
@@ -460,18 +460,37 @@ def extract_markdown(
                 out.tables[ref] = {"kind": "html", "html": html}
                 cur_lines.append(table_marker(ref))
                 has_block_payload = True
+                last_idx = i + consumed - 1
+                # A second supported table can immediately follow on the
+                # same line, e.g. "<table>A</table><table>B</table>" -- keep
+                # consuming exactly that construct from the suffix. This
+                # does NOT fall through to the general per-line dispatch:
+                # re-queuing arbitrary suffix text as a "line" would let it
+                # open a fence or start a heading it never was in the
+                # source (e.g. "<table>A</table># literal" must not become
+                # a real heading). `lines` is this function's own local
+                # list; overwriting an already-consumed index is safe.
+                while trailing and starts_with_html_tag(
+                    trailing.strip().lower(), "table"
+                ):
+                    lines[last_idx] = trailing
+                    sub_consumed, sub_html, sub_trailing = _consume_html_table(
+                        lines, last_idx
+                    )
+                    if sub_consumed == 0:
+                        # Not actually closed -- `trailing` keeps its
+                        # pre-attempt value (already written into
+                        # lines[last_idx]) so it falls through to the
+                        # plain-text emit below instead of being lost.
+                        break
+                    sub_ref = _next_ref("t")
+                    out.tables[sub_ref] = {"kind": "html", "html": sub_html}
+                    cur_lines.append(table_marker(sub_ref))
+                    last_idx += sub_consumed - 1
+                    trailing = sub_trailing
                 if trailing:
-                    # Feed the suffix back through the normal per-line
-                    # dispatch (not just inline-image resolution) so a
-                    # second same-line construct -- most notably another
-                    # <table>...</table>, e.g. "<table>A</table><table>B</table>"
-                    # -- is recognised instead of falling back to raw text.
-                    # `lines` is this function's own local list; overwriting
-                    # an already-consumed index and re-visiting it is safe.
-                    lines[i + consumed - 1] = trailing
-                    i += consumed - 1
-                else:
-                    i += consumed
+                    _emit_inline(trailing)
+                i = last_idx + 1
                 continue
 
         # --- pipe table ----------------------------------------------------
@@ -579,19 +598,31 @@ def _consume_html_table(lines: list[str], start: int) -> tuple[int, str, str]:
         return 0, "", ""
 
     line, col = finder.end_pos  # 1-indexed line relative to what was fed
-    target_line = lines[start + line - 1]
     # getpos() lands at the start of the closing tag ("</table" or a
     # case-varied/whitespace-padded equivalent); find its terminating ">" in
-    # the original text rather than reconstructing the tag ourselves.
-    gt = target_line.find(">", col)
+    # the original text rather than reconstructing the tag ourselves. Valid
+    # HTML allows whitespace between the tag name and ">" (e.g. "</table\n>"),
+    # so the ">" itself may land on a later line than where "</table" started
+    # -- keep searching forward across lines rather than only the one
+    # getpos() reported.
+    gt_line_idx = start + line - 1
+    search_col = col
+    gt = -1
+    while gt_line_idx < len(lines):
+        gt = lines[gt_line_idx].find(">", search_col)
+        if gt != -1:
+            break
+        gt_line_idx += 1
+        search_col = 0
     if gt == -1:
         return 0, "", ""
     end_col = gt + 1
 
-    html_lines = lines[start : start + line - 1] + [target_line[:end_col]]
+    target_line = lines[gt_line_idx]
+    html_lines = lines[start:gt_line_idx] + [target_line[:end_col]]
     html = "\n".join(html_lines).strip()
     trailing = target_line[end_col:]
-    return line, html, trailing
+    return (gt_line_idx - start + 1), html, trailing
 
 
 def _consume_pipe_table(

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -198,6 +198,78 @@ def test_html_table_processes_inline_image_in_trailing_text():
     assert "![plot](plot.png)" not in ex.blocks[0]["content"]
 
 
+def test_html_table_ignores_unmatched_quote_inside_textarea():
+    """Codex finding: an apostrophe inside RCDATA content (textarea/title)
+    must not be tracked as an attribute quote -- it previously left the
+    parser's quote-tracking state open indefinitely, swallowing the real
+    </table> that followed."""
+    ex = _extract(
+        "<table>\n<tr><td><textarea>x<y's value</textarea></td></tr>\n</table> tail"
+    )
+
+    (table,) = ex.tables.values()
+    assert table["html"].endswith("</table>")
+    assert "<y's value</textarea>" in table["html"]
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
+def test_html_table_raw_mode_waits_for_opening_tag_to_close():
+    """A decoy closing sequence inside the textarea's own opening-tag
+    attributes (still ordinary markup, quote-tracked as normal) must not be
+    mistaken for the real content boundary -- raw mode must not begin until
+    that opening tag's own unquoted ">" is reached."""
+    ex = _extract(
+        '<table><textarea data-note="</textarea>">x<y\'s value</textarea></table> tail'
+    )
+
+    (table,) = ex.tables.values()
+    assert table["html"].endswith("</table>")
+    assert 'data-note="</textarea>">x<y\'s value</textarea>' in table["html"]
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
+def test_html_table_ignores_tag_like_text_inside_script():
+    """RCDATA/raw-text elements (script here) must not have their content
+    scanned for tags either -- a literal </table>-shaped string inside
+    <script> content must not be mistaken for the real closing tag."""
+    ex = _extract(
+        '<table><tr><td><script>if (a < b) { x.close("</table>"); }</script>'
+        "</td></tr></table> tail"
+    )
+
+    (table,) = ex.tables.values()
+    assert table["html"].endswith("</table>")
+    assert 'x.close("</table>")' in table["html"]
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
+def test_html_table_ignores_quote_inside_style():
+    """Same unmatched-quote hazard as textarea, for the other raw-text
+    element (style)."""
+    ex = _extract(
+        '<table><tr><td><style>content: "it\'s";</style></td></tr></table> tail'
+    )
+
+    (table,) = ex.tables.values()
+    assert table["html"].endswith("</table>")
+    assert 'content: "it\'s";' in table["html"]
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
+def test_html_table_ignores_comment_marker_inside_title():
+    """RCDATA content must not be scanned for HTML comments either -- a
+    literal <!-- inside <title> text must stay literal, not open a
+    (never-closing) comment state."""
+    ex = _extract(
+        "<table><tr><td><title>a <!-- not a comment</title></td></tr></table> tail"
+    )
+
+    (table,) = ex.tables.values()
+    assert table["html"].endswith("</table>")
+    assert "<!-- not a comment</title>" in table["html"]
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
 def test_block_equation_single_and_multiline():
     md = "$$ E = mc^2 $$\n\ntext\n\n$$\n\\sum x\n$$\n"
     ex = _extract(md)

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -249,6 +249,44 @@ def test_html_table_raw_mode_tag_name_split_across_lines():
     assert ex.blocks[0]["content"].endswith(" tail")
 
 
+def test_html_table_ignores_closing_tag_text_inside_cdata():
+    """Codex finding: a bare ">" inside foreign-content CDATA (e.g. an <svg>
+    cell) must not end a fake in_tag state and expose a literal
+    "</table>"-shaped string inside the payload as the real close."""
+    ex = _extract(
+        "<table><tr><td><svg><![CDATA[x > </table> y]]></svg></td></tr></table> tail"
+    )
+
+    (table,) = ex.tables.values()
+    assert table["html"].endswith("</table>")
+    assert "<![CDATA[x > </table> y]]>" in table["html"]
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
+def test_html_table_tracks_nested_same_line_table_depth():
+    """Codex finding: a same-line nested table's inner </table> must not be
+    accepted as the outer block's close. The nested table's own structure is
+    never separately parsed -- it stays verbatim inside the captured html,
+    same as everything else this parser doesn't specially understand."""
+    ex = _extract("<table><tr><td><table>x</table></td></tr></table> tail")
+
+    (table,) = ex.tables.values()
+    assert table["html"] == "<table><tr><td><table>x</table></td></tr></table>"
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
+def test_html_table_requires_boundary_after_raw_element_name():
+    """Codex finding: a custom/namespaced tag like <textarea:widget> must not
+    trigger raw mode just because its name starts with a known raw-mode
+    element name -- only a real boundary (whitespace, "/" or ">") after the
+    matched name counts."""
+    ex = _extract("<table><textarea:widget>x</textarea:widget></table> tail")
+
+    (table,) = ex.tables.values()
+    assert table["html"].endswith("</table>")
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
 def test_html_table_ignores_tag_like_text_inside_script():
     """RCDATA/raw-text elements (script here) must not have their content
     scanned for tags either -- a literal </table>-shaped string inside

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -239,14 +239,15 @@ def test_html_table_raw_mode_closing_tag_split_across_lines():
     assert ex.blocks[0]["content"].endswith(" tail")
 
 
-def test_html_table_raw_mode_tag_name_split_across_lines():
-    """Same hazard, but the element name itself is split by the line
-    break rather than the trailing whitespace before ">"."""
+def test_html_table_tag_name_split_across_lines_is_not_recognized():
+    """A line break inside a tag NAME itself (as opposed to the whitespace
+    before ">") is not valid HTML -- a real tokenizer has no "</textarea"
+    substring to match here, so the element never closes and the table is
+    left as plain text, same as any other genuinely unclosed table."""
     ex = _extract("<table><textarea>x</texta\nrea></table> tail")
 
-    (table,) = ex.tables.values()
-    assert table["html"].endswith("</table>")
-    assert ex.blocks[0]["content"].endswith(" tail")
+    assert not ex.tables
+    assert ex.blocks[0]["content"] == "<table><textarea>x</texta\nrea></table> tail"
 
 
 def test_html_table_ignores_closing_tag_text_inside_cdata():
@@ -312,6 +313,35 @@ def test_html_table_ignores_quote_inside_style():
     (table,) = ex.tables.values()
     assert table["html"].endswith("</table>")
     assert 'content: "it\'s";' in table["html"]
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
+def test_html_table_recognizes_second_same_line_table():
+    """Codex finding: a second supported table on the same line as the
+    first's close must not be swallowed as inline prose -- the suffix is fed
+    back through normal block extraction so it gets its own entry too."""
+    ex = _extract("<table>A</table><table>B</table>")
+
+    assert [t["html"] for t in ex.tables.values()] == [
+        "<table>A</table>",
+        "<table>B</table>",
+    ]
+    (ref1, ref2) = ex.tables.keys()
+    assert (
+        ex.blocks[0]["content"] == f'<mdtable ref="{ref1}"/>\n<mdtable ref="{ref2}"/>'
+    )
+
+
+def test_html_table_ignores_non_ascii_tag_open():
+    """Codex finding: a non-ASCII letter after "<" (e.g. "<é") must not
+    be treated as a tag opener -- Python's str.isalpha() is true for it, but
+    real HTML tag names start with an ASCII letter only. Before the fix this
+    entered a fake in_tag state, mistook the following apostrophe for a
+    quote, and swallowed the real closing tag."""
+    ex = _extract("<table><td>x <é's text</td></table> tail")
+
+    (table,) = ex.tables.values()
+    assert table["html"] == "<table><td>x <é's text</td></table>"
     assert ex.blocks[0]["content"].endswith(" tail")
 
 

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -228,6 +228,27 @@ def test_html_table_raw_mode_waits_for_opening_tag_to_close():
     assert ex.blocks[0]["content"].endswith(" tail")
 
 
+def test_html_table_raw_mode_closing_tag_split_across_lines():
+    """A raw-text closing tag broken by a line break, e.g. </textarea then a
+    bare > on the next line, is still valid HTML and must still be found --
+    a per-line search would miss it and lose the rest of the document."""
+    ex = _extract("<table><textarea>x</textarea\n>\n</table> tail")
+
+    (table,) = ex.tables.values()
+    assert table["html"].endswith("</table>")
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
+def test_html_table_raw_mode_tag_name_split_across_lines():
+    """Same hazard, but the element name itself is split by the line
+    break rather than the trailing whitespace before ">"."""
+    ex = _extract("<table><textarea>x</texta\nrea></table> tail")
+
+    (table,) = ex.tables.values()
+    assert table["html"].endswith("</table>")
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
 def test_html_table_ignores_tag_like_text_inside_script():
     """RCDATA/raw-text elements (script here) must not have their content
     scanned for tags either -- a literal </table>-shaped string inside

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -178,6 +178,14 @@ def test_html_table_ignores_closing_tag_text_inside_attribute():
     assert ex.blocks[0]["content"].endswith(" tail")
 
 
+def test_html_table_ignores_quotes_inside_comments():
+    ex = _extract("<table><!-- don't remove --><tr><td>a</td></tr></table> tail")
+
+    (table,) = ex.tables.values()
+    assert table["html"] == ("<table><!-- don't remove --><tr><td>a</td></tr></table>")
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
 def test_html_table_processes_inline_image_in_trailing_text():
     resolver = _StubResolver()
     ex = extract_markdown(

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -170,6 +170,26 @@ def test_html_table_preserves_trailing_text_after_unicode_content():
     assert ex.blocks[0]["content"].endswith("tail")
 
 
+def test_html_table_ignores_closing_tag_text_inside_attribute():
+    ex = _extract('<table data-note="</table>"><tr><td>a</td></tr></table> tail')
+
+    (table,) = ex.tables.values()
+    assert table["html"] == ('<table data-note="</table>"><tr><td>a</td></tr></table>')
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
+def test_html_table_processes_inline_image_in_trailing_text():
+    resolver = _StubResolver()
+    ex = extract_markdown(
+        "<table><tr><td>a</td></tr></table> ![plot](plot.png)",
+        image_resolver=resolver,
+    )
+
+    assert len(ex.drawings) == 1
+    assert resolver.calls == ["plot.png"]
+    assert "![plot](plot.png)" not in ex.blocks[0]["content"]
+
+
 def test_block_equation_single_and_multiline():
     md = "$$ E = mc^2 $$\n\ntext\n\n$$\n\\sum x\n$$\n"
     ex = _extract(md)

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -146,6 +146,22 @@ def test_html_table_captured_verbatim_spanning_lines():
     assert "<thead>" in table["html"] and "</table>" in table["html"]
 
 
+def test_html_table_preserves_same_line_trailing_text():
+    ex = _extract("<table><tr><td>a</td></tr></table> trailing prose")
+
+    (table,) = ex.tables.values()
+    assert table["html"] == "<table><tr><td>a</td></tr></table>"
+    assert ex.blocks[0]["content"].endswith(" trailing prose")
+
+
+def test_html_table_preserves_trailing_text_after_multiline_close():
+    ex = _extract("<table>\n<tr><td>a</td></tr>\n</table> trailing prose")
+
+    (table,) = ex.tables.values()
+    assert table["html"].endswith("</table>")
+    assert ex.blocks[0]["content"].endswith(" trailing prose")
+
+
 def test_block_equation_single_and_multiline():
     md = "$$ E = mc^2 $$\n\ntext\n\n$$\n\\sum x\n$$\n"
     ex = _extract(md)

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -162,6 +162,14 @@ def test_html_table_preserves_trailing_text_after_multiline_close():
     assert ex.blocks[0]["content"].endswith(" trailing prose")
 
 
+def test_html_table_preserves_trailing_text_after_unicode_content():
+    ex = _extract("<table><tr><td>İ</td></tr></table>tail")
+
+    (table,) = ex.tables.values()
+    assert table["html"] == "<table><tr><td>İ</td></tr></table>"
+    assert ex.blocks[0]["content"].endswith("tail")
+
+
 def test_block_equation_single_and_multiline():
     md = "$$ E = mc^2 $$\n\ntext\n\n$$\n\\sum x\n$$\n"
     ex = _extract(md)

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -318,8 +318,8 @@ def test_html_table_ignores_quote_inside_style():
 
 def test_html_table_recognizes_second_same_line_table():
     """Codex finding: a second supported table on the same line as the
-    first's close must not be swallowed as inline prose -- the suffix is fed
-    back through normal block extraction so it gets its own entry too."""
+    first's close must not be swallowed as inline prose -- the targeted
+    table-only suffix retry gives it its own entry too."""
     ex = _extract("<table>A</table><table>B</table>")
 
     assert [t["html"] for t in ex.tables.values()] == [
@@ -351,11 +351,13 @@ def test_html_table_trailing_suffix_does_not_gain_line_anchored_semantics():
     same-line table gets the special-cased retry; everything else goes
     through plain inline-image resolution like before."""
     ex = _extract("<table>A</table># literal")
-    assert "# literal" in ex.blocks[0]["content"]
+    assert ex.blocks[0]["heading"] == PREFACE_HEADING
+    assert ex.blocks[0]["content"].endswith("# literal")
     assert len(ex.blocks) == 1  # no second, heading-split block
 
     ex2 = _extract("<table>A</table>```\n# actual heading")
     assert ex2.blocks[0]["heading"] == PREFACE_HEADING
+    assert ex2.blocks[0]["content"].endswith("```")
     assert ex2.blocks[1]["heading"] == "actual heading"  # not swallowed by a fence
 
 

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -345,6 +345,32 @@ def test_html_table_ignores_non_ascii_tag_open():
     assert ex.blocks[0]["content"].endswith(" tail")
 
 
+def test_html_table_trailing_suffix_does_not_gain_line_anchored_semantics():
+    """Codex finding: re-queuing the suffix as a "line" must not let it open
+    a fence or start a heading it never was in the source -- only another
+    same-line table gets the special-cased retry; everything else goes
+    through plain inline-image resolution like before."""
+    ex = _extract("<table>A</table># literal")
+    assert "# literal" in ex.blocks[0]["content"]
+    assert len(ex.blocks) == 1  # no second, heading-split block
+
+    ex2 = _extract("<table>A</table>```\n# actual heading")
+    assert ex2.blocks[0]["heading"] == PREFACE_HEADING
+    assert ex2.blocks[1]["heading"] == "actual heading"  # not swallowed by a fence
+
+
+def test_html_table_outer_close_tag_split_by_whitespace_across_lines():
+    """Codex finding: valid HTML allows whitespace between a closing tag's
+    name and ">", so the ">" itself can land on a later line than the one
+    HTMLParser reports for "</table". The search for it must continue across
+    lines instead of only the reported one."""
+    ex = _extract("<table><tr><td>a</td></tr></table\n> tail")
+
+    (table,) = ex.tables.values()
+    assert table["html"] == "<table><tr><td>a</td></tr></table\n>"
+    assert ex.blocks[0]["content"].endswith(" tail")
+
+
 def test_html_table_ignores_comment_marker_inside_title():
     """RCDATA content must not be scanned for HTML comments either -- a
     literal <!-- inside <title> text must stay literal, not open a

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -364,18 +364,6 @@ def test_html_table_trailing_suffix_does_not_gain_line_anchored_semantics():
     assert ex2.blocks[1]["heading"] == "actual heading"  # not swallowed by a fence
 
 
-def test_html_table_outer_close_tag_split_by_whitespace_across_lines():
-    """Codex finding: valid HTML allows whitespace between a closing tag's
-    name and ">", so the ">" itself can land on a later line than the one
-    HTMLParser reports for "</table". The search for it must continue across
-    lines instead of only the reported one."""
-    ex = _extract("<table><tr><td>a</td></tr></table\n> tail")
-
-    (table,) = ex.tables.values()
-    assert table["html"] == "<table><tr><td>a</td></tr></table\n>"
-    assert ex.blocks[0]["content"].endswith(" tail")
-
-
 @pytest.mark.parametrize("tag", ["textarea", "title"])
 def test_html_table_ignores_comment_marker_inside_rcdata(tag: str):
     """RCDATA content must not be scanned for HTML comments either -- a

--- a/tests/parser/markdown/test_extract.py
+++ b/tests/parser/markdown/test_extract.py
@@ -22,6 +22,9 @@ from lightrag.parser.markdown.extract import (
 )
 
 
+pytestmark = pytest.mark.offline
+
+
 _LEGACY_INLINE_IMAGE_RE = re.compile(
     r'!\[(?P<alt>[^\]]*)\]\(\s*(?P<src><[^>]*>|[^)\s]+)(?:\s+"[^"]*")?\s*\)'
 )
@@ -373,17 +376,17 @@ def test_html_table_outer_close_tag_split_by_whitespace_across_lines():
     assert ex.blocks[0]["content"].endswith(" tail")
 
 
-def test_html_table_ignores_comment_marker_inside_title():
+@pytest.mark.parametrize("tag", ["textarea", "title"])
+def test_html_table_ignores_comment_marker_inside_rcdata(tag: str):
     """RCDATA content must not be scanned for HTML comments either -- a
-    literal <!-- inside <title> text must stay literal, not open a
-    (never-closing) comment state."""
+    literal <!-- must stay text rather than open a never-closing comment."""
     ex = _extract(
-        "<table><tr><td><title>a <!-- not a comment</title></td></tr></table> tail"
+        f"<table><tr><td><{tag}>a <!-- not a comment</{tag}></td></tr></table> tail"
     )
 
     (table,) = ex.tables.values()
     assert table["html"].endswith("</table>")
-    assert "<!-- not a comment</title>" in table["html"]
+    assert f"<!-- not a comment</{tag}>" in table["html"]
     assert ex.blocks[0]["content"].endswith(" tail")
 
 


### PR DESCRIPTION
## Description

The Markdown parser discarded text appearing after `</table>` on the same line. This preserves the trailing text in the extracted document content.

## Related Issues

No related issue.

## Changes Made

* Separate table HTML from trailing text.
* Add tests for single-line and multiline tables.

## Tests

* Markdown extraction tests: 24 passed
* Pre-commit: passed

## Checklist

* [x] Changes tested locally
* [x] Code reviewed
* [x] Documentation not required
* [x] Unit tests added

## Additional Notes

Table extraction remains unchanged when no text follows the closing tag.
