### PR TITLE
fix(retrieval): preserve candidate order for vector similarity ties

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -6013,11 +6013,12 @@ async def pick_by_vector_similarity(
     if not entity_info or num_of_chunks <= 0:
         return []
 
-    # Collect all unique chunk IDs from entity info
-    all_chunk_ids = set()
-    for i, entity in enumerate(entity_info):
-        chunk_ids = entity.get("sorted_chunks", [])
-        all_chunk_ids.update(chunk_ids)
+    # Preserve first occurrence order for similarity ties and fallback selection.
+    all_chunk_ids = dict.fromkeys(
+        chunk_id
+        for entity in entity_info
+        for chunk_id in entity.get("sorted_chunks", [])
+    )
 
     if not all_chunk_ids:
         logger.warning(

--- a/tests/llm/test_vector_similarity_order.py
+++ b/tests/llm/test_vector_similarity_order.py
@@ -1,0 +1,134 @@
+import asyncio
+from copy import deepcopy
+from itertools import permutations
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+from lightrag.utils import pick_by_vector_similarity
+
+
+class VectorStore:
+    def __init__(self, vectors):
+        self.vectors = vectors
+        self.requested_ids = None
+
+    async def get_vectors_by_ids(self, ids):
+        self.requested_ids = list(ids)
+        # The returned mapping's order must not control tie-breaking either.
+        return {key: self.vectors[key] for key in reversed(ids) if key in self.vectors}
+
+
+def _select(entities, vectors, count, *, embedding=None, query_embedding=None):
+    store = VectorStore(vectors)
+    result = asyncio.run(
+        pick_by_vector_similarity(
+            query="evidence",
+            text_chunks_storage=None,
+            chunks_vdb=store,
+            num_of_chunks=count,
+            entity_info=entities,
+            embedding_func=embedding,
+            query_embedding=(
+                np.array([1.0, 0.0]) if query_embedding is None else query_embedding
+            ),
+        )
+    )
+    return result, store
+
+
+@pytest.mark.parametrize("order", list(permutations(["chunk-a", "chunk-b", "chunk-c"])))
+def test_similarity_ties_preserve_candidate_order(order):
+    vectors = {key: np.array([1.0, 0.0]) for key in order}
+    result, store = _select([{"sorted_chunks": list(order)}], vectors, 2)
+    assert result == list(order[:2])
+    assert store.requested_ids == list(order)
+
+
+def test_duplicate_chunks_keep_their_first_position():
+    entities = [
+        {"sorted_chunks": ["chunk-c", "chunk-a", "chunk-c"]},
+        {"sorted_chunks": ["chunk-b", "chunk-a"]},
+    ]
+    before = deepcopy(entities)
+    vectors = {key: np.array([1.0, 0.0]) for key in ["chunk-a", "chunk-b", "chunk-c"]}
+    result, store = _select(entities, vectors, 10)
+    assert result == ["chunk-c", "chunk-a", "chunk-b"]
+    assert store.requested_ids == result
+    assert entities == before
+
+
+def test_similarity_still_takes_precedence_over_candidate_order():
+    vectors = {
+        "low": np.array([-1.0, 0.0]),
+        "high": np.array([1.0, 0.0]),
+        "middle": np.array([0.0, 1.0]),
+    }
+    result, _ = _select([{"sorted_chunks": ["low", "high", "middle"]}], vectors, 2)
+    assert result == ["high", "middle"]
+
+
+def test_ties_only_affect_equal_scores():
+    vectors = {
+        "tie-b": np.array([0.0, 1.0]),
+        "best": np.array([1.0, 0.0]),
+        "tie-a": np.array([0.0, -1.0]),
+        "worst": np.array([-1.0, 0.0]),
+    }
+    result, _ = _select([{"sorted_chunks": list(vectors)}], vectors, 3)
+    assert result == ["best", "tie-b", "tie-a"]
+
+
+@pytest.mark.parametrize("order", list(permutations(["chunk-a", "chunk-b", "chunk-c"])))
+def test_storage_error_fallback_preserves_candidate_order(order):
+    class FailingStore:
+        async def get_vectors_by_ids(self, ids):
+            raise RuntimeError("storage unavailable")
+
+    result = asyncio.run(
+        pick_by_vector_similarity(
+            "evidence",
+            None,
+            FailingStore(),
+            2,
+            [{"sorted_chunks": list(order)}],
+            None,
+            query_embedding=np.array([1.0, 0.0]),
+        )
+    )
+    assert result == list(order[:2])
+
+
+@pytest.mark.parametrize("vectors", [{}, {"chunk-a": np.array([1.0, 0.0])}])
+def test_missing_vectors_still_request_weight_fallback(vectors):
+    result, _ = _select([{"sorted_chunks": ["chunk-a", "chunk-b"]}], vectors, 2)
+    assert result == []
+
+
+@pytest.mark.parametrize(
+    "entities, count",
+    [([], 2), ([{}], 2), ([{"sorted_chunks": ["a"]}], 0)],
+)
+def test_empty_selection_does_not_read_vectors(entities, count):
+    result, store = _select(entities, {}, count)
+    assert result == []
+    assert store.requested_ids is None
+
+
+def test_embedding_computation_path_uses_same_ordering():
+    embedding = AsyncMock(return_value=np.array([[1.0, 0.0]]))
+    vectors = {key: np.array([1.0, 0.0]) for key in ["chunk-c", "chunk-a", "chunk-b"]}
+    store = VectorStore(vectors)
+    result = asyncio.run(
+        pick_by_vector_similarity(
+            "evidence",
+            None,
+            store,
+            2,
+            [{"sorted_chunks": list(vectors)}],
+            embedding,
+        )
+    )
+    embedding.assert_awaited_once_with(["evidence"], context="query")
+    assert result == ["chunk-c", "chunk-a"]

--- a/tests/utils/test_pick_by_vector_similarity_order.py
+++ b/tests/utils/test_pick_by_vector_similarity_order.py
@@ -1,4 +1,11 @@
-import asyncio
+"""Determinism tests for :func:`lightrag.utils.pick_by_vector_similarity`.
+
+Candidate chunk IDs are deduplicated while preserving first-occurrence order.
+That order is the tie-break for equal cosine similarities and is also what the
+storage-error fallback truncates, so a hash-seed dependent order would make the
+evidence handed to the LLM vary between processes for the same query.
+"""
+
 from copy import deepcopy
 from itertools import permutations
 from unittest.mock import AsyncMock
@@ -7,6 +14,8 @@ import numpy as np
 import pytest
 
 from lightrag.utils import pick_by_vector_similarity
+
+pytestmark = pytest.mark.offline
 
 
 class VectorStore:
@@ -20,115 +29,105 @@ class VectorStore:
         return {key: self.vectors[key] for key in reversed(ids) if key in self.vectors}
 
 
-def _select(entities, vectors, count, *, embedding=None, query_embedding=None):
+async def _select(entities, vectors, count, *, embedding=None, query_embedding=None):
     store = VectorStore(vectors)
-    result = asyncio.run(
-        pick_by_vector_similarity(
-            query="evidence",
-            text_chunks_storage=None,
-            chunks_vdb=store,
-            num_of_chunks=count,
-            entity_info=entities,
-            embedding_func=embedding,
-            query_embedding=(
-                np.array([1.0, 0.0]) if query_embedding is None else query_embedding
-            ),
-        )
+    result = await pick_by_vector_similarity(
+        query="evidence",
+        text_chunks_storage=None,
+        chunks_vdb=store,
+        num_of_chunks=count,
+        entity_info=entities,
+        embedding_func=embedding,
+        query_embedding=(
+            np.array([1.0, 0.0]) if query_embedding is None else query_embedding
+        ),
     )
     return result, store
 
 
 @pytest.mark.parametrize("order", list(permutations(["chunk-a", "chunk-b", "chunk-c"])))
-def test_similarity_ties_preserve_candidate_order(order):
+async def test_similarity_ties_preserve_candidate_order(order):
     vectors = {key: np.array([1.0, 0.0]) for key in order}
-    result, store = _select([{"sorted_chunks": list(order)}], vectors, 2)
+    result, store = await _select([{"sorted_chunks": list(order)}], vectors, 2)
     assert result == list(order[:2])
     assert store.requested_ids == list(order)
 
 
-def test_duplicate_chunks_keep_their_first_position():
+async def test_duplicate_chunks_keep_their_first_position():
     entities = [
         {"sorted_chunks": ["chunk-c", "chunk-a", "chunk-c"]},
         {"sorted_chunks": ["chunk-b", "chunk-a"]},
     ]
     before = deepcopy(entities)
     vectors = {key: np.array([1.0, 0.0]) for key in ["chunk-a", "chunk-b", "chunk-c"]}
-    result, store = _select(entities, vectors, 10)
+    result, store = await _select(entities, vectors, 10)
     assert result == ["chunk-c", "chunk-a", "chunk-b"]
     assert store.requested_ids == result
     assert entities == before
 
 
-def test_similarity_still_takes_precedence_over_candidate_order():
+async def test_similarity_still_takes_precedence_over_candidate_order():
     vectors = {
         "low": np.array([-1.0, 0.0]),
         "high": np.array([1.0, 0.0]),
         "middle": np.array([0.0, 1.0]),
     }
-    result, _ = _select([{"sorted_chunks": ["low", "high", "middle"]}], vectors, 2)
+    result, _ = await _select(
+        [{"sorted_chunks": ["low", "high", "middle"]}], vectors, 2
+    )
     assert result == ["high", "middle"]
 
 
-def test_ties_only_affect_equal_scores():
+async def test_ties_only_affect_equal_scores():
     vectors = {
         "tie-b": np.array([0.0, 1.0]),
         "best": np.array([1.0, 0.0]),
         "tie-a": np.array([0.0, -1.0]),
         "worst": np.array([-1.0, 0.0]),
     }
-    result, _ = _select([{"sorted_chunks": list(vectors)}], vectors, 3)
+    result, _ = await _select([{"sorted_chunks": list(vectors)}], vectors, 3)
     assert result == ["best", "tie-b", "tie-a"]
 
 
 @pytest.mark.parametrize("order", list(permutations(["chunk-a", "chunk-b", "chunk-c"])))
-def test_storage_error_fallback_preserves_candidate_order(order):
+async def test_storage_error_fallback_preserves_candidate_order(order):
     class FailingStore:
         async def get_vectors_by_ids(self, ids):
             raise RuntimeError("storage unavailable")
 
-    result = asyncio.run(
-        pick_by_vector_similarity(
-            "evidence",
-            None,
-            FailingStore(),
-            2,
-            [{"sorted_chunks": list(order)}],
-            None,
-            query_embedding=np.array([1.0, 0.0]),
-        )
+    result = await pick_by_vector_similarity(
+        "evidence",
+        None,
+        FailingStore(),
+        2,
+        [{"sorted_chunks": list(order)}],
+        None,
+        query_embedding=np.array([1.0, 0.0]),
     )
     assert result == list(order[:2])
-
-
-@pytest.mark.parametrize("vectors", [{}, {"chunk-a": np.array([1.0, 0.0])}])
-def test_missing_vectors_still_request_weight_fallback(vectors):
-    result, _ = _select([{"sorted_chunks": ["chunk-a", "chunk-b"]}], vectors, 2)
-    assert result == []
 
 
 @pytest.mark.parametrize(
     "entities, count",
     [([], 2), ([{}], 2), ([{"sorted_chunks": ["a"]}], 0)],
 )
-def test_empty_selection_does_not_read_vectors(entities, count):
-    result, store = _select(entities, {}, count)
+async def test_empty_selection_does_not_read_vectors(entities, count):
+    result, store = await _select(entities, {}, count)
     assert result == []
     assert store.requested_ids is None
 
 
-def test_embedding_computation_path_uses_same_ordering():
+async def test_embedding_computation_path_uses_same_ordering():
     embedding = AsyncMock(return_value=np.array([[1.0, 0.0]]))
     vectors = {key: np.array([1.0, 0.0]) for key in ["chunk-c", "chunk-a", "chunk-b"]}
     store = VectorStore(vectors)
-    result = asyncio.run(
-        pick_by_vector_similarity(
-            "evidence",
-            None,
-            store,
-            2,
-            [{"sorted_chunks": list(vectors)}],
-            embedding,
-        )
+    result = await pick_by_vector_similarity(
+        "evidence",
+        None,
+        store,
+        2,
+        [{"sorted_chunks": list(vectors)}],
+        embedding,
     )
     embedding.assert_awaited_once_with(["evidence"], context="query")
     assert result == ["chunk-c", "chunk-a"]


### PR DESCRIPTION
## Description

Preserve first-occurrence order when deduplicating candidate chunk IDs in `pick_by_vector_similarity`.

The previous set-to-list conversion made tied-score selection and the storage-error fallback depend on Python's hash seed. With a result limit, identical ordered candidates could therefore yield different evidence across processes. An insertion-ordered dictionary keeps deduplication while giving the existing stable sort a deterministic tie-break.

Distinct-score ranking, missing-vector handling (`[]` for the caller's WEIGHT fallback), and caller inputs are unchanged. This guarantees repeatability for fixed ordered candidates, not invariance to arbitrary candidate permutations.

## Tests

Native editable installation on Ubuntu / Python 3.12.14, using the actual `lightrag.utils` import:

```bash
PYTHONHASHSEED=0 python -m pytest tests/utils/test_pick_by_vector_similarity_order.py -q
# unchanged source: 11 failed, 10 passed
# fixed source:     21 passed
```

The fixed suite also passes all 21 cases with `PYTHONHASHSEED=1,2,3,7,42`. It covers equal and distinct scores, duplicates, missing vectors, storage failures, empty inputs, and query-embedding generation.

Ruff 0.15.17 (the repository's pinned version) reports zero source/test lint findings; test formatting and `git diff --check` pass. No external model or database calls were used; storage responses are controlled test doubles. The full repository suite and live-model evaluation were not run.

[Executed validation and retained logs](https://github.com/Anormalm/LightRAG/actions/runs/34042440104). The validation workflow is fork-only and is not included in this PR.

---

## Maintainer follow-up (commit `d09252c`)

The regression tests were originally added at `tests/llm/test_vector_similarity_order.py` with no
`offline` marker. CI runs `pytest tests/ -m offline`, so all of them were deselected — the fix would
have shipped unguarded. Follow-up commit:

- Moved the file to `tests/utils/test_pick_by_vector_similarity_order.py`, mirroring `lightrag/utils.py`
  per the repository test layout and placing it beside the existing `test_pick_by_vector_similarity.py`.
- Added `pytestmark = pytest.mark.offline` so the CI gate selects it.
- Dropped `asyncio.run` in favour of the repository's `asyncio_mode = "auto"`, and added a module docstring.
- Removed the missing-vector case already covered by `test_pick_by_vector_similarity.py`.

Verification: `./scripts/test.sh tests/utils -m offline` → **307 passed, 15 deselected**, with 19 cases
from the new file now selected (previously 0). Reverting `lightrag/utils.py` to the pre-fix source fails
13 of those 19 on assertion, so the suite still proves the fix. `ruff check` and `pre-commit` clean.
