### PR TITLE
fix(utils): validate embedding shape directly, not by element count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,21 +242,7 @@ asyncio.run(main())
 
 ### Custom Embedding Functions
 
-Use `@wrap_embedding_func_with_attrs` decorator and call `.func` when wrapping (already-decorated functions cannot be wrapped again — access the underlying via `.func`):
-
-```python
-from lightrag.utils import wrap_embedding_func_with_attrs
-
-@wrap_embedding_func_with_attrs(embedding_dim=1536, max_token_size=8192)
-async def custom_embed(texts: list[str]) -> np.ndarray:
-    # Call underlying function, not wrapped version
-    return await openai_embed.func(texts, model="text-embedding-3-large")
-
-# Wrong: EmbeddingFunc(func=openai_embed)
-# Right: EmbeddingFunc(func=openai_embed.func)
-```
-
-> **Pitfall — switching embedding models**: when changing the embedding model you MUST clear the data directory (optionally keeping `kv_store_llm_response_cache.json` for LLM cache). Existing vectors will not match the new model's space.
+**Full guide: [docs/ProgramingWithCore.md](docs/ProgramingWithCore.md#custom-embedding-functions)** — the `.func` unwrapping rule, `max_token_size`, the `(len(texts), embedding_dim)` return contract that `EmbeddingFunc.__call__` enforces on every call, and the clear-the-data-directory pitfall when switching models. Read it before writing or wrapping an embedding function.
 
 ### Storage Configuration
 

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -585,7 +585,9 @@ async def custom_embed(texts: list[str]) -> np.ndarray:
 
 ### Embedding Function Return Contract
 
-Every embedding function — built-in or custom — MUST return a 2D numpy array of shape `(len(texts), embedding_dim)`: exactly one row per input text, in input order. Every vector storage backend consumes the result positionally (`embeddings[i]` is stored for `texts[i]`), so `EmbeddingFunc` validates the shape on every call and raises `ValueError` on any mismatch. It never reshapes, slices or pads the result — once the row-to-input mapping is wrong it cannot be recovered, and a silent repair would store vectors under the wrong records.
+Every embedding function — built-in or custom — MUST return a 2D numpy array of shape `(len(texts), embedding_dim)`: exactly one row per input text, in input order. Every vector storage backend consumes the result positionally (`embeddings[i]` is stored for `texts[i]`), so `EmbeddingFunc` validates the result on every call and raises `ValueError` on any mismatch. It never reshapes, slices or pads the result — once the row-to-input mapping is wrong it cannot be recovered, and a silent repair would store vectors under the wrong records.
+
+The array rank and the dimension are always checked. The row count is checked against the input batch, which is read from the first positional argument, or — for a keyword call — from the kwarg matching the wrapped function's first parameter name. If the batch cannot be resolved that way (a callable whose first parameter is positional-only or `*args`, or one exposing no signature), the row count alone is left unverified rather than guessed at.
 
 | Returned shape | Result |
 | --- | --- |

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -563,6 +563,47 @@ rag = LightRAG(
 )
 ```
 
+### Custom Embedding Functions
+
+Use the `@wrap_embedding_func_with_attrs` decorator, and call `.func` when building on an already-decorated function — a decorated function cannot be wrapped again, so the underlying callable must be reached through `.func`:
+
+```python
+from lightrag.utils import wrap_embedding_func_with_attrs
+
+@wrap_embedding_func_with_attrs(embedding_dim=1536, max_token_size=8192)
+async def custom_embed(texts: list[str]) -> np.ndarray:
+    # Call the underlying function, not the wrapped version
+    return await openai_embed.func(texts, model="text-embedding-3-large")
+
+# Wrong: EmbeddingFunc(func=openai_embed)
+# Right: EmbeddingFunc(func=openai_embed.func)
+```
+
+`max_token_size` declares the model's real input limit. It is what keeps an over-long text from reaching a service that would split it internally and return one vector per segment — which the return contract below rejects as a vector count mismatch.
+
+> **Pitfall — switching embedding models**: when changing the embedding model you MUST clear the data directory (optionally keeping `kv_store_llm_response_cache.json` for the LLM cache). Existing vectors will not match the new model's space.
+
+### Embedding Function Return Contract
+
+Every embedding function — built-in or custom — MUST return a 2D numpy array of shape `(len(texts), embedding_dim)`: exactly one row per input text, in input order. Every vector storage backend consumes the result positionally (`embeddings[i]` is stored for `texts[i]`), so `EmbeddingFunc` validates the shape on every call and raises `ValueError` on any mismatch. It never reshapes, slices or pads the result — once the row-to-input mapping is wrong it cannot be recovered, and a silent repair would store vectors under the wrong records.
+
+| Returned shape | Result |
+| --- | --- |
+| `(len(texts), embedding_dim)` | Accepted |
+| Empty array for an empty input list | Accepted (including a bare `np.array([])`) |
+| `(embedding_dim,)` for a single input | `ValueError` — a single input still returns `(1, embedding_dim)` |
+| More rows than inputs | `ValueError: Vector count mismatch` |
+| Fewer rows than inputs | `ValueError: Vector count mismatch` |
+| Wrong number of columns | `ValueError: Embedding dimension mismatch` |
+| Flattened (1D) or nested (3D) array | `ValueError: unexpected shape` |
+
+The two mismatches that look alike are distinguished deliberately, because their fixes differ:
+
+- **Vector count mismatch** (more rows than inputs) usually means the embedding service split an over-long input internally and returned one vector per segment. Declare the model's real token limit so texts are truncated before the call — `EMBEDDING_TOKEN_LIMIT` on the API server, or `max_token_size` on `@wrap_embedding_func_with_attrs` for a custom function. A provider that legitimately emits several vectors per input needs a dedicated adapter that normalizes its output to one vector per input, with an explicit mapping, before it reaches `EmbeddingFunc`.
+- **Embedding dimension mismatch** (wrong number of columns) means the declared `embedding_dim` does not match the model actually being called, or the endpoint ignored the requested output dimension. Reconcile `EMBEDDING_DIM` / `embedding_dim` with the model. Vectors already stored under the previously declared dimension do not match the corrected one, so clear the data directory as well unless nothing has been indexed yet.
+
+Each `ValueError` is accompanied by a `logger.error` carrying the likely cause and the remedy, so the diagnosis stays in the server log even when only the short exception message surfaces.
+
 ### Rerank Function Injection
 
 To enhance retrieval quality, documents can be re-ranked based on a more effective relevance scoring model. The `rerank.py` file provides three Reranker provider driver functions:

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -661,6 +661,24 @@ class EmbeddingFunc:
             embeddings = await embed_func(texts, context="document")  # For indexing
             embeddings = await embed_func([query], context="query")   # For search
 
+    Return shape contract:
+        The wrapped function MUST return a 2D numpy array of shape
+        ``(len(texts), embedding_dim)`` -- exactly one row per input text, in
+        input order. Every storage backend consumes the result positionally
+        (``embeddings[i]`` belongs to ``texts[i]``), so any other shape is
+        rejected with a ValueError; the wrapper never reshapes, slices or pads
+        the result, because the row-to-input mapping cannot be recovered once
+        it is wrong. In particular:
+
+        - A single input still returns ``(1, embedding_dim)``, not
+          ``(embedding_dim,)``.
+        - A provider that returns more vectors than inputs (e.g. one vector
+          per internally split segment of an over-long text) needs its token
+          limit declared via ``max_token_size``, or a dedicated adapter that
+          normalizes the output to one vector per input.
+        - An empty input list may return any empty array, including a bare
+          ``np.array([])``.
+
     Args:
         embedding_dim: Expected dimension of the embeddings(For dimension checking and workspace data isolation in vector DB)
         func: The actual embedding function to wrap
@@ -751,30 +769,78 @@ class EmbeddingFunc:
         # (N, 2D) -- both divide out to the same "actual vectors" number, so
         # the wrong one of the two gets reported. Checking ndim/shape[0]/
         # shape[1] directly identifies which one actually happened.
+        #
+        # Every mismatch is fatal: the wrapper never reshapes, slices or pads
+        # the result. Each raise is preceded by a logger.error carrying the
+        # likely cause and the fix, so the short exception message stays
+        # readable while the diagnosis is still available in the logs.
         expected_dim = self.embedding_dim
+        # None means "the caller did not pass the texts positionally", so the
+        # input count is unknown and the vector count cannot be checked.
+        expected_vectors = (
+            len(args[0]) if args and isinstance(args[0], (list, tuple)) else None
+        )
+
+        # An empty batch carries no vectors and no dimension to validate. A
+        # provider that short-circuits with `if not texts: return np.array([])`
+        # yields a 1D (0,) array, which is a correct answer to a zero-input
+        # request and must not be rejected by the 2D check below. An empty
+        # input paired with a non-empty result still falls through and fails.
+        if expected_vectors == 0 and result.size == 0:
+            return result
+
         if result.ndim != 2:
+            logger.error(
+                f"Embedding result has unexpected shape {result.shape}: this "
+                f"wrapper requires a 2D array of exactly one row per input "
+                f"text, i.e. (len(texts), {expected_dim}). A single input "
+                f"must still come back as (1, {expected_dim}), not "
+                f"({expected_dim},); a flattened or nested array is rejected "
+                f"rather than reshaped, because the row-to-input mapping "
+                f"cannot be recovered from it."
+            )
             raise ValueError(
                 f"Embedding result has unexpected shape: expected a 2D "
                 f"array (vectors, dimension) but got ndim={result.ndim} "
                 f"(shape={result.shape})."
             )
 
-        if args and isinstance(args[0], (list, tuple)):
-            expected_vectors = len(args[0])
-            if result.shape[0] != expected_vectors:
-                raise ValueError(
-                    f"Vector count mismatch: expected {expected_vectors} "
-                    f"vectors (one per input text) but got {result.shape[0]} "
-                    f"(shape={result.shape}). If this embedding provider "
-                    f"legitimately returns multiple vectors per input, "
-                    f"normalize its output to one vector per input in a "
-                    f"dedicated provider adapter before it reaches this "
-                    f"wrapper -- do not silently reshape or truncate here, "
-                    f"since there is no general contract for which rows "
-                    f"correspond to which inputs."
-                )
+        if expected_vectors is not None and result.shape[0] != expected_vectors:
+            logger.error(
+                f"Embedding vector count mismatch: {expected_vectors} text(s) "
+                f"in, {result.shape[0]} vector(s) out (shape={result.shape}). "
+                f"The usual cause is an embedding service that splits an "
+                f"over-long input internally and returns one vector per "
+                f"segment: declare the model's real token limit so texts are "
+                f"truncated before the call -- EMBEDDING_TOKEN_LIMIT on the "
+                f"API server, or max_token_size on "
+                f"@wrap_embedding_func_with_attrs for a custom embedding "
+                f"function. A provider that legitimately returns multiple "
+                f"vectors per input needs a dedicated adapter that normalizes "
+                f"its output to one vector per input before it reaches this "
+                f"wrapper; nothing is reshaped or truncated here, since there "
+                f"is no general contract for which rows correspond to which "
+                f"inputs."
+            )
+            raise ValueError(
+                f"Vector count mismatch: expected {expected_vectors} vectors "
+                f"(one per input text) but got {result.shape[0]} "
+                f"(shape={result.shape})."
+            )
 
         if result.shape[1] != expected_dim:
+            logger.error(
+                f"Embedding dimension mismatch: the model returned "
+                f"{result.shape[1]}-dimensional vectors but this embedding "
+                f"function declares {expected_dim} (shape={result.shape}). "
+                f"Check that EMBEDDING_DIM (or the embedding_dim passed to "
+                f"@wrap_embedding_func_with_attrs / EmbeddingFunc) matches "
+                f"the model actually being called, and that the endpoint "
+                f"honours the requested output dimension. Vectors already "
+                f"stored under the previously declared dimension do not match "
+                f"the corrected one, so clear the data directory too unless "
+                f"nothing has been indexed yet."
+            )
             raise ValueError(
                 f"Embedding dimension mismatch: expected dimension "
                 f"{expected_dim} but got {result.shape[1]} (shape={result.shape})."

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -745,27 +745,40 @@ class EmbeddingFunc:
         # Call the actual embedding function
         result = await self.func(*args, **kwargs)
 
-        # Validate embedding dimensions using total element count
-        total_elements = result.size  # Total number of elements in the numpy array
+        # Validate the result shape directly rather than inferring it from a
+        # total-element count. A total-element check cannot tell a genuine
+        # vector-count mismatch (2N, D) apart from a dimension mismatch
+        # (N, 2D) -- both divide out to the same "actual vectors" number, so
+        # the wrong one of the two gets reported. Checking ndim/shape[0]/
+        # shape[1] directly identifies which one actually happened.
         expected_dim = self.embedding_dim
-
-        # Check if total elements can be evenly divided by embedding_dim
-        if total_elements % expected_dim != 0:
+        if result.ndim != 2:
             raise ValueError(
-                f"Embedding dimension mismatch detected: "
-                f"total elements ({total_elements}) cannot be evenly divided by "
-                f"expected dimension ({expected_dim}). "
+                f"Embedding result has unexpected shape: expected a 2D "
+                f"array (vectors, dimension) but got ndim={result.ndim} "
+                f"(shape={result.shape})."
             )
 
-        # Optional: Verify vector count matches input text count
-        actual_vectors = total_elements // expected_dim
         if args and isinstance(args[0], (list, tuple)):
             expected_vectors = len(args[0])
-            if actual_vectors != expected_vectors:
+            if result.shape[0] != expected_vectors:
                 raise ValueError(
-                    f"Vector count mismatch: "
-                    f"expected {expected_vectors} vectors but got {actual_vectors} vectors (from embedding result)."
+                    f"Vector count mismatch: expected {expected_vectors} "
+                    f"vectors (one per input text) but got {result.shape[0]} "
+                    f"(shape={result.shape}). If this embedding provider "
+                    f"legitimately returns multiple vectors per input, "
+                    f"normalize its output to one vector per input in a "
+                    f"dedicated provider adapter before it reaches this "
+                    f"wrapper -- do not silently reshape or truncate here, "
+                    f"since there is no general contract for which rows "
+                    f"correspond to which inputs."
                 )
+
+        if result.shape[1] != expected_dim:
+            raise ValueError(
+                f"Embedding dimension mismatch: expected dimension "
+                f"{expected_dim} but got {result.shape[1]} (shape={result.shape})."
+            )
 
         return result
 

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -668,7 +668,13 @@ class EmbeddingFunc:
         (``embeddings[i]`` belongs to ``texts[i]``), so any other shape is
         rejected with a ValueError; the wrapper never reshapes, slices or pads
         the result, because the row-to-input mapping cannot be recovered once
-        it is wrong. In particular:
+        it is wrong.
+
+        Rank and dimension are always checked. The row count is checked
+        against the input batch, resolved from the first positional argument
+        or from the kwarg named after the wrapped function's first parameter;
+        when neither applies the row count is left unverified rather than
+        guessed at. In particular:
 
         - A single input still returns ``(1, embedding_dim)``, not
           ``(embedding_dim,)``.
@@ -727,6 +733,40 @@ class EmbeddingFunc:
                 "Consider using .func to access the unwrapped function directly."
             )
 
+    def _resolve_input_batch(self, args: tuple, kwargs: dict) -> Any:
+        """Return the sequence of texts the caller passed, or None if unknown.
+
+        The vector count can only be checked against something. Positional is
+        the overwhelmingly common path and costs nothing to read. A keyword
+        call needs the wrapped function's first parameter name to know which
+        kwarg holds the texts, so the signature is inspected only on that
+        path -- and only the parameter name is read, never a full bind(),
+        which would raise on the extra kwargs this wrapper and its priority
+        decorator pass through (``_priority``, ``context``, ...).
+
+        Returning None means "not resolvable", which downgrades the vector
+        count check to unverifiable rather than guessing at a mapping.
+        """
+        if args:
+            return args[0]
+        if not kwargs:
+            return None
+        try:
+            params = inspect.signature(self.func).parameters
+        except (TypeError, ValueError):
+            # Builtins and C-implemented callables expose no signature.
+            return None
+        for param in params.values():
+            if param.kind in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            ):
+                return kwargs.get(param.name)
+            # A positional-only or *args first parameter cannot be addressed
+            # by keyword at all, so the batch stays unknown.
+            return None
+        return None
+
     async def __call__(self, *args, **kwargs) -> np.ndarray:
         # Only inject embedding_dim when send_dimensions is True
         if self.send_dimensions:
@@ -775,10 +815,11 @@ class EmbeddingFunc:
         # likely cause and the fix, so the short exception message stays
         # readable while the diagnosis is still available in the logs.
         expected_dim = self.embedding_dim
-        # None means "the caller did not pass the texts positionally", so the
-        # input count is unknown and the vector count cannot be checked.
+        # None means the input batch could not be resolved from the call, so
+        # the vector count is unverifiable -- see _resolve_input_batch.
+        input_batch = self._resolve_input_batch(args, kwargs)
         expected_vectors = (
-            len(args[0]) if args and isinstance(args[0], (list, tuple)) else None
+            len(input_batch) if isinstance(input_batch, (list, tuple)) else None
         )
 
         # An empty batch carries no vectors and no dimension to validate. A

--- a/tests/utils/test_embedding_func_shape_validation.py
+++ b/tests/utils/test_embedding_func_shape_validation.py
@@ -12,10 +12,17 @@ result has no general contract for which N of the 2N rows are the real ones.
 
 The fix instead checks result.ndim / result.shape[0] / result.shape[1]
 directly, so each shape mismatch is identified and rejected on its own
-terms -- never reshaped, sliced, or silently accepted.
+terms -- never reshaped, sliced, or silently accepted. The raised message
+stays short; the likely cause and the fix go to logger.error next to it.
+
+The one shape that is NOT a mismatch is the empty batch: zero inputs carry
+no vectors and no dimension to check, so a provider that short-circuits with
+``if not texts: return np.array([])`` keeps working.
 """
 
 from __future__ import annotations
+
+import logging
 
 import numpy as np
 import pytest
@@ -23,6 +30,18 @@ import pytest
 from lightrag.utils import EmbeddingFunc
 
 pytestmark = pytest.mark.offline
+
+
+@pytest.fixture
+def _propagate_lightrag_logs():
+    """The ``lightrag`` logger sets propagate=False; caplog needs it on."""
+    lg = logging.getLogger("lightrag")
+    old = lg.propagate
+    lg.propagate = True
+    try:
+        yield
+    finally:
+        lg.propagate = old
 
 
 def _make(func, embedding_dim=4):
@@ -63,6 +82,19 @@ async def test_doubled_vector_count_is_rejected_not_sliced():
 
 
 @pytest.mark.asyncio
+async def test_too_few_vectors_is_rejected():
+    """(N//2, D): underflow is as fatal as overflow. Backends index the
+    result positionally, so a short result would silently pair vectors with
+    the wrong texts (or IndexError) rather than fail here."""
+
+    async def embed(texts):
+        return np.zeros((len(texts) // 2, 4), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="Vector count mismatch"):
+        await _make(embed)(["a", "b", "c", "d"])
+
+
+@pytest.mark.asyncio
 async def test_doubled_dimension_is_rejected_as_dimension_not_count():
     """(N, 2D): a genuine dimension mismatch. Must be reported as a
     dimension mismatch, not misdiagnosed as a doubled vector count -- a
@@ -74,6 +106,20 @@ async def test_doubled_dimension_is_rejected_as_dimension_not_count():
 
     with pytest.raises(ValueError, match="Embedding dimension mismatch"):
         await _make(embed)(["a", "b", "c"])
+
+
+@pytest.mark.asyncio
+async def test_dimension_is_checked_when_texts_are_not_passed_positionally():
+    """The vector count check needs the input list to compare against, so it
+    is skipped when the texts arrive by keyword. The dimension check does not
+    depend on the input count and must still run -- under the old
+    total-element logic this path accepted (N, 2D) outright."""
+
+    async def embed(texts=None):
+        return np.zeros((len(texts), 8), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="Embedding dimension mismatch"):
+        await _make(embed)(texts=["a", "b", "c"])
 
 
 @pytest.mark.asyncio
@@ -92,3 +138,97 @@ async def test_3d_result_is_rejected():
 
     with pytest.raises(ValueError, match="unexpected shape"):
         await _make(embed)(["a", "b"])
+
+
+@pytest.mark.asyncio
+async def test_empty_batch_with_bare_empty_array_is_accepted():
+    """Zero inputs means zero vectors and no dimension to validate. A
+    provider short-circuiting with ``np.array([])`` returns a 1D (0,) array;
+    rejecting it on ndim would break a common custom-embedding idiom for a
+    request that asked for nothing."""
+
+    async def embed(texts):
+        if not texts:
+            return np.array([])
+        return np.zeros((len(texts), 4), dtype=np.float32)
+
+    result = await _make(embed)([])
+    assert result.size == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_batch_with_empty_2d_array_is_accepted():
+    async def embed(texts):
+        return np.zeros((0, 4), dtype=np.float32)
+
+    result = await _make(embed)([])
+    assert result.shape == (0, 4)
+
+
+@pytest.mark.asyncio
+async def test_empty_input_with_non_empty_result_is_rejected():
+    """The empty-batch allowance is keyed on an empty result too: vectors
+    returned for zero inputs are a real mismatch, not a no-op."""
+
+    async def embed(texts):
+        return np.zeros((1, 4), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="Vector count mismatch"):
+        await _make(embed)([])
+
+
+@pytest.mark.asyncio
+async def test_unexpected_ndim_logs_the_required_shape(
+    caplog, _propagate_lightrag_logs
+):
+    """The ndim rejection is the one an author of a custom embedding function
+    hits first, so the log has to state the shape actually required rather
+    than only the one that arrived."""
+
+    async def embed(texts):
+        return np.zeros(4, dtype=np.float32)
+
+    with caplog.at_level(logging.ERROR, logger="lightrag"):
+        with pytest.raises(ValueError):
+            await _make(embed)(["only one"])
+
+    assert "(len(texts), 4)" in caplog.text
+    assert "(1, 4)" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_count_mismatch_logs_token_limit_remedy(caplog, _propagate_lightrag_logs):
+    """A provider splitting an over-long input internally is the documented
+    primary cause of this mismatch (issue #2549), and declaring the model's
+    token limit is the fix. Keep that remedy in the operator-facing log --
+    the short exception message alone does not point anywhere."""
+
+    async def embed(texts):
+        return np.zeros((len(texts) * 2, 4), dtype=np.float32)
+
+    with caplog.at_level(logging.ERROR, logger="lightrag"):
+        with pytest.raises(ValueError):
+            await _make(embed)(["a", "b"])
+
+    assert "EMBEDDING_TOKEN_LIMIT" in caplog.text
+    assert "max_token_size" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_dimension_mismatch_logs_declared_dimension_remedy(
+    caplog, _propagate_lightrag_logs
+):
+    """The actionable fix for (N, 2D) is reconciling the declared dimension
+    with the model actually being called -- and clearing the data directory
+    afterwards, since existing vectors live in the old space."""
+
+    async def embed(texts):
+        return np.zeros((len(texts), 8), dtype=np.float32)
+
+    with caplog.at_level(logging.ERROR, logger="lightrag"):
+        with pytest.raises(ValueError):
+            await _make(embed)(["a", "b"])
+
+    assert "EMBEDDING_DIM" in caplog.text
+    assert "returned 8-dimensional" in caplog.text
+    assert "declares 4" in caplog.text

--- a/tests/utils/test_embedding_func_shape_validation.py
+++ b/tests/utils/test_embedding_func_shape_validation.py
@@ -123,6 +123,45 @@ async def test_dimension_is_checked_when_texts_are_not_passed_positionally():
 
 
 @pytest.mark.asyncio
+async def test_count_is_checked_when_texts_arrive_by_keyword():
+    """The input batch is resolved from the wrapped function's first
+    parameter name when the caller does not pass it positionally, so the
+    vector count is verifiable on that path too. Before this, a keyword call
+    skipped the count check entirely."""
+
+    async def embed(texts):
+        return np.zeros((len(texts) * 2, 4), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="Vector count mismatch"):
+        await _make(embed)(texts=["a", "b", "c"])
+
+
+@pytest.mark.asyncio
+async def test_keyword_batch_resolution_is_not_hardcoded_to_texts():
+    """Resolution reads the wrapped function's actual first parameter, so a
+    custom embedding function is free to name it something else."""
+
+    async def embed(sentences):
+        return np.zeros((len(sentences) * 2, 4), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="Vector count mismatch"):
+        await _make(embed)(sentences=["a", "b", "c"])
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_keyword_batch_skips_the_count_check():
+    """A *args-only signature cannot map a keyword to the batch. That makes
+    the count unverifiable, which must degrade to skipping that one check --
+    not to an error and not to a guess. The dimension check still runs."""
+
+    async def embed(**kwargs):
+        return np.zeros((5, 4), dtype=np.float32)
+
+    result = await _make(embed)(texts=["a", "b", "c"])
+    assert result.shape == (5, 4)
+
+
+@pytest.mark.asyncio
 async def test_1d_result_is_rejected():
     async def embed(texts):
         return np.zeros(4, dtype=np.float32)
@@ -153,6 +192,22 @@ async def test_empty_batch_with_bare_empty_array_is_accepted():
         return np.zeros((len(texts), 4), dtype=np.float32)
 
     result = await _make(embed)([])
+    assert result.size == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_batch_by_keyword_is_accepted():
+    """Same allowance on the keyword path. Keying the empty-batch exemption
+    to positional arguments only would reject `np.array([])` here while
+    accepting it two lines above -- and the element-count check this PR
+    replaces accepted both."""
+
+    async def embed(texts):
+        if not texts:
+            return np.array([])
+        return np.zeros((len(texts), 4), dtype=np.float32)
+
+    result = await _make(embed)(texts=[])
     assert result.size == 0
 
 

--- a/tests/utils/test_embedding_func_shape_validation.py
+++ b/tests/utils/test_embedding_func_shape_validation.py
@@ -1,0 +1,94 @@
+"""EmbeddingFunc.__call__: result shape validation must identify WHICH shape
+mismatch happened, not just that total elements did not add up.
+
+Issue #2549: multimodal PDF ingestion crashed when an embedding provider
+returned twice as many vectors as expected. A prior fix (rejected, see PR
+#3537) tried to detect the 2x case from total element count and silently
+slice the "extra" rows off. That is unsafe: a (N, 2D) result (wrong output
+dimension) divides out to the same "actual vectors" number as a genuine
+(2N, D) result (wrong vector count), so a total-element check reports the
+wrong diagnosis for one of the two cases, and slicing rows off a (2N, D)
+result has no general contract for which N of the 2N rows are the real ones.
+
+The fix instead checks result.ndim / result.shape[0] / result.shape[1]
+directly, so each shape mismatch is identified and rejected on its own
+terms -- never reshaped, sliced, or silently accepted.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from lightrag.utils import EmbeddingFunc
+
+pytestmark = pytest.mark.offline
+
+
+def _make(func, embedding_dim=4):
+    return EmbeddingFunc(embedding_dim=embedding_dim, func=func)
+
+
+@pytest.mark.asyncio
+async def test_correct_shape_passes_through_unchanged():
+    async def embed(texts):
+        return np.zeros((len(texts), 4), dtype=np.float32)
+
+    result = await _make(embed)(["a", "b", "c"])
+    assert result.shape == (3, 4)
+
+
+@pytest.mark.asyncio
+async def test_single_item_batch_with_2d_result_passes():
+    # Real providers wrap a single embedding in a (1, D) array, not a bare
+    # 1D (D,) vector -- confirm the strict ndim==2 check accepts that shape.
+    async def embed(texts):
+        return np.zeros((len(texts), 4), dtype=np.float32)
+
+    result = await _make(embed)(["only one"])
+    assert result.shape == (1, 4)
+
+
+@pytest.mark.asyncio
+async def test_doubled_vector_count_is_rejected_not_sliced():
+    """(2N, D): a genuine vector-count doubling. Must raise -- never
+    silently truncated to the first N rows, since there is no contract
+    that the first N rows are the real ones."""
+
+    async def embed(texts):
+        return np.zeros((len(texts) * 2, 4), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="Vector count mismatch"):
+        await _make(embed)(["a", "b", "c"])
+
+
+@pytest.mark.asyncio
+async def test_doubled_dimension_is_rejected_as_dimension_not_count():
+    """(N, 2D): a genuine dimension mismatch. Must be reported as a
+    dimension mismatch, not misdiagnosed as a doubled vector count -- a
+    total-element-count check cannot tell these two cases apart since both
+    divide out to the same "actual vectors" total."""
+
+    async def embed(texts):
+        return np.zeros((len(texts), 8), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="Embedding dimension mismatch"):
+        await _make(embed)(["a", "b", "c"])
+
+
+@pytest.mark.asyncio
+async def test_1d_result_is_rejected():
+    async def embed(texts):
+        return np.zeros(4, dtype=np.float32)
+
+    with pytest.raises(ValueError, match="unexpected shape"):
+        await _make(embed)(["only one"])
+
+
+@pytest.mark.asyncio
+async def test_3d_result_is_rejected():
+    async def embed(texts):
+        return np.zeros((len(texts), 2, 4), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="unexpected shape"):
+        await _make(embed)(["a", "b"])


### PR DESCRIPTION
**Problem**

`EmbeddingFunc` validated the result by total element count, deriving "actual vectors" from `result.size // embedding_dim`. That number cannot tell a genuine vector-count doubling `(2N, D)` apart from a dimension mismatch `(N, 2D)` — both divide out identically — so one of the two always got the wrong diagnosis. A misconfigured `embedding_dim` surfaced as `Vector count mismatch: expected 6 vectors but got 12`, sending operators after a vector-count problem they did not have. That misdiagnosis is what led the earlier attempts (#2731, #3537) to try slicing the "extra" rows off, which would have stored vectors under the wrong records.

A second, quieter defect: any `ndim != 2` result was accepted as long as the total divided evenly. A flattened `(N*D,)` array, or `(N, 2D)` arriving by keyword, passed validation and reached backends that index the result positionally.

**Change**

Check `ndim`, `shape[0]` and `shape[1]` directly. Nothing is reshaped, sliced or padded.

Formally, the accepted set strictly narrows: anything the new check accepts, the old one accepted too (`ndim == 2 ∧ shape[1] == dim` implies `size` divides evenly, and `shape[0] == N` implies `size // dim == N`). So there is no case the old code caught and this one misses — only cases it now catches that previously slipped through.

| Returned shape | Before | After |
| --- | --- | --- |
| `(N, D)` | pass | pass |
| `(2N, D)` — real doubling | count mismatch ✅ | count mismatch ✅ |
| **`(N, 2D)` — wrong dimension** | **count mismatch ❌** | **dimension mismatch ✅** |
| `(N, D')`, `D'` not a multiple of `D` | "cannot be evenly divided" ⚠️ | dimension mismatch ✅ |
| Flattened `(N*D,)` | pass ⚠️ | rejected ✅ |
| `(D,)` for a single input | pass ⚠️ | rejected ✅ |
| 3D | count mismatch ❌ | unexpected shape ✅ |
| `(N, 2D)` passed by keyword | pass ⚠️ | rejected ✅ |
| `(2N, D)` passed by keyword | pass ⚠️ | rejected ✅ |
| Empty result for an empty input list | pass | pass |

**What this does and does not do**

It does **not** make a failing ingestion succeed — every mismatch still raises, which is the intended contract for this wrapper (see the review on #3537). What it fixes is that the error now names the right problem, so it is actionable:

- A **count mismatch** points at the model's real token limit — the documented primary cause of #2549 is a service that splits an over-long input internally and returns one vector per segment. The remedy (`EMBEDDING_TOKEN_LIMIT`, or `max_token_size` on the decorator) is now stated in the log.
- A **dimension mismatch** points at reconciling the declared `embedding_dim` with the model actually being called — which for most #2549 reporters is very likely the real cause, previously hidden behind a vector-count message.

Each raise is preceded by a `logger.error` carrying the likely cause and the remedy; the exception message itself stays short.

**Empty batch**

An empty batch is the one shape the stricter check must not reject: zero inputs carry no vectors and no dimension to validate, so a provider that short-circuits with `if not texts: return np.array([])` (a common custom-embedding idiom, returning a 1D `(0,)` array) keeps working. An empty input paired with a non-empty result still fails.

This holds on both call paths. The input batch is resolved from the first positional argument, or — for a keyword call — from the kwarg matching the wrapped function's first parameter name (only the name is read; a full `Signature.bind()` would raise on the extra kwargs this wrapper and its priority decorator pass through). That also closes a pre-existing gap where a keyword call skipped the row-count check entirely. Where the batch is genuinely unresolvable (a positional-only or `*args` first parameter, or a callable exposing no signature), the row count alone is left unverified rather than guessed at, while rank and dimension are still enforced — and the docs state that scope rather than claiming every call is fully checked.

**Documentation**

The return contract was enforced but never written down. It is now stated in the `EmbeddingFunc` docstring and documented as a table in `docs/ProgramingWithCore.md`, together with the two distinct remedies. The `Custom Embedding Functions` section moved out of `AGENTS.md` into that same document, leaving a pointer behind.

**Tests**

`tests/utils/test_embedding_func_shape_validation.py` — 18 passed. Covers the happy path, `(2N, D)`, `(N, 2D)`, underflow, 1D, 3D, the keyword-argument path (row count, a non-`texts` parameter name, and the unresolvable-signature degrade-to-skip), all three empty-batch variants, and the diagnostic content of each of the three error logs. Every case was verified to fail when the mechanism it pins is removed.

- `tests/utils`: 340 passed
- `tests/llm` + `tests/chunker` + `tests/kg/nano_impl`: 928 passed
- Full suite: 8076 passed, 6 failed — the 6 are pre-existing local-environment failures in `tests/api` (missing `.env` / unbuilt WebUI), identical to the same 6 on the parent commit
- `pre-commit` passed

**Related Issue**

Fixes #2549.

