### PR TITLE
fix: repair broken relative links in k8s deploy guides and workspace test README

### DIFF
--- a/k8s-deploy/K8S-README-zh.md
+++ b/k8s-deploy/K8S-README-zh.md
@@ -72,7 +72,7 @@ kubectl --namespace rag port-forward svc/lightrag-dev 9621:9621
 ## 生产环境部署（使用外部数据库）
 
 ### 1. 安装数据库
-> 如果您已经准备好了数据库，可以跳过此步骤。详细信息可以在：[K8S-DB-README.md](databases%2FK8S-DB-README.md)中找到。
+> 如果您已经准备好了数据库，可以跳过此步骤。详细信息可以在：[K8S-DB-README.md](databases/K8S-DB-README.md)中找到。
 
 我们推荐使用KubeBlocks进行数据库部署。KubeBlocks是一个云原生数据库操作符，可以轻松地在Kubernetes上以生产规模运行任何数据库。
 
@@ -81,7 +81,7 @@ kubectl --namespace rag port-forward svc/lightrag-dev 9621:9621
 bash ./databases/01-prepare.sh
 ```
 
-然后安装所需的数据库。默认情况下，这将安装PostgreSQL和Neo4J，但您可以修改[00-config.sh](databases%2F00-config.sh)以根据需要选择不同的数据库：
+然后安装所需的数据库。默认情况下，这将安装PostgreSQL和Neo4J，但您可以修改[00-config.sh](databases/00-config.sh)以根据需要选择不同的数据库：
 ```bash
 bash ./databases/02-install-database.sh
 ```

--- a/k8s-deploy/K8S-README.md
+++ b/k8s-deploy/K8S-README.md
@@ -72,7 +72,7 @@ kubectl --namespace rag port-forward svc/lightrag-dev 9621:9621
 ## Production Deployment (Using External Databases)
 
 ### 1. Install Databases
-> You can skip this step if you've already prepared databases. Detailed information can be found in: [K8S-DB-README.md](databases%2FK8S-DB-README.md).
+> You can skip this step if you've already prepared databases. Detailed information can be found in: [K8S-DB-README.md](databases/K8S-DB-README.md).
 
 We recommend KubeBlocks for database deployment. KubeBlocks is a cloud-native database operator that makes it easy to run any database on Kubernetes at production scale.
 
@@ -81,7 +81,7 @@ First, install KubeBlocks and KubeBlocks-Addons (skip if already installed):
 bash ./databases/01-prepare.sh
 ```
 
-Then install the required databases. By default, this will install PostgreSQL and Neo4J, but you can modify [00-config.sh](databases%2F00-config.sh) to select different databases based on your needs:
+Then install the required databases. By default, this will install PostgreSQL and Neo4J, but you can modify [00-config.sh](databases/00-config.sh) to select different databases based on your needs:
 ```bash
 bash ./databases/02-install-database.sh
 ```

--- a/tests/workspace/README_WORKSPACE_ISOLATION_TESTS.md
+++ b/tests/workspace/README_WORKSPACE_ISOLATION_TESTS.md
@@ -243,9 +243,7 @@ async def test_new_feature():
 
 ## Related Documentation
 
-- [Workspace Isolation Design Doc](../docs/LightRAG_concurrent_explain.md)
-- [Project Intelligence](.clinerules/01-basic.md)
-- [Memory Bank](../.memory-bank/)
+- [Project Intelligence](../../.clinerules/01-basic.md)
 
 ## Test Coverage Matrix
 


### PR DESCRIPTION
## What does this PR do?

Repairs broken relative links, all verified against the repo tree:

1. `k8s-deploy/K8S-README.md` and `k8s-deploy/K8S-README-zh.md` used `%2F` instead of `/` inside two link targets each (`databases%2FK8S-DB-README.md`, `databases%2F00-config.sh`). GitHub does not treat `%2F` as a path separator in blob URLs, so both links resolved to a nonexistent file named `databases/K8S-DB-README.md` and 404'd. Both target files exist under `k8s-deploy/databases/`.
2. `tests/workspace/README_WORKSPACE_ISOLATION_TESTS.md`: the "Related Documentation" list linked `../docs/LightRAG_concurrent_explain.md` and `../.memory-bank/`, neither of which exists anywhere in the repo — removed both entries; and `.clinerules/01-basic.md` → `../../.clinerules/01-basic.md` (the file lives at the repo root, two levels up from `tests/workspace/`).

## Why is this change needed?

The links 404 when clicked on GitHub; the `.clinerules` one pointed into a directory that does not exist under `tests/workspace/`.

## Related Issue

None (docs-only fix).

## Checklist

- [x] Changes are limited to documentation files
- [x] All updated link targets verified to exist in the repository
- [ ] Unit tests updated (not applicable — docs only)
