### PR TITLE
feat(api): add delete_parsed_files flag to DELETE /documents

### DIFF
--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -832,9 +832,10 @@ __parsed__/<base>.docling_raw/
 | 首次解析 | 取回产物，然后原子写入 `_manifest.json`。docling 的取回过程是 `POST /v1/convert/file/async` → 长轮询 `/v1/status/poll/{task_id}?wait=N` → `GET /v1/result/{task_id}` → 安全解压 zip（拒绝绝对路径与 `..`）。 |
 | 重新解析（缓存命中） | 不调用外部服务，不重写产物；仅重跑 adapter + writer 重新生成 sidecar（这正是 adapter 升级代价很低的原因）。 |
 | 重新解析（缓存未命中） | 清空目录，重新取回并写 manifest。 |
-| `DELETE /documents` 且 `delete_file=True` | `*.parsed/`、原始产物包、源文件一并删除。 |
-| `DELETE /documents` 且 `delete_file=False` | 保留全部产物，仅删除 doc_status 与 KG 数据。 |
-| `clear_documents` / 整体清空 `__parsed__` | 随之一并清除。 |
+| `DELETE /documents/delete_document` 且 `delete_file=True` | `*.parsed/`、原始产物包、源文件一并删除。 |
+| `DELETE /documents/delete_document` 且 `delete_file=False` | 保留全部产物，仅删除 doc_status 与 KG 数据。 |
+| `DELETE /documents`（`clear_documents`）且 `delete_parsed_files=true` | 整体删除 `__parsed__`；顶层输入文件始终会被删除，与此参数无关。 |
+| `DELETE /documents`（`clear_documents`）且 `delete_parsed_files=false`（默认） | 保留 `__parsed__`；顶层输入文件仍会被删除。 |
 | scan 周期 | **不会**回收孤立的产物包——只有用户显式删除时才移除，避免误扫掉调试现场。 |
 
 强制重解析（完全绕过缓存）：`LIGHTRAG_FORCE_REPARSE_NATIVE` / `LIGHTRAG_FORCE_REPARSE_MINERU` / `LIGHTRAG_FORCE_REPARSE_DOCLING`（§3.7）。

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -832,9 +832,10 @@ Lifecycle, identical for all three bundles:
 | First parse | Fetch the artifacts, then atomically write `_manifest.json`. For docling that is `POST /v1/convert/file/async` → long-poll `/v1/status/poll/{task_id}?wait=N` → `GET /v1/result/{task_id}` → safe extraction of the zip, rejecting absolute paths and `..`. |
 | Re-parse (cache hit) | Do not call the external service; do not rewrite artifacts; rerun adapter + writer to regenerate the sidecar (this is what makes an adapter upgrade cheap). |
 | Re-parse (cache miss) | Clear the directory, then fetch and write the manifest again. |
-| `DELETE /documents` with `delete_file=True` | `*.parsed/`, the raw bundle, and the original file are all removed together. |
-| `DELETE /documents` with `delete_file=False` | All artifacts are preserved; only doc_status and KG data are deleted. |
-| `clear_documents` / a full sweep of `__parsed__` | Naturally cleared together. |
+| `DELETE /documents/delete_document` with `delete_file=True` | `*.parsed/`, the raw bundle, and the original file are all removed together. |
+| `DELETE /documents/delete_document` with `delete_file=False` | All artifacts are preserved; only doc_status and KG data are deleted. |
+| `DELETE /documents` (`clear_documents`) with `delete_parsed_files=true` | `__parsed__` is removed as a whole; top-level input files are always deleted regardless of this flag. |
+| `DELETE /documents` (`clear_documents`) with `delete_parsed_files=false` (default) | `__parsed__` is preserved; top-level input files are still deleted. |
 | scan cycle | Does **not** GC orphaned bundles — they are removed only on an explicit user deletion, so a debugging site is never swept away by accident. |
 
 Force re-parse (bypass the cache entirely): `LIGHTRAG_FORCE_REPARSE_NATIVE` / `LIGHTRAG_FORCE_REPARSE_MINERU` / `LIGHTRAG_FORCE_REPARSE_DOCLING` (§3.7).

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -22,6 +22,8 @@ from lightrag.utils import (
     performance_timing_log,
     safe_log_value,
     validate_workspace,
+    _consume_future_exception,
+    _wait_deferring_cancellation,
 )
 import aiofiles
 import traceback
@@ -6041,18 +6043,41 @@ def create_document_routes(
             parsed_dir = doc_manager.input_dir / PARSED_DIR_NAME
             if delete_parsed_files:
                 if parsed_dir.exists():
-                    try:
-                        # __parsed__ can hold many files; run the recursive
-                        # delete off the event loop thread so a large
-                        # directory doesn't block every other request.
-                        await asyncio.to_thread(shutil.rmtree, parsed_dir)
-                        parsed_dir_message = " Deleted __parsed__ directory."
-                        append_pipeline_history(
-                            pipeline_status, "Deleted __parsed__ directory"
-                        )
-                    except Exception as e:
-                        logger.error(f"Error deleting {parsed_dir}: {str(e)}")
-                        errors.append(f"Failed to delete __parsed__ directory: {e}")
+                    # __parsed__ can hold many files; run the recursive
+                    # delete off the event loop thread so a large directory
+                    # doesn't block every other request. A bare cancel (e.g.
+                    # the client disconnecting) would only cancel this
+                    # await -- the rmtree keeps running in the background --
+                    # while the `finally` below releases destructive_busy
+                    # immediately, letting a new request race an in-flight
+                    # delete. Defer the cancellation until rmtree actually
+                    # finishes, same idiom as milvus_impl.py's flush.
+                    rmtree_future = asyncio.ensure_future(
+                        asyncio.to_thread(shutil.rmtree, parsed_dir)
+                    )
+                    rmtree_future.add_done_callback(_consume_future_exception)
+                    pending_cancel = await _wait_deferring_cancellation(
+                        rmtree_future, None
+                    )
+                    if pending_cancel is not None and not rmtree_future.cancelled():
+                        rmtree_exc = rmtree_future.exception()
+                        if rmtree_exc is not None:
+                            logger.error(
+                                f"Error deleting {parsed_dir} while cancelled: "
+                                f"{rmtree_exc}"
+                            )
+                    elif pending_cancel is None:
+                        try:
+                            rmtree_future.result()
+                            parsed_dir_message = " Deleted __parsed__ directory."
+                            append_pipeline_history(
+                                pipeline_status, "Deleted __parsed__ directory"
+                            )
+                        except Exception as e:
+                            logger.error(f"Error deleting {parsed_dir}: {str(e)}")
+                            errors.append(f"Failed to delete __parsed__ directory: {e}")
+                    if pending_cancel is not None:
+                        raise pending_cancel
             elif parsed_dir.exists():
                 parsed_dir_message = (
                     " __parsed__ preserved (pass delete_parsed_files=true to "

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -5769,6 +5769,13 @@ def create_document_routes(
         from the input directory. The __parsed__ directory is preserved unless
         delete_parsed_files=True is passed.
 
+        Top-level input files are always deleted unconditionally: a later
+        /documents/scan would otherwise re-enqueue them. The __parsed__
+        directory is opt-in only, since it holds pre-parsed cache artifacts
+        that let a re-added file skip re-parsing. A partial shutil.rmtree
+        failure (e.g. a locked file) can leave __parsed__ incomplete; re-run
+        with delete_parsed_files=True to retry.
+
         **Concurrency Constraint:**
         - Atomically reserves the destructive slot (sets ``busy=True``
           and ``destructive_busy=True``) before dropping anything.
@@ -6031,8 +6038,8 @@ def create_document_routes(
             # upload can still be recovered from there. Only remove it when
             # the caller explicitly opts in.
             parsed_dir_message = ""
+            parsed_dir = doc_manager.input_dir / PARSED_DIR_NAME
             if delete_parsed_files:
-                parsed_dir = doc_manager.input_dir / PARSED_DIR_NAME
                 if parsed_dir.exists():
                     try:
                         shutil.rmtree(parsed_dir)
@@ -6043,6 +6050,11 @@ def create_document_routes(
                     except Exception as e:
                         logger.error(f"Error deleting {parsed_dir}: {str(e)}")
                         errors.append(f"Failed to delete __parsed__ directory: {e}")
+            elif parsed_dir.exists():
+                parsed_dir_message = (
+                    " __parsed__ preserved (pass delete_parsed_files=true to "
+                    "remove it)."
+                )
 
             # Prepare final result message
             final_message = ""

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -6042,7 +6042,10 @@ def create_document_routes(
             if delete_parsed_files:
                 if parsed_dir.exists():
                     try:
-                        shutil.rmtree(parsed_dir)
+                        # __parsed__ can hold many files; run the recursive
+                        # delete off the event loop thread so a large
+                        # directory doesn't block every other request.
+                        await asyncio.to_thread(shutil.rmtree, parsed_dir)
                         parsed_dir_message = " Deleted __parsed__ directory."
                         append_pipeline_history(
                             pipeline_status, "Deleted __parsed__ directory"

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -5749,13 +5749,25 @@ def create_document_routes(
     @router.delete(
         "", response_model=ClearDocumentsResponse, dependencies=[Depends(combined_auth)]
     )
-    async def clear_documents():
+    async def clear_documents(
+        delete_parsed_files: Annotated[
+            bool,
+            Query(
+                description=(
+                    "Also delete the __parsed__ directory contents. Preserved "
+                    "by default so parsed artifacts survive re-adding the "
+                    "same files."
+                )
+            ),
+        ] = False,
+    ):
         """
         Clear all documents from the RAG system.
 
         This endpoint deletes all documents, entities, relationships, and files from the system.
         It uses the storage drop methods to properly clean up all data and removes all files
-        from the input directory.
+        from the input directory. The __parsed__ directory is preserved unless
+        delete_parsed_files=True is passed.
 
         **Concurrency Constraint:**
         - Atomically reserves the destructive slot (sets ``busy=True``
@@ -6014,13 +6026,37 @@ def create_document_routes(
                     pipeline_status, f"Successfully deleted {deleted_files_count} files"
                 )
 
+            # __parsed__ is preserved by default so re-adding the same file
+            # does not require re-parsing, and so a deleted document's raw
+            # upload can still be recovered from there. Only remove it when
+            # the caller explicitly opts in.
+            parsed_dir_message = ""
+            if delete_parsed_files:
+                parsed_dir = doc_manager.input_dir / PARSED_DIR_NAME
+                if parsed_dir.exists():
+                    try:
+                        shutil.rmtree(parsed_dir)
+                        parsed_dir_message = " Deleted __parsed__ directory."
+                        append_pipeline_history(
+                            pipeline_status, "Deleted __parsed__ directory"
+                        )
+                    except Exception as e:
+                        logger.error(f"Error deleting {parsed_dir}: {str(e)}")
+                        errors.append(f"Failed to delete __parsed__ directory: {e}")
+
             # Prepare final result message
             final_message = ""
             if errors:
-                final_message = f"Cleared documents with some errors. Deleted {deleted_files_count} files."
+                final_message = (
+                    f"Cleared documents with some errors. Deleted "
+                    f"{deleted_files_count} files.{parsed_dir_message}"
+                )
                 status = "partial_success"
             else:
-                final_message = f"All documents cleared successfully. Deleted {deleted_files_count} files."
+                final_message = (
+                    f"All documents cleared successfully. Deleted "
+                    f"{deleted_files_count} files.{parsed_dir_message}"
+                )
                 status = "success"
 
             # Log final result

--- a/tests/api/routes/test_clear_documents_parsed_files.py
+++ b/tests/api/routes/test_clear_documents_parsed_files.py
@@ -84,7 +84,8 @@ async def test_clear_documents_preserves_parsed_dir_by_default(tmp_path):
     assert response.status in ("success", "partial_success")
     assert parsed_dir.exists()
     assert (parsed_dir / "a.parsed.json").exists()
-    assert "__parsed__" not in response.message
+    assert "__parsed__ preserved" in response.message
+    assert "delete_parsed_files=true" in response.message
 
 
 async def test_clear_documents_deletes_parsed_dir_when_opted_in(tmp_path):
@@ -115,3 +116,16 @@ async def test_clear_documents_opt_in_is_a_noop_without_parsed_dir(tmp_path):
     response = await endpoint(delete_parsed_files=True)
 
     assert response.status in ("success", "partial_success")
+
+
+async def test_clear_documents_default_message_silent_without_parsed_dir(tmp_path):
+    workspace = f"clear-parsed-silent-{uuid4().hex[:8]}"
+    await _init_workspace(workspace)
+
+    rag = _ClearRag(workspace)
+    endpoint = _clear_endpoint(rag, tmp_path)
+
+    response = await endpoint()
+
+    assert response.status in ("success", "partial_success")
+    assert "__parsed__" not in response.message

--- a/tests/api/routes/test_clear_documents_parsed_files.py
+++ b/tests/api/routes/test_clear_documents_parsed_files.py
@@ -1,0 +1,117 @@
+"""``/documents`` DELETE (clear all): __parsed__ is preserved by default, and
+only removed when the caller passes delete_parsed_files=True.
+
+Preserving __parsed__ by default lets re-adding the same file skip
+re-parsing and keeps a deleted document's raw upload recoverable -- the
+same reasoning already documented for the per-document delete_file flag.
+"""
+
+import importlib
+import sys
+from uuid import uuid4
+
+import pytest
+
+_original_argv = sys.argv[:]
+sys.argv = [sys.argv[0]]
+_document_routes = importlib.import_module("lightrag.api.routers.document_routes")
+sys.argv = _original_argv
+
+from lightrag.constants import PARSED_DIR_NAME  # noqa: E402
+
+DocumentManager = _document_routes.DocumentManager
+create_document_routes = _document_routes.create_document_routes
+
+pytestmark = pytest.mark.offline
+
+
+class _NoopStorage:
+    namespace = "noop"
+
+    async def drop(self):
+        return {"status": "success", "message": "data dropped"}
+
+
+class _ClearRag:
+    def __init__(self, workspace: str):
+        self.workspace = workspace
+        storage = _NoopStorage()
+        storage.workspace = workspace
+        self.text_chunks = storage
+        self.full_docs = storage
+        self.full_entities = storage
+        self.full_relations = storage
+        self.entity_chunks = storage
+        self.relation_chunks = storage
+        self.entities_vdb = storage
+        self.relationships_vdb = storage
+        self.chunks_vdb = storage
+        self.chunk_entity_relation_graph = storage
+        self.doc_status = storage
+
+    async def aclear_cache(self, modes=None):
+        return None
+
+
+def _clear_endpoint(rag, input_dir):
+    router = create_document_routes(rag, DocumentManager(str(input_dir)))
+    return [
+        route.endpoint
+        for route in router.routes
+        if getattr(route, "name", "") == "clear_documents"
+    ][-1]
+
+
+async def _init_workspace(workspace):
+    shared_storage = importlib.import_module("lightrag.kg.shared_storage")
+    shared_storage.initialize_share_data()
+    await shared_storage.initialize_pipeline_status(workspace=workspace)
+
+
+async def test_clear_documents_preserves_parsed_dir_by_default(tmp_path):
+    workspace = f"clear-parsed-default-{uuid4().hex[:8]}"
+    await _init_workspace(workspace)
+
+    parsed_dir = tmp_path / PARSED_DIR_NAME
+    parsed_dir.mkdir()
+    (parsed_dir / "a.parsed.json").write_text("{}")
+
+    rag = _ClearRag(workspace)
+    endpoint = _clear_endpoint(rag, tmp_path)
+
+    response = await endpoint()
+
+    assert response.status in ("success", "partial_success")
+    assert parsed_dir.exists()
+    assert (parsed_dir / "a.parsed.json").exists()
+    assert "__parsed__" not in response.message
+
+
+async def test_clear_documents_deletes_parsed_dir_when_opted_in(tmp_path):
+    workspace = f"clear-parsed-optin-{uuid4().hex[:8]}"
+    await _init_workspace(workspace)
+
+    parsed_dir = tmp_path / PARSED_DIR_NAME
+    parsed_dir.mkdir()
+    (parsed_dir / "a.parsed.json").write_text("{}")
+
+    rag = _ClearRag(workspace)
+    endpoint = _clear_endpoint(rag, tmp_path)
+
+    response = await endpoint(delete_parsed_files=True)
+
+    assert response.status in ("success", "partial_success")
+    assert not parsed_dir.exists()
+    assert "__parsed__" in response.message
+
+
+async def test_clear_documents_opt_in_is_a_noop_without_parsed_dir(tmp_path):
+    workspace = f"clear-parsed-missing-{uuid4().hex[:8]}"
+    await _init_workspace(workspace)
+
+    rag = _ClearRag(workspace)
+    endpoint = _clear_endpoint(rag, tmp_path)
+
+    response = await endpoint(delete_parsed_files=True)
+
+    assert response.status in ("success", "partial_success")

--- a/tests/api/routes/test_clear_documents_parsed_files.py
+++ b/tests/api/routes/test_clear_documents_parsed_files.py
@@ -6,6 +6,7 @@ re-parsing and keeps a deleted document's raw upload recoverable -- the
 same reasoning already documented for the per-document delete_file flag.
 """
 
+import asyncio
 import importlib
 import shutil
 import sys
@@ -148,6 +149,64 @@ async def test_clear_documents_deletes_parsed_dir_off_the_event_loop_thread(tmp_
     assert response.status in ("success", "partial_success")
     assert not parsed_dir.exists()
     assert call_thread_id["id"] != main_thread_id
+
+
+async def test_clear_documents_cancel_defers_until_rmtree_finishes_before_releasing_lock(
+    tmp_path,
+):
+    """A bare cancel (e.g. the client disconnecting) during the rmtree
+    await must not let the finally block release destructive_busy while
+    the delete is still running in the background -- that would let a new
+    request race an in-flight __parsed__ deletion."""
+    workspace = f"clear-parsed-cancel-{uuid4().hex[:8]}"
+    await _init_workspace(workspace)
+
+    parsed_dir = tmp_path / PARSED_DIR_NAME
+    parsed_dir.mkdir()
+    (parsed_dir / "a.parsed.json").write_text("{}")
+
+    call_started = threading.Event()
+    release_call = threading.Event()
+    real_rmtree = shutil.rmtree
+
+    def fake_rmtree(path, *args, **kwargs):
+        call_started.set()
+        release_call.wait(timeout=5)
+        return real_rmtree(path, *args, **kwargs)
+
+    rag = _ClearRag(workspace)
+    endpoint = _clear_endpoint(rag, tmp_path)
+    shared_storage = importlib.import_module("lightrag.kg.shared_storage")
+
+    with patch.object(shutil, "rmtree", side_effect=fake_rmtree):
+        task = asyncio.ensure_future(endpoint(delete_parsed_files=True))
+        for _ in range(500):
+            if call_started.is_set():
+                break
+            await asyncio.sleep(0.01)
+        assert call_started.is_set()
+
+        task.cancel()
+        # Give the cancelled task a chance to re-suspend on the deferred
+        # wait before checking the lock state.
+        for _ in range(10):
+            await asyncio.sleep(0.01)
+
+        pipeline_status = await shared_storage.get_namespace_data(
+            "pipeline_status", workspace=workspace
+        )
+        assert pipeline_status["destructive_busy"] is True
+
+        release_call.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert not parsed_dir.exists()
+    pipeline_status = await shared_storage.get_namespace_data(
+        "pipeline_status", workspace=workspace
+    )
+    assert pipeline_status["destructive_busy"] is False
 
 
 async def test_clear_documents_default_message_silent_without_parsed_dir(tmp_path):

--- a/tests/api/routes/test_clear_documents_parsed_files.py
+++ b/tests/api/routes/test_clear_documents_parsed_files.py
@@ -7,7 +7,10 @@ same reasoning already documented for the per-document delete_file flag.
 """
 
 import importlib
+import shutil
 import sys
+import threading
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -116,6 +119,35 @@ async def test_clear_documents_opt_in_is_a_noop_without_parsed_dir(tmp_path):
     response = await endpoint(delete_parsed_files=True)
 
     assert response.status in ("success", "partial_success")
+
+
+async def test_clear_documents_deletes_parsed_dir_off_the_event_loop_thread(tmp_path):
+    """__parsed__ can hold many files; shutil.rmtree on it must not block
+    the event loop for the duration of a large recursive delete."""
+    workspace = f"clear-parsed-thread-{uuid4().hex[:8]}"
+    await _init_workspace(workspace)
+
+    parsed_dir = tmp_path / PARSED_DIR_NAME
+    parsed_dir.mkdir()
+    (parsed_dir / "a.parsed.json").write_text("{}")
+
+    main_thread_id = threading.get_ident()
+    call_thread_id = {}
+    real_rmtree = shutil.rmtree
+
+    def fake_rmtree(path, *args, **kwargs):
+        call_thread_id["id"] = threading.get_ident()
+        return real_rmtree(path, *args, **kwargs)
+
+    rag = _ClearRag(workspace)
+    endpoint = _clear_endpoint(rag, tmp_path)
+
+    with patch.object(shutil, "rmtree", side_effect=fake_rmtree):
+        response = await endpoint(delete_parsed_files=True)
+
+    assert response.status in ("success", "partial_success")
+    assert not parsed_dir.exists()
+    assert call_thread_id["id"] != main_thread_id
 
 
 async def test_clear_documents_default_message_silent_without_parsed_dir(tmp_path):


### PR DESCRIPTION
**Problem**

DELETE /documents (clear all) has no way to also remove the __parsed__ directory. A prior PR that deleted it unconditionally was rejected since parsed artifacts should stay recoverable by default.

**Change**

Add an opt in delete_parsed_files query flag, default false, matching the maintainer's suggested shape from that review.

**Tests**

- New tests: 3 passed
- Full api/routes suite: 571 passed (19 pre-existing unrelated failures, missing ollama package in sandbox)
- Pre-commit passed
- git diff --check passed

**Related Issue**

No related issue.