### PR TITLE
docs: fix docstring ghosts in parse_args and process_chunks_unified

### DIFF
--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -347,9 +347,6 @@ def parse_args() -> argparse.Namespace:
     """
     Parse command line arguments with environment variable fallback
 
-    Args:
-        is_uvicorn_mode: Whether running under uvicorn mode
-
     Returns:
         argparse.Namespace: Parsed arguments
     """

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -6306,7 +6306,7 @@ async def process_chunks_unified(
 
     Args:
         query: Search query for reranking
-        chunks: List of text chunks to process
+        unique_chunks: List of deduplicated text chunks to process
         query_param: Query parameters containing configuration
         global_config: Global configuration dictionary
         source_type: Source type for logging ("vector", "entity", "relationship", "mixed")


### PR DESCRIPTION
Two docstring fixes, each verified against the signature:

1. `lightrag/api/config.py` `parse_args()` documented an `is_uvicorn_mode` argument it does not take.
2. `lightrag/utils.py` `process_chunks_unified` documented a `chunks` parameter — the actual parameter is `unique_chunks` (the audit flag; the docstring's own description of deduplication matches the unique_chunks semantics).