### PR TITLE
fix: apply chunk transforms across ingestion paths

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -542,6 +542,25 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     tiktoken_model_name: str = field(default="gpt-4o-mini")
     """Model name used for tokenization when chunking text with tiktoken. Defaults to `gpt-4o-mini`."""
 
+    chunk_transform_func: (
+        Callable[
+            [list[dict[str, Any]], Any],
+            Union[
+                list[dict[str, Any]],
+                tuple[dict[str, Any], ...],
+                Awaitable[Union[list[dict[str, Any]], tuple[dict[str, Any], ...]]],
+            ],
+        ]
+        | None
+    ) = field(default=None)
+    """Optional instance-level transform applied after any base chunker completes.
+
+    The callback receives the chunk dictionaries and an immutable document
+    context. It may be synchronous or asynchronous and must return a list or
+    tuple containing only dictionaries. ``None`` preserves the existing
+    pipeline behavior exactly.
+    """
+
     chunking_func: Callable[
         [
             Tokenizer,

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -457,6 +457,42 @@ _CUSTOM_CHUNKING_METHOD = "custom_chunking_func"
 _CUSTOM_CHUNKING_FALLBACK_METHOD = "custom_chunking_fallback_fixed_token"
 
 
+@dataclass(frozen=True)
+class ChunkTransformContext:
+    """Immutable document context supplied to ``chunk_transform_func``."""
+
+    doc_id: str
+    file_path: str | None
+    process_options: str
+    sidecar_location: str | None
+
+
+async def _apply_chunk_transform(
+    transform: Any,
+    chunks: list[dict[str, Any]] | tuple[dict[str, Any], ...],
+    context: ChunkTransformContext,
+) -> list[dict[str, Any]] | tuple[dict[str, Any], ...]:
+    """Apply and validate the optional post-chunking transform."""
+    if transform is None:
+        return chunks
+    try:
+        result = transform(chunks, context)
+        if inspect.isawaitable(result):
+            result = await result
+    except Exception as exc:
+        raise RuntimeError(
+            f"chunk_transform_func failed for d-id {context.doc_id}: {exc}"
+        ) from exc
+    if not isinstance(result, (list, tuple)) or not all(
+        isinstance(chunk, dict) for chunk in result
+    ):
+        raise TypeError(
+            "chunk_transform_func must return a list or tuple of dicts "
+            f"for d-id {context.doc_id}, got {type(result)}"
+        )
+    return result
+
+
 _CHUNK_LOG_KEY_ALIASES: dict[str, str] = {
     "chunk_overlap_token_size": "overlap",
     "breakpoint_threshold_type": "break",
@@ -5237,6 +5273,17 @@ class _PipelineMixin:
                         f"chunking_func must return a list or tuple of dicts, "
                         f"got {type(chunking_result)}"
                     )
+
+                chunking_result = await _apply_chunk_transform(
+                    self.chunk_transform_func,
+                    chunking_result,
+                    ChunkTransformContext(
+                        doc_id=doc_id,
+                        file_path=file_path,
+                        process_options=(content_data or {}).get("process_options", ""),
+                        sidecar_location=(content_data or {}).get("sidecar_location"),
+                    ),
+                )
 
                 # Reflect the format actually persisted in full_docs.
                 # Previously a structured-parse fallback always tagged

--- a/tests/pipeline/test_custom_chunking_selector.py
+++ b/tests/pipeline/test_custom_chunking_selector.py
@@ -442,3 +442,122 @@ def test_reprocess_persisted_c_after_callback_removal_uses_observable_fallback(
         assert len(warnings) == 1
 
     asyncio.run(_run())
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("process_options", ["F!", "!"])
+def test_chunk_transform_runs_after_builtin_and_legacy_chunkers(
+    tmp_path, process_options
+):
+    captured = {}
+
+    def _transform(chunks, context):
+        captured["chunks"] = chunks
+        captured["context"] = context
+        transformed = [dict(chunk) for chunk in chunks]
+        transformed[0]["content"] = f"transformed:{transformed[0]['content']}"
+        return transformed
+
+    async def _run():
+        rag = _new_rag(tmp_path, chunk_transform_func=_transform)
+        await rag.initialize_storages()
+        try:
+            row = await _ingest(
+                rag,
+                doc_id=f"doc-transform-{process_options or 'legacy'}",
+                process_options=process_options,
+            )
+        finally:
+            await rag.finalize_storages()
+
+        assert DocStatus(row["status"]) is DocStatus.PROCESSED
+        assert captured["chunks"]
+        context = captured["context"]
+        assert context.doc_id.startswith("doc-transform-")
+        assert context.file_path.endswith(".txt")
+        assert context.process_options == process_options
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_chunk_transform_awaits_async_callback(tmp_path):
+    calls = 0
+
+    async def _transform(chunks, context):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0)
+        return tuple(dict(chunk) for chunk in chunks)
+
+    async def _run():
+        rag = _new_rag(tmp_path, chunk_transform_func=_transform)
+        await rag.initialize_storages()
+        try:
+            row = await _ingest(
+                rag,
+                doc_id="doc-transform-async",
+                process_options="F!",
+            )
+        finally:
+            await rag.finalize_storages()
+
+        assert calls == 1
+        assert DocStatus(row["status"]) is DocStatus.PROCESSED
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("invalid_result", [None, {"content": "not-a-list"}, ["bad"]])
+def test_chunk_transform_rejects_invalid_return_value(tmp_path, invalid_result):
+    def _transform(chunks, context):
+        return invalid_result
+
+    async def _run():
+        rag = _new_rag(tmp_path, chunk_transform_func=_transform)
+        await rag.initialize_storages()
+        try:
+            row = await _ingest(
+                rag,
+                doc_id="doc-transform-invalid",
+                process_options="F!",
+            )
+        finally:
+            await rag.finalize_storages()
+
+        assert DocStatus(row["status"]) is DocStatus.FAILED
+        assert "doc-transform-invalid" in row["error_msg"]
+        assert "list or tuple of dicts" in row["error_msg"]
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_chunk_transform_exception_fails_document_with_doc_id(tmp_path):
+    def _transform(chunks, context):
+        raise ValueError("transform exploded")
+
+    async def _run():
+        rag = _new_rag(tmp_path, chunk_transform_func=_transform)
+        await rag.initialize_storages()
+        try:
+            row = await _ingest(
+                rag,
+                doc_id="doc-transform-error",
+                process_options="F!",
+            )
+        finally:
+            await rag.finalize_storages()
+
+        assert DocStatus(row["status"]) is DocStatus.FAILED
+        assert "doc-transform-error" in row["error_msg"]
+        assert "transform exploded" in row["error_msg"]
+
+    asyncio.run(_run())
+
+
+@pytest.mark.offline
+def test_default_chunk_transform_is_noop(tmp_path):
+    rag = _new_rag(tmp_path)
+    assert rag.chunk_transform_func is None


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

Apply an optional per-chunk transform after chunking so metadata and text breadcrumbs are preserved consistently across direct insertion, document upload, and document scan ingestion paths.

## Related Issues

Fixes #3603

## Changes Made

- Add a sync or async `chunk_transform_func` hook to `LightRAG`.
- Apply the hook to all chunk-producing ingestion paths.
- Validate transformed chunk shape and preserve deterministic chunk identifiers.
- Add focused regression coverage for direct, upload, and scan selectors.

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]


## Validation

- `python3.11 -m pytest -o 'addopts=' tests/pipeline/test_custom_chunking_selector.py -q` (14 passed)
- `pre-commit run --files lightrag/lightrag.py lightrag/pipeline.py tests/pipeline/test_custom_chunking_selector.py`
- `git diff --check`
