### PR TITLE
fix(lmdeploy): handle truncated responses

### DIFF
--- a/lightrag/llm/lmdeploy.py
+++ b/lightrag/llm/lmdeploy.py
@@ -18,6 +18,8 @@ from tenacity import (
     retry_if_exception_type,
 )
 
+from lightrag.utils import TruncatedResponse
+
 
 from functools import lru_cache
 
@@ -168,6 +170,7 @@ async def lmdeploy_model_if_cache(
     )
 
     response = ""
+    finish_reason = None
     async for res in lmdeploy_pipe.generate(
         messages,
         gen_config=gen_config,
@@ -175,5 +178,9 @@ async def lmdeploy_model_if_cache(
         stream_response=False,
         session_id=1,
     ):
-        response += res.response
+        response += getattr(res, "text", getattr(res, "response", ""))
+        if getattr(res, "finish_reason", None) is not None:
+            finish_reason = res.finish_reason
+    if finish_reason == "length":
+        return TruncatedResponse(response)
     return response

--- a/tests/llm/lmdeploy_impl/test_lmdeploy_do_sample.py
+++ b/tests/llm/lmdeploy_impl/test_lmdeploy_do_sample.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 import pytest
 
 from lightrag.llm.lmdeploy import lmdeploy_model_if_cache
+from lightrag.utils import TruncatedResponse
 
 pytestmark = [pytest.mark.offline, pytest.mark.asyncio]
 
@@ -39,7 +40,7 @@ def _install_fake_lmdeploy(monkeypatch, *, less_than_0_6_0: bool) -> dict:
             captured_gen_config_kwargs.update(kwargs)
 
     async def fake_generate(*_args, **_kwargs):
-        yield SimpleNamespace(response="{}")
+        yield SimpleNamespace(response="{}", finish_reason="stop")
 
     monkeypatch.setattr(
         "lightrag.llm.lmdeploy.initialize_lmdeploy_pipeline",
@@ -135,3 +136,44 @@ async def test_pre_0_6_0_version_guard_still_raises(monkeypatch, do_sample_kwarg
             prompt="hello",
             **do_sample_kwarg,
         )
+
+
+@pytest.mark.parametrize(
+    ("finish_reason", "expected_type"),
+    [
+        pytest.param("stop", str, id="natural-stop"),
+        pytest.param("length", TruncatedResponse, id="token-limit"),
+    ],
+)
+async def test_generation_finish_reason_controls_truncation_marker(
+    monkeypatch, finish_reason, expected_type
+):
+    async def fake_generate(*_args, **_kwargs):
+        yield SimpleNamespace(text="generated text", finish_reason=finish_reason)
+
+    _install_fake_lmdeploy(monkeypatch, less_than_0_6_0=False)
+    monkeypatch.setattr(
+        "lightrag.llm.lmdeploy.initialize_lmdeploy_pipeline",
+        lambda **_kwargs: SimpleNamespace(generate=fake_generate),
+    )
+
+    result = await lmdeploy_model_if_cache(model="lmdeploy-model", prompt="hello")
+
+    assert type(result) is expected_type
+    assert result == "generated text"
+
+
+async def test_legacy_response_attribute_remains_supported(monkeypatch):
+    async def fake_generate(*_args, **_kwargs):
+        yield SimpleNamespace(response="legacy text", finish_reason="stop")
+
+    _install_fake_lmdeploy(monkeypatch, less_than_0_6_0=False)
+    monkeypatch.setattr(
+        "lightrag.llm.lmdeploy.initialize_lmdeploy_pipeline",
+        lambda **_kwargs: SimpleNamespace(generate=fake_generate),
+    )
+
+    result = await lmdeploy_model_if_cache(model="lmdeploy-model", prompt="hello")
+
+    assert type(result) is str
+    assert result == "legacy text"


### PR DESCRIPTION
## Problem

The LMDeploy adapter reads the legacy `response` field and does not mark token-limited output as truncated.

## Change

Read the current `text` field with legacy compatibility. Return `TruncatedResponse` when LMDeploy reports `finish_reason="length"`.

## Tests

- LMDeploy tests: 13 passed
- Full LLM tests: 528 passed
- Pre-commit: passed
- `git diff --check`: passed

## Related issue

None.