### PR TITLE
fix(zhipu): support token_tracker instead of forwarding it to the API

### DIFF
--- a/lightrag/llm/zhipu.py
+++ b/lightrag/llm/zhipu.py
@@ -30,7 +30,7 @@ from lightrag.utils import (
 )
 
 import numpy as np
-from typing import Union, List, Optional, Dict
+from typing import Any, Union, List, Optional, Dict
 
 
 @retry(
@@ -50,6 +50,7 @@ async def zhipu_complete_if_cache(
     thinking: Optional[
         Dict[str, object]
     ] = None,  # Zhipu request param: use {"type": "enabled"} to enable thinking
+    token_tracker: Any | None = None,
     **kwargs,
 ) -> str:
     """Call Zhipu chat completions with optional official thinking support.
@@ -62,6 +63,8 @@ async def zhipu_complete_if_cache(
       `<think>...</think>`.
     - `response_format`: forwarded as Zhipu's OpenAI-compatible structured
       output parameter when supplied by callers.
+    - `token_tracker`: optional token usage tracker, recorded from the
+      response's `usage` field.
     - Deprecated `keyword_extraction` and `entity_extraction` booleans are
       compatibility shims; when no explicit `response_format` is supplied,
       they are mapped to `{"type": "json_object"}`.
@@ -138,6 +141,19 @@ async def zhipu_complete_if_cache(
         kwargs["thinking"] = thinking
 
     response = client.chat.completions.create(model=model, messages=messages, **kwargs)
+
+    # Record usage before extracting content: the API call is already billed
+    # and response.usage is already populated at this point, regardless of
+    # whether the response has a usable choice below.
+    if token_tracker and getattr(response, "usage", None):
+        token_tracker.add_usage(
+            {
+                "prompt_tokens": getattr(response.usage, "prompt_tokens", 0),
+                "completion_tokens": getattr(response.usage, "completion_tokens", 0),
+                "total_tokens": getattr(response.usage, "total_tokens", 0),
+            }
+        )
+
     if not response.choices or response.choices[0].message is None:
         return ""
     message = response.choices[0].message

--- a/tests/llm/zhipu_impl/test_zhipu_llm.py
+++ b/tests/llm/zhipu_impl/test_zhipu_llm.py
@@ -10,12 +10,12 @@ def _fake_embedding_vector(dim=1024):
     return [0.1] * dim
 
 
-def _fake_chat_response(content="", reasoning_content=""):
+def _fake_chat_response(content="", reasoning_content="", usage=None):
     message = SimpleNamespace(
         content=content,
         reasoning_content=reasoning_content,
     )
-    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)], usage=usage)
 
 
 def _load_zhipu_module(monkeypatch, client_factory):
@@ -120,6 +120,71 @@ async def test_zhipu_complete_forwards_official_thinking(monkeypatch):
 
     assert result == "final answer"
     assert captured_calls[0]["thinking"] == {"type": "enabled"}
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_zhipu_complete_records_token_usage(monkeypatch):
+    usage = SimpleNamespace(prompt_tokens=10, completion_tokens=4, total_tokens=14)
+
+    class FakeClient:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+
+        def create(self, **kwargs):
+            return _fake_chat_response(content="answer", usage=usage)
+
+    zhipu_module = _load_zhipu_module(monkeypatch, FakeClient)
+
+    class FakeTracker:
+        def __init__(self):
+            self.calls = []
+
+        def add_usage(self, token_counts):
+            self.calls.append(token_counts)
+
+    tracker = FakeTracker()
+    result = await zhipu_module.zhipu_complete_if_cache(
+        prompt="hello", api_key="test-key", token_tracker=tracker
+    )
+
+    assert result == "answer"
+    assert tracker.calls == [
+        {"prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14}
+    ]
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_zhipu_complete_token_tracker_never_reaches_the_raw_client_call(
+    monkeypatch,
+):
+    """token_tracker is a LightRAG-only concept, not a real Zhipu API field --
+    it must be consumed as a named parameter, never forwarded through
+    **kwargs into the raw client call."""
+    captured_calls = []
+
+    class FakeClient:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+
+        def create(self, **kwargs):
+            captured_calls.append(kwargs)
+            return _fake_chat_response(content="answer")
+
+    zhipu_module = _load_zhipu_module(monkeypatch, FakeClient)
+
+    class FakeTracker:
+        def add_usage(self, token_counts):
+            pass
+
+    await zhipu_module.zhipu_complete_if_cache(
+        prompt="hello", api_key="test-key", token_tracker=FakeTracker()
+    )
+
+    assert "token_tracker" not in captured_calls[0]
 
 
 @pytest.mark.offline


### PR DESCRIPTION
**Problem**

Every other completion provider accepts token_tracker to record usage. Zhipu had no such parameter, so passing one forwarded it through kwargs straight into the client call, which rejects it as an unexpected argument.

**Change**

Add the parameter and record usage from response.usage before extracting content.

**Tests**

- Zhipu tests: 10 passed
- Pre-commit passed
- git diff --check passed

**Related Issue**

No related issue.