### PR TITLE
fix: make addon parameter updates atomic

### DIFF
--- a/lightrag/addon_params.py
+++ b/lightrag/addon_params.py
@@ -157,7 +157,11 @@ class ObservableAddonParams(dict[str, Any]):
     def update(self, *args: Any, **kwargs: Any) -> None:
         if not args and not kwargs:
             return
-        super().update(*args, **kwargs)
+        # Materialize first because dict.update() can apply valid iterable
+        # entries before a later malformed entry raises. Live configuration and
+        # its derived cache must change together or not at all.
+        pending = dict(*args, **kwargs)
+        super().update(pending)
         self._changed()
 
     def __ior__(self, other: Mapping[str, Any]):

--- a/lightrag/addon_params.py
+++ b/lightrag/addon_params.py
@@ -14,7 +14,7 @@ module exposes:
 
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Iterable, Mapping
 
 from lightrag.constants import DEFAULT_SUMMARY_LANGUAGE
 from lightrag.utils import get_env_value, logger
@@ -164,7 +164,12 @@ class ObservableAddonParams(dict[str, Any]):
         super().update(pending)
         self._changed()
 
-    def __ior__(self, other: Mapping[str, Any]):
-        super().__ior__(other)
+    def __ior__(self, other: Mapping[str, Any] | Iterable[tuple[str, Any]]):
+        # ``dict.__ior__`` accepts any iterable of key/value pairs (PEP 584),
+        # not just the Mapping this signature advertises, so ``|=`` carries the
+        # same partial-application hazard as ``update``. Materialize first for
+        # the same reason.
+        pending = dict(other)
+        super().__ior__(pending)
         self._changed()
         return self

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1034,20 +1034,30 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         ``recursive_character`` dict stays the object that is read later, and so
         it cannot recursively re-enter this callback through
         ``ObservableAddonParams.__setitem__``.
-        """
-        chunker_config = self._addon_params.get("chunker")
-        if isinstance(chunker_config, Mapping):
-            from lightrag.parser.routing import normalize_chunker_r_separators
 
-            normalized, corrected = normalize_chunker_r_separators(
-                chunker_config, context="addon_params['chunker']", in_place=True
-            )
-            if corrected and normalized is not chunker_config:
-                # ``in_place`` could not apply (an immutable mapping was
-                # supplied). Store the corrected copy without re-entering this
-                # callback; the dirty mark below already covers it.
-                dict.__setitem__(self._addon_params, "chunker", dict(normalized))
-        self._mark_addon_params_dirty()
+        The dirty mark is in a ``finally`` on purpose. By the time this callback
+        runs the live mapping has ALREADY changed, so the derived cache is
+        already stale — normalization raising (a malformed replacement chunker
+        config such as ``{"separators": [1, 2]}`` reaches ``len()`` on a
+        non-string) must not be able to leave the mapping ahead of a cache that
+        still looks clean. The caller still sees the error; it just cannot cost
+        us the invalidation.
+        """
+        try:
+            chunker_config = self._addon_params.get("chunker")
+            if isinstance(chunker_config, Mapping):
+                from lightrag.parser.routing import normalize_chunker_r_separators
+
+                normalized, corrected = normalize_chunker_r_separators(
+                    chunker_config, context="addon_params['chunker']", in_place=True
+                )
+                if corrected and normalized is not chunker_config:
+                    # ``in_place`` could not apply (an immutable mapping was
+                    # supplied). Store the corrected copy without re-entering
+                    # this callback; the dirty mark below already covers it.
+                    dict.__setitem__(self._addon_params, "chunker", dict(normalized))
+        finally:
+            self._mark_addon_params_dirty()
 
     def _replace_addon_params(
         self, addon_params: Mapping[str, Any] | None, *, mark_dirty: bool

--- a/tests/test_addon_params.py
+++ b/tests/test_addon_params.py
@@ -1,5 +1,7 @@
 """Tests for observable runtime addon parameters."""
 
+from typing import Any
+
 import pytest
 
 from lightrag.addon_params import ObservableAddonParams
@@ -32,7 +34,10 @@ def test_update_is_atomic_when_an_iterable_is_malformed() -> None:
         yield ("language", "French")
         yield ("malformed",)
 
-    with pytest.raises(ValueError, match="dictionary update sequence element #1"):
+    # Match on the exception type only: the "dictionary update sequence
+    # element #1 ..." wording is a CPython implementation detail, and what this
+    # regression is about is the mapping's state, not the message.
+    with pytest.raises(ValueError):
         params.update(partly_invalid_items())
 
     # A failed live-config update must not leave the mapping ahead of its
@@ -52,3 +57,90 @@ def test_update_does_not_notify_when_validation_fails_before_a_write() -> None:
 
     assert params == {"language": "English"}
     assert changes == []
+
+
+def test_ior_is_atomic_when_an_iterable_is_malformed() -> None:
+    """``|=`` takes iterables too (PEP 584), so it needs update()'s guarantee.
+
+    ``dict.__ior__`` is not restricted to the ``Mapping`` its signature
+    advertises, so without materializing first it applies leading pairs and then
+    raises, skipping the change notification exactly like ``update`` did.
+    """
+    changes: list[str] = []
+
+    def unexpected_change() -> None:
+        changes.append("changed")
+        raise AssertionError("failed updates must not trigger callbacks")
+
+    params = ObservableAddonParams({"language": "English"}, on_change=unexpected_change)
+
+    def partly_invalid_items():
+        yield ("language", "French")
+        yield ("malformed",)
+
+    with pytest.raises(ValueError):
+        params |= partly_invalid_items()
+
+    assert params == {"language": "English"}
+    assert changes == []
+
+
+def test_ior_commits_a_mapping_and_notifies_once() -> None:
+    changes: list[str] = []
+    params = ObservableAddonParams(
+        {"language": "English"}, on_change=lambda: changes.append("changed")
+    )
+
+    params |= {"language": "French"}
+
+    assert params == {"language": "French"}
+    assert changes == ["changed"]
+
+
+def _addon_params_change_observer() -> Any:
+    """A minimal stand-in carrying only LightRAG's addon-params cache hooks.
+
+    Constructing a real ``LightRAG`` needs storages, an LLM func and an
+    embedding func; the invalidation contract under test is just these two
+    methods plus the two attributes they touch.
+    """
+    from lightrag.lightrag import LightRAG
+
+    class _CacheOwner:
+        _on_addon_params_changed = LightRAG._on_addon_params_changed
+        _mark_addon_params_dirty = LightRAG._mark_addon_params_dirty
+
+        def __init__(self) -> None:
+            self._addon_params_dirty = False
+            self._addon_params = ObservableAddonParams(
+                {"chunker": {}}, on_change=self._on_addon_params_changed
+            )
+
+    return _CacheOwner()
+
+
+def test_cache_is_invalidated_even_when_the_change_callback_raises() -> None:
+    """A raising callback must not leave the mapping ahead of a clean cache.
+
+    ``separators`` holding non-strings reaches ``len()`` on an ``int`` inside
+    ``inspect_r_separators``. The assignment itself has already committed by
+    then, so skipping the dirty mark would keep the stale summary language and
+    prompt profile alive until some unrelated later mutation happened to
+    invalidate them.
+    """
+    owner = _addon_params_change_observer()
+    malformed = {"recursive_character": {"separators": [1, 2]}}
+
+    with pytest.raises(TypeError):
+        owner._addon_params["chunker"] = malformed
+
+    assert owner._addon_params["chunker"] == malformed
+    assert owner._addon_params_dirty is True
+
+
+def test_cache_is_invalidated_on_a_normal_chunker_replacement() -> None:
+    owner = _addon_params_change_observer()
+
+    owner._addon_params["chunker"] = {"recursive_character": {"separators": ["\n"]}}
+
+    assert owner._addon_params_dirty is True

--- a/tests/test_addon_params.py
+++ b/tests/test_addon_params.py
@@ -1,0 +1,54 @@
+"""Tests for observable runtime addon parameters."""
+
+import pytest
+
+from lightrag.addon_params import ObservableAddonParams
+
+pytestmark = pytest.mark.offline
+
+
+def test_update_commits_valid_input_and_notifies_once() -> None:
+    changes: list[str] = []
+    params = ObservableAddonParams(
+        {"language": "English"}, on_change=lambda: changes.append("changed")
+    )
+
+    params.update([("language", "French")], entity_types=["person"])
+
+    assert params == {"language": "French", "entity_types": ["person"]}
+    assert changes == ["changed"]
+
+
+def test_update_is_atomic_when_an_iterable_is_malformed() -> None:
+    changes: list[str] = []
+
+    def unexpected_change() -> None:
+        changes.append("changed")
+        raise AssertionError("failed updates must not trigger callbacks")
+
+    params = ObservableAddonParams({"language": "English"}, on_change=unexpected_change)
+
+    def partly_invalid_items():
+        yield ("language", "French")
+        yield ("malformed",)
+
+    with pytest.raises(ValueError, match="dictionary update sequence element #1"):
+        params.update(partly_invalid_items())
+
+    # A failed live-config update must not leave the mapping ahead of its
+    # derived cache or emit a change notification for an update that failed.
+    assert params == {"language": "English"}
+    assert changes == []
+
+
+def test_update_does_not_notify_when_validation_fails_before_a_write() -> None:
+    changes: list[str] = []
+    params = ObservableAddonParams(
+        {"language": "English"}, on_change=lambda: changes.append("changed")
+    )
+
+    with pytest.raises(TypeError):
+        params.update(42)
+
+    assert params == {"language": "English"}
+    assert changes == []


### PR DESCRIPTION
## Description

`ObservableAddonParams.update()` currently passes caller input straight to
`dict.update()`. For iterable input, Python can apply earlier entries before a
later malformed entry raises `ValueError`. Because that exception skips the
subsequent change callback, the live mapping is left partially updated while
LightRAG's derived configuration cache retains its old values.

This change first materializes the requested update in a temporary `dict`.
Validation failures therefore leave both the live mapping and its callback state
untouched; successful updates are applied once and emit the existing single
invalidation notification.

## Related Issues

N/A — this boundary defect was found through focused inspection. Searches for
the exception text, affected method, stale addon-parameter cache behavior, and
open pull requests changing `lightrag/addon_params.py` found no equivalent fix.

## Changes Made

- Validate the complete update input before mutating live addon parameters.
- Keep failed updates atomic and avoid invoking callbacks when no update commits.
- Add offline regressions for partial iterable failures and failures before the
  first write, including a callback that would otherwise obscure the original
  validation error.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (not needed; no public API or configuration contract changed)
- [x] Unit tests added (if applicable)

## Additional Notes

Regression evidence on the exact upstream base `ad55b31`:

- Before the fix: one regression failed because `language` changed from
  `English` to `French` even though the update raised `ValueError`.
- After the fix: both failed-update regressions pass without mutating the mapping
  or invoking its callback.

Verification:

- Python 3.14 focused addon/config suite: 79 passed.
- Python 3.14 full offline suite: 6,437 passed, 48 skipped, 1,564 deselected
  (one third-party deprecation warning).
- Full-repository pre-commit hooks: all passed (`ruff format`, `ruff`, and repository
  file checks).
