### PR TITLE
fix(cache): partition LLM responses by max tokens

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -5245,6 +5245,8 @@ async def use_llm_func_with_cache(
             _prompt,
             "\n<response_format>\n",
             response_format_key,
+            "\n<max_tokens>\n",
+            _serialize_cache_variant(max_tokens),
             "\n<llm_identity>\n",
             llm_identity_key,
         )

--- a/tests/llm/test_utils_llm_cache.py
+++ b/tests/llm/test_utils_llm_cache.py
@@ -83,6 +83,31 @@ async def test_use_llm_func_with_cache_partitions_cache_by_llm_identity():
 
 @pytest.mark.offline
 @pytest.mark.asyncio
+async def test_use_llm_func_with_cache_partitions_cache_by_max_tokens():
+    cache = _FakeKVStorage()
+    llm_func = AsyncMock(side_effect=["short-budget", "large-budget"])
+
+    short_result, _ = await use_llm_func_with_cache(
+        "same prompt",
+        llm_func,
+        llm_response_cache=cache,
+        max_tokens=10,
+    )
+    large_result, _ = await use_llm_func_with_cache(
+        "same prompt",
+        llm_func,
+        llm_response_cache=cache,
+        max_tokens=100,
+    )
+
+    assert short_result == "short-budget"
+    assert large_result == "large-budget"
+    assert llm_func.await_count == 2
+    assert len(cache._store) == 2
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
 async def test_use_llm_func_with_cache_skips_caching_truncated_response():
     """A token-limit-truncated response is returned but never persisted.
 


### PR DESCRIPTION
## Description

LLM cache keys did not include `max_tokens`, allowing calls with different output budgets to share a cached response.

## Changes Made

- Include `max_tokens` in the LLM cache key.
- Add a regression test for cache partitioning.

## Related Issues

No related issue.

## Test Results

- Full LLM suite: 526 passed
- Pre-commit: passed
- `git diff --check`: passed

## Compatibility and Risk

Low risk. Existing cache entries will miss once and be regenerated.