### PR TITLE
fix(hf): avoid caching truncated responses

### DIFF
--- a/lightrag/llm/hf.py
+++ b/lightrag/llm/hf.py
@@ -27,7 +27,7 @@ from lightrag.exceptions import (
 )
 import torch
 import numpy as np
-from lightrag.utils import wrap_embedding_func_with_attrs
+from lightrag.utils import TruncatedResponse, wrap_embedding_func_with_attrs
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -123,9 +123,28 @@ async def hf_model_if_cache(
         num_return_sequences=1,
         early_stopping=True,
     )
-    response_text = hf_tokenizer.decode(
-        output[0][len(inputs["input_ids"][0]) :], skip_special_tokens=True
+    generated_ids = output[0][len(inputs["input_ids"][0]) :]
+    response_text = hf_tokenizer.decode(generated_ids, skip_special_tokens=True)
+
+    eos_token_id = getattr(
+        getattr(hf_model, "generation_config", None), "eos_token_id", None
     )
+    if eos_token_id is None:
+        eos_token_id = getattr(hf_tokenizer, "eos_token_id", None)
+    eos_token_ids = (
+        set(eos_token_id)
+        if isinstance(eos_token_id, (list, tuple, set))
+        else {eos_token_id}
+        if eos_token_id is not None
+        else set()
+    )
+    last_token_id = generated_ids[-1].item() if len(generated_ids) else None
+    if (
+        max_new_tokens is not None
+        and len(generated_ids) >= max_new_tokens
+        and last_token_id not in eos_token_ids
+    ):
+        response_text = TruncatedResponse(response_text)
 
     return response_text
 

--- a/tests/llm/hf_impl/test_hf_model_if_cache_device_placement.py
+++ b/tests/llm/hf_impl/test_hf_model_if_cache_device_placement.py
@@ -76,6 +76,9 @@ class FakeTensor:
     def __getitem__(self, idx):
         return FakeTensor(self.data[idx], self.device, self._host_has_cuda)
 
+    def item(self):
+        return self.data
+
     def __repr__(self):
         return f"FakeTensor(data={self.data!r}, device={self.device.type!r})"
 
@@ -84,6 +87,8 @@ class FakeModel:
     def __init__(self, device):
         self.device = FakeDevice(device)
         self.received_kwargs = None
+        self.generated_ids = [901, 902]
+        self.generation_config = types.SimpleNamespace(eos_token_id=0)
 
     def generate(self, **kwargs):
         self.received_kwargs = kwargs
@@ -97,7 +102,7 @@ class FakeModel:
                 f"{input_ids.device.type}:0!"
             )
         prompt_ids = input_ids.data[0]
-        generated_ids = prompt_ids + [901, 902]  # arbitrary new-token suffix
+        generated_ids = prompt_ids + self.generated_ids
         return FakeTensor([generated_ids], self.device, input_ids._host_has_cuda)
 
 
@@ -105,6 +110,7 @@ class FakeTokenizer:
     def __init__(self, prompt_ids, host_has_cuda=True):
         self._prompt_ids = list(prompt_ids)
         self._host_has_cuda = host_has_cuda
+        self.eos_token_id = 0
 
     def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
         return "<rendered-prompt>"
@@ -250,3 +256,30 @@ async def test_generation_token_limit_precedence(
 
     assert fake_model.received_kwargs["max_new_tokens"] == expected_max_new_tokens
     assert "max_tokens" not in fake_model.received_kwargs
+
+
+@pytest.mark.asyncio
+async def test_token_limited_generation_is_marked_truncated(monkeypatch):
+    hf_module, fake_model, _ = make_hf_module(
+        monkeypatch, model_device="cpu", host_has_cuda=False
+    )
+
+    result = await hf_module.hf_model_if_cache(
+        "fake-model", "hello world", max_new_tokens=2
+    )
+
+    assert isinstance(result, hf_module.TruncatedResponse)
+
+
+@pytest.mark.asyncio
+async def test_eos_completion_at_token_limit_is_not_marked_truncated(monkeypatch):
+    hf_module, fake_model, _ = make_hf_module(
+        monkeypatch, model_device="cpu", host_has_cuda=False
+    )
+    fake_model.generated_ids = [901, 0]
+
+    result = await hf_module.hf_model_if_cache(
+        "fake-model", "hello world", max_new_tokens=2
+    )
+
+    assert type(result) is str


### PR DESCRIPTION
## Problem

Hugging Face responses that exhausted `max_new_tokens` were cached as complete.

## Change

Mark token-limited responses as truncated while preserving natural EOS completions.

## Tests

* Hugging Face tests: 18 passed
* Pre-commit: passed

## Compatibility and Risk

Low risk. Normal completions and model generation settings are unchanged.

## Related Issue

No related issue.
