### PR TITLE
fix: correct copy-pasted help text for --summary-length-recommended

### DIFF
--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -417,7 +417,7 @@ def parse_args() -> argparse.Namespace:
         default=get_env_value(
             "SUMMARY_LENGTH_RECOMMENDED", DEFAULT_SUMMARY_LENGTH_RECOMMENDED, int
         ),
-        help=f"LLM Summary Context size (default: from env or {DEFAULT_SUMMARY_LENGTH_RECOMMENDED})",
+        help=f"Recommended length of the LLM summary output (default: from env or {DEFAULT_SUMMARY_LENGTH_RECOMMENDED})",
     )
 
     # Logging configuration


### PR DESCRIPTION
## What does this PR do?

Fixes the `--summary-length-recommended` help text in `lightrag/api/config.py`, which was copy-pasted from `--summary-context-size` two blocks above and read "LLM Summary Context size". The flag actually sets `summary_length_recommended` — the recommended *output* length of the LLM summary, injected into the summarization prompt as `summary_length` (`lightrag/operate.py`) — not a context window size.

## Why is this change needed?

Anyone reading `--help` (or `lightrag.server` docs generated from it) gets the wrong meaning for the flag and sets it expecting a context-size behavior.

## Related Issue

None.

## Checklist

- [x] Help-string-only change; no behavior change
- [ ] Unit tests updated (not applicable)
