### PR TITLE
fix(zhipu): run blocking client calls off the event loop

### DIFF
--- a/lightrag/llm/zhipu.py
+++ b/lightrag/llm/zhipu.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 import warnings
 from ..utils import verbose_debug
@@ -137,7 +138,13 @@ async def zhipu_complete_if_cache(
     if thinking is not None:
         kwargs["thinking"] = thinking
 
-    response = client.chat.completions.create(model=model, messages=messages, **kwargs)
+    # ZhipuAI's client wraps a synchronous httpx.Client, not an async one --
+    # calling it directly here would block the whole event loop for the
+    # duration of the HTTP request, stalling every other concurrent task
+    # (other LLM calls, embeddings, storage I/O) sharing the loop.
+    response = await asyncio.to_thread(
+        client.chat.completions.create, model=model, messages=messages, **kwargs
+    )
     if not response.choices or response.choices[0].message is None:
         return ""
     message = response.choices[0].message
@@ -246,8 +253,13 @@ async def zhipu_embedding(
             request_kwargs = dict(kwargs)
             if embedding_dim is not None:
                 request_kwargs["dimensions"] = embedding_dim
-            response = client.embeddings.create(
-                model=model, input=[text], **request_kwargs
+            # Same blocking-client concern as zhipu_complete_if_cache: run
+            # each synchronous HTTP call off the event loop thread.
+            response = await asyncio.to_thread(
+                client.embeddings.create,
+                model=model,
+                input=[text],
+                **request_kwargs,
             )
             embeddings.append(response.data[0].embedding)
         except Exception as e:

--- a/tests/llm/zhipu_impl/test_zhipu_llm.py
+++ b/tests/llm/zhipu_impl/test_zhipu_llm.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+import threading
 from types import SimpleNamespace
 
 import numpy as np
@@ -229,6 +230,58 @@ async def test_zhipu_if_cache_entity_extraction_maps_to_json_object(monkeypatch)
     assert result == '{"entities":[],"relationships":[]}'
     assert captured_calls[0]["response_format"] == {"type": "json_object"}
     assert "entity_extraction" not in captured_calls[0]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_zhipu_complete_runs_client_call_off_the_event_loop_thread(monkeypatch):
+    """ZhipuAI wraps a synchronous httpx.Client, so calling it directly from
+    this async function would block the event loop for the whole HTTP
+    request. The call must run on a worker thread instead."""
+    call_thread_id = {}
+    main_thread_id = threading.get_ident()
+
+    class FakeClient:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+
+        def create(self, **kwargs):
+            call_thread_id["id"] = threading.get_ident()
+            return _fake_chat_response(content="answer")
+
+    zhipu_module = _load_zhipu_module(monkeypatch, FakeClient)
+
+    result = await zhipu_module.zhipu_complete_if_cache(
+        prompt="hello", api_key="test-key"
+    )
+
+    assert result == "answer"
+    assert call_thread_id["id"] != main_thread_id
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_zhipu_embedding_runs_client_call_off_the_event_loop_thread(monkeypatch):
+    call_thread_id = {}
+    main_thread_id = threading.get_ident()
+
+    class FakeClient:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+            self.embeddings = SimpleNamespace(create=self.create)
+
+        def create(self, **kwargs):
+            call_thread_id["id"] = threading.get_ident()
+            return SimpleNamespace(
+                data=[SimpleNamespace(embedding=_fake_embedding_vector())]
+            )
+
+    zhipu_module = _load_zhipu_module(monkeypatch, FakeClient)
+
+    await zhipu_module.zhipu_embedding.func(["hello"], api_key="test-key")
+
+    assert call_thread_id["id"] != main_thread_id
 
 
 @pytest.mark.offline


### PR DESCRIPTION
**Problem**

ZhipuAI wraps a synchronous httpx.Client. Calling it directly from these async functions blocks the whole event loop during the HTTP request, stalling every other concurrent task.

**Change**

Run both the chat and embedding calls through asyncio.to_thread.

**Tests**

- Zhipu tests: 10 passed
- Pre-commit passed
- git diff --check passed

**Related Issue**

No related issue.