### PR TITLE
feat: add shared runtime Langfuse tracing toggle

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -71,6 +71,7 @@ from lightrag.parser.external.mineru.cache import MinerUParserOptions
 from lightrag.api.routers.query_routes import create_query_routes
 from lightrag.api.routers.graph_routes import create_graph_routes
 from lightrag.api.routers.ollama_api import OllamaAPI
+from lightrag.api.routers.observability_routes import create_observability_routes
 from lightrag.api.routers.ui_customization_routes import create_ui_customization_routes
 from lightrag.api.ui_customization import (
     WEBUI_CHROME_LOCALES,
@@ -79,6 +80,7 @@ from lightrag.api.ui_customization import (
 )
 
 from lightrag.utils import logger, set_verbose_debug
+from lightrag.llm.langfuse_tracing import initialize_langfuse_tracing
 from lightrag.kg.shared_storage import (
     get_namespace_data,
     get_default_workspace,
@@ -1593,6 +1595,7 @@ def create_app(args):
             # Initialize database connections
             # Note: initialize_storages() now auto-initializes pipeline_status for rag.workspace
             await rag.initialize_storages()
+            await initialize_langfuse_tracing()
 
             # Data migration regardless of storage implementation
             await rag.check_and_migrate_data()
@@ -2540,6 +2543,7 @@ def create_app(args):
     app.include_router(create_document_routes(rag, doc_manager, api_key))
     app.include_router(create_query_routes(rag, api_key, args.top_k))
     app.include_router(create_graph_routes(rag, api_key))
+    app.include_router(create_observability_routes(api_key))
     # Public read-only customization surface — registered unconditionally:
     # without a bundle it answers 200 {"customized": false, ...}.
     app.include_router(

--- a/lightrag/api/routers/observability_routes.py
+++ b/lightrag/api/routers/observability_routes.py
@@ -1,0 +1,80 @@
+"""Authenticated runtime observability controls."""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from lightrag.api.utils_api import get_combined_auth_dependency
+from lightrag.llm.langfuse_tracing import (
+    get_langfuse_tracing_status,
+    set_langfuse_tracing_enabled,
+)
+
+
+class LangfuseTracingStatus(BaseModel):
+    installed: bool
+    configured: bool
+    enabled: bool
+    active: bool
+
+
+class LangfuseTracingUpdate(BaseModel):
+    enabled: bool = Field(
+        ...,
+        description="Enable or disable Langfuse trace export at runtime.",
+    )
+
+
+def create_observability_routes(api_key: Optional[str] = None) -> APIRouter:
+    """Create routes for runtime observability controls."""
+
+    router = APIRouter(
+        prefix="/observability",
+        tags=["observability"],
+    )
+    auth_dependency = get_combined_auth_dependency(
+        api_key,
+        respect_whitelist=False,
+    )
+
+    @router.get(
+        "/langfuse/tracing",
+        response_model=LangfuseTracingStatus,
+        dependencies=[Depends(auth_dependency)],
+    )
+    async def get_langfuse_tracing() -> LangfuseTracingStatus:
+        return LangfuseTracingStatus(**get_langfuse_tracing_status())
+
+    @router.put(
+        "/langfuse/tracing",
+        response_model=LangfuseTracingStatus,
+        dependencies=[Depends(auth_dependency)],
+    )
+    async def update_langfuse_tracing(
+        request: LangfuseTracingUpdate,
+    ) -> LangfuseTracingStatus:
+        current = get_langfuse_tracing_status()
+
+        if not current["installed"]:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Langfuse observability support is not installed",
+            )
+        if not current["configured"]:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Langfuse credentials are not configured",
+            )
+
+        try:
+            set_langfuse_tracing_enabled(request.enabled)
+        except RuntimeError:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Langfuse runtime tracing state is unavailable",
+            ) from None
+
+        return LangfuseTracingStatus(**get_langfuse_tracing_status())
+
+    return router

