### PR TITLE
fix(storage): preserve successful NetworkX drops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ LightRAG uses 4 storage types with pluggable backends:
 
 Each `LightRAG` instance can pass a `workspace` parameter for data isolation. Implementation differs per storage type:
 - **File-based**: subdirectories under `working_dir`.
+- **NetworkX destructive status**: `NetworkXStorage.drop()` reports the durable GraphML deletion. A later peer reload-notification failure is logged as partial propagation and must not turn that completed deletion into an error response; `/documents/clear` uses the status to decide whether input files are safe to delete.
 - **Collection-based**: collection name prefixes.
 - **Relational DB**: workspace column filtering.
 - **Qdrant**: payload-based partitioning.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,6 @@ LightRAG uses 4 storage types with pluggable backends:
 
 Each `LightRAG` instance can pass a `workspace` parameter for data isolation. Implementation differs per storage type:
 - **File-based**: subdirectories under `working_dir`.
-- **NetworkX destructive status**: `NetworkXStorage.drop()` reports the durable GraphML deletion. A later peer reload-notification failure is logged as partial propagation and must not turn that completed deletion into an error response; `/documents/clear` uses the status to decide whether input files are safe to delete.
 - **Collection-based**: collection name prefixes.
 - **Relational DB**: workspace column filtering.
 - **Qdrant**: payload-based partitioning.

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -1110,48 +1110,64 @@ class NetworkXStorage(BaseGraphStorage):
 
             A peer notification failure after the file deletion is logged but
             does not change the successful status of the completed drop.
+            This status confirms durable deletion, not convergence of all worker
+            snapshots. A worker that missed the notification may later write its
+            stale graph back. Stop workspace writes and restart affected workers
+            before resuming; if stale data has already been written, clear again.
+
+        Cancellation:
+            Before submission, cancellation leaves storage unchanged. Once file
+            deletion is submitted, the storage lock stays held until deletion
+            and its notification/reset/logging hook finish, then caller
+            cancellation propagates. Notification errors are still logged.
         """
+
+        def _delete_file() -> None:
+            if os.path.exists(self._graphml_xml_file):
+                os.remove(self._graphml_xml_file)
+
+        async def _committed() -> None:
+            self._graph = nx.Graph()
+            # Keep publication under the storage lock. Once deletion starts,
+            # commit_in_storage_io defers caller cancellation through this hook
+            # so it cannot release readers before the notification attempt.
+            try:
+                await set_all_update_flags(self.namespace, workspace=self.workspace)
+            except Exception as notification_error:
+                # Notification can fail partway through the registered flags.
+                # A missed worker may later become the writer and persist its
+                # stale graph, resurrecting deleted data. A notification from
+                # that writer would spread the stale state, not repair it.
+                logger.error(
+                    f"[{self.workspace}] Dropped graph file:{self._graphml_xml_file}, "
+                    "but failed while notifying all processes; some processes may "
+                    "not reload and may restore deleted data if they later write. "
+                    "Stop workspace writes and restart all affected workers before "
+                    f"resuming: {notification_error}"
+                )
+            # The local graph is already empty, even after partial notification.
+            # A broken shared-state manager can fail this reset independently;
+            # report it without misclassifying the durable deletion as failed.
+            try:
+                self.storage_updated.value = False
+            except Exception as reset_error:
+                logger.error(
+                    f"[{self.workspace}] Dropped graph file:{self._graphml_xml_file}, "
+                    f"but failed to reset the writer reload flag: {reset_error}"
+                )
+            # Log inside the cancellation-protected hook: the caller may receive
+            # CancelledError after it completes instead of a success response.
+            logger.info(
+                f"[{self.workspace}] Process {os.getpid()} drop graph file:{self._graphml_xml_file}"
+            )
+
         try:
             async with self._storage_lock:
-                # delete _client_file_name
-                if os.path.exists(self._graphml_xml_file):
-                    os.remove(self._graphml_xml_file)
-                self._graph = nx.Graph()
-                # The file deletion above is the durable operation. Cross-process
-                # notification cannot make that deletion fail. Keep notification and
-                # writer-flag reset under the lock so readers cannot pass between the
-                # deletion and publication of the reload signal.
-                # ``set_all_update_flags`` updates peers one by one, so an exception may
-                # mean that only some readers missed the reload signal. Those
-                # readers retain a stale snapshot until a later successful
-                # notification or a process restart reloads the durable state.
-                try:
-                    await set_all_update_flags(self.namespace, workspace=self.workspace)
-                except Exception as notification_error:
-                    logger.error(
-                        f"[{self.workspace}] Dropped graph file:{self._graphml_xml_file}, "
-                        "but failed while notifying all processes; some processes may "
-                        f"not reload: {notification_error}"
-                    )
-                # The writer already owns the new empty graph and must not reload
-                # itself even when peer notification stopped partway through. A broken
-                # shared-state manager can make this assignment fail independently;
-                # that degradation still cannot undo the durable deletion.
-                try:
-                    self.storage_updated.value = False
-                except Exception as reset_error:
-                    logger.error(
-                        f"[{self.workspace}] Dropped graph file:{self._graphml_xml_file}, "
-                        f"but failed to reset the writer reload flag: {reset_error}"
-                    )
-
+                await commit_in_storage_io(_delete_file, _committed)
         except Exception as e:
             logger.error(
                 f"[{self.workspace}] Error dropping graph file:{self._graphml_xml_file}: {e}"
             )
             return {"status": "error", "message": str(e)}
 
-        logger.info(
-            f"[{self.workspace}] Process {os.getpid()} drop graph file:{self._graphml_xml_file}"
-        )
         return {"status": "success", "message": "data dropped"}

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -1064,7 +1064,10 @@ class NetworkXStorage(BaseGraphStorage):
         Returns:
             dict[str, str]: Operation status and message
             - On success: {"status": "success", "message": "data dropped"}
-            - On failure: {"status": "error", "message": "<error details>"}
+            - On destructive failure: {"status": "error", "message": "<error details>"}
+
+            A peer notification failure after the file deletion is logged but
+            does not change the successful status of the completed drop.
         """
         try:
             async with self._storage_lock:
@@ -1072,16 +1075,37 @@ class NetworkXStorage(BaseGraphStorage):
                 if os.path.exists(self._graphml_xml_file):
                     os.remove(self._graphml_xml_file)
                 self._graph = nx.Graph()
-                # Notify other processes that data has been updated
-                await set_all_update_flags(self.namespace, workspace=self.workspace)
-                # Reset own update flag to avoid self-reloading
-                self.storage_updated.value = False
-                logger.info(
-                    f"[{self.workspace}] Process {os.getpid()} drop graph file:{self._graphml_xml_file}"
-                )
-            return {"status": "success", "message": "data dropped"}
         except Exception as e:
             logger.error(
                 f"[{self.workspace}] Error dropping graph file:{self._graphml_xml_file}: {e}"
             )
             return {"status": "error", "message": str(e)}
+
+        # The file deletion above is the durable operation. Cross-process
+        # notification happens afterwards and cannot make that deletion fail.
+        # ``set_all_update_flags`` updates peers one by one, so an exception may
+        # mean that only some readers missed the reload signal.
+        try:
+            await set_all_update_flags(self.namespace, workspace=self.workspace)
+        except Exception as notification_error:
+            logger.error(
+                f"[{self.workspace}] Dropped graph file:{self._graphml_xml_file}, "
+                "but failed while notifying all processes; some processes may "
+                f"not reload: {notification_error}"
+            )
+        # The writer already owns the new empty graph and must not reload
+        # itself even when peer notification stopped partway through. A broken
+        # shared-state manager can make this assignment fail independently;
+        # that degradation still cannot undo the durable deletion.
+        try:
+            self.storage_updated.value = False
+        except Exception as reset_error:
+            logger.error(
+                f"[{self.workspace}] Dropped graph file:{self._graphml_xml_file}, "
+                f"but failed to reset the writer reload flag: {reset_error}"
+            )
+
+        logger.info(
+            f"[{self.workspace}] Process {os.getpid()} drop graph file:{self._graphml_xml_file}"
+        )
+        return {"status": "success", "message": "data dropped"}

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -1117,35 +1117,39 @@ class NetworkXStorage(BaseGraphStorage):
                 if os.path.exists(self._graphml_xml_file):
                     os.remove(self._graphml_xml_file)
                 self._graph = nx.Graph()
+                # The file deletion above is the durable operation. Cross-process
+                # notification cannot make that deletion fail. Keep notification and
+                # writer-flag reset under the lock so readers cannot pass between the
+                # deletion and publication of the reload signal.
+                # ``set_all_update_flags`` updates peers one by one, so an exception may
+                # mean that only some readers missed the reload signal. Those
+                # readers retain a stale snapshot until a later successful
+                # notification or a process restart reloads the durable state.
+                try:
+                    await set_all_update_flags(self.namespace, workspace=self.workspace)
+                except Exception as notification_error:
+                    logger.error(
+                        f"[{self.workspace}] Dropped graph file:{self._graphml_xml_file}, "
+                        "but failed while notifying all processes; some processes may "
+                        f"not reload: {notification_error}"
+                    )
+                # The writer already owns the new empty graph and must not reload
+                # itself even when peer notification stopped partway through. A broken
+                # shared-state manager can make this assignment fail independently;
+                # that degradation still cannot undo the durable deletion.
+                try:
+                    self.storage_updated.value = False
+                except Exception as reset_error:
+                    logger.error(
+                        f"[{self.workspace}] Dropped graph file:{self._graphml_xml_file}, "
+                        f"but failed to reset the writer reload flag: {reset_error}"
+                    )
+
         except Exception as e:
             logger.error(
                 f"[{self.workspace}] Error dropping graph file:{self._graphml_xml_file}: {e}"
             )
             return {"status": "error", "message": str(e)}
-
-        # The file deletion above is the durable operation. Cross-process
-        # notification happens afterwards and cannot make that deletion fail.
-        # ``set_all_update_flags`` updates peers one by one, so an exception may
-        # mean that only some readers missed the reload signal.
-        try:
-            await set_all_update_flags(self.namespace, workspace=self.workspace)
-        except Exception as notification_error:
-            logger.error(
-                f"[{self.workspace}] Dropped graph file:{self._graphml_xml_file}, "
-                "but failed while notifying all processes; some processes may "
-                f"not reload: {notification_error}"
-            )
-        # The writer already owns the new empty graph and must not reload
-        # itself even when peer notification stopped partway through. A broken
-        # shared-state manager can make this assignment fail independently;
-        # that degradation still cannot undo the durable deletion.
-        try:
-            self.storage_updated.value = False
-        except Exception as reset_error:
-            logger.error(
-                f"[{self.workspace}] Dropped graph file:{self._graphml_xml_file}, "
-                f"but failed to reset the writer reload flag: {reset_error}"
-            )
 
         logger.info(
             f"[{self.workspace}] Process {os.getpid()} drop graph file:{self._graphml_xml_file}"

--- a/tests/api/routes/test_clear_documents_ingress.py
+++ b/tests/api/routes/test_clear_documents_ingress.py
@@ -182,13 +182,15 @@ async def test_clear_documents_survives_ingress_clear_failure(tmp_path):
     assert pipeline_status.get("destructive_busy") is False
 
 
-async def test_clear_documents_counts_notified_failed_networkx_drop_as_success(
+async def test_clear_documents_counts_notification_failed_networkx_drop_as_success(
     tmp_path, monkeypatch
 ):
     """A peer reload-notification failure happens after the graph is gone.
 
-    The endpoint must continue deleting input files instead of reporting that
-    every storage survived and leaving the files ready for re-ingestion.
+    Other storages succeed in this fixture, so input files are deleted even
+    before the fix. The regression assertion is the response status: a
+    completed graph drop must not be counted as a storage error and turn
+    success into partial_success.
     """
     workspace = f"clear-networkx-notify-{uuid4().hex[:8]}"
     shared_storage = importlib.import_module("lightrag.kg.shared_storage")
@@ -218,7 +220,7 @@ async def test_clear_documents_counts_notified_failed_networkx_drop_as_success(
             raise RuntimeError("notification boom")
 
         monkeypatch.setattr(networkx_impl, "set_all_update_flags", notification_boom)
-        input_file = tmp_path / "would-be-reingested.txt"
+        input_file = tmp_path / "cleared-input.txt"
         input_file.write_text("already cleared graph data")
 
         rag = _ClearRag(workspace)

--- a/tests/api/routes/test_clear_documents_ingress.py
+++ b/tests/api/routes/test_clear_documents_ingress.py
@@ -9,8 +9,10 @@ the document/auto channels are emptied.
 
 import importlib
 import sys
+from pathlib import Path
 from uuid import uuid4
 
+import numpy as np
 import pytest
 
 _original_argv = sys.argv[:]
@@ -22,8 +24,10 @@ from lightrag.kg.pipeline_ingress import (  # noqa: E402
     ManualRetryPublishResult,
     PipelineIngressMessage,
 )
+from lightrag.kg.networkx_impl import NetworkXStorage  # noqa: E402
 from lightrag.kg.scan_job_store import ScanJobStatus  # noqa: E402
 from lightrag.kg.shared_storage import get_pipeline_ingress  # noqa: E402
+from lightrag.utils import EmbeddingFunc  # noqa: E402
 
 DocumentManager = _document_routes.DocumentManager
 create_document_routes = _document_routes.create_document_routes
@@ -176,6 +180,66 @@ async def test_clear_documents_survives_ingress_clear_failure(tmp_path):
     )
     assert pipeline_status.get("busy") is False
     assert pipeline_status.get("destructive_busy") is False
+
+
+async def test_clear_documents_counts_notified_failed_networkx_drop_as_success(
+    tmp_path, monkeypatch
+):
+    """A peer reload-notification failure happens after the graph is gone.
+
+    The endpoint must continue deleting input files instead of reporting that
+    every storage survived and leaving the files ready for re-ingestion.
+    """
+    workspace = f"clear-networkx-notify-{uuid4().hex[:8]}"
+    shared_storage = importlib.import_module("lightrag.kg.shared_storage")
+    networkx_impl = importlib.import_module("lightrag.kg.networkx_impl")
+    shared_storage.initialize_share_data()
+    await shared_storage.initialize_pipeline_status(workspace=workspace)
+
+    async def embed(texts):
+        return np.random.rand(len(texts), 8)
+
+    graph = NetworkXStorage(
+        namespace="chunk_entity_relation",
+        workspace=workspace,
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 10,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.5},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=8, max_token_size=512, func=embed),
+    )
+    await graph.initialize()
+    try:
+        await graph.upsert_node("n1", {"entity_id": "n1"})
+        await graph.index_done_callback()
+
+        async def notification_boom(namespace, workspace=None):
+            raise RuntimeError("notification boom")
+
+        monkeypatch.setattr(networkx_impl, "set_all_update_flags", notification_boom)
+        input_file = tmp_path / "would-be-reingested.txt"
+        input_file.write_text("already cleared graph data")
+
+        rag = _ClearRag(workspace)
+        rag.chunk_entity_relation_graph = graph
+        router = create_document_routes(rag, DocumentManager(str(tmp_path)))
+        clear_endpoint = [
+            route.endpoint
+            for route in router.routes
+            if getattr(route, "name", "") == "clear_documents"
+        ][-1]
+
+        logged_errors = []
+        monkeypatch.setattr(networkx_impl.logger, "error", logged_errors.append)
+        response = await clear_endpoint()
+
+        assert response.status == "success"
+        assert not input_file.exists()
+        assert not Path(graph._graphml_xml_file).exists()
+        assert any("some processes may not reload" in msg for msg in logged_errors)
+    finally:
+        await graph.finalize()
 
 
 async def test_clear_documents_retires_finished_scan_jobs_only(tmp_path):

--- a/tests/kg/networkx_impl/test_networkx_drop.py
+++ b/tests/kg/networkx_impl/test_networkx_drop.py
@@ -1,0 +1,91 @@
+"""NetworkXStorage drop status follows the durable operation, not notification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from lightrag.kg import networkx_impl
+from lightrag.kg.networkx_impl import NetworkXStorage
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+from lightrag.utils import EmbeddingFunc
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+async def _embed(texts):
+    return np.random.rand(len(texts), 8)
+
+
+def _make_storage(tmp_path) -> NetworkXStorage:
+    return NetworkXStorage(
+        namespace="test_graph",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 10,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.5},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=8, max_token_size=512, func=_embed),
+    )
+
+
+@pytest.mark.asyncio
+async def test_drop_stays_successful_when_peer_notification_fails(
+    tmp_path, monkeypatch
+):
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+    try:
+        await storage.upsert_node("n1", {"entity_id": "n1"})
+        await storage.index_done_callback()
+        assert Path(storage._graphml_xml_file).exists()
+
+        async def notification_boom(namespace, workspace=None):
+            raise RuntimeError("notification boom")
+
+        monkeypatch.setattr(networkx_impl, "set_all_update_flags", notification_boom)
+        logged_errors = []
+        monkeypatch.setattr(networkx_impl.logger, "error", logged_errors.append)
+        result = await storage.drop()
+
+        assert result == {"status": "success", "message": "data dropped"}
+        assert not Path(storage._graphml_xml_file).exists()
+        assert storage._graph.number_of_nodes() == 0
+        assert storage.storage_updated.value is False
+        assert any("some processes may not reload" in msg for msg in logged_errors)
+        assert any("notification boom" in msg for msg in logged_errors)
+    finally:
+        await storage.finalize()
+
+
+@pytest.mark.asyncio
+async def test_drop_reports_a_destructive_file_failure(tmp_path, monkeypatch):
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+    try:
+        await storage.upsert_node("n1", {"entity_id": "n1"})
+        await storage.index_done_callback()
+
+        def remove_boom(path):
+            raise OSError("delete boom")
+
+        monkeypatch.setattr(networkx_impl.os, "remove", remove_boom)
+
+        result = await storage.drop()
+
+        assert result == {"status": "error", "message": "delete boom"}
+        assert Path(storage._graphml_xml_file).exists()
+        assert storage._graph.has_node("n1")
+    finally:
+        await storage.finalize()

--- a/tests/kg/networkx_impl/test_networkx_drop.py
+++ b/tests/kg/networkx_impl/test_networkx_drop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import numpy as np
@@ -52,6 +53,7 @@ async def test_drop_stays_successful_when_peer_notification_fails(
         assert Path(storage._graphml_xml_file).exists()
 
         async def notification_boom(namespace, workspace=None):
+            storage.storage_updated.value = True
             raise RuntimeError("notification boom")
 
         monkeypatch.setattr(networkx_impl, "set_all_update_flags", notification_boom)
@@ -87,5 +89,77 @@ async def test_drop_reports_a_destructive_file_failure(tmp_path, monkeypatch):
         assert result == {"status": "error", "message": "delete boom"}
         assert Path(storage._graphml_xml_file).exists()
         assert storage._graph.has_node("n1")
+    finally:
+        await storage.finalize()
+
+
+@pytest.mark.asyncio
+async def test_drop_blocks_peer_reads_until_notification_completes(
+    tmp_path, monkeypatch
+):
+    writer = _make_storage(tmp_path)
+    await writer.initialize()
+    await writer.upsert_node("n1", {"entity_id": "n1"})
+    await writer.index_done_callback()
+    peer = _make_storage(tmp_path)
+    await peer.initialize()
+    notification_started = asyncio.Event()
+    allow_notification = asyncio.Event()
+    notify = networkx_impl.set_all_update_flags
+
+    async def paused_notification(namespace, workspace=None):
+        notification_started.set()
+        await allow_notification.wait()
+        await notify(namespace, workspace=workspace)
+
+    monkeypatch.setattr(networkx_impl, "set_all_update_flags", paused_notification)
+    drop_task = asyncio.create_task(writer.drop())
+    read_task = None
+    try:
+        await asyncio.wait_for(notification_started.wait(), timeout=2)
+        assert not Path(writer._graphml_xml_file).exists()
+        read_task = asyncio.create_task(peer.has_node("n1"))
+        # A reader arriving after deletion must wait for the reload signal.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(read_task), timeout=0.1)
+        allow_notification.set()
+        assert (await asyncio.wait_for(drop_task, timeout=2))["status"] == "success"
+        assert await asyncio.wait_for(read_task, timeout=2) is False
+        assert writer.storage_updated.value is False
+    finally:
+        allow_notification.set()
+        await asyncio.gather(drop_task, *([read_task] if read_task else []))
+        await peer.finalize()
+        await writer.finalize()
+
+
+@pytest.mark.asyncio
+async def test_drop_stays_successful_when_writer_flag_reset_fails(
+    tmp_path, monkeypatch
+):
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+    try:
+        await storage.upsert_node("n1", {"entity_id": "n1"})
+        await storage.index_done_callback()
+
+        class BrokenResetFlag:
+            @property
+            def value(self):
+                return True
+
+            @value.setter
+            def value(self, value):
+                raise RuntimeError("reset boom")
+
+        monkeypatch.setattr(storage, "storage_updated", BrokenResetFlag())
+        logged_errors = []
+        monkeypatch.setattr(networkx_impl.logger, "error", logged_errors.append)
+        result = await storage.drop()
+
+        assert result == {"status": "success", "message": "data dropped"}
+        assert not Path(storage._graphml_xml_file).exists()
+        assert storage._graph.number_of_nodes() == 0
+        assert any("reset boom" in msg for msg in logged_errors)
     finally:
         await storage.finalize()

--- a/tests/kg/networkx_impl/test_networkx_drop.py
+++ b/tests/kg/networkx_impl/test_networkx_drop.py
@@ -163,3 +163,66 @@ async def test_drop_stays_successful_when_writer_flag_reset_fails(
         assert any("reset boom" in msg for msg in logged_errors)
     finally:
         await storage.finalize()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("notification_fails", [False, True])
+async def test_cancelled_drop_finishes_notification_and_logs(
+    tmp_path, monkeypatch, notification_fails
+):
+    writer = _make_storage(tmp_path)
+    await writer.initialize()
+    await writer.upsert_node("n1", {"entity_id": "n1"})
+    await writer.index_done_callback()
+    peer = _make_storage(tmp_path)
+    await peer.initialize()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+    notify = networkx_impl.set_all_update_flags
+    errors = []
+    infos = []
+
+    async def paused_notification(namespace, workspace=None):
+        started.set()
+        await release.wait()
+        # Model partial publication before a notification failure.
+        writer.storage_updated.value = True
+        finished.set()
+        if notification_fails:
+            raise RuntimeError("notification boom")
+        await notify(namespace, workspace=workspace)
+
+    monkeypatch.setattr(networkx_impl, "set_all_update_flags", paused_notification)
+    monkeypatch.setattr(networkx_impl.logger, "error", errors.append)
+    monkeypatch.setattr(networkx_impl.logger, "info", infos.append)
+    task = asyncio.create_task(writer.drop())
+    try:
+        await asyncio.wait_for(started.wait(), timeout=2)
+        assert not Path(writer._graphml_xml_file).exists()
+        task.cancel()
+        # Deliver cancellation while publication is still suspended.
+        await asyncio.sleep(0)
+        task.cancel()
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=2)
+        assert finished.is_set()
+        assert writer.storage_updated.value is False
+        assert writer._graph.number_of_nodes() == 0
+        assert any("drop graph file:" in msg for msg in infos)
+        if notification_fails:
+            assert any("notification boom" in msg for msg in errors)
+            assert any("restart" in msg for msg in errors)
+        else:
+            assert await asyncio.wait_for(peer.has_node("n1"), timeout=2) is False
+            # Writer ownership may move to this peer after the clear.
+            await peer.upsert_node("n2", {"entity_id": "n2"})
+            await peer.index_done_callback()
+            durable = NetworkXStorage.load_nx_graph(peer._graphml_xml_file)
+            assert set(durable.nodes) == {"n2"}
+    finally:
+        release.set()
+        await asyncio.gather(task, return_exceptions=True)
+        await peer.finalize()
+        await writer.finalize()


### PR DESCRIPTION
## Description

A completed NetworkX GraphML deletion now remains a successful drop when the later cross-process reload notification fails. The failure is logged as potentially partial, and the writer reload flag is reset independently so `/documents/clear` can safely continue deleting input files.

## Related Issues

Closes #3849.

## Changes Made

- separate the durable file deletion from peer notification status
- add backend coverage for notification failure and destructive failure
- add endpoint coverage proving input deletion continues after a successful NetworkX drop
- document the destructive-status invariant in `AGENTS.md`

## Validation

- `./scripts/test.sh tests/kg/networkx_impl` — 94 passed
- focused backend and clear-route tests — 7 passed
- Ruff check and format check passed
- mutation returning an error for notification failure made both regressions fail

## Backend audit

JSON KV and doc-status drops notify before their empty state is persisted, so their notification errors still represent incomplete drops. FAISS and NanoVectorDB delete their files before notification and retain the same classification shape; their backend-specific reset and redo-log semantics should be handled in separate follow-ups rather than folded into this NetworkX issue.

AI-assisted tooling was used; I reviewed the change and ran the reported checks.
