### PR TITLE
fix: align stale docstring parameter names with actual signatures

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3925,7 +3925,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         Args:
             query (str): The query to be executed.
             param (QueryParam): Configuration parameters for query execution.
-            prompt (Optional[str]): Custom prompts for fine-tuned control over the system's behavior. Defaults to None, which uses PROMPTS["rag_response"].
+            system_prompt (Optional[str]): Custom prompts for fine-tuned control over the system's behavior. Defaults to None, which uses PROMPTS["rag_response"].
 
         Returns:
             str: The result of the query execution.

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -542,8 +542,9 @@ async def _summarize_descriptions(
     """Helper function to summarize a list of descriptions using LLM.
 
     Args:
-        entity_or_relation_name: Name of the entity or relation being summarized
-        descriptions: List of description strings to summarize
+        description_type: Type of the descriptions being summarized (entity or relation)
+        description_name: Name of the entity or relation being summarized
+        description_list: List of description strings to summarize
         global_config: Global configuration containing LLM function and settings
         llm_response_cache: Optional cache for LLM responses
         truncation_tally: Optional accumulator for token-limit truncation. A

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -5174,14 +5174,14 @@ async def use_llm_func_with_cache(
     This function applies text sanitization to prevent UTF-8 encoding errors for all LLM providers.
 
     Args:
-        input_text: Input text to send to LLM
+        user_prompt: Input text to send to LLM
         use_llm_func: LLM function with higher priority
         llm_response_cache: Cache storage instance
         max_tokens: Maximum tokens for generation
         history_messages: History messages list
         cache_type: Type of cache
         chunk_id: Chunk identifier to store in cache
-        text_chunks_storage: Text chunks storage to update llm_cache_list
+        system_prompt: Optional system prompt sent alongside the user prompt
         cache_keys_collector: Optional list to collect cache keys for batch processing
         response_format: Structured output control forwarded to the LLM provider.
             Providers translate this to their native structured-output surface
@@ -5371,13 +5371,13 @@ def get_content_summary(content: str, max_length: int = 250) -> str:
 def sanitize_and_normalize_extracted_text(
     input_text: str, remove_inner_quotes=False
 ) -> str:
-    """Santitize and normalize extracted text
+    """Sanitize and normalize extracted text
     Args:
         input_text: text string to be processed
-        is_name: whether the input text is a entity or relation name
+        remove_inner_quotes: whether to strip enclosing inner quotes
 
     Returns:
-        Santitized and normalized text string
+        Sanitized and normalized text string
     """
     safe_input_text = sanitize_text_for_encoding(input_text)
     if safe_input_text:
@@ -5414,7 +5414,7 @@ def normalize_extracted_info(name: str, remove_inner_quotes=False) -> str:
 
     Args:
         name: Entity name to normalize
-        is_entity: Whether this is an entity name (affects quote handling)
+        remove_inner_quotes: whether to strip inner/enclosing quotes during normalization
 
     Returns:
         Normalized entity name

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -5372,9 +5372,13 @@ def sanitize_and_normalize_extracted_text(
     input_text: str, remove_inner_quotes=False
 ) -> str:
     """Sanitize and normalize extracted text
+
     Args:
         input_text: text string to be processed
-        remove_inner_quotes: whether to strip enclosing inner quotes
+        remove_inner_quotes: whether to remove Chinese quotation marks and
+            English quotation marks adjacent to Chinese characters, and to
+            normalize non-breaking spaces. Matching outer quotation marks are
+            removed regardless of this option.
 
     Returns:
         Sanitized and normalized text string
@@ -5402,19 +5406,19 @@ def normalize_extracted_info(name: str, remove_inner_quotes=False) -> str:
     - Preserve spaces within English text and numbers
     - Replace Chinese parentheses with English parentheses
     - Replace Chinese dash with English dash
-    - Remove English quotation marks from the beginning and end of the text
-    - Remove English quotation marks in and around chinese
-    - Remove Chinese quotation marks
+    - Remove matching outer English/Chinese quotation marks or book title marks
     - Filter out short numeric-only text (length < 3 and only digits/dots)
     - remove_inner_quotes = True
-        remove Chinese quotes
-        remove English quotes in and around chinese
-        Convert non-breaking spaces to regular spaces
-        Convert narrow non-breaking spaces after non-digits to regular spaces
+        - Remove Chinese quotation marks
+        - Remove English quotation marks adjacent to Chinese characters
+        - Convert non-breaking spaces to regular spaces
+        - Convert narrow non-breaking spaces after non-digits to regular spaces
 
     Args:
         name: Entity name to normalize
-        remove_inner_quotes: whether to strip inner/enclosing quotes during normalization
+        remove_inner_quotes: whether to apply the optional quote and
+            non-breaking-space rules above. Matching outer quotation marks are
+            removed regardless of this option.
 
     Returns:
         Normalized entity name

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -5378,7 +5378,8 @@ def sanitize_and_normalize_extracted_text(
         remove_inner_quotes: whether to remove Chinese quotation marks and
             English quotation marks adjacent to Chinese characters, and to
             normalize non-breaking spaces. Matching outer quotation marks are
-            removed regardless of this option.
+            removed independently of this option only when the enclosed text
+            contains no corresponding quote characters.
 
     Returns:
         Sanitized and normalized text string
@@ -5406,7 +5407,8 @@ def normalize_extracted_info(name: str, remove_inner_quotes=False) -> str:
     - Preserve spaces within English text and numbers
     - Replace Chinese parentheses with English parentheses
     - Replace Chinese dash with English dash
-    - Remove matching outer English/Chinese quotation marks or book title marks
+    - Remove a matching outer English/Chinese quote or book title mark pair only
+      when the enclosed text contains no corresponding mark characters
     - Filter out short numeric-only text (length < 3 and only digits/dots)
     - remove_inner_quotes = True
         - Remove Chinese quotation marks
@@ -5418,7 +5420,8 @@ def normalize_extracted_info(name: str, remove_inner_quotes=False) -> str:
         name: Entity name to normalize
         remove_inner_quotes: whether to apply the optional quote and
             non-breaking-space rules above. Matching outer quotation marks are
-            removed regardless of this option.
+            removed independently of this option only when the enclosed text
+            contains no corresponding quote characters.
 
     Returns:
         Normalized entity name


### PR DESCRIPTION
## What does this PR do?

Aligns four stale docstrings with their actual signatures (docstring-only, no behavior change):

1. `lightrag/operate.py` `_summarize_descriptions` — documented `entity_or_relation_name` / `descriptions` from before the type-aware refactor; the actual parameters are `description_type` / `description_name` / `description_list`.
2. `lightrag/lightrag.py` `LightRAG.query` — documented a `prompt` parameter; the actual parameter is `system_prompt` (the async twin `aquery` documents it correctly — copy-paste artifact).
3. `lightrag/utils.py` — `sanitize_and_normalize_extracted_text` documented `is_name` and `normalize_extracted_info` documented `is_entity`; both parameters were replaced by `remove_inner_quotes`, which neither docstring mentioned. Also fixes the `Santitize`/`Santitized` typos.
4. `lightrag/utils.py` `use_llm_func_with_cache` — documented `input_text` (actual: `user_prompt`) and a nonexistent `text_chunks_storage` parameter while omitting `system_prompt`.

## Why is this change needed?

The docstrings feed IDE hints and API references with wrong parameter names — e.g. calling `query(..., prompt=...)` raises `TypeError`.

## Related Issue

None (docstring-only fix).

## Checklist

- [x] Docstring-only change; `ruff format --check` passes on all touched files
- [ ] Unit tests updated (not applicable — no code change)