--- a/lightrag/llm/langfuse_tracing.py
+++ b/lightrag/llm/langfuse_tracing.py
@@ -1,0 +1,135 @@
+"""Runtime control for Langfuse tracing.
+
+Credentials and the Langfuse destination remain operator-managed environment
+configuration. This module controls only whether configured tracing is active
+at runtime.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from collections.abc import MutableMapping
+from typing import Any
+
+from lightrag.kg.shared_storage import get_namespace_data
+from lightrag.utils import logger
+
+
+LANGFUSE_TRACING_NAMESPACE = "langfuse_tracing"
+LANGFUSE_TRACING_ENABLED_KEY = "enabled"
+
+_langfuse_tracing_state: MutableMapping[str, Any] | None = None
+_langfuse_client: Any | None = None
+
+
+def _configured_default() -> bool:
+    """Return the operator-configured tracing default.
+
+    Tracing remains enabled by default when Langfuse credentials are present,
+    preserving the behavior that predates LANGFUSE_ENABLE_TRACE.
+    """
+
+    value = os.getenv("LANGFUSE_ENABLE_TRACE")
+    if value is None:
+        return True
+
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+
+    logger.warning(
+        "Invalid LANGFUSE_ENABLE_TRACE value; expected true/false, "
+        "1/0, yes/no, or on/off. Defaulting to enabled."
+    )
+    return True
+
+
+def is_langfuse_installed() -> bool:
+    """Return whether the optional Langfuse dependency is installed."""
+
+    try:
+        return importlib.util.find_spec("langfuse") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def is_langfuse_configured() -> bool:
+    """Return whether the operator supplied both required credentials."""
+
+    return bool(
+        os.getenv("LANGFUSE_PUBLIC_KEY") and os.getenv("LANGFUSE_SECRET_KEY")
+    )
+
+
+def should_export_langfuse_span(_span: Any) -> bool:
+    """Evaluate the live shared tracing switch for each span."""
+
+    state = _langfuse_tracing_state
+    if state is None:
+        return False
+
+    try:
+        return bool(state.get(LANGFUSE_TRACING_ENABLED_KEY, False))
+    except Exception:
+        # Shared storage may already be shutting down. Observability must never
+        # break an application request during teardown.
+        return False
+
+
+async def initialize_langfuse_tracing() -> None:
+    """Resolve shared state and construct the configured Langfuse client."""
+
+    global _langfuse_tracing_state, _langfuse_client
+
+    state = await get_namespace_data(LANGFUSE_TRACING_NAMESPACE, workspace="")
+    state.setdefault(LANGFUSE_TRACING_ENABLED_KEY, _configured_default())
+    _langfuse_tracing_state = state
+
+    if not is_langfuse_installed() or not is_langfuse_configured():
+        _langfuse_client = None
+        return
+
+    from langfuse import Langfuse
+
+    _langfuse_client = Langfuse(
+        should_export_span=should_export_langfuse_span,
+    )
+    logger.info("Langfuse runtime tracing control initialized")
+
+
+def set_langfuse_tracing_enabled(enabled: bool) -> None:
+    """Update the deployment-wide runtime tracing switch."""
+
+    state = _langfuse_tracing_state
+    if state is None:
+        raise RuntimeError("Langfuse runtime tracing state is unavailable")
+
+    try:
+        # A single manager.dict assignment is one atomic IPC operation, so this
+        # boolean update does not require a namespace lock.
+        state[LANGFUSE_TRACING_ENABLED_KEY] = bool(enabled)
+    except Exception as exc:
+        raise RuntimeError(
+            "Langfuse runtime tracing state is unavailable"
+        ) from exc
+
+
+def get_langfuse_tracing_status() -> dict[str, bool]:
+    """Return non-sensitive runtime tracing status."""
+
+    installed = is_langfuse_installed()
+    configured = is_langfuse_configured()
+    enabled = should_export_langfuse_span(None)
+
+    return {
+        "installed": installed,
+        "configured": configured,
+        "enabled": enabled,
+        "active": installed
+        and configured
+        and enabled
+        and _langfuse_client is not None,
+    }

--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -382,6 +382,13 @@ export type LoginResponse = {
   ai_content_notice_enabled?: boolean
 }
 
+export type LangfuseTracingStatus = {
+  installed: boolean
+  configured: boolean
+  enabled: boolean
+  active: boolean
+}
+
 export const InvalidApiKeyError = 'Invalid API Key'
 export const RequireApiKeError = 'API Key required'
 
@@ -637,6 +644,16 @@ export const checkHealth = async (): Promise<
       message: errorMessage(error)
     }
   }
+}
+
+export const getLangfuseTracingStatus = async (): Promise<LangfuseTracingStatus> => {
+  const response = await axiosInstance.get('/observability/langfuse/tracing')
+  return response.data
+}
+
+export const updateLangfuseTracing = async (enabled: boolean): Promise<LangfuseTracingStatus> => {
+  const response = await axiosInstance.put('/observability/langfuse/tracing', { enabled })
+  return response.data
 }
 
 /**

--- a/lightrag_webui/src/components/AppSettings.tsx
+++ b/lightrag_webui/src/components/AppSettings.tsx
@@ -1,11 +1,18 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/Popover'
 import Button from '@/components/ui/Button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select'
+import Separator from '@/components/ui/Separator'
 import { useSettingsStore } from '@/stores/settings'
 import { PaletteIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
+import {
+  getLangfuseTracingStatus,
+  updateLangfuseTracing,
+  type LangfuseTracingStatus
+} from '@/api/lightrag'
 
 interface AppSettingsProps {
   className?: string
@@ -13,6 +20,9 @@ interface AppSettingsProps {
 
 export default function AppSettings({ className }: AppSettingsProps) {
   const [opened, setOpened] = useState<boolean>(false)
+  const [langfuseStatus, setLangfuseStatus] = useState<LangfuseTracingStatus | null>(null)
+  const [isLangfuseLoading, setIsLangfuseLoading] = useState(false)
+  const [isLangfuseUpdating, setIsLangfuseUpdating] = useState(false)
   const { t } = useTranslation()
 
   const language = useSettingsStore.use.language()
@@ -28,6 +38,55 @@ export default function AppSettings({ className }: AppSettingsProps) {
   const handleThemeChange = useCallback((value: string) => {
     setTheme(value as 'light' | 'dark' | 'system')
   }, [setTheme])
+
+  useEffect(() => {
+    if (!opened) return
+
+    let cancelled = false
+
+    const loadLangfuseStatus = async () => {
+      setIsLangfuseLoading(true)
+      try {
+        const status = await getLangfuseTracingStatus()
+        if (!cancelled) setLangfuseStatus(status)
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Failed to load Langfuse tracing status:', error)
+          toast.error(t('settings.langfuseLoadFailed'))
+        }
+      } finally {
+        if (!cancelled) setIsLangfuseLoading(false)
+      }
+    }
+
+    void loadLangfuseStatus()
+
+    return () => {
+      cancelled = true
+    }
+  }, [opened, t])
+
+  const handleLangfuseTracingChange = useCallback(async () => {
+    if (
+      !langfuseStatus ||
+      isLangfuseUpdating ||
+      !langfuseStatus.installed ||
+      !langfuseStatus.configured
+    ) {
+      return
+    }
+
+    setIsLangfuseUpdating(true)
+    try {
+      const status = await updateLangfuseTracing(!langfuseStatus.enabled)
+      setLangfuseStatus(status)
+    } catch (error) {
+      console.error('Failed to update Langfuse tracing:', error)
+      toast.error(t('settings.langfuseUpdateFailed'))
+    } finally {
+      setIsLangfuseUpdating(false)
+    }
+  }, [isLangfuseUpdating, langfuseStatus, t])
 
   return (
     <Popover open={opened} onOpenChange={setOpened}>
@@ -50,7 +109,7 @@ export default function AppSettings({ className }: AppSettingsProps) {
           <PaletteIcon className="h-5 w-5" aria-hidden="true" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent side="bottom" align="end" className="w-56">
+      <PopoverContent side="bottom" align="end" className="w-80">
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
             <label className="text-sm font-medium">{t('settings.language')}</label>
@@ -87,6 +146,49 @@ export default function AppSettings({ className }: AppSettingsProps) {
                 <SelectItem value="system">{t('settings.system')}</SelectItem>
               </SelectContent>
             </Select>
+          </div>
+
+          <Separator />
+
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <label htmlFor="langfuse-tracing-toggle" className="text-sm font-medium">
+                {t('settings.langfuseTracing')}
+              </label>
+              <p className="text-muted-foreground mt-1 text-xs">
+                {langfuseStatus && (!langfuseStatus.installed || !langfuseStatus.configured)
+                  ? t('settings.langfuseUnavailable')
+                  : t('settings.langfuseTracingDescription')}
+              </p>
+            </div>
+            <button
+              id="langfuse-tracing-toggle"
+              type="button"
+              role="switch"
+              aria-label={t('settings.langfuseTracing')}
+              aria-checked={langfuseStatus?.enabled ?? false}
+              disabled={
+                isLangfuseLoading ||
+                isLangfuseUpdating ||
+                !langfuseStatus?.installed ||
+                !langfuseStatus.configured
+              }
+              onClick={handleLangfuseTracingChange}
+              className={cn(
+                'relative mt-0.5 inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+                'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+                'disabled:cursor-not-allowed disabled:opacity-50',
+                langfuseStatus?.enabled ? 'bg-primary' : 'bg-input'
+              )}
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  'bg-background pointer-events-none block h-5 w-5 rounded-full shadow-lg ring-0 transition-transform',
+                  langfuseStatus?.enabled ? 'translate-x-5' : 'translate-x-0'
+                )}
+              />
+            </button>
           </div>
         </div>
       </PopoverContent>

--- a/lightrag_webui/src/locales/ar.json
+++ b/lightrag_webui/src/locales/ar.json
@@ -4,7 +4,12 @@
     "theme": "السمة",
     "light": "فاتح",
     "dark": "داكن",
-    "system": "النظام"
+    "system": "النظام",
+    "langfuseTracing": "تتبّع Langfuse",
+    "langfuseTracingDescription": "تصدير تتبّعات نماذج اللغة المتوافقة مع OpenAI عبر اتصال Langfuse الذي أعدّه المشغّل.",
+    "langfuseUnavailable": "ثبّت إضافة قابلية المراقبة واضبط بيانات اعتماد Langfuse لاستخدام مفتاح التبديل هذا.",
+    "langfuseLoadFailed": "تعذّر تحميل حالة تتبّع Langfuse.",
+    "langfuseUpdateFailed": "تعذّر تحديث تتبّع Langfuse."
   },
   "header": {
     "documents": "المستندات",

--- a/lightrag_webui/src/locales/de.json
+++ b/lightrag_webui/src/locales/de.json
@@ -4,7 +4,12 @@
     "theme": "Design",
     "light": "Hell",
     "dark": "Dunkel",
-    "system": "System"
+    "system": "System",
+    "langfuseTracing": "Langfuse-Tracing",
+    "langfuseTracingDescription": "Exportiert OpenAI-kompatible LLM-Traces über die vom Betreiber konfigurierte Langfuse-Verbindung.",
+    "langfuseUnavailable": "Installieren Sie das Observability-Extra und konfigurieren Sie die Langfuse-Zugangsdaten, um diesen Schalter zu verwenden.",
+    "langfuseLoadFailed": "Der Langfuse-Tracing-Status konnte nicht geladen werden.",
+    "langfuseUpdateFailed": "Langfuse-Tracing konnte nicht aktualisiert werden."
   },
   "header": {
     "documents": "Dokumente",

--- a/lightrag_webui/src/locales/en.json
+++ b/lightrag_webui/src/locales/en.json
@@ -4,7 +4,12 @@
     "theme": "Theme",
     "light": "Light",
     "dark": "Dark",
-    "system": "System"
+    "system": "System",
+    "langfuseTracing": "Langfuse tracing",
+    "langfuseTracingDescription": "Export OpenAI-compatible LLM traces through the operator-configured Langfuse connection.",
+    "langfuseUnavailable": "Install the observability extra and configure Langfuse credentials to use this toggle.",
+    "langfuseLoadFailed": "Unable to load Langfuse tracing status.",
+    "langfuseUpdateFailed": "Unable to update Langfuse tracing."
   },
   "header": {
     "documents": "Documents",

--- a/lightrag_webui/src/locales/fr.json
+++ b/lightrag_webui/src/locales/fr.json
@@ -4,7 +4,12 @@
     "theme": "Thème",
     "light": "Clair",
     "dark": "Sombre",
-    "system": "Système"
+    "system": "Système",
+    "langfuseTracing": "Traçage Langfuse",
+    "langfuseTracingDescription": "Exportez les traces LLM compatibles avec OpenAI via la connexion Langfuse configurée par l’opérateur.",
+    "langfuseUnavailable": "Installez l’extension d’observabilité et configurez les identifiants Langfuse pour utiliser ce bouton.",
+    "langfuseLoadFailed": "Impossible de charger l’état du traçage Langfuse.",
+    "langfuseUpdateFailed": "Impossible de mettre à jour le traçage Langfuse."
   },
   "header": {
     "documents": "Documents",

--- a/lightrag_webui/src/locales/id.json
+++ b/lightrag_webui/src/locales/id.json
@@ -4,7 +4,12 @@
     "theme": "Tema",
     "light": "Terang",
     "dark": "Gelap",
-    "system": "Sistem"
+    "system": "Sistem",
+    "langfuseTracing": "Pelacakan Langfuse",
+    "langfuseTracingDescription": "Ekspor jejak LLM yang kompatibel dengan OpenAI melalui koneksi Langfuse yang dikonfigurasi operator.",
+    "langfuseUnavailable": "Instal fitur observabilitas dan konfigurasikan kredensial Langfuse untuk menggunakan tombol ini.",
+    "langfuseLoadFailed": "Tidak dapat memuat status pelacakan Langfuse.",
+    "langfuseUpdateFailed": "Tidak dapat memperbarui pelacakan Langfuse."
   },
   "header": {
     "documents": "Dokumen",

--- a/lightrag_webui/src/locales/ja.json
+++ b/lightrag_webui/src/locales/ja.json
@@ -4,7 +4,12 @@
     "theme": "テーマ",
     "light": "ライト",
     "dark": "ダーク",
-    "system": "システム"
+    "system": "システム",
+    "langfuseTracing": "Langfuse トレーシング",
+    "langfuseTracingDescription": "運用者が設定した Langfuse 接続を通じて、OpenAI 互換の LLM トレースをエクスポートします。",
+    "langfuseUnavailable": "この切り替えを使用するには、オブザーバビリティ拡張をインストールし、Langfuse の認証情報を設定してください。",
+    "langfuseLoadFailed": "Langfuse トレーシングの状態を読み込めませんでした。",
+    "langfuseUpdateFailed": "Langfuse トレーシングを更新できませんでした。"
   },
   "header": {
     "documents": "ドキュメント",

--- a/lightrag_webui/src/locales/ko.json
+++ b/lightrag_webui/src/locales/ko.json
@@ -4,7 +4,12 @@
     "theme": "테마",
     "light": "라이트",
     "dark": "다크",
-    "system": "시스템"
+    "system": "시스템",
+    "langfuseTracing": "Langfuse 추적",
+    "langfuseTracingDescription": "운영자가 구성한 Langfuse 연결을 통해 OpenAI 호환 LLM 추적을 내보냅니다.",
+    "langfuseUnavailable": "이 토글을 사용하려면 관측 가능성 추가 기능을 설치하고 Langfuse 자격 증명을 구성하세요.",
+    "langfuseLoadFailed": "Langfuse 추적 상태를 불러올 수 없습니다.",
+    "langfuseUpdateFailed": "Langfuse 추적을 업데이트할 수 없습니다."
   },
   "header": {
     "documents": "문서",

--- a/lightrag_webui/src/locales/ru.json
+++ b/lightrag_webui/src/locales/ru.json
@@ -4,7 +4,12 @@
     "theme": "Тема",
     "light": "Светлая",
     "dark": "Тёмная",
-    "system": "Системная"
+    "system": "Системная",
+    "langfuseTracing": "Трассировка Langfuse",
+    "langfuseTracingDescription": "Экспортируйте совместимые с OpenAI трассировки LLM через настроенное оператором подключение Langfuse.",
+    "langfuseUnavailable": "Установите дополнение для наблюдаемости и настройте учётные данные Langfuse, чтобы использовать этот переключатель.",
+    "langfuseLoadFailed": "Не удалось загрузить состояние трассировки Langfuse.",
+    "langfuseUpdateFailed": "Не удалось обновить трассировку Langfuse."
   },
   "header": {
     "documents": "Документы",

--- a/lightrag_webui/src/locales/uk.json
+++ b/lightrag_webui/src/locales/uk.json
@@ -4,7 +4,12 @@
     "theme": "Тема",
     "light": "Світла",
     "dark": "Темна",
-    "system": "Системна"
+    "system": "Системна",
+    "langfuseTracing": "Трасування Langfuse",
+    "langfuseTracingDescription": "Експортуйте сумісні з OpenAI трасування LLM через налаштоване оператором підключення Langfuse.",
+    "langfuseUnavailable": "Установіть доповнення для спостережуваності та налаштуйте облікові дані Langfuse, щоб використовувати цей перемикач.",
+    "langfuseLoadFailed": "Не вдалося завантажити стан трасування Langfuse.",
+    "langfuseUpdateFailed": "Не вдалося оновити трасування Langfuse."
   },
   "header": {
     "documents": "Документи",

--- a/lightrag_webui/src/locales/vi.json
+++ b/lightrag_webui/src/locales/vi.json
@@ -4,7 +4,12 @@
     "theme": "Giao diện",
     "light": "Sáng",
     "dark": "Tối",
-    "system": "Hệ thống"
+    "system": "Hệ thống",
+    "langfuseTracing": "Theo dõi Langfuse",
+    "langfuseTracingDescription": "Xuất dữ liệu theo dõi LLM tương thích với OpenAI qua kết nối Langfuse do người vận hành cấu hình.",
+    "langfuseUnavailable": "Cài đặt tiện ích quan sát và cấu hình thông tin xác thực Langfuse để sử dụng nút chuyển này.",
+    "langfuseLoadFailed": "Không thể tải trạng thái theo dõi Langfuse.",
+    "langfuseUpdateFailed": "Không thể cập nhật tính năng theo dõi Langfuse."
   },
   "header": {
     "documents": "Tài liệu",

--- a/lightrag_webui/src/locales/zh.json
+++ b/lightrag_webui/src/locales/zh.json
@@ -4,7 +4,12 @@
     "theme": "主题",
     "light": "浅色",
     "dark": "深色",
-    "system": "系统"
+    "system": "系统",
+    "langfuseTracing": "Langfuse 追踪",
+    "langfuseTracingDescription": "通过运维人员配置的 Langfuse 连接导出兼容 OpenAI 的 LLM 追踪数据。",
+    "langfuseUnavailable": "安装可观测性扩展并配置 Langfuse 凭据后才能使用此开关。",
+    "langfuseLoadFailed": "无法加载 Langfuse 追踪状态。",
+    "langfuseUpdateFailed": "无法更新 Langfuse 追踪设置。"
   },
   "header": {
     "documents": "文档",

--- a/lightrag_webui/src/locales/zh_TW.json
+++ b/lightrag_webui/src/locales/zh_TW.json
@@ -4,7 +4,12 @@
     "theme": "主題",
     "light": "淺色",
     "dark": "深色",
-    "system": "系統"
+    "system": "系統",
+    "langfuseTracing": "Langfuse 追蹤",
+    "langfuseTracingDescription": "透過維運人員設定的 Langfuse 連線匯出與 OpenAI 相容的 LLM 追蹤資料。",
+    "langfuseUnavailable": "安裝可觀測性擴充功能並設定 Langfuse 憑證後才能使用此開關。",
+    "langfuseLoadFailed": "無法載入 Langfuse 追蹤狀態。",
+    "langfuseUpdateFailed": "無法更新 Langfuse 追蹤設定。"
   },
   "header": {
     "documents": "文件",

--- a/tests/api/routes/test_observability_routes.py
+++ b/tests/api/routes/test_observability_routes.py
@@ -1,0 +1,126 @@
+"""Tests for authenticated runtime observability routes."""
+
+import importlib
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+_original_argv = sys.argv[:]
+try:
+    sys.argv = [sys.argv[0]]
+    utils_api = importlib.import_module("lightrag.api.utils_api")
+    observability_routes = importlib.import_module(
+        "lightrag.api.routers.observability_routes"
+    )
+finally:
+    sys.argv = _original_argv
+
+
+def make_client(api_key="test-api-key"):
+    app = FastAPI()
+    app.include_router(observability_routes.create_observability_routes(api_key))
+    return TestClient(app)
+
+
+def test_langfuse_status_requires_credentials_even_when_whitelisted(monkeypatch):
+    monkeypatch.setattr(utils_api, "path_is_whitelisted", lambda _scope: True)
+    monkeypatch.setattr(
+        observability_routes,
+        "get_langfuse_tracing_status",
+        lambda: {
+            "installed": True,
+            "configured": True,
+            "enabled": True,
+            "active": True,
+        },
+    )
+
+    response = make_client().get("/observability/langfuse/tracing")
+
+    assert response.status_code in {401, 403}
+
+
+def test_langfuse_status_accepts_api_key(monkeypatch):
+    monkeypatch.setattr(
+        observability_routes,
+        "get_langfuse_tracing_status",
+        lambda: {
+            "installed": True,
+            "configured": True,
+            "enabled": False,
+            "active": False,
+        },
+    )
+
+    response = make_client().get(
+        "/observability/langfuse/tracing",
+        headers={"X-API-Key": "test-api-key"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "installed": True,
+        "configured": True,
+        "enabled": False,
+        "active": False,
+    }
+
+
+def test_langfuse_toggle_updates_runtime_state(monkeypatch):
+    state = {"enabled": False}
+
+    def get_status():
+        return {
+            "installed": True,
+            "configured": True,
+            "enabled": state["enabled"],
+            "active": state["enabled"],
+        }
+
+    def set_enabled(enabled):
+        state["enabled"] = enabled
+
+    monkeypatch.setattr(
+        observability_routes,
+        "get_langfuse_tracing_status",
+        get_status,
+    )
+    monkeypatch.setattr(
+        observability_routes,
+        "set_langfuse_tracing_enabled",
+        set_enabled,
+    )
+
+    response = make_client().put(
+        "/observability/langfuse/tracing",
+        headers={"X-API-Key": "test-api-key"},
+        json={"enabled": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["enabled"] is True
+    assert response.json()["active"] is True
+
+
+def test_langfuse_toggle_rejects_unconfigured_installation(monkeypatch):
+    monkeypatch.setattr(
+        observability_routes,
+        "get_langfuse_tracing_status",
+        lambda: {
+            "installed": True,
+            "configured": False,
+            "enabled": False,
+            "active": False,
+        },
+    )
+
+    response = make_client().put(
+        "/observability/langfuse/tracing",
+        headers={"X-API-Key": "test-api-key"},
+        json={"enabled": True},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Langfuse credentials are not configured"}

--- a/tests/llm/test_langfuse_tracing.py
+++ b/tests/llm/test_langfuse_tracing.py
@@ -1,0 +1,126 @@
+"""Tests for the shared Langfuse runtime tracing switch."""
+
+import asyncio
+import multiprocessing
+import sys
+from types import ModuleType
+
+import pytest
+
+from lightrag.kg.shared_storage import (
+    finalize_share_data,
+    get_namespace_data,
+    initialize_share_data,
+)
+from lightrag.llm import langfuse_tracing as tracing
+
+
+@pytest.fixture(autouse=True)
+def reset_tracing_state(monkeypatch):
+    monkeypatch.setattr(tracing, "_langfuse_tracing_state", None)
+    monkeypatch.setattr(tracing, "_langfuse_client", None)
+    monkeypatch.delenv("LANGFUSE_ENABLE_TRACE", raising=False)
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+
+
+def test_initialize_passes_live_span_filter_to_langfuse(monkeypatch):
+    state = {}
+    captured = {}
+
+    async def fake_get_namespace_data(namespace, workspace=None):
+        assert namespace == tracing.LANGFUSE_TRACING_NAMESPACE
+        assert workspace == ""
+        return state
+
+    class FakeLangfuse:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+    monkeypatch.setattr(tracing, "get_namespace_data", fake_get_namespace_data)
+    monkeypatch.setattr(tracing, "is_langfuse_installed", lambda: True)
+    fake_langfuse = ModuleType("langfuse")
+    fake_langfuse.Langfuse = FakeLangfuse
+    monkeypatch.setitem(sys.modules, "langfuse", fake_langfuse)
+
+    asyncio.run(tracing.initialize_langfuse_tracing())
+
+    assert state[tracing.LANGFUSE_TRACING_ENABLED_KEY] is True
+    assert captured["should_export_span"] is tracing.should_export_langfuse_span
+    assert tracing.should_export_langfuse_span(None) is True
+
+    tracing.set_langfuse_tracing_enabled(False)
+    assert tracing.should_export_langfuse_span(None) is False
+
+
+def _read_tracing_state_in_worker(result_queue):
+    async def read_state():
+        state = await get_namespace_data(
+            tracing.LANGFUSE_TRACING_NAMESPACE,
+            workspace="",
+        )
+        tracing._langfuse_tracing_state = state
+        result_queue.put(tracing.should_export_langfuse_span(None))
+
+    asyncio.run(read_state())
+
+
+def test_runtime_toggle_is_visible_in_another_worker():
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("cross-worker shared-storage test requires fork")
+
+    finalize_share_data()
+    initialize_share_data(workers=2)
+
+    try:
+        state = asyncio.run(
+            get_namespace_data(tracing.LANGFUSE_TRACING_NAMESPACE, workspace="")
+        )
+        state[tracing.LANGFUSE_TRACING_ENABLED_KEY] = False
+
+        context = multiprocessing.get_context("fork")
+        result_queue = context.Queue()
+        process = context.Process(
+            target=_read_tracing_state_in_worker,
+            args=(result_queue,),
+        )
+        process.start()
+        process.join(timeout=10)
+
+        assert process.exitcode == 0
+        assert result_queue.get(timeout=2) is False
+
+        state[tracing.LANGFUSE_TRACING_ENABLED_KEY] = True
+        second_queue = context.Queue()
+        second_process = context.Process(
+            target=_read_tracing_state_in_worker,
+            args=(second_queue,),
+        )
+        second_process.start()
+        second_process.join(timeout=10)
+
+        assert second_process.exitcode == 0
+        assert second_queue.get(timeout=2) is True
+
+        result_queue.close()
+        result_queue.join_thread()
+        second_queue.close()
+        second_queue.join_thread()
+    finally:
+        finalize_share_data()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("true", True),
+        ("1", True),
+        ("off", False),
+        ("0", False),
+    ],
+)
+def test_operator_default_is_parsed(monkeypatch, value, expected):
+    monkeypatch.setenv("LANGFUSE_ENABLE_TRACE", value)
+    assert tracing._configured_default() is expected


### PR DESCRIPTION
## Description

Adds an authenticated runtime toggle for Langfuse trace export while keeping Langfuse credentials and host configuration under operator control.

The toggle is evaluated live for every span through the Langfuse client’s `should_export_span` predicate. Its state is backed by LightRAG’s existing shared namespace mechanism so all Gunicorn workers observe the same value.

This PR does not expose or modify credentials, change the Langfuse destination, or write to `.env`.

## Related Issues

Related to #2419.

Follow-up to the maintainer feedback on #3812. This PR implements only the runtime tracing-toggle portion; credential and host changes remain operator-managed and therefore this does not close #2419.

## Changes Made

* Added shared runtime tracing state using `get_namespace_data("langfuse_tracing", workspace="")`.
* Wired the shared state into the Langfuse client’s `should_export_span` predicate at construction so it is checked live for every span.
* Used the existing documented `LANGFUSE_ENABLE_TRACE` setting as the initial value while preserving tracing as enabled by default when it is unset.
* Added authenticated `GET` and `PUT` endpoints at `/observability/langfuse/tracing`.
* Kept the endpoint outside the default unauthenticated `/api/*` whitelist and explicitly disabled whitelist bypass for its authentication dependency.
* Added a WebUI tracing switch that reports unavailable states without exposing credentials.
* Routed all new UI text through i18next for every supported locale.
* Added tests covering:

  * endpoint authentication;
  * unavailable and error responses;
  * live per-span enable/disable behavior;
  * shared-state visibility across worker-local clients;
  * initial environment-default handling.
* Retained Bun as the WebUI package manager with no `package-lock.json` changes.

## Checklist

* [x] Changes tested locally
* [x] Code reviewed
* [x] Documentation updated (not required; this wires the existing documented `LANGFUSE_ENABLE_TRACE` setting)
* [x] Unit tests added

## Additional Notes

The shared namespace proxy is resolved during server initialization and cached so the synchronous `should_export_span` callback can read it without awaiting. Runtime updates use a single manager-dictionary key assignment, so no namespace lock or read-modify-write sequence is required.

The toggle is intentionally runtime state rather than persisted configuration. After a full server restart, it returns to the operator-configured `LANGFUSE_ENABLE_TRACE` default.

Validation completed:

* Backend targeted tests: 10 passed
* WebUI test suite: 626 passed
* TypeScript check: passed
* ESLint check for the modified component: passed
* Whitespace validation: passed