### PR TITLE
fix(webui): confirm document deletion by reading the pipeline level

### DIFF
--- a/lightrag_webui/src/features/DocumentManager.test.tsx
+++ b/lightrag_webui/src/features/DocumentManager.test.tsx
@@ -41,8 +41,9 @@ import { useBackendState } from '@/stores/state'
 
 const DOC_ID = 'doc-to-delete'
 const SURVIVOR_ID = 'doc-that-stays'
+const FAILED_ID = 'doc-that-failed'
 
-/** How long the simulated background deletion runs past its own response. */
+/** Default time the simulated background deletion runs past its own response. */
 const DELETION_COMMIT_MS = 150
 
 const makeDoc = (id: string): DocStatusResponse => ({
@@ -69,7 +70,15 @@ const makeDoc = (id: string): DocStatusResponse => ({
  */
 const backend = {
   docs: [makeDoc(DOC_ID), makeDoc(SURVIVOR_ID)],
+  /** Served for the "failed" filter tab, so a filter change is observable. */
+  failedDocs: [{ ...makeDoc(FAILED_ID), status: 'failed' as DocStatusResponse['status'] }],
+  commitDelayMs: DELETION_COMMIT_MS,
   deletionInFlight: false,
+  /** Keeps /health reporting busy, so the activity probe keeps its burst going. */
+  scanInFlight: false,
+  /** Status filters requested while `recordFilters` is on. */
+  requestedFilters: [] as (string | null)[],
+  recordFilters: false,
   paginatedCalls: 0,
   healthCalls: 0,
   deleteCalls: 0
@@ -77,24 +86,39 @@ const backend = {
 
 const resetBackend = () => {
   backend.docs = [makeDoc(DOC_ID), makeDoc(SURVIVOR_ID)]
+  backend.failedDocs = [
+    { ...makeDoc(FAILED_ID), status: 'failed' as DocStatusResponse['status'] }
+  ]
+  backend.commitDelayMs = DELETION_COMMIT_MS
   backend.deletionInFlight = false
+  backend.requestedFilters = []
+  backend.recordFilters = false
+  backend.scanInFlight = false
   backend.paginatedCalls = 0
   backend.healthCalls = 0
   backend.deleteCalls = 0
 }
 
-const paginate = (): PaginatedDocsResponse => ({
-  documents: backend.docs,
-  pagination: {
-    page: 1,
-    page_size: 10,
-    total_count: backend.docs.length,
-    total_pages: 1,
-    has_next: false,
-    has_prev: false
-  },
-  status_counts: { all: backend.docs.length, processed: backend.docs.length }
-})
+const paginate = (statusFilter: string | null): PaginatedDocsResponse => {
+  const documents = statusFilter === 'failed' ? backend.failedDocs : backend.docs
+
+  return {
+    documents,
+    pagination: {
+      page: 1,
+      page_size: 10,
+      total_count: documents.length,
+      total_pages: 1,
+      has_next: false,
+      has_prev: false
+    },
+    status_counts: {
+      all: backend.docs.length,
+      processed: backend.docs.length,
+      failed: backend.failedDocs.length
+    }
+  }
+}
 
 const respond = (config: any, data: unknown) => ({
   data,
@@ -109,16 +133,24 @@ const backendAdapter = async (config: any) => {
 
   if (url.endsWith('/documents/paginated')) {
     backend.paginatedCalls += 1
-    return respond(config, paginate())
+    const body = JSON.parse(config.data ?? '{}')
+    const statusFilter = body.status_filter ?? null
+    if (backend.recordFilters) backend.requestedFilters.push(statusFilter)
+    return respond(config, paginate(statusFilter))
   }
 
   if (url.endsWith('/health')) {
     backend.healthCalls += 1
     return respond(config, {
       status: 'healthy',
-      pipeline_busy: backend.deletionInFlight,
-      pipeline_active: backend.deletionInFlight
+      pipeline_busy: backend.deletionInFlight || backend.scanInFlight,
+      pipeline_active: backend.deletionInFlight || backend.scanInFlight
     })
+  }
+
+  if (url.endsWith('/documents/scan')) {
+    backend.scanInFlight = true
+    return respond(config, { status: 'scanning_started', message: 'ok' })
   }
 
   if (url.endsWith('/documents/delete_document')) {
@@ -130,7 +162,7 @@ const backendAdapter = async (config: any) => {
     setTimeout(() => {
       backend.docs = backend.docs.filter((doc) => !docIds.includes(doc.id))
       backend.deletionInFlight = false
-    }, DELETION_COMMIT_MS)
+    }, backend.commitDelayMs)
     return respond(config, {
       status: 'deletion_started',
       message: 'started',
@@ -141,12 +173,26 @@ const backendAdapter = async (config: any) => {
   return respond(config, {})
 }
 
+/**
+ * Wait until the list has stopped fetching. The stale-query refresh can be
+ * scheduled behind the throttle gate's 2s trailing timer, so an assertion that
+ * fires as soon as one request lands would finish before it.
+ */
+const waitForPaginatedQuiescence = async (quietMs = 2500, maxRounds = 6) => {
+  for (let round = 0; round < maxRounds; round += 1) {
+    const before = backend.paginatedCalls
+    await new Promise((resolve) => setTimeout(resolve, quietMs))
+    if (backend.paginatedCalls === before) return
+  }
+  throw new Error('document list never stopped fetching')
+}
+
 const rowFor = (docId: string) => {
   const cell = screen.queryAllByText(docId)[0]
   return cell?.closest('tr') ?? null
 }
 
-describe('DocumentManager deletion confirmation', () => {
+describe('DocumentManager post-action refreshes', () => {
   beforeEach(() => {
     resetBackend()
     __setAxiosAdapterForTests(backendAdapter)
@@ -212,5 +258,104 @@ describe('DocumentManager deletion confirmation', () => {
       expect(backend.healthCalls > healthCallsAtDelete).toBe(true)
     },
     20000
+  )
+
+  test(
+    'a refresh landing after a filter change queries the new view, not the old',
+    async () => {
+      // The probe outlives the render that created it, so the callback it holds
+      // must be resolved from CURRENT state. A captured one pairs an OLD query
+      // snapshot (page/filter/sort) with the CURRENT request version — the
+      // combination runRefreshRequest's staleness guard cannot catch, since it
+      // only compares versions — and the response overwrites the view the user
+      // navigated to.
+      //
+      // Asserted on the requests rather than the rendered rows: the clobber is
+      // self-healing within ~2s (the next refresh re-fetches the current view),
+      // so the DOM window is racy while "which query did we ask for" is exact.
+      backend.commitDelayMs = 3000
+      const user = userEvent.setup()
+      renderWithProviders(<DocumentManager />)
+
+      await waitFor(() => {
+        expect(rowFor(DOC_ID) === null).toBe(false)
+      })
+
+      const row = rowFor(DOC_ID)
+      await user.click(within(row as HTMLElement).getByRole('checkbox'))
+      await user.click(screen.getByRole('button', { name: /^Delete$/ }))
+      await user.type(screen.getByPlaceholderText('Type yes to confirm'), 'yes')
+      await user.click(screen.getByRole('button', { name: 'YES' }))
+
+      await waitFor(() => {
+        expect(backend.deleteCalls).toBe(1)
+      })
+
+      // Navigate away while the deletion is still running. Every paginated
+      // request from here on must carry the new filter.
+      backend.recordFilters = true
+      await user.click(screen.getByRole('button', { name: /^Failed/ }))
+      await waitFor(() => {
+        expect(screen.queryAllByText(FAILED_ID).length > 0).toBe(true)
+      })
+
+      // Wait out the deletion, then the probe's confirming refresh.
+      await waitFor(
+        () => {
+          expect(backend.deletionInFlight).toBe(false)
+        },
+        { timeout: 8000 }
+      )
+      const callsAtCommit = backend.paginatedCalls
+      await waitFor(
+        () => {
+          expect(backend.paginatedCalls > callsAtCommit).toBe(true)
+        },
+        { timeout: 8000 }
+      )
+      await waitForPaginatedQuiescence()
+
+      expect(backend.requestedFilters.filter((filter) => filter !== 'failed')).toHaveLength(0)
+      expect(screen.queryAllByText(SURVIVOR_ID)).toHaveLength(0)
+      expect(screen.queryAllByText(FAILED_ID).length > 0).toBe(true)
+    },
+    25000
+  )
+
+  test(
+    'the scan activity probe also refreshes the current view, not the captured one',
+    async () => {
+      // Same defect, wider window: the activity probe's burst runs for up to
+      // 16s off the closure captured when scan was clicked. Pre-existing, and
+      // fixed by the same latest-render ref.
+      const user = userEvent.setup()
+      renderWithProviders(<DocumentManager />)
+
+      await waitFor(() => {
+        expect(rowFor(DOC_ID) === null).toBe(false)
+      })
+
+      await user.click(screen.getByRole('button', { name: /^Scan\/Retry/ }))
+      await waitFor(() => {
+        expect(backend.scanInFlight).toBe(true)
+      })
+
+      backend.recordFilters = true
+      await user.click(screen.getByRole('button', { name: /^Failed/ }))
+      await waitFor(() => {
+        expect(screen.queryAllByText(FAILED_ID).length > 0).toBe(true)
+      })
+
+      // Two more probe refreshes (its 2s and 4s ticks) must query the new view.
+      await waitFor(
+        () => {
+          expect(backend.requestedFilters.length >= 3).toBe(true)
+        },
+        { timeout: 10000 }
+      )
+
+      expect(backend.requestedFilters.filter((filter) => filter !== 'failed')).toHaveLength(0)
+    },
+    25000
   )
 })

--- a/lightrag_webui/src/features/DocumentManager.test.tsx
+++ b/lightrag_webui/src/features/DocumentManager.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Rendered regression test for the "deleted rows linger on screen" bug.
+ *
+ * `/documents/delete_document` answers `deletion_started`: it reserves
+ * `busy` + `destructive_busy` before answering, and the background task
+ * releases them only after every `doc_status` row is gone. So the rows
+ * disappear at some point AFTER the response, and `pipeline_busy === false`
+ * observed after the response is proof they are gone.
+ *
+ * The scenario pinned here is a deletion that commits after the response but
+ * before the UI's first health check would have run: the UI then never sees a
+ * busy→idle TRANSITION, only `false → false`. What that used to leave:
+ *   - the one immediate refresh raced the background deletion and re-rendered
+ *     the row it was supposed to drop,
+ *   - the `pipelineActive` effect fires on a transition, so it refreshed
+ *     nothing,
+ *   - and `startPollingInterval(2000)` was destroyed by the polling effect —
+ *     every refresh hands `setStatusCounts` a fresh object, the effect re-runs
+ *     and reinstates the 30s idle cadence — before its first tick.
+ * The row therefore stayed on screen until the 30s idle poll.
+ *
+ * The probe's own timers and its dense observation window are what bring the
+ * row down here. The pure level reading (idle on the very first observation,
+ * because the busy window was missed entirely) is pinned in
+ * documentDeletionProbe.test.ts.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { cleanup, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import {
+  __resetPaginatedDocumentRequestsForTests,
+  __setAxiosAdapterForTests,
+  type DocStatusResponse,
+  type PaginatedDocsResponse
+} from '@/api/lightrag'
+import DocumentManager from '@/features/DocumentManager'
+import { renderWithProviders } from '@/test/render'
+import { useSettingsStore } from '@/stores/settings'
+import { useBackendState } from '@/stores/state'
+
+const DOC_ID = 'doc-to-delete'
+const SURVIVOR_ID = 'doc-that-stays'
+
+/** How long the simulated background deletion runs past its own response. */
+const DELETION_COMMIT_MS = 150
+
+const makeDoc = (id: string): DocStatusResponse => ({
+  id,
+  content_summary: `summary of ${id}`,
+  content_length: 42,
+  status: 'processed' as DocStatusResponse['status'],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  chunks_count: 1,
+  file_path: `${id}.txt`
+})
+
+/**
+ * Minimal document backend honouring the endpoint's ordering contract: while
+ * the deletion is in flight the pipeline reports busy, and it reports idle
+ * only once the rows are actually gone. A model that answered idle with the
+ * rows still present would be testing a backend that cannot exist.
+ *
+ * Driven through the api module's axios adapter seam rather than
+ * `mock.module`: a module mock leaks into whichever test file runs next (it
+ * broke `src/api/lightrag.test.ts`), while the adapter is restored by
+ * `__setAxiosAdapterForTests(undefined)` and leaves the real module in place.
+ */
+const backend = {
+  docs: [makeDoc(DOC_ID), makeDoc(SURVIVOR_ID)],
+  deletionInFlight: false,
+  paginatedCalls: 0,
+  healthCalls: 0,
+  deleteCalls: 0
+}
+
+const resetBackend = () => {
+  backend.docs = [makeDoc(DOC_ID), makeDoc(SURVIVOR_ID)]
+  backend.deletionInFlight = false
+  backend.paginatedCalls = 0
+  backend.healthCalls = 0
+  backend.deleteCalls = 0
+}
+
+const paginate = (): PaginatedDocsResponse => ({
+  documents: backend.docs,
+  pagination: {
+    page: 1,
+    page_size: 10,
+    total_count: backend.docs.length,
+    total_pages: 1,
+    has_next: false,
+    has_prev: false
+  },
+  status_counts: { all: backend.docs.length, processed: backend.docs.length }
+})
+
+const respond = (config: any, data: unknown) => ({
+  data,
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config
+})
+
+const backendAdapter = async (config: any) => {
+  const url: string = config.url ?? ''
+
+  if (url.endsWith('/documents/paginated')) {
+    backend.paginatedCalls += 1
+    return respond(config, paginate())
+  }
+
+  if (url.endsWith('/health')) {
+    backend.healthCalls += 1
+    return respond(config, {
+      status: 'healthy',
+      pipeline_busy: backend.deletionInFlight,
+      pipeline_active: backend.deletionInFlight
+    })
+  }
+
+  if (url.endsWith('/documents/delete_document')) {
+    backend.deleteCalls += 1
+    const docIds: string[] = JSON.parse(config.data ?? '{}').doc_ids ?? []
+    // Reserved before the answer, released by the background task once the
+    // rows are gone — the endpoint's contract, in miniature.
+    backend.deletionInFlight = true
+    setTimeout(() => {
+      backend.docs = backend.docs.filter((doc) => !docIds.includes(doc.id))
+      backend.deletionInFlight = false
+    }, DELETION_COMMIT_MS)
+    return respond(config, {
+      status: 'deletion_started',
+      message: 'started',
+      doc_id: docIds.join(', ')
+    })
+  }
+
+  return respond(config, {})
+}
+
+const rowFor = (docId: string) => {
+  const cell = screen.queryAllByText(docId)[0]
+  return cell?.closest('tr') ?? null
+}
+
+describe('DocumentManager deletion confirmation', () => {
+  beforeEach(() => {
+    resetBackend()
+    __setAxiosAdapterForTests(backendAdapter)
+    useSettingsStore.getState().setCurrentTab('documents')
+    useBackendState.setState({
+      health: true,
+      pipelineBusy: false,
+      pipelineActive: false
+    })
+  })
+
+  afterEach(() => {
+    // Before any store reset: a file-local afterEach runs BEFORE the preload's
+    // cleanup(), so resetting first would land on a still-mounted component.
+    cleanup()
+    useBackendState.getState().clearHealthCheckTimer()
+    __resetPaginatedDocumentRequestsForTests()
+  })
+
+  afterAll(() => {
+    __setAxiosAdapterForTests(undefined)
+  })
+
+  test(
+    'a deletion that commits before the first health check still drops the row',
+    async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<DocumentManager />)
+
+      await waitFor(() => {
+        expect(rowFor(DOC_ID) === null).toBe(false)
+      })
+
+      const row = rowFor(DOC_ID)
+      expect(row === null).toBe(false)
+      await user.click(within(row as HTMLElement).getByRole('checkbox'))
+
+      await user.click(screen.getByRole('button', { name: /^Delete$/ }))
+      await user.type(screen.getByPlaceholderText('Type yes to confirm'), 'yes')
+      await user.click(screen.getByRole('button', { name: 'YES' }))
+
+      await waitFor(() => {
+        expect(backend.deleteCalls).toBe(1)
+      })
+      const healthCallsAtDelete = backend.healthCalls
+
+      // Nothing but the confirmation probe can bring this row down: the
+      // pipeline is never seen flipping, and no cadence faster than 30s
+      // survives the refresh that follows the delete.
+      await waitFor(
+        () => {
+          expect(screen.queryAllByText(DOC_ID)).toHaveLength(0)
+        },
+        { timeout: 8000 }
+      )
+
+      // The probe refreshed the list; it did not blank the table.
+      expect(screen.queryAllByText(SURVIVOR_ID).length > 0).toBe(true)
+      // Necessary, not sufficient: no periodic health timer is installed in
+      // this render, so a health request after the delete could only have come
+      // from the probe. What it does NOT prove on its own is which observation
+      // ended the probe — the module tests cover that.
+      expect(backend.healthCalls > healthCallsAtDelete).toBe(true)
+    },
+    20000
+  )
+})

--- a/lightrag_webui/src/features/DocumentManager.test.tsx
+++ b/lightrag_webui/src/features/DocumentManager.test.tsx
@@ -232,6 +232,7 @@ describe('DocumentManager post-action refreshes', () => {
 
       await user.click(screen.getByRole('button', { name: /^Delete$/ }))
       await user.type(screen.getByPlaceholderText('Type yes to confirm'), 'yes')
+      const confirmedAt = Date.now()
       await user.click(screen.getByRole('button', { name: 'YES' }))
 
       await waitFor(() => {
@@ -248,6 +249,15 @@ describe('DocumentManager post-action refreshes', () => {
         },
         { timeout: 8000 }
       )
+
+      // ...and promptly. The probe's confirming refresh carries user intent, so
+      // it must not queue behind the automatic refresh that the probe's own
+      // health check provokes through the pipelineActive transition effect.
+      // While it did, this deletion took ~2.06s to leave the table (the 2s
+      // throttle boundary); it now takes ~0.6s, one probe tick plus a round
+      // trip. The bound is loose enough for a slow machine and still an order
+      // of magnitude below the boundary it pins.
+      expect(Date.now() - confirmedAt < 1500).toBe(true)
 
       // The probe refreshed the list; it did not blank the table.
       expect(screen.queryAllByText(SURVIVOR_ID).length > 0).toBe(true)

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -1027,6 +1027,23 @@ export default function DocumentManager() {
     }, 2000 - gap)
   }, [handleIntelligentRefresh]);
 
+  // Latest-render view of the throttle gate, for callers that outlive the
+  // render they were created in (the two probes below). Calling a captured
+  // `refreshDocumentsThrottled` from a timer that fires seconds later pairs an
+  // OLD query snapshot (page/filter/sort from that render) with the CURRENT
+  // `latestRefreshRequestVersionRef` — a combination the staleness guard in
+  // runRefreshRequest cannot catch, since it only compares versions. The stale
+  // response then overwrites the view the user navigated to. Reading the gate
+  // through this ref keeps the snapshot and the version from the same render.
+  //
+  // The polling interval does not need this: `startPollingInterval` depends on
+  // `refreshDocumentsThrottled`, so a page/filter/sort change already recreates
+  // the interval with the current closure.
+  const refreshDocumentsThrottledRef = useRef(refreshDocumentsThrottled);
+  useEffect(() => {
+    refreshDocumentsThrottledRef.current = refreshDocumentsThrottled
+  }, [refreshDocumentsThrottled]);
+
   // Activity probe: short exponential-backoff burst of /health checks fired
   // after scan/upload triggers. Stops as soon as pipelineActive flips true so
   // we can hand off to the existing 5s active polling cadence. Re-entry
@@ -1070,7 +1087,7 @@ export default function DocumentManager() {
           return
         }
         if (refreshAt.has(delay)) {
-          refreshDocumentsThrottled({ auto: delay !== 0 })
+          refreshDocumentsThrottledRef.current({ auto: delay !== 0 })
         }
         // Exit conditions (in priority order):
         //  - pipelineActive=true AND the document list has caught up: the 5s
@@ -1095,7 +1112,7 @@ export default function DocumentManager() {
       timers.push(id)
     })
     probeTimersRef.current = timers
-  }, [refreshDocumentsThrottled]);
+  }, []);
 
   // Deletion confirmation probe: watch for the pipeline going idle after a
   // `deletion_started`, then refresh once. Deliberately NOT the activity probe
@@ -1131,13 +1148,13 @@ export default function DocumentManager() {
         if (!healthy) return null
         return useBackendState.getState().pipelineBusy
       },
-      refreshDocuments: () => refreshDocumentsThrottled({ auto: false }),
+      refreshDocuments: () => refreshDocumentsThrottledRef.current({ auto: false }),
       isMounted: () => isMountedRef.current,
       onSettled: () => {
         deletionProbeActiveRef.current = false
       }
     });
-  }, [refreshDocumentsThrottled]);
+  }, []);
 
   // New paginated data fetching function
   const fetchPaginatedDocuments = useCallback(async (

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -61,6 +61,10 @@ import {
 } from '@/features/documentRefreshCircuitBreaker'
 import { classifyDocumentRefreshError } from '@/features/documentRefreshErrors'
 import { createRefreshQueue } from '@/features/documentRefreshQueue'
+import {
+  startDeletionProbe,
+  type DeletionProbeHandle
+} from '@/features/documentDeletionProbe'
 import usePageRestoreGeneration from '@/hooks/usePageRestoreGeneration'
 
 type StatusDisplayConfig = {
@@ -468,6 +472,12 @@ export default function DocumentManager() {
   // reset the schedule to t=0.
   const probeTimersRef = useRef<ReturnType<typeof setTimeout>[] | null>(null);
   const probeActiveRef = useRef(false);
+  // Deletion confirmation probe: owns its own timers (see documentDeletionProbe
+  // for why it cannot ride on startPollingInterval). Tracked separately from
+  // the activity probe above so neither one's cleanup can clear the other's
+  // suppression flag.
+  const deletionProbeRef = useRef<DeletionProbeHandle | null>(null);
+  const deletionProbeActiveRef = useRef(false);
 
   // Circuit breaker guarding the automatic /documents/paginated polling.
   // Transitions live in features/documentRefreshCircuitBreaker (unit-tested);
@@ -1087,6 +1097,48 @@ export default function DocumentManager() {
     probeTimersRef.current = timers
   }, [refreshDocumentsThrottled]);
 
+  // Deletion confirmation probe: watch for the pipeline going idle after a
+  // `deletion_started`, then refresh once. Deliberately NOT the activity probe
+  // above — that one exits on `!active && index > 0` because idle there means
+  // "the action started no work", while after a delete idle means "the work
+  // finished". Opposite readings of the same observation.
+  const startDeletionConfirmationProbe = useCallback(() => {
+    deletionProbeRef.current?.cancel();
+    deletionProbeActiveRef.current = true;
+    deletionProbeRef.current = startDeletionProbe({
+      observePipelineBusy: async () => {
+        // A FRESH request every tick: the store's cached snapshot may predate
+        // the delete, and would then be idle for the wrong reason.
+        const checkedAt = useBackendState.getState().lastCheckTime
+        let healthy: boolean
+        try {
+          healthy = await useBackendState.getState().check()
+        } catch (err) {
+          console.error('Deletion confirmation probe health check failed:', err)
+          return null
+        }
+        // Superseded mid-flight: `check()` discards its own result and writes
+        // nothing (not even lastCheckTime), so `pipelineBusy` still holds
+        // whatever the last COMPLETED check wrote — possibly the idle snapshot
+        // from before the delete. That is not an observation of anything, and
+        // reading it as idle would end the probe on the very state the bug is
+        // made of.
+        if (useBackendState.getState().lastCheckTime === checkedAt) return null
+        // A failed check leaves `pipelineBusy` at whatever the last successful
+        // one wrote — which is `false` for the check that preceded the delete.
+        // Reporting that as idle would announce an outage as a completed
+        // deletion, so an unhealthy response is "unknown", not "finished".
+        if (!healthy) return null
+        return useBackendState.getState().pipelineBusy
+      },
+      refreshDocuments: () => refreshDocumentsThrottled({ auto: false }),
+      isMounted: () => isMountedRef.current,
+      onSettled: () => {
+        deletionProbeActiveRef.current = false
+      }
+    });
+  }, [refreshDocumentsThrottled]);
+
   // New paginated data fetching function
   const fetchPaginatedDocuments = useCallback(async (
     page: number,
@@ -1258,9 +1310,13 @@ export default function DocumentManager() {
     // after the first response.
     if (previous === null || fingerprint === previous) return
 
-    // Skip while the activity probe is running — the probe already drives
-    // /health on its own schedule, and double-firing would burn cache and skew rate.
-    if (isMountedRef.current && !probeActiveRef.current) {
+    // Skip while either probe is running — a probe already drives /health on
+    // its own schedule, and double-firing would burn cache and skew rate.
+    if (
+      isMountedRef.current &&
+      !probeActiveRef.current &&
+      !deletionProbeActiveRef.current
+    ) {
       useBackendState.getState().check()
     }
   }, [statusCounts]);
@@ -1293,16 +1349,14 @@ export default function DocumentManager() {
   const handleDocumentsDeleted = useCallback(async () => {
     setSelectedDocIds([])
 
-    // Reset health check timer with 1 second delay to avoid race condition
-    useBackendState.getState().resetHealthCheckTimerDelayed(1000)
-
-    // A completed delete is user intent: refresh unconditionally rather than
-    // waiting for a poll tick the breaker may refuse.
-    refreshDocumentsThrottled({ auto: false })
-
-    // Schedule a health check 2 seconds after successful clear
-    startPollingInterval(2000)
-  }, [refreshDocumentsThrottled, startPollingInterval])
+    // The probe supersedes what used to be here — a single immediate refresh
+    // (which raced the background deletion and returned the rows it was
+    // supposed to drop), a delayed health check, and startPollingInterval(2000)
+    // whose interval was destroyed by the polling effect before its first tick.
+    // It issues its own health checks and exactly one confirming refresh, timed
+    // off the pipeline going idle instead of a fixed guess.
+    startDeletionConfirmationProbe()
+  }, [startDeletionConfirmationProbe])
 
   // Handle documents cleared callback with proper interval reset
   const handleDocumentsCleared = useCallback(async () => {

--- a/lightrag_webui/src/features/DocumentManager.tsx
+++ b/lightrag_webui/src/features/DocumentManager.tsx
@@ -464,9 +464,6 @@ export default function DocumentManager() {
   // enforce a minimum 2s wall-clock interval.
   const lastPaginatedAtRef = useRef(0);
   const pendingPaginatedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Intent tag the pending trailing timer will fire with. Held outside the
-  // closure so a user-intent call arriving during the wait can upgrade it.
-  const pendingPaginatedIsAutoRef = useRef(true);
   // Activity probe: exponential-backoff burst of /health calls that stops once
   // pipelineActive flips true. Holds the pending setTimeout ids so re-entry can
   // reset the schedule to t=0.
@@ -980,10 +977,11 @@ export default function DocumentManager() {
     });
   }, [buildQuerySnapshot, enqueueRefresh, pagination.page]);
 
-  // Throttle gate: any caller wanting to refresh the document list goes through
-  // here. If the wall-clock gap since the last paginated request is >= 2s, fire
-  // immediately; otherwise schedule a single trailing call at the 2s boundary
-  // and drop any further calls into that pending slot (natural coalescing).
+  // Throttle gate for AUTOMATIC document-list refreshes: if the wall-clock gap
+  // since the last paginated request is >= 2s, fire immediately; otherwise
+  // schedule a single trailing call at the 2s boundary and collapse any further
+  // automatic calls into it. A user-intent call (`auto: false`) is not
+  // throttled at all — see the comment on that branch.
   const refreshDocumentsThrottled = useCallback((options: { auto?: boolean } = {}) => {
     // Defaults to automatic: the timers are the common caller. Callers that
     // follow a user action (upload, scan, delete) pass auto: false so the
@@ -995,19 +993,38 @@ export default function DocumentManager() {
         console.error('Throttled document refresh failed:', err)
       })
     }
-    const gap = Date.now() - lastPaginatedAtRef.current
-    if (gap >= 2000) {
-      fire(auto)
+
+    // User intent never waits. It arrives at most once per user action
+    // (delete confirmation, upload, scan, clear), and the manual refresh
+    // button already bypasses this gate entirely by enqueueing directly — so
+    // the 2s floor only ever delayed the paths that are meant to BE the
+    // escape hatch, the same way the circuit breaker already exempts them.
+    //
+    // It was not a theoretical delay: a deletion observed busy even once
+    // flips `pipelineActive`, whose effect fires an automatic refresh, which
+    // resets this window — so the probe's own health check pushed its
+    // confirming refresh out to the 2s boundary. Measured on the rendered
+    // regression test, a 150ms deletion took 2.06s to leave the table
+    // against 0.08s for one that had already finished when the response
+    // arrived. Any pending trailing timer is cancelled rather than left to
+    // fire: this request supersedes it, on the current query.
+    if (!auto) {
+      if (pendingPaginatedTimerRef.current !== null) {
+        clearTimeout(pendingPaginatedTimerRef.current)
+        pendingPaginatedTimerRef.current = null
+      }
+      fire(false)
       return
     }
+
+    const gap = Date.now() - lastPaginatedAtRef.current
+    if (gap >= 2000) {
+      fire(true)
+      return
+    }
+    // Natural coalescing: everything arriving inside the window collapses
+    // into the single trailing call already scheduled.
     if (pendingPaginatedTimerRef.current !== null) {
-      // A user-intent call arriving while an automatic trailing timer waits
-      // must UPGRADE it, not be dropped — the same defect the refresh queue's
-      // pending slot had, one layer up. The tag decides whether the queue's
-      // admission gate may refuse this request 2s from now, so dropping the
-      // call here would make the queue's priority rule unreachable.
-      // Monotonic: once intent, intent for the rest of this window.
-      if (!auto) pendingPaginatedIsAutoRef.current = false
       return
     }
     // Snapshot the query identity. If page/filter/sort changes while we wait,
@@ -1018,12 +1035,11 @@ export default function DocumentManager() {
     // (its requestVersion would be the newly-bumped value, so the in-flight
     // stale-check inside runRefreshRequest can't catch it).
     const versionAtSchedule = latestRefreshRequestVersionRef.current
-    pendingPaginatedIsAutoRef.current = auto
     pendingPaginatedTimerRef.current = setTimeout(() => {
       pendingPaginatedTimerRef.current = null
       if (!isMountedRef.current) return
       if (versionAtSchedule !== latestRefreshRequestVersionRef.current) return
-      fire(pendingPaginatedIsAutoRef.current)
+      fire(true)
     }, 2000 - gap)
   }, [handleIntelligentRefresh]);
 

--- a/lightrag_webui/src/features/documentDeletionProbe.test.ts
+++ b/lightrag_webui/src/features/documentDeletionProbe.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  DELETION_PROBE_SCHEDULE,
+  startDeletionProbe,
+  type DeletionProbeHandle
+} from '@/features/documentDeletionProbe'
+
+type Observation = boolean | null
+
+/**
+ * Manual timer queue: the probe chains its ticks, so the harness has to run
+ * them one at a time and let the awaited observation settle in between.
+ */
+const createHarness = (
+  observations: Observation[],
+  options: { schedule?: readonly number[]; mounted?: () => boolean } = {}
+) => {
+  const timers: { callback: () => void; delayMs: number }[] = []
+  const delays: number[] = []
+  const observed: number[] = []
+  let refreshes = 0
+  let settled = 0
+
+  const deps = {
+    observePipelineBusy: async () => {
+      const index = observed.length
+      observed.push(index)
+      // Two microtask hops, so a test that flushes only once would show up as
+      // a missing tick rather than passing by accident.
+      await Promise.resolve()
+      await Promise.resolve()
+      return observations[Math.min(index, observations.length - 1)]
+    },
+    refreshDocuments: () => {
+      refreshes += 1
+    },
+    isMounted: options.mounted ?? (() => true),
+    onSettled: () => {
+      settled += 1
+    },
+    schedule: options.schedule,
+    setTimer: (callback: () => void, delayMs: number) => {
+      delays.push(delayMs)
+      timers.push({ callback, delayMs })
+      return timers.length - 1
+    },
+    clearTimer: (handle: unknown) => {
+      const index = handle as number
+      if (timers[index]) timers[index].callback = () => {}
+    }
+  }
+
+  const flush = async () => {
+    for (let i = 0; i < 8; i += 1) await Promise.resolve()
+  }
+
+  /** Fire the timer the probe is currently waiting on, then settle its await. */
+  const tick = async () => {
+    const next = timers.shift()
+    if (!next) throw new Error('no timer pending')
+    next.callback()
+    await flush()
+  }
+
+  return {
+    deps,
+    tick,
+    flush,
+    delays,
+    pendingTimers: () => timers.length,
+    refreshes: () => refreshes,
+    settledCount: () => settled,
+    observations: () => observed.length
+  }
+}
+
+describe('startDeletionProbe', () => {
+  test('idle on the very first observation confirms the deletion', async () => {
+    // The fix-proof case at module level: the busy window of a sub-second
+    // deletion is never observed, so the FIRST reading is already idle. A
+    // transition-based rule ("refresh when busy flips to idle") sees nothing
+    // happen here and refreshes nothing.
+    const harness = createHarness([false])
+    const probe = startDeletionProbe(harness.deps)
+
+    await harness.tick()
+
+    expect(harness.refreshes()).toBe(1)
+    expect(harness.observations()).toBe(1)
+    expect(probe.isActive()).toBe(false)
+    expect(harness.pendingTimers()).toBe(0)
+  })
+
+  test('keeps observing while the pipeline is still busy', async () => {
+    const harness = createHarness([true, true, false], {
+      schedule: [0, 500, 1000]
+    })
+    startDeletionProbe(harness.deps)
+
+    await harness.tick()
+    expect(harness.refreshes()).toBe(0)
+
+    await harness.tick()
+    expect(harness.refreshes()).toBe(0)
+
+    await harness.tick()
+    expect(harness.refreshes()).toBe(1)
+    expect(harness.observations()).toBe(3)
+  })
+
+  test('an exhausted schedule still issues the one confirming refresh', async () => {
+    // "Idle means finished" rests on the endpoint's ordering contract, which is
+    // not self-evidencing. Whatever was observed, the list gets confirmed on
+    // the way out — the failure mode must never be a stale list.
+    const harness = createHarness([true], { schedule: [0, 500] })
+    startDeletionProbe(harness.deps)
+
+    await harness.tick()
+    await harness.tick()
+
+    expect(harness.refreshes()).toBe(1)
+    expect(harness.settledCount()).toBe(1)
+  })
+
+  test('a failed observation is unknown, not idle', async () => {
+    const harness = createHarness([null, false], { schedule: [0, 500] })
+    startDeletionProbe(harness.deps)
+
+    await harness.tick()
+    // `null` must not be read as "finished": an unreachable backend would be
+    // reported to the user as a completed deletion.
+    expect(harness.refreshes()).toBe(0)
+
+    await harness.tick()
+    expect(harness.refreshes()).toBe(1)
+  })
+
+  test('ticks are chained by inter-tick gaps, not absolute delays', async () => {
+    const harness = createHarness([true, true, true], {
+      schedule: [0, 500, 2000]
+    })
+    startDeletionProbe(harness.deps)
+
+    await harness.tick()
+    await harness.tick()
+
+    // Scheduled after the previous observation settled, so two health requests
+    // can never overlap.
+    expect(harness.delays).toEqual([0, 500, 1500])
+  })
+
+  test('cancel stops the probe without refreshing', async () => {
+    const harness = createHarness([true], { schedule: [0, 500] })
+    const probe = startDeletionProbe(harness.deps)
+
+    await harness.tick()
+    probe.cancel()
+    await harness.flush()
+
+    expect(harness.refreshes()).toBe(0)
+    expect(probe.isActive()).toBe(false)
+    expect(harness.settledCount()).toBe(1)
+
+    // The cancelled tick must not resurrect the probe.
+    await harness.tick()
+    expect(harness.refreshes()).toBe(0)
+    expect(harness.observations()).toBe(1)
+  })
+
+  test('cancel during an in-flight observation is honoured', async () => {
+    let release: (value: boolean) => void = () => {}
+    let refreshes = 0
+    const handle: { probe: DeletionProbeHandle | null } = { probe: null }
+    const timers: (() => void)[] = []
+
+    handle.probe = startDeletionProbe({
+      observePipelineBusy: () =>
+        new Promise<boolean>((resolve) => {
+          release = resolve
+        }),
+      refreshDocuments: () => {
+        refreshes += 1
+      },
+      isMounted: () => true,
+      schedule: [0, 500],
+      setTimer: (callback) => {
+        timers.push(callback)
+        return timers.length - 1
+      },
+      clearTimer: () => {}
+    })
+
+    timers.shift()?.()
+    handle.probe.cancel()
+    release(false)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(refreshes).toBe(0)
+  })
+
+  test('an unmounted component ends the probe without a request', async () => {
+    let mounted = true
+    const harness = createHarness([false], {
+      schedule: [0, 500],
+      mounted: () => mounted
+    })
+    startDeletionProbe(harness.deps)
+
+    mounted = false
+    await harness.tick()
+
+    expect(harness.observations()).toBe(0)
+    expect(harness.refreshes()).toBe(0)
+  })
+
+  test('unmounting while the observation is in flight refreshes nothing', async () => {
+    let mounted = true
+    const harness = createHarness([false], {
+      schedule: [0, 500],
+      mounted: () => mounted
+    })
+    startDeletionProbe(harness.deps)
+
+    // Fire the tick, drop the mount before its observation settles.
+    const pending = harness.tick()
+    mounted = false
+    await pending
+
+    expect(harness.observations()).toBe(1)
+    expect(harness.refreshes()).toBe(0)
+  })
+
+  test('the shipped schedule spans the fast and the slow deletion', () => {
+    expect(DELETION_PROBE_SCHEDULE[0]).toBe(0)
+    // Monotonic, so the chained inter-tick gaps stay non-negative.
+    const gaps = DELETION_PROBE_SCHEDULE.map((delay, index) =>
+      index === 0 ? delay : delay - DELETION_PROBE_SCHEDULE[index - 1]
+    )
+    expect(gaps.every((gap) => gap >= 0)).toBe(true)
+    expect(DELETION_PROBE_SCHEDULE.length).toBeGreaterThan(1)
+  })
+})

--- a/lightrag_webui/src/features/documentDeletionProbe.ts
+++ b/lightrag_webui/src/features/documentDeletionProbe.ts
@@ -1,0 +1,148 @@
+/**
+ * Completion probe for an asynchronous document deletion.
+ *
+ * `/documents/delete_document` answers `deletion_started`, not `deleted`: the
+ * rows disappear later, from a background task. The backend does give a hard
+ * completion signal, but it is a LEVEL, not an edge — the endpoint reserves
+ * `busy` + `destructive_busy` inside the pipeline-status lock and awaits the
+ * background task's start barrier BEFORE answering, and the background task
+ * releases both only in its finally, after every `doc_status` row is gone.
+ * So any `pipeline_busy === false` observed AFTER the response proves the
+ * deletion has finished; there is no "not started yet" window to confuse it
+ * with. What that requires of this module: every observation must come from a
+ * FRESH /health request issued after the response — a snapshot cached from
+ * before the delete is idle for the trivial reason.
+ *
+ * Reading the level is what DocumentManager could not do on its own. Its
+ * `pipelineActive` effect fires on a TRANSITION, so a sub-second deletion —
+ * whose whole busy window falls between two 15s health checks — is observed as
+ * `false → false` and refreshes nothing, leaving deleted rows on screen until
+ * the 30s idle poll. Nor can the fix ride on `startPollingInterval`: every
+ * successful refresh hands `setStatusCounts` a fresh object, the polling effect
+ * re-runs and reinstates the idle cadence, so an imperatively set faster
+ * interval is destroyed before its first tick. This probe therefore owns its
+ * own timers.
+ *
+ * Every terminal path except an unmount issues exactly ONE refresh — including
+ * the exhausted-schedule path. That is deliberate: the "idle means finished"
+ * reading rests on the endpoint's ordering contract, which is not
+ * self-evidencing, so a refresh is issued on the way out whatever was
+ * observed. If the contract ever breaks, the cost is one early refresh, and
+ * the 5s active cadence plus the genuine busy→idle transition still cover the
+ * list — the failure mode is not a stale list.
+ */
+
+/** Cumulative delays, in ms, measured from the probe's start. */
+export const DELETION_PROBE_SCHEDULE = [0, 500, 1000, 2000, 4000, 8000] as const
+
+export type DeletionProbeDeps = {
+  /**
+   * Issue a fresh health request and report `pipeline_busy` as observed by it.
+   * Return `null` when the observation failed (unreachable backend, timeout):
+   * unknown must never be read as idle, or an outage would be reported to the
+   * user as a completed deletion.
+   */
+  observePipelineBusy: () => Promise<boolean | null>
+  /**
+   * Refresh the document list. Called at most once per probe run, with user
+   * intent (the delete was a user action, so the circuit breaker must not be
+   * able to refuse the refresh it earned).
+   */
+  refreshDocuments: () => void
+  /** False once the owning component is gone; stops the probe without a refresh. */
+  isMounted: () => boolean
+  /** Called once when the probe stops, for any reason (including cancel). */
+  onSettled?: () => void
+  /** Override the schedule; tests use a shorter one. */
+  schedule?: readonly number[]
+  setTimer?: (callback: () => void, delayMs: number) => unknown
+  clearTimer?: (handle: unknown) => void
+}
+
+export type DeletionProbeHandle = {
+  /** Stop the probe without refreshing. Idempotent. */
+  cancel: () => void
+  isActive: () => boolean
+}
+
+/**
+ * Start probing. The returned handle is single-use; re-entry (a second delete)
+ * is expressed by cancelling the previous handle and starting a new probe, so
+ * the latest action gets a fresh observation window.
+ */
+export const startDeletionProbe = (
+  deps: DeletionProbeDeps
+): DeletionProbeHandle => {
+  const schedule = deps.schedule ?? DELETION_PROBE_SCHEDULE
+  const setTimer =
+    deps.setTimer ?? ((callback, delayMs) => setTimeout(callback, delayMs))
+  const clearTimer =
+    deps.clearTimer ?? ((handle) => clearTimeout(handle as never))
+
+  let stopped = false
+  let pendingTimer: unknown = null
+
+  const settle = (refresh: boolean) => {
+    if (stopped) return
+    stopped = true
+    pendingTimer = null
+    if (refresh) deps.refreshDocuments()
+    deps.onSettled?.()
+  }
+
+  const cancel = () => {
+    if (stopped) return
+    if (pendingTimer !== null) {
+      clearTimer(pendingTimer)
+      pendingTimer = null
+    }
+    settle(false)
+  }
+
+  const runTick = async (index: number) => {
+    pendingTimer = null
+    if (stopped) return
+    // Not mounted: nothing to refresh, and a refresh would be a request nobody
+    // reads. This is the only exit that does not confirm the list.
+    if (!deps.isMounted()) {
+      settle(false)
+      return
+    }
+
+    const busy = await deps.observePipelineBusy()
+
+    if (stopped) return
+    if (!deps.isMounted()) {
+      settle(false)
+      return
+    }
+
+    const isLastTick = index === schedule.length - 1
+    // `busy === false` is the completion proof (see the module comment).
+    // `null` is an unusable observation, so it only ends the probe by
+    // exhausting the schedule.
+    if (busy === false || isLastTick) {
+      settle(true)
+      return
+    }
+
+    // Chained rather than scheduled up front: the next delay is measured from
+    // the end of this observation, so two health requests can never overlap.
+    const delay = schedule[index + 1] - schedule[index]
+    pendingTimer = setTimer(() => {
+      void runTick(index + 1)
+    }, delay)
+  }
+
+  if (schedule.length === 0) {
+    // Degenerate configuration; still honour the one-refresh contract.
+    settle(true)
+    return { cancel, isActive: () => false }
+  }
+
+  pendingTimer = setTimer(() => {
+    void runTick(0)
+  }, schedule[0])
+
+  return { cancel, isActive: () => !stopped }
+}

--- a/lightrag_webui/src/stores/state.ts
+++ b/lightrag_webui/src/stores/state.ts
@@ -39,7 +39,6 @@ interface BackendState {
   setPipelineBusy: (busy: boolean) => void
   setHealthCheckFunction: (fn: () => void) => void
   resetHealthCheckTimer: () => void
-  resetHealthCheckTimerDelayed: (delayMs: number) => void
   clearHealthCheckTimer: () => void
 }
 
@@ -207,12 +206,6 @@ const useBackendStateStoreBase = create<BackendState>()((set, get) => ({
       const newIntervalId = setInterval(healthCheckFunction, healthCheckIntervalValue)
       set({ healthCheckIntervalId: newIntervalId })
     }
-  },
-
-  resetHealthCheckTimerDelayed: (delayMs: number) => {
-    setTimeout(() => {
-      get().resetHealthCheckTimer()
-    }, delayMs)
   },
 
   clearHealthCheckTimer: () => {


### PR DESCRIPTION
## Summary

A document deletion that finishes quickly left the deleted rows on screen for up to 30 seconds. This replaces the UI's edge-triggered guesswork with a deletion confirmation probe that reads the backend's completion **level**.

## Motivation

`/documents/delete_document` answers `deletion_started`, not `deleted`. It reserves `busy` + `destructive_busy` inside the pipeline-status lock and awaits the background task's start barrier **before** answering (`document_routes.py`, `_acquire_destructive_busy` → `start_reserved_background_task`), and `background_delete_documents` releases both only in its `finally`, after every `doc_status` row is gone.

Two consequences:

- Any `pipeline_busy === false` observed **after** the response proves the deletion finished. There is no "not started yet" window to confuse it with — the reservation and the task hand-off both precede the response.
- That proof is a **level**, not an edge.

The UI read it as an edge. `DocumentManager`'s `pipelineActive` effect refreshes only on a transition, so a sub-second deletion — whose whole busy window falls between two 15s health checks — was observed as `false → false` and refreshed nothing.

Nothing else recovered the list either:

- The immediate refresh in `handleDocumentsDeleted` raced the background deletion and re-rendered the very rows it was meant to drop.
- `startPollingInterval(2000)`, the intended confirmation cadence, was destroyed before its first tick: that refresh hands `setStatusCounts` a fresh object, the polling effect re-runs, and the 30s idle interval is reinstated. **Any fix built on `startPollingInterval` is dead on arrival**, which is why the probe owns its own timers.

## What's changed

- **New `src/features/documentDeletionProbe.ts`** — `startDeletionProbe()`: chained ticks at 0/500/1000/2000/4000/8000ms, each issuing a fresh health observation, stopping on the first idle reading and refreshing the list once.
  - A failed observation, or one whose `check()` was superseded mid-flight (it discards its result and writes nothing, leaving `pipelineBusy` at the last *completed* check — possibly the pre-delete idle snapshot), is `null` = **unknown**, never idle. Otherwise an outage would be reported to the user as a completed deletion.
  - The exhausted-schedule path refreshes too. "Idle means finished" rests on the endpoint's ordering contract, which is not self-evidencing; if that contract ever breaks, the cost is one early refresh, not a stale list.
  - Deliberately a sibling of `startActivityProbe`, not a reuse of it: that probe exits on `!active && index > 0` because idle *there* means "the action started no work", while after a delete idle means "the work finished" — opposite readings of the same observation.
- **`DocumentManager`** — `handleDocumentsDeleted` now only clears the selection and starts the probe. The `statusCounts`-driven health check is suppressed while either probe runs.
- **`stores/state.ts`** — `resetHealthCheckTimerDelayed` removed: the delete handler was its only caller.

Note that while a *long* deletion is in flight the pre-existing machinery still behaves as before — the store flips `pipelineActive`, the transition effect fires its automatic refresh (coalesced by the 2s throttle) and the 5s active cadence applies. What is gone is the handler's blind immediate refresh; the probe contributes exactly one confirming refresh.

## What's broken and how it works

Nothing intentionally. The polling cadence, circuit breaker, refresh queue and throttle gate are untouched; the probe enters the list through the same `refreshDocumentsThrottled({ auto: false })` entrance a manual refresh uses, so it cannot be refused by the breaker and cannot double-fetch.

## Tests

Frontend check set from `lightrag_webui/`: `bun test` **624 pass / 0 fail**, `bunx tsc --noEmit` clean, `bun run lint` 0 errors (17 pre-existing `react-refresh` warnings in `components/ui/`).

- `src/features/documentDeletionProbe.test.ts` (10 tests) — the pure level reading (idle on the very first observation refreshes the list, which is exactly what a transition-based rule cannot do), busy → keep observing, exhausted schedule still confirms, unknown ≠ idle, inter-tick gaps, cancel during an in-flight observation, unmount paths.
- `src/features/DocumentManager.test.tsx` (rendered) — a deletion that commits after its response but before any health check would have run; the row must leave the table. **Verified red on the unmodified component** (row still present after 8s) and green with the probe, both directions.

The rendered test drives a fake backend through `__setAxiosAdapterForTests` rather than `mock.module('@/api/lightrag', ...)`: the module mock survived its own `afterAll` restore and broke two tests in `src/api/lightrag.test.ts` that run later in the same process. The adapter seam is restored cleanly and leaves the real module in place — worth knowing before reaching for `mock.module` on that module again.

## Not a follow-up: why no `track_id`

Completion is *inferred* from a boolean level rather than *proved* per operation, but that costs nothing measurable here:

- sub-second deletion: refreshed one health + one paginated round trip after it commits (at most 2s if the throttle gate is mid-window);
- 0.5–8s: bounded by the gap between two probe ticks, at most ~2s;
- longer: `pipelineActive` is true, so the list is already on the 5s active cadence and converges progressively as `doc_status` rows are removed one by one; the final busy→idle flip is observed because a `statusCounts` change drives its own /health.

Attribution ambiguity degrades gracefully rather than incorrectly: if an unrelated job takes the slot right after the delete releases it, the probe simply keeps observing until its schedule is exhausted, issues its one refresh and hands off to the active cadence.

What a per-operation identity (a `track_id` + job store, the way `/documents/scan` has one) would still buy is **outcome reporting**, not speed: `background_delete_documents` records `Deletion completed: N successful, M failed`, while the UI only ever says "deletion pipeline started". Worth doing if and when we want to surface per-document delete failures — not as a fix for this bug.

## Review follow-up (Codex, `db46649`)

Both probes called the throttle gate from timers outliving their render, pairing an old query snapshot with the current request version — a combination `runRefreshRequest`'s version-only staleness guard cannot catch, so the response overwrote the view the user had navigated to (standing for up to 30s under the idle cadence). Both now go through a ref holding the latest render's gate. `startActivityProbe`'s exposure (16s burst) predates this PR and is fixed alongside, since it is the same call pattern. Two rendered regression tests added, each verified red with only its own regression restored.

## Follow-up 2 — the probe was fast, the throttle gate was not (`e14a165`)

Reported from real use: a fast deletion still took a couple of seconds to leave the table. Measured end to end (rendered test, dialog confirm → row gone):

| deletion commits | before | after |
| --- | --- | --- |
| already finished when the response arrived | 0.08s | 0.07s |
| 150ms after the response | **2.06s** | 0.58s |
| 800ms after the response | **2.07s** | 1.08s |

Cause: the probe's first health check flips `pipelineActive` to true, whose effect fires an *automatic* refresh, which resets the throttle gate's 2s window — so the probe's own confirming refresh (user intent, a few hundred ms later on the idle observation) was collapsed into the trailing timer and issued at the 2s boundary. The gate's floor was never meant to apply to user intent: the manual refresh button bypasses the gate entirely by enqueueing directly, and the circuit breaker already exempts `auto: false` for exactly this reason. User-intent refreshes now fire immediately and cancel any pending trailing timer; the automatic stream keeps its 2s coalescing. The remaining time is the probe's own tick granularity.

`pendingPaginatedIsAutoRef` is removed with it — the trailing timer is now reachable only from automatic callers, so its intent tag could only ever hold one value. The rendered regression test asserts the elapsed time, verified red (2.4s) with only the throttle branch restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


