### PR TITLE
fix(opensearch): refuse to attach to another workspace's indexes

### DIFF
--- a/env.example
+++ b/env.example
@@ -1501,6 +1501,12 @@ OPENSEARCH_VERIFY_CERTS=false
 # OPENSEARCH_DELETE_MAX_RECORDS_PER_BATCH=1000
 ### DB specific workspace should not be set, keep for compatible only
 # OPENSEARCH_WORKSPACE=forced_workspace_name
+### NOTE: OpenSearch index names must be lowercase, so the workspace is
+### lowercased (and any character outside [a-z0-9_-] folded to '_') when the
+### index name is built. Two workspaces that differ only in case or
+### punctuation therefore map to the SAME indexes. When several LightRAG
+### deployments share one OpenSearch cluster, give them workspace names that
+### differ by more than case -- a colliding deployment refuses to start.
 
 ### Milvus Configuration
 MILVUS_URI=http://localhost:19530

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -322,6 +322,164 @@ async def _run_chunked_async_bulk(
 # PGGraphStorage-style startup so it runs at most once per index.
 _EDGE_ID_CANONICAL_META_FLAG = "edge_id_canonical_v1"
 
+# Keys recorded in every index mapping's ``_meta`` naming the LightRAG
+# workspace and namespace the index belongs to, in their ORIGINAL form --
+# before the lowercase + character folding applied by
+# ``_sanitize_index_name``.
+#
+# That folding is not injective: ``TeamA`` and ``teama`` (both legal under the
+# workspace charset documented in env.example, and both preserved verbatim by
+# ``lightrag/api/config.py``) resolve to the same physical index, as do
+# ``v1.0`` and ``v1_0`` for direct library users. Two deployments that collide
+# this way share every index -- reading each other's documents, overwriting
+# each other's rows, and, because ``drop()`` deletes the whole physical index
+# on this backend, destroying each other's data on ``/documents/clear``.
+#
+# The marker turns that silent commingling into a startup failure. It is
+# deliberately a detection mechanism and not a renaming scheme: renaming the
+# index (e.g. by appending a hash of the workspace) would force a migration on
+# every existing deployment, including the overwhelming majority that never
+# collide. See issue #3827.
+_WORKSPACE_META_KEY = "lightrag_workspace"
+_FINAL_NAMESPACE_META_KEY = "lightrag_final_namespace"
+# Both keys identify the owner: the joined ``{workspace}_{namespace}`` is
+# itself ambiguous (workspace ``foo`` + namespace ``text_chunks`` joins to the
+# same string as workspace ``foo_text`` + namespace ``chunks``, and both are
+# real LightRAG namespaces), so the workspace must be compared alongside it.
+_WORKSPACE_IDENTITY_KEYS = (_WORKSPACE_META_KEY, _FINAL_NAMESPACE_META_KEY)
+
+
+class WorkspaceIndexCollisionError(ValueError):
+    """An index is already claimed by a different LightRAG workspace.
+
+    Raised from index initialization, so a colliding deployment fails to start
+    (or fails its next write, when the index is being recreated after a drop)
+    instead of silently attaching to another workspace's data.
+    """
+
+
+def _workspace_index_meta(workspace: str, final_namespace: str) -> dict[str, str]:
+    """Build the ``_meta`` payload identifying an index's owning workspace."""
+    return {
+        _WORKSPACE_META_KEY: workspace,
+        _FINAL_NAMESPACE_META_KEY: final_namespace,
+    }
+
+
+def _stored_index_identity(meta: dict) -> dict[str, str | None]:
+    """Extract the owning-workspace identity recorded in an index ``_meta``."""
+    return {key: meta.get(key) for key in _WORKSPACE_IDENTITY_KEYS}
+
+
+def _describe_index_identity(identity: dict[str, str | None]) -> str:
+    """Render an index identity for an operator-facing message."""
+    return (
+        f"workspace '{identity.get(_WORKSPACE_META_KEY)}' / namespace "
+        f"'{identity.get(_FINAL_NAMESPACE_META_KEY)}'"
+    )
+
+
+def _workspace_collision_error(
+    index_name: str,
+    stored: dict[str, str | None],
+    expected: dict[str, str | None],
+) -> WorkspaceIndexCollisionError:
+    """Build the collision error, naming both sides and the way out."""
+    return WorkspaceIndexCollisionError(
+        f"OpenSearch index '{index_name}' belongs to "
+        f"{_describe_index_identity(stored)}, but this instance resolves to "
+        f"{_describe_index_identity(expected)}. Index names are lowercased, "
+        f"non-alphanumeric characters are folded to '_', and the workspace is "
+        f"joined to the namespace with '_', so these two configurations map to "
+        f"the same index and would share, overwrite and delete each other's "
+        f"data. Rename one of the workspaces (WORKSPACE / "
+        f"OPENSEARCH_WORKSPACE) so the two no longer fold together, or point "
+        f"this instance at a different OpenSearch cluster. Do NOT drop the "
+        f"index -- it holds the other workspace's data."
+    )
+
+
+async def _claim_index_for_workspace(
+    client,
+    index_name: str,
+    workspace: str,
+    final_namespace: str,
+) -> None:
+    """Verify (or record) that ``index_name`` belongs to this workspace.
+
+    Three outcomes:
+
+    * The stored marker matches -- the common path, nothing to do.
+    * The stored marker names a *different* owner -- raise
+      ``WorkspaceIndexCollisionError``. Never rewrite the marker: the index
+      holds another deployment's data. Both identity fields are compared,
+      because the joined ``{workspace}_{namespace}`` alone is ambiguous.
+    * No marker at all (an index created before this check existed) -- adopt
+      the index by writing the marker. ``_meta`` is replaced wholesale by
+      ``put_mapping``, so the existing ``_meta`` is merged rather than
+      overwritten, keeping flags such as ``_EDGE_ID_CANONICAL_META_FLAG``.
+
+    **Adopting a legacy index is not atomic across deployments.** Creating an
+    index is: only one caller wins ``indices.create``, and the loser reads the
+    winner's marker. But an already-existing unmarked index offers no
+    cluster-side compare-and-set, so two colliding deployments upgrading at the
+    same moment can both read "no marker" and both claim it. The confirmation
+    read below narrows that window -- it catches the other deployment writing
+    before we re-read -- but does not close it: a write landing after our
+    re-read leaves both deployments running for that session, which is exactly
+    where an unmarked index already was, and the mismatch surfaces on the next
+    attach. Two processes of the *same* workspace racing here write the same
+    value, which is idempotent and must never be reported as a collision; the
+    confirmation therefore compares the identity itself and never a
+    per-process token.
+    """
+    expected = _workspace_index_meta(workspace, final_namespace)
+    mapping = await client.indices.get_mapping(index=index_name)
+    meta = (mapping.get(index_name) or {}).get("mappings", {}).get("_meta") or {}
+    stored = _stored_index_identity(meta)
+    if stored == expected:
+        return
+    if any(value is not None for value in stored.values()):
+        # A partially written marker counts as claimed: an identity we cannot
+        # fully match is not ours to overwrite.
+        raise _workspace_collision_error(index_name, stored, expected)
+
+    try:
+        await client.indices.put_mapping(
+            index=index_name,
+            body={"_meta": {**meta, **expected}},
+        )
+    except OpenSearchException as e:
+        # Adopting a legacy index is the only part of this check that needs
+        # write access to the mapping. A read-only account, a restored
+        # snapshot or ``index.blocks.write`` must not turn a zero-migration
+        # safeguard into a startup failure: the index simply stays unmarked
+        # and unprotected, which is exactly where it was before this check
+        # existed. Detecting a marker that names a *different* workspace needs
+        # no write and still fails fast.
+        logger.warning(
+            f"[{workspace}] Could not record the workspace marker on index "
+            f"'{index_name}' ({e}); it stays unmarked, so a workspace whose "
+            f"name folds onto the same index cannot be detected"
+        )
+        return
+    logger.info(
+        f"[{workspace}] Claimed pre-existing index '{index_name}' for workspace "
+        f"namespace '{final_namespace}'"
+    )
+
+    confirmation = await client.indices.get_mapping(index=index_name)
+    confirmed = _stored_index_identity(
+        (confirmation.get(index_name) or {}).get("mappings", {}).get("_meta") or {}
+    )
+    # An entirely absent marker on re-read means the write has not become
+    # visible yet, not that another workspace owns the index -- only a
+    # *differing* identity is evidence of a collision.
+    if confirmed == expected or all(value is None for value in confirmed.values()):
+        return
+    raise _workspace_collision_error(index_name, confirmed, expected)
+
+
 # Emit a migration progress line every this many scanned edges, so operators
 # watching a large-index reindex see liveness and an X/total denominator.
 _EDGE_MIGRATION_PROGRESS_INTERVAL = 50_000
@@ -765,6 +923,9 @@ class OpenSearchKVStorage(BaseKVStorage):
                 body = {
                     "mappings": {
                         "dynamic": True,
+                        "_meta": _workspace_index_meta(
+                            self.workspace, self.final_namespace
+                        ),
                         "properties": {
                             "__mirrored_id": {"type": "keyword"},
                         },
@@ -779,6 +940,16 @@ class OpenSearchKVStorage(BaseKVStorage):
                 await self.client.indices.create(index=self._index_name, body=body)
                 logger.info(f"[{self.workspace}] Created index: {self._index_name}")
             else:
+                # Ownership before any mapping mutation: never touch an index
+                # that turns out to belong to a different workspace. The
+                # trailing claim below still covers the freshly-created and
+                # lost-the-create-race paths.
+                await _claim_index_for_workspace(
+                    self.client,
+                    self._index_name,
+                    self.workspace,
+                    self.final_namespace,
+                )
                 await _verify_mirrored_id_mapping(self.client, self._index_name)
         except RequestError as e:
             if "resource_already_exists_exception" not in str(e):
@@ -786,6 +957,14 @@ class OpenSearchKVStorage(BaseKVStorage):
         except OpenSearchException as e:
             logger.error(f"[{self.workspace}] Error creating index: {e}")
             raise
+
+        # Verify the index we just created (or attached to) is ours. The
+        # workspace-to-index-name mapping is lossy, so a differently-named
+        # workspace can resolve to this same index -- fail fast instead of
+        # silently sharing its data. See issue #3827.
+        await _claim_index_for_workspace(
+            self.client, self._index_name, self.workspace, self.final_namespace
+        )
 
     async def finalize(self):
         """Flush pending writes and release the OpenSearch client connection.
@@ -1520,6 +1699,9 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                 body = {
                     "mappings": {
                         "dynamic": True,
+                        "_meta": _workspace_index_meta(
+                            self.workspace, self.final_namespace
+                        ),
                         "properties": {
                             "__mirrored_id": {"type": "keyword"},
                             "status": {"type": "keyword"},
@@ -1542,6 +1724,16 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
                     f"[{self.workspace}] Created doc status index: {self._index_name}"
                 )
             else:
+                # Ownership before any mapping mutation: never touch an index
+                # that turns out to belong to a different workspace. The
+                # trailing claim below still covers the freshly-created and
+                # lost-the-create-race paths.
+                await _claim_index_for_workspace(
+                    self.client,
+                    self._index_name,
+                    self.workspace,
+                    self.final_namespace,
+                )
                 await self._ensure_content_hash_mapping()
                 await self._ensure_scheduling_fields_mapping()
                 # Unconditional for every pre-existing index. Gating this on
@@ -1562,6 +1754,14 @@ class OpenSearchDocStatusStorage(DocStatusStorage):
         except OpenSearchException as e:
             logger.error(f"[{self.workspace}] Error creating doc status index: {e}")
             raise
+
+        # Verify the index we just created (or attached to) is ours. The
+        # workspace-to-index-name mapping is lossy, so a differently-named
+        # workspace can resolve to this same index -- fail fast instead of
+        # silently sharing its data. See issue #3827.
+        await _claim_index_for_workspace(
+            self.client, self._index_name, self.workspace, self.final_namespace
+        )
 
     async def _ensure_content_hash_mapping(self) -> None:
         """Add the content_hash keyword mapping to a pre-existing doc status index.
@@ -3280,6 +3480,9 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 body = {
                     "mappings": {
                         "dynamic": True,
+                        "_meta": _workspace_index_meta(
+                            self.workspace, self.final_namespace
+                        ),
                         "properties": {
                             "entity_id": {"type": "keyword"},
                             "entity_type": {"type": "keyword"},
@@ -3310,6 +3513,9 @@ class OpenSearchGraphStorage(BaseGraphStorage):
                 body = {
                     "mappings": {
                         "dynamic": True,
+                        "_meta": _workspace_index_meta(
+                            self.workspace, self.final_namespace
+                        ),
                         "properties": {
                             "source_node_id": {"type": "keyword"},
                             "target_node_id": {"type": "keyword"},
@@ -3337,6 +3543,14 @@ class OpenSearchGraphStorage(BaseGraphStorage):
         except RequestError as e:
             if "resource_already_exists_exception" not in str(e):
                 raise
+
+        # Runs before _migrate_edges_to_canonical_id_if_needed (see
+        # initialize) so a colliding deployment never reindexes another
+        # workspace's edges. See issue #3827.
+        for index_name in (self._nodes_index, self._edges_index):
+            await _claim_index_for_workspace(
+                self.client, index_name, self.workspace, self.final_namespace
+            )
 
     async def _migrate_edges_to_canonical_id_if_needed(self) -> None:
         """One-time reindex of edge docs onto canonical (sorted-pair) ``_id``s.
@@ -5591,6 +5805,14 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
     async def _create_knn_index_if_not_exists(self):
         try:
             if await self.client.indices.exists(index=self._index_name):
+                # Ownership before compatibility: an index belonging to a
+                # different workspace must not be judged by our dimensions.
+                await _claim_index_for_workspace(
+                    self.client,
+                    self._index_name,
+                    self.workspace,
+                    self.final_namespace,
+                )
                 # Validate existing index dimension
                 try:
                     mapping = await self.client.indices.get_mapping(
@@ -5654,6 +5876,9 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
                         "created_at": {"type": "long"},
                     },
                     "dynamic": True,
+                    "_meta": _workspace_index_meta(
+                        self.workspace, self.final_namespace
+                    ),
                 },
             }
             await self.client.indices.create(index=self._index_name, body=body)
@@ -5668,6 +5893,14 @@ class OpenSearchVectorDBStorage(BaseVectorStorage):
         except OpenSearchException as e:
             logger.error(f"[{self.workspace}] Error creating k-NN index: {e}")
             raise
+
+        # Verify the index we just created (or attached to) is ours. The
+        # workspace-to-index-name mapping is lossy, so a differently-named
+        # workspace can resolve to this same index -- fail fast instead of
+        # silently sharing its data. See issue #3827.
+        await _claim_index_for_workspace(
+            self.client, self._index_name, self.workspace, self.final_namespace
+        )
 
     async def finalize(self):
         """Flush pending writes and release the OpenSearch client connection.

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -1960,11 +1960,16 @@ class TestDocStatusStorage:
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
-            mock_client.indices.put_mapping.assert_awaited_once()
-            kwargs = mock_client.indices.put_mapping.call_args.kwargs
-            assert kwargs["body"] == {
-                "properties": {"content_hash": {"type": "keyword"}}
-            }
+            # Startup also stamps the workspace marker into ``_meta`` on this
+            # unmarked pre-existing index, so filter for the content_hash call.
+            property_bodies = [
+                call.kwargs["body"]
+                for call in mock_client.indices.put_mapping.await_args_list
+                if "properties" in call.kwargs["body"]
+            ]
+            assert property_bodies == [
+                {"properties": {"content_hash": {"type": "keyword"}}}
+            ]
 
     @pytest.mark.asyncio
     async def test_ensure_content_hash_mapping_skipped_when_present(
@@ -1991,7 +1996,14 @@ class TestDocStatusStorage:
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
-            mock_client.indices.put_mapping.assert_not_awaited()
+            # Only the workspace ``_meta`` marker may be written; no mapping
+            # property is added to an index that already has content_hash.
+            property_calls = [
+                call
+                for call in mock_client.indices.put_mapping.await_args_list
+                if "properties" in call.kwargs["body"]
+            ]
+            assert property_calls == []
 
     @pytest.mark.asyncio
     async def test_prepare_doc_status_data(self, global_config, embed_func):

--- a/tests/kg/opensearch_impl/test_workspace_index_collision.py
+++ b/tests/kg/opensearch_impl/test_workspace_index_collision.py
@@ -1,0 +1,504 @@
+"""Regression tests for workspace/index collisions on the OpenSearch backend.
+
+``_sanitize_index_name`` lowercases the workspace and folds every character
+outside ``[a-z0-9_-]`` to ``_``, so distinct workspaces (``TeamA`` / ``teama``,
+``v1.0`` / ``v1_0``) resolve to the same physical index. Sharing an index means
+sharing documents, overwriting each other's rows and -- because ``drop()``
+deletes the whole index on this backend -- destroying each other's data.
+
+Each storage class must therefore record its *original* workspace namespace in
+the index mapping's ``_meta`` and refuse to attach to an index claimed by a
+different one. See issue #3827.
+"""
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import numpy as np
+import pytest
+
+pytest.importorskip(
+    "opensearchpy",
+    reason="opensearchpy is required for OpenSearch storage tests",
+)
+
+from opensearchpy.exceptions import OpenSearchException  # type: ignore  # noqa: E402
+
+from lightrag.kg.opensearch_impl import (  # noqa: E402
+    ClientManager,
+    OpenSearchDocStatusStorage,
+    OpenSearchGraphStorage,
+    OpenSearchKVStorage,
+    OpenSearchVectorDBStorage,
+    WorkspaceIndexCollisionError,
+    _EDGE_ID_CANONICAL_META_FLAG,
+    _FINAL_NAMESPACE_META_KEY,
+    _WORKSPACE_META_KEY,
+    _claim_index_for_workspace,
+    _sanitize_index_name,
+)
+
+pytestmark = pytest.mark.offline
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / fakes
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _mock_lock():
+    yield
+
+
+def _mock_lock_factory(*args, **kwargs):
+    return _mock_lock()
+
+
+@pytest.fixture(autouse=True)
+def patch_locks():
+    """Run initialize() without the shared-storage machinery."""
+    cache: dict[tuple, asyncio.Lock] = {}
+
+    def namespace_lock(namespace, workspace=None, enable_logging=False):
+        return cache.setdefault((namespace, workspace), asyncio.Lock())
+
+    with (
+        patch(
+            "lightrag.kg.opensearch_impl.get_data_init_lock",
+            side_effect=_mock_lock_factory,
+        ),
+        patch(
+            "lightrag.kg.opensearch_impl.get_namespace_lock",
+            side_effect=namespace_lock,
+        ),
+        patch("lightrag.kg.opensearch_impl._shard_doc_supported", True),
+    ):
+        yield
+
+
+class FakeCluster:
+    """Minimal stateful stand-in for one shared OpenSearch cluster.
+
+    Index mappings are kept in a dict, so two storage instances built against
+    the same ``FakeCluster`` really do collide on the same index name -- which
+    is the whole point of these tests. A per-call ``AsyncMock`` cannot express
+    that: it has no memory of what the previous instance created.
+    """
+
+    def __init__(self):
+        self.mappings: dict[str, dict] = {}
+
+    # -- indices sub-client -------------------------------------------------
+    async def exists(self, index):
+        return index in self.mappings
+
+    async def create(self, index, body=None):
+        # Mirrors OpenSearch: creating an existing index is an error. Tests
+        # that need the lost-race path drive it explicitly.
+        assert index not in self.mappings, f"index {index} already exists"
+        self.mappings[index] = dict((body or {}).get("mappings", {}))
+
+    async def get_mapping(self, index):
+        if index not in self.mappings:
+            return {}
+        return {index: {"mappings": self.mappings[index]}}
+
+    async def put_mapping(self, index, body):
+        mappings = self.mappings[index]
+        if "_meta" in body:
+            mappings["_meta"] = body["_meta"]
+        if "properties" in body:
+            mappings.setdefault("properties", {}).update(body["properties"])
+
+    async def delete(self, index, **kwargs):
+        self.mappings.pop(index, None)
+
+    async def refresh(self, index=None, **kwargs):
+        return None
+
+    # -- client -------------------------------------------------------------
+    def client(self):
+        from opensearchpy import AsyncOpenSearch
+
+        client = AsyncMock(spec=AsyncOpenSearch)
+        client.indices = AsyncMock()
+        client.indices.exists = AsyncMock(side_effect=self.exists)
+        client.indices.create = AsyncMock(side_effect=self.create)
+        client.indices.get_mapping = AsyncMock(side_effect=self.get_mapping)
+        client.indices.put_mapping = AsyncMock(side_effect=self.put_mapping)
+        client.indices.delete = AsyncMock(side_effect=self.delete)
+        client.indices.refresh = AsyncMock(side_effect=self.refresh)
+        client.transport = AsyncMock()
+        client.transport.perform_request = AsyncMock(
+            side_effect=Exception("PPL not available")
+        )
+        # Empty index: no scheduling backfill, no edge migration work.
+        client.count = AsyncMock(return_value={"count": 0})
+        client.search = AsyncMock(
+            return_value={"hits": {"hits": [], "total": {"value": 0}}}
+        )
+        return client
+
+
+class _Embed:
+    embedding_dim = 8
+    max_token_size = 100
+
+    async def __call__(self, texts):
+        return np.zeros((len(texts), self.embedding_dim), dtype=np.float32)
+
+
+@pytest.fixture
+def cluster():
+    return FakeCluster()
+
+
+@pytest.fixture
+def global_config():
+    return {
+        "embedding_batch_num": 10,
+        "max_graph_nodes": 1000,
+        "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+    }
+
+
+STORAGE_CASES = [
+    pytest.param(OpenSearchKVStorage, "text_chunks", id="kv"),
+    pytest.param(OpenSearchDocStatusStorage, "doc_status", id="doc_status"),
+    pytest.param(OpenSearchGraphStorage, "chunk_entity_relation", id="graph"),
+    pytest.param(OpenSearchVectorDBStorage, "entities", id="vector"),
+]
+
+
+async def _initialize(cls, namespace, workspace, global_config, cluster):
+    storage = cls(
+        namespace=namespace,
+        global_config=global_config,
+        embedding_func=_Embed(),
+        workspace=workspace,
+    )
+    with patch.object(ClientManager, "get_client", return_value=cluster.client()):
+        await storage.initialize()
+    return storage
+
+
+# ---------------------------------------------------------------------------
+# The collision itself
+# ---------------------------------------------------------------------------
+
+
+class TestCaseVariantWorkspacesCollide:
+    def test_index_names_really_collide(self):
+        """The precondition: the name mapping is not injective."""
+        assert _sanitize_index_name("TeamA_text_chunks") == "teama_text_chunks"
+        assert _sanitize_index_name("teama_text_chunks") == "teama_text_chunks"
+        assert _sanitize_index_name("v1.0_text_chunks") == "v1_0_text_chunks"
+        assert _sanitize_index_name("v1_0_text_chunks") == "v1_0_text_chunks"
+
+    @pytest.mark.parametrize("cls,namespace", STORAGE_CASES)
+    @pytest.mark.asyncio
+    async def test_second_workspace_is_refused(
+        self, cls, namespace, global_config, cluster
+    ):
+        """``teama`` must not attach to the index ``TeamA`` created."""
+        await _initialize(cls, namespace, "TeamA", global_config, cluster)
+
+        with pytest.raises(WorkspaceIndexCollisionError) as excinfo:
+            await _initialize(cls, namespace, "teama", global_config, cluster)
+
+        message = str(excinfo.value)
+        assert f"TeamA_{namespace}" in message
+        assert f"teama_{namespace}" in message
+        # The way out is renaming a workspace. Dropping the index would
+        # destroy the other workspace's data, so every mention of dropping
+        # must stay negated.
+        assert "Rename one of the" in message
+        assert message.count("drop") == message.count("Do NOT drop")
+
+    @pytest.mark.parametrize("cls,namespace", STORAGE_CASES)
+    @pytest.mark.asyncio
+    async def test_punctuation_variant_is_refused(
+        self, cls, namespace, global_config, cluster
+    ):
+        """Folding of non-alphanumeric characters collides the same way."""
+        await _initialize(cls, namespace, "v1.0", global_config, cluster)
+
+        with pytest.raises(WorkspaceIndexCollisionError):
+            await _initialize(cls, namespace, "v1_0", global_config, cluster)
+
+    @pytest.mark.parametrize("cls,namespace", STORAGE_CASES)
+    @pytest.mark.asyncio
+    async def test_same_workspace_reattaches(
+        self, cls, namespace, global_config, cluster
+    ):
+        """The ordinary multi-worker case must stay silent."""
+        await _initialize(cls, namespace, "TeamA", global_config, cluster)
+        await _initialize(cls, namespace, "TeamA", global_config, cluster)
+        await _initialize(cls, namespace, "TeamA", global_config, cluster)
+
+    @pytest.mark.parametrize("cls,namespace", STORAGE_CASES)
+    @pytest.mark.asyncio
+    async def test_distinct_workspaces_are_untouched(
+        self, cls, namespace, global_config, cluster
+    ):
+        """Workspaces that do not fold together keep working independently."""
+        await _initialize(cls, namespace, "TeamA", global_config, cluster)
+        await _initialize(cls, namespace, "TeamB", global_config, cluster)
+
+
+class TestAmbiguousJoinedNamespace:
+    """``{workspace}_{namespace}`` is itself a lossy join.
+
+    Workspace ``foo`` with namespace ``text_chunks`` and workspace ``foo_text``
+    with namespace ``chunks`` -- both real LightRAG namespaces -- produce the
+    same joined name and therefore the same index. Comparing only the joined
+    name would wave the second deployment through.
+    """
+
+    @pytest.mark.asyncio
+    async def test_joined_names_really_collide(self, global_config, cluster):
+        kv = OpenSearchKVStorage(
+            namespace="text_chunks",
+            global_config=global_config,
+            embedding_func=_Embed(),
+            workspace="foo",
+        )
+        vector = OpenSearchVectorDBStorage(
+            namespace="chunks",
+            global_config=global_config,
+            embedding_func=_Embed(),
+            workspace="foo_text",
+        )
+        assert kv._index_name == vector._index_name == "foo_text_chunks"
+        assert kv.final_namespace == vector.final_namespace == "foo_text_chunks"
+
+    @pytest.mark.asyncio
+    async def test_different_workspace_same_joined_name_is_refused(
+        self, global_config, cluster
+    ):
+        await _initialize(
+            OpenSearchKVStorage, "text_chunks", "foo", global_config, cluster
+        )
+        with pytest.raises(WorkspaceIndexCollisionError) as excinfo:
+            await _initialize(
+                OpenSearchVectorDBStorage, "chunks", "foo_text", global_config, cluster
+            )
+        message = str(excinfo.value)
+        assert "'foo'" in message
+        assert "'foo_text'" in message
+
+    @pytest.mark.asyncio
+    async def test_partial_marker_is_not_adopted(self, cluster):
+        """An identity we cannot fully match is not ours to overwrite."""
+        cluster.mappings["teama_text_chunks"] = {
+            "_meta": {_WORKSPACE_META_KEY: "TeamA"},
+            "properties": {},
+        }
+        client = cluster.client()
+        with pytest.raises(WorkspaceIndexCollisionError):
+            await _claim_index_for_workspace(
+                client, "teama_text_chunks", "TeamA", "TeamA_text_chunks"
+            )
+        client.indices.put_mapping.assert_not_awaited()
+
+
+class TestMarkerIsRecorded:
+    @pytest.mark.asyncio
+    async def test_every_created_index_carries_the_marker(self, global_config, cluster):
+        await _initialize(
+            OpenSearchGraphStorage,
+            "chunk_entity_relation",
+            "TeamA",
+            global_config,
+            cluster,
+        )
+        # The graph storage owns two indices; both must be marked, or the
+        # unmarked one silently stays shareable.
+        assert set(cluster.mappings) == {
+            "teama_chunk_entity_relation-nodes",
+            "teama_chunk_entity_relation-edges",
+        }
+        for mappings in cluster.mappings.values():
+            meta = mappings["_meta"]
+            assert meta[_WORKSPACE_META_KEY] == "TeamA"
+            assert meta[_FINAL_NAMESPACE_META_KEY] == "TeamA_chunk_entity_relation"
+        # The edge-migration flag also lives in ``_meta`` and is written after
+        # the marker; neither write may clobber the other.
+        edges_meta = cluster.mappings["teama_chunk_entity_relation-edges"]["_meta"]
+        assert edges_meta[_EDGE_ID_CANONICAL_META_FLAG] is True
+
+    @pytest.mark.asyncio
+    async def test_drop_and_recreate_remarks_the_index(self, global_config, cluster):
+        storage = await _initialize(
+            OpenSearchKVStorage, "text_chunks", "TeamA", global_config, cluster
+        )
+        with patch.object(ClientManager, "get_client", return_value=cluster.client()):
+            await storage.drop()
+            await storage._ensure_index_ready()
+        assert cluster.mappings["teama_text_chunks"]["_meta"] == {
+            _WORKSPACE_META_KEY: "TeamA",
+            _FINAL_NAMESPACE_META_KEY: "TeamA_text_chunks",
+        }
+
+
+class TestLegacyIndexAdoption:
+    """Indices created before the marker existed carry no ``_meta``."""
+
+    @pytest.mark.asyncio
+    async def test_unmarked_index_is_adopted(self, global_config, cluster):
+        cluster.mappings["teama_text_chunks"] = {
+            "properties": {"__mirrored_id": {"type": "keyword"}}
+        }
+        await _initialize(
+            OpenSearchKVStorage, "text_chunks", "TeamA", global_config, cluster
+        )
+        assert cluster.mappings["teama_text_chunks"]["_meta"] == {
+            _WORKSPACE_META_KEY: "TeamA",
+            _FINAL_NAMESPACE_META_KEY: "TeamA_text_chunks",
+        }
+
+    @pytest.mark.asyncio
+    async def test_adoption_is_first_come_first_served(self, global_config, cluster):
+        cluster.mappings["teama_text_chunks"] = {"properties": {}}
+        await _initialize(
+            OpenSearchKVStorage, "text_chunks", "TeamA", global_config, cluster
+        )
+        with pytest.raises(WorkspaceIndexCollisionError):
+            await _initialize(
+                OpenSearchKVStorage, "text_chunks", "teama", global_config, cluster
+            )
+
+    @pytest.mark.asyncio
+    async def test_adoption_preserves_existing_meta(self, cluster):
+        """``put_mapping`` replaces ``_meta`` wholesale, so it must be merged.
+
+        Dropping ``_EDGE_ID_CANONICAL_META_FLAG`` here would silently re-run
+        the one-time canonical edge-id reindex on every later startup.
+        """
+        cluster.mappings["teama_graph-edges"] = {
+            "_meta": {_EDGE_ID_CANONICAL_META_FLAG: True},
+            "properties": {},
+        }
+        client = cluster.client()
+        await _claim_index_for_workspace(
+            client, "teama_graph-edges", "TeamA", "TeamA_graph"
+        )
+        assert cluster.mappings["teama_graph-edges"]["_meta"] == {
+            _EDGE_ID_CANONICAL_META_FLAG: True,
+            _WORKSPACE_META_KEY: "TeamA",
+            _FINAL_NAMESPACE_META_KEY: "TeamA_graph",
+        }
+
+
+class TestConcurrentAdoption:
+    @pytest.mark.asyncio
+    async def test_same_workspace_racing_adoption_is_idempotent(self, cluster):
+        """Two workers of one deployment writing the same marker must not raise."""
+        cluster.mappings["teama_text_chunks"] = {"properties": {}}
+        client = cluster.client()
+        await asyncio.gather(
+            *[
+                _claim_index_for_workspace(
+                    client, "teama_text_chunks", "TeamA", "TeamA_text_chunks"
+                )
+                for _ in range(4)
+            ]
+        )
+        assert cluster.mappings["teama_text_chunks"]["_meta"] == {
+            _WORKSPACE_META_KEY: "TeamA",
+            _FINAL_NAMESPACE_META_KEY: "TeamA_text_chunks",
+        }
+
+    @pytest.mark.asyncio
+    async def test_losing_an_adoption_race_is_detected(self, cluster):
+        """A different workspace claiming between our write and re-read raises."""
+        cluster.mappings["teama_text_chunks"] = {"properties": {}}
+        client = cluster.client()
+        original_put = cluster.put_mapping
+
+        async def steal_after_write(index, body):
+            await original_put(index, body)
+            cluster.mappings[index]["_meta"] = {
+                _WORKSPACE_META_KEY: "teama",
+                _FINAL_NAMESPACE_META_KEY: "teama_text_chunks",
+            }
+
+        client.indices.put_mapping = AsyncMock(side_effect=steal_after_write)
+        with pytest.raises(WorkspaceIndexCollisionError):
+            await _claim_index_for_workspace(
+                client, "teama_text_chunks", "TeamA", "TeamA_text_chunks"
+            )
+
+    @pytest.mark.asyncio
+    async def test_invisible_write_is_not_a_collision(self, cluster):
+        """A marker that is not yet readable back must not fail startup."""
+        cluster.mappings["teama_text_chunks"] = {"properties": {}}
+        client = cluster.client()
+
+        async def swallow_write(index, body):
+            return None
+
+        client.indices.put_mapping = AsyncMock(side_effect=swallow_write)
+        await _claim_index_for_workspace(
+            client, "teama_text_chunks", "TeamA", "TeamA_text_chunks"
+        )
+
+
+class TestUnwritableMapping:
+    """A read-only account must not be turned away by the marker write."""
+
+    @pytest.mark.asyncio
+    async def test_startup_survives_a_rejected_marker_write(
+        self, global_config, cluster, caplog
+    ):
+        cluster.mappings["teama_text_chunks"] = {
+            "properties": {"__mirrored_id": {"type": "keyword"}}
+        }
+        client = cluster.client()
+        client.indices.put_mapping = AsyncMock(
+            side_effect=OpenSearchException("security_exception: no write privilege")
+        )
+        storage = OpenSearchKVStorage(
+            namespace="text_chunks",
+            global_config=global_config,
+            embedding_func=_Embed(),
+            workspace="TeamA",
+        )
+        # lightrag's logger does not propagate, so caplog sees nothing unless
+        # propagation is enabled for the duration of the assertion.
+        from lightrag.utils import logger as lightrag_logger
+
+        previous = lightrag_logger.propagate
+        lightrag_logger.propagate = True
+        try:
+            with caplog.at_level(logging.WARNING, logger=lightrag_logger.name):
+                with patch.object(ClientManager, "get_client", return_value=client):
+                    await storage.initialize()
+        finally:
+            lightrag_logger.propagate = previous
+
+        assert "teama_text_chunks" in caplog.text
+        assert "stays unmarked" in caplog.text
+        assert "_meta" not in cluster.mappings["teama_text_chunks"]
+
+    @pytest.mark.asyncio
+    async def test_collision_still_raises_without_write_access(self, cluster):
+        """Detecting a foreign marker needs no write, so it must still fail."""
+        cluster.mappings["teama_text_chunks"] = {
+            "_meta": {
+                _WORKSPACE_META_KEY: "teama",
+                _FINAL_NAMESPACE_META_KEY: "teama_text_chunks",
+            }
+        }
+        client = cluster.client()
+        client.indices.put_mapping = AsyncMock(
+            side_effect=OpenSearchException("security_exception: no write privilege")
+        )
+        with pytest.raises(WorkspaceIndexCollisionError):
+            await _claim_index_for_workspace(
+                client, "teama_text_chunks", "TeamA", "TeamA_text_chunks"
+            )
+        client.indices.put_mapping.assert_not_awaited()


### PR DESCRIPTION
## Summary

Fixes #3827. The OpenSearch backend maps a LightRAG workspace to an index name through a **non-injective** transformation, so two distinct workspaces sharing one cluster silently attach to the same physical indexes. This PR makes that a startup failure instead of silent data commingling.

**This is a data-integrity bug, not an externally triggerable vulnerability.** The workspace comes from server configuration and cannot be selected per request — the `LIGHTRAG-WORKSPACE` header has exactly one consumer (`lightrag_server.py`, the `/health` pipeline-status lookup) and never reaches a storage path. There is no patch window to race here.

## Motivation

OpenSearch requires lowercase index names, so `_sanitize_index_name` lowercases the workspace and folds every character outside `[a-z0-9_-]` to `_`:

```
WORKSPACE=TeamA  ->  teama_chunks
WORKSPACE=teama  ->  teama_chunks
```

Both names are legal under the workspace charset documented in `env.example`, and `lightrag/api/config.py` preserves case deliberately, so both operators are following the documented contract — only the backend is lossy. Direct library users additionally collide on punctuation (`v1.0` / `v1_0`), since `validate_workspace` only rejects path traversal.

`_build_index_name` is the single index-name construction point for **all four** storage classes, so the collision covers KV, vector, graph and doc-status. Beyond read-side commingling it is destructive: `drop()` deletes the entire physical index on this backend (unlike the row-level clears in PostgreSQL/MongoDB/Redis/JSON), so `/documents/clear` on one deployment removes the other's data.

Checked against the other backends — this is OpenSearch-specific. PostgreSQL (workspace column), MongoDB/Redis (prefixes), Qdrant (payload partitioning) and Milvus do not case-fold. Neo4j and Memgraph preserve case in the workspace label. Neo4j's `_normalize_index_suffix` (full-text index names) is lossy, but the query carries a residual label filter, so colliding suffixes can only conflict at index-creation time — no data commingling.

## What's changed

- Every index created by the OpenSearch backend records the **original**, pre-sanitization workspace and final namespace in its mapping `_meta` (`lightrag_workspace` / `lightrag_final_namespace`).
- `_claim_index_for_workspace` verifies that marker on every attach. **Both fields are compared**: the joined `{workspace}_{namespace}` is itself ambiguous (workspace `foo` + namespace `text_chunks` joins to the same string as workspace `foo_text` + namespace `chunks`, and both are real LightRAG namespaces), so the workspace must be checked alongside it. A partially written marker counts as claimed — an identity that cannot be fully matched is not ours to overwrite. A mismatch raises the new `WorkspaceIndexCollisionError` naming the index, both identities, and the way out (rename a workspace or use a different cluster — explicitly *not* "drop the index", which holds the other workspace's data).
- Ownership is checked **before any mapping mutation**, and for the graph storage before `_migrate_edges_to_canonical_id_if_needed`, so a colliding deployment never writes to or reindexes another workspace's data on its way to failing.
- Writing the marker on a legacy index is the only step that needs mapping-write access. If it is rejected (read-only account, restored snapshot, `index.blocks.write`) the failure degrades to a warning and startup continues: the index stays unmarked and unprotected, exactly where it was before this check existed. Detecting a marker that names a *different* workspace needs no write and still fails fast.
- `env.example` documents the constraint next to `OPENSEARCH_WORKSPACE`.

### Why detection instead of renaming

Appending a hash of the workspace to the index name would close the collision, but it renames the indexes of **every** existing deployment, including the overwhelming majority that never collide. Rejecting non-canonical workspace names at startup is zero-migration but breaks every current `WORKSPACE=TeamA` user. Marker-based detection costs one `get_mapping` per index at startup, needs no migration, and stays useful as defense in depth after workspace identifiers move to UUIDs.

### Legacy indexes

An index created before this change carries no marker. It is adopted on first attach:

- The write merges into any existing `_meta`, so `edge_id_canonical_v1` is not clobbered (which would silently re-run the one-time canonical edge-id reindex on every startup). The reverse also holds — the migration's own `_meta` write already merges, so it preserves the new marker.
- The confirmation read afterwards compares against the identity itself, never a per-process token: two workers of one deployment racing to adopt write the same value and both succeed.
- A marker that is not yet readable back is treated as "not visible yet", not as a collision — only a differing identity fails.

**Adopting a legacy index is not atomic across deployments**, and the docstring says so. Index *creation* is atomic — one caller wins `indices.create`, the loser reads the winner's marker — so this window exists only for indexes that predate the marker, once each. Two colliding deployments upgrading at the same instant can both read "no marker" and both claim it; the confirmation read narrows that window but does not close it. Within the window the outcome is exactly the status quo before this change (both attached, sharing), and the mismatch surfaces on the next attach. Closing it would need a cluster-side compare-and-set, which OpenSearch does not offer for mappings: the alternatives are writing a marker *document* into the data index (polluting counts, scrolls and sweeps) or introducing a registry index (new index and write-permission surface, which would undo the read-only tolerance above). This is a detection safeguard, not a distributed lock.

## What's broken / behavior changes

- A deployment whose workspace folds onto an index owned by a different workspace **now fails to start** (or fails its next write, if the index is being recreated after a drop) instead of silently sharing data. That is the intended change; the error names both workspaces and does not suggest dropping anything.
- Two existing tests in `test_opensearch_storage.py` asserted `put_mapping` call counts on pre-existing doc-status indexes. Startup now also stamps the `_meta` marker there, so those assertions were narrowed to the `properties` bodies they were actually about.

## Testing

New `tests/kg/opensearch_impl/test_workspace_index_collision.py` drives a stateful fake cluster, so two storage instances really do collide on one index — a per-call `AsyncMock` cannot express that. Coverage: collision refused for all four storage classes (case and punctuation variants), the ambiguous-join case (`foo`/`text_chunks` vs `foo_text`/`chunks`) and a partially written marker, same-workspace re-attach stays silent, non-colliding workspaces unaffected, both graph indexes marked, drop/recreate re-marks, legacy adoption, `_meta` merge preserving the canonical flag, concurrent same-workspace adoption, losing an adoption race, an invisible write, and a rejected marker write (startup survives with a warning; a foreign marker still raises).

Fix-proof: with the marker logic stubbed out on the pre-change file, 17 of the new tests fail **behaviorally** (no exception raised, no marker written, no warning logged — not an `ImportError`), while the 10 stability tests still pass.

```
./scripts/test.sh tests/kg/opensearch_impl   ->  392 passed
```

## Credit

Reported privately by a security researcher via GitHub Security Advisories. The root-cause analysis was accurate and the report was explicit about the deployment preconditions; it is handled here as a normal bug because there is no attacker-controlled input.
