### PR TITLE
Clarify Neo4j URI scheme selection and troubleshooting

### DIFF
--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -851,11 +851,24 @@ Example connection configurations for each storage type can be found in the repo
 For production level scenarios you will most likely want to leverage an enterprise solution for KG storage. Running Neo4J in Docker is recommended for seamless local testing. See: https://hub.docker.com/_/neo4j
 
 ```bash
-export NEO4J_URI="neo4j://localhost:7687"
+export NEO4J_URI="bolt://localhost:7687"  # Single instance / Docker: direct connection
 export NEO4J_USERNAME="neo4j"
 export NEO4J_PASSWORD="password"
 export NEO4J_DATABASE="neo4j"  # Required for community edition
 ```
+
+**Choosing the URI scheme.** The scheme prefix of `NEO4J_URI` selects the driver's connection mode:
+
+- `bolt://` / `bolt+s://` — direct connection. The driver talks only to the host and port written in the URI. Use this for a single Neo4j instance, a single Docker container, or any deployment reached through a port mapping or proxy.
+- `neo4j://` / `neo4j+s://` — routing connection. The driver first asks the server for a routing table and then connects to the addresses the server advertises. Use this for Neo4j Aura and clustered deployments, where it provides read/write routing and failover.
+
+**Troubleshooting `Unable to retrieve routing information`.** This error is raised by the Neo4j driver, not by LightRAG, and it only occurs with the `neo4j://` scheme. It means none of the routers returned a routing table. Check, in order:
+
+1. The Neo4j server is actually running and reachable on the configured host and port (a stopped or restarting instance produces exactly this message).
+2. If the instance is a single node or a Docker container, switch `NEO4J_URI` to `bolt://`. A single instance advertises its own address in the routing table; when the server is reached through Docker port mapping or a proxy, that advertised address is often not reachable from the client, so the routing refresh fails even though the initial connection succeeded. The direct scheme skips the routing table entirely.
+3. If you must keep `neo4j://` against a single Docker container, set `server.default_advertised_address` on the Neo4j side to an address the client can reach.
+
+LightRAG retries transient `ServiceUnavailable` errors a few times with backoff, but it cannot recover from a database that stays unreachable; the storage call fails after the retries are exhausted.
 
 ```python
 from lightrag.utils import setup_logger

--- a/env.example
+++ b/env.example
@@ -1444,7 +1444,10 @@ POSTGRES_VCHORDRQ_EPSILON=1.9
 # POSTGRES_AGE_ALLOW_UNSUPPORTED_VERSION=false
 
 ### Neo4j Configuration
+### Use neo4j:// or neo4j+s:// for Aura and clusters (routing); use bolt:// for a single
+### instance or a single Docker container to avoid "Unable to retrieve routing information"
 NEO4J_URI=neo4j+s://xxxxxxxx.databases.neo4j.io
+# NEO4J_URI=bolt://localhost:7687
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD='your_password'
 NEO4J_DATABASE=neo4j

--- a/env.example
+++ b/env.example
@@ -1447,7 +1447,6 @@ POSTGRES_VCHORDRQ_EPSILON=1.9
 ### Use neo4j:// or neo4j+s:// for Aura and clusters (routing); use bolt:// for a single
 ### instance or a single Docker container to avoid "Unable to retrieve routing information"
 NEO4J_URI=neo4j+s://xxxxxxxx.databases.neo4j.io
-# NEO4J_URI=bolt://localhost:7687
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD='your_password'
 NEO4J_DATABASE=neo4j


### PR DESCRIPTION
## Description

This PR improves the Neo4j configuration documentation by clarifying the differences between URI schemes (`bolt://` vs `neo4j://`) and providing comprehensive troubleshooting guidance for the common "Unable to retrieve routing information" error.

## Related Issues

N/A

## Changes Made

- Updated `docs/ProgramingWithCore.md` to:
  - Changed the example `NEO4J_URI` from `neo4j://` to `bolt://` with a clarifying comment
  - Added a new "Choosing the URI scheme" section explaining when to use `bolt://` (direct connection for single instances/Docker) vs `neo4j://` (routing for Aura/clusters)
  - Added a "Troubleshooting `Unable to retrieve routing information`" section with step-by-step diagnosis and solutions, including the common Docker port mapping issue

- Updated `env.example` to:
  - Added inline comments explaining the difference between `neo4j://` and `bolt://` schemes
  - Clarified that `bolt://` should be used for single instances or Docker containers

## Checklist

- [x] Changes tested locally
- [x] Documentation updated
- [ ] Unit tests added (N/A - documentation only)

## Additional Notes

These changes address a frequently encountered issue where users get "Unable to retrieve routing information" errors when using `neo4j://` with single Neo4j instances or Docker containers. The documentation now clearly explains the root cause (routing table advertisement through port mapping) and provides the correct solution (use `bolt://` instead). This should significantly reduce confusion and support requests related to Neo4j connectivity.

https://claude.ai/code/session_01U6Dn2du2WyKJDhYnxuv7EP