### PR TITLE
fix(anthropic): track token usage

### DIFF
--- a/lightrag/llm/anthropic.py
+++ b/lightrag/llm/anthropic.py
@@ -58,8 +58,8 @@ async def anthropic_complete_if_cache(
     enable_cot: bool = False,
     base_url: str | None = None,
     api_key: str | None = None,
-    token_tracker: Any | None = None,
     image_inputs: list[Any] | None = None,
+    token_tracker: Any | None = None,
     **kwargs: Any,
 ) -> Union[str, AsyncIterator[str]]:
     """Call Anthropic Messages API with LightRAG-compatible shims.
@@ -222,7 +222,11 @@ async def anthropic_complete_if_cache(
 
     if not stream:
         try:
-            content = response.content[0].text
+            # Record usage before extracting content text: the API call is
+            # already billed and response.usage is already populated at this
+            # point, but content[0].text raises if the first content block
+            # isn't a text block (or content is empty) -- that must not cost
+            # the tracker a real, billed call.
             if token_tracker and getattr(response, "usage", None):
                 usage = response.usage
                 prompt_tokens = sum(
@@ -241,6 +245,7 @@ async def anthropic_complete_if_cache(
                         "total_tokens": prompt_tokens + output_tokens,
                     }
                 )
+            content = response.content[0].text
             if getattr(response, "stop_reason", None) == "max_tokens":
                 content = TruncatedResponse(content)
             return content

--- a/lightrag/llm/anthropic.py
+++ b/lightrag/llm/anthropic.py
@@ -58,6 +58,7 @@ async def anthropic_complete_if_cache(
     enable_cot: bool = False,
     base_url: str | None = None,
     api_key: str | None = None,
+    token_tracker: Any | None = None,
     image_inputs: list[Any] | None = None,
     **kwargs: Any,
 ) -> Union[str, AsyncIterator[str]]:
@@ -222,6 +223,24 @@ async def anthropic_complete_if_cache(
     if not stream:
         try:
             content = response.content[0].text
+            if token_tracker and getattr(response, "usage", None):
+                usage = response.usage
+                prompt_tokens = sum(
+                    getattr(usage, field, 0) or 0
+                    for field in (
+                        "input_tokens",
+                        "cache_creation_input_tokens",
+                        "cache_read_input_tokens",
+                    )
+                )
+                output_tokens = getattr(usage, "output_tokens", 0) or 0
+                token_tracker.add_usage(
+                    {
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": output_tokens,
+                        "total_tokens": prompt_tokens + output_tokens,
+                    }
+                )
             if getattr(response, "stop_reason", None) == "max_tokens":
                 content = TruncatedResponse(content)
             return content
@@ -232,8 +251,22 @@ async def anthropic_complete_if_cache(
                 logger.warning(f"Failed to close Anthropic client: {close_error}")
 
     async def stream_response():
+        usage_counts: dict[str, int] = {}
         try:
             async for event in response:
+                usage = getattr(event, "usage", None)
+                if usage is None:
+                    usage = getattr(getattr(event, "message", None), "usage", None)
+                if usage is not None:
+                    for field in (
+                        "input_tokens",
+                        "output_tokens",
+                        "cache_creation_input_tokens",
+                        "cache_read_input_tokens",
+                    ):
+                        value = getattr(usage, field, None)
+                        if value is not None:
+                            usage_counts[field] = value
                 content = (
                     event.delta.text
                     if hasattr(event, "delta")
@@ -246,6 +279,23 @@ async def anthropic_complete_if_cache(
                 if r"\u" in content:
                     content = safe_unicode_decode(content.encode("utf-8"))
                 yield content
+            if token_tracker and usage_counts:
+                prompt_tokens = sum(
+                    usage_counts.get(field, 0)
+                    for field in (
+                        "input_tokens",
+                        "cache_creation_input_tokens",
+                        "cache_read_input_tokens",
+                    )
+                )
+                output_tokens = usage_counts.get("output_tokens", 0)
+                token_tracker.add_usage(
+                    {
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": output_tokens,
+                        "total_tokens": prompt_tokens + output_tokens,
+                    }
+                )
         except Exception as e:
             logger.error(f"Error in stream response: {str(e)}")
             raise

--- a/tests/llm/anthropic_impl/test_anthropic_token_usage.py
+++ b/tests/llm/anthropic_impl/test_anthropic_token_usage.py
@@ -1,0 +1,120 @@
+"""Offline tests for Anthropic token usage tracking."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lightrag.llm.anthropic import anthropic_complete_if_cache
+from lightrag.utils import TokenTracker
+
+pytestmark = [pytest.mark.offline, pytest.mark.asyncio]
+
+
+def _usage(*, input_tokens, output_tokens, cache_creation=None, cache_read=None):
+    return SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_creation_input_tokens=cache_creation,
+        cache_read_input_tokens=cache_read,
+    )
+
+
+class _Stream:
+    def __init__(self, events):
+        self._events = iter(events)
+        self.close = AsyncMock()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._events)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+async def test_non_streaming_usage_is_tracked_without_reaching_sdk():
+    tracker = TokenTracker()
+    response = SimpleNamespace(
+        content=[SimpleNamespace(text="answer")],
+        stop_reason="end_turn",
+        usage=_usage(
+            input_tokens=10,
+            output_tokens=4,
+            cache_creation=3,
+            cache_read=2,
+        ),
+    )
+    create = AsyncMock(return_value=response)
+    client = SimpleNamespace(
+        messages=SimpleNamespace(create=create),
+        close=AsyncMock(),
+    )
+
+    with patch("lightrag.llm.anthropic.AsyncAnthropic", return_value=client):
+        result = await anthropic_complete_if_cache.__wrapped__(
+            model="claude-test",
+            prompt="hello",
+            api_key="test-key",
+            token_tracker=tracker,
+        )
+
+    assert result == "answer"
+    assert tracker.get_usage() == {
+        "prompt_tokens": 15,
+        "completion_tokens": 4,
+        "total_tokens": 19,
+        "call_count": 1,
+    }
+    assert "token_tracker" not in create.await_args.kwargs
+
+
+async def test_streaming_usage_is_tracked_after_full_consumption():
+    tracker = TokenTracker()
+    stream = _Stream(
+        [
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    usage=_usage(
+                        input_tokens=8,
+                        output_tokens=1,
+                        cache_creation=2,
+                        cache_read=3,
+                    )
+                )
+            ),
+            SimpleNamespace(delta=SimpleNamespace(text="answer")),
+            SimpleNamespace(
+                delta=SimpleNamespace(),
+                usage=_usage(input_tokens=None, output_tokens=5),
+            ),
+        ]
+    )
+    create = AsyncMock(return_value=stream)
+    client = SimpleNamespace(
+        messages=SimpleNamespace(create=create),
+        close=AsyncMock(),
+    )
+
+    with patch("lightrag.llm.anthropic.AsyncAnthropic", return_value=client):
+        result = await anthropic_complete_if_cache.__wrapped__(
+            model="claude-test",
+            prompt="hello",
+            api_key="test-key",
+            stream=True,
+            token_tracker=tracker,
+        )
+        chunks = [chunk async for chunk in result]
+
+    assert chunks == ["answer"]
+    assert tracker.get_usage() == {
+        "prompt_tokens": 13,
+        "completion_tokens": 5,
+        "total_tokens": 18,
+        "call_count": 1,
+    }
+    assert "token_tracker" not in create.await_args.kwargs
+    stream.close.assert_awaited_once()
+

--- a/tests/llm/anthropic_impl/test_anthropic_token_usage.py
+++ b/tests/llm/anthropic_impl/test_anthropic_token_usage.py
@@ -71,6 +71,51 @@ async def test_non_streaming_usage_is_tracked_without_reaching_sdk():
     assert "token_tracker" not in create.await_args.kwargs
 
 
+async def test_image_inputs_keeps_its_position_ahead_of_token_tracker():
+    """Codex finding: token_tracker must not shift image_inputs out of the
+    position an existing positional caller relies on. Confirms the current
+    parameter order rather than a specific one, so a future reordering that
+    reintroduces the hazard fails this test."""
+    import inspect
+
+    params = list(inspect.signature(anthropic_complete_if_cache.__wrapped__).parameters)
+    assert params.index("image_inputs") < params.index("token_tracker")
+
+
+async def test_usage_recorded_even_when_content_extraction_fails():
+    """Codex finding: response.usage is already populated once the API call
+    returns, so a real, billed call's usage must be recorded even if
+    response.content[0].text later raises (e.g. an empty or non-text content
+    list)."""
+    tracker = TokenTracker()
+    response = SimpleNamespace(
+        content=[],  # empty -- content[0] raises IndexError
+        stop_reason="end_turn",
+        usage=_usage(input_tokens=10, output_tokens=4),
+    )
+    create = AsyncMock(return_value=response)
+    client = SimpleNamespace(
+        messages=SimpleNamespace(create=create),
+        close=AsyncMock(),
+    )
+
+    with patch("lightrag.llm.anthropic.AsyncAnthropic", return_value=client):
+        with pytest.raises(IndexError):
+            await anthropic_complete_if_cache.__wrapped__(
+                model="claude-test",
+                prompt="hello",
+                api_key="test-key",
+                token_tracker=tracker,
+            )
+
+    assert tracker.get_usage() == {
+        "prompt_tokens": 10,
+        "completion_tokens": 4,
+        "total_tokens": 14,
+        "call_count": 1,
+    }
+
+
 async def test_streaming_usage_is_tracked_after_full_consumption():
     tracker = TokenTracker()
     stream = _Stream(
@@ -117,4 +162,3 @@ async def test_streaming_usage_is_tracked_after_full_consumption():
     }
     assert "token_tracker" not in create.await_args.kwargs
     stream.close.assert_awaited_once()
-


### PR DESCRIPTION
## Problem

The Anthropic binding forwards `token_tracker` to the SDK instead of recording usage.

## Change

Support token tracking for completed streaming and non-streaming responses, including cached input tokens.

## Tests

- Anthropic tests: 16 passed
- Full LLM tests: 527 passed
- Pre-commit passed
- `git diff --check` passed

## Related Issue

No related issue.