### PR TITLE
fix(graph): reset evidence on explicit creation (#3838 R1)

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -6817,6 +6817,8 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             self.relationships_vdb,
             entity_name,
             entity_data,
+            entity_chunks_storage=self.entity_chunks,
+            relation_chunks_storage=self.relation_chunks,
         )
 
     def create_entity(
@@ -6858,6 +6860,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             source_entity,
             target_entity,
             relation_data,
+            relation_chunks_storage=self.relation_chunks,
         )
 
     def create_relation(

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -1557,6 +1557,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         self._llm_role_builder = None
         self._retired_llm_queue_cleanup_tasks: set[asyncio.Task] = set()
+        self._chunk_tracking_migration_checked = False
 
         # The event loop this instance's storages bind to (set in
         # initialize_storages). Kept off the dataclass fields so asdict() in

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -6817,6 +6817,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             self.relationships_vdb,
             entity_name,
             entity_data,
+            before_create=self._migrate_chunk_tracking_before_creation,
             entity_chunks_storage=self.entity_chunks,
             relation_chunks_storage=self.relation_chunks,
         )
@@ -6860,6 +6861,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             source_entity,
             target_entity,
             relation_data,
+            before_create=self._migrate_chunk_tracking_before_creation,
             relation_chunks_storage=self.relation_chunks,
         )
 

--- a/lightrag/storage_migrations.py
+++ b/lightrag/storage_migrations.py
@@ -210,9 +210,18 @@ class _StorageMigrationMixin:
         migration lock and propagate failures before any creation write. This
         checks only chunk tracking, not document-anchor migrations, and leaves
         existing non-empty namespaces (including authoritative empty rows) alone.
+        A successful check is cached per instance, including when a namespace
+        stays empty. Failed checks remain retryable; each worker checks once.
         """
+        if self._chunk_tracking_migration_checked:
+            return
         async with get_data_init_lock():
+            # Another creation on this instance may have completed the check
+            # while this caller waited for the shared initialization lock.
+            if self._chunk_tracking_migration_checked:
+                return
             await self._migrate_chunk_tracking_storage()
+            self._chunk_tracking_migration_checked = True
 
     async def _migrate_chunk_tracking_storage(self) -> None:
         """Ensure entity/relation chunk tracking KV stores exist and are seeded."""

--- a/lightrag/storage_migrations.py
+++ b/lightrag/storage_migrations.py
@@ -1,7 +1,8 @@
 """Storage data migration helpers for :class:`LightRAG`.
 
-Mixed into LightRAG and runs once at startup (``initialize_storages`` →
-``check_and_migrate_data``) to upgrade legacy data layouts:
+Mixed into LightRAG. Server startup calls ``check_and_migrate_data`` after
+``initialize_storages`` to upgrade legacy data layouts; SDK explicit creation
+also checks chunk tracking before writing its first new row:
 
 - Backfill ``full_entities`` / ``full_relations`` from the graph + doc_status
   history when those KV stores are empty (entity-relation migration).
@@ -201,6 +202,17 @@ class _StorageMigrationMixin:
         logger.info(
             f"Data migration completed: migrated {migration_count} documents with entities/relations"
         )
+
+    async def _migrate_chunk_tracking_before_creation(self) -> None:
+        """Seed legacy tracking before a new row can suppress empty-store migration.
+
+        SDK callers do not run the server's startup migrations. Use the same
+        migration lock and propagate failures before any creation write. This
+        checks only chunk tracking, not document-anchor migrations, and leaves
+        existing non-empty namespaces (including authoritative empty rows) alone.
+        """
+        async with get_data_init_lock():
+            await self._migrate_chunk_tracking_storage()
 
     async def _migrate_chunk_tracking_storage(self) -> None:
         """Ensure entity/relation chunk tracking KV stores exist and are seeded."""

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1689,7 +1689,9 @@ async def acreate_entity(
     """Asynchronously create a new entity.
 
     Creates a new entity in the knowledge graph and adds it to the vector database.
-    Also synchronizes entity_chunks_storage to track chunk references.
+    Replaces entity chunk tracking with the distinct real source IDs supplied
+    for this creation, or an explicit empty row when there are none. Historical
+    no-source placeholders do not count as evidence.
 
     Args:
         chunk_entity_relation_graph: Graph storage instance
@@ -1795,20 +1797,27 @@ async def acreate_entity(
             # Update entity_chunks_storage to track chunk references
             if entity_chunks_storage is not None:
                 source_id = node_data.get("source_id", "")
-                chunk_ids = [cid for cid in source_id.split(GRAPH_FIELD_SEP) if cid]
+                chunk_ids = list(
+                    dict.fromkeys(
+                        cid
+                        for cid in source_id.split(GRAPH_FIELD_SEP)
+                        if cid and cid not in RELATION_NO_EVIDENCE_SOURCE_IDS
+                    )
+                )
 
-                if chunk_ids:
-                    await entity_chunks_storage.upsert(
-                        {
-                            entity_name: {
-                                "chunk_ids": chunk_ids,
-                                "count": len(chunk_ids),
-                            }
+                # Explicit creation starts new attribution, never inherits an
+                # orphan row from a previously deleted object (issue #3838).
+                await entity_chunks_storage.upsert(
+                    {
+                        entity_name: {
+                            "chunk_ids": chunk_ids,
+                            "count": len(chunk_ids),
                         }
-                    )
-                    logger.info(
-                        f"Entity Create: tracked {len(chunk_ids)} chunks for `{entity_name}`"
-                    )
+                    }
+                )
+                logger.info(
+                    f"Entity Create: tracked {len(chunk_ids)} chunks for `{entity_name}`"
+                )
 
             # Save changes
             await _persist_graph_updates(
@@ -1843,7 +1852,9 @@ async def acreate_relation(
     """Asynchronously create a new relation between entities.
 
     Creates a new relation (edge) in the knowledge graph and adds it to the vector database.
-    Also synchronizes relation_chunks_storage to track chunk references.
+    Replaces relation chunk tracking with the distinct real source IDs supplied
+    for this creation, or an explicit empty row when there are none. Orphan rows
+    from a previous relation are never inherited.
 
     Args:
         chunk_entity_relation_graph: Graph storage instance
@@ -1981,18 +1992,19 @@ async def acreate_relation(
                 source_id = edge_data.get("source_id", "")
                 chunk_ids = relation_evidence_source_ids(source_id)
 
-                if chunk_ids:
-                    await relation_chunks_storage.upsert(
-                        {
-                            storage_key: {
-                                "chunk_ids": chunk_ids,
-                                "count": len(chunk_ids),
-                            }
+                # Explicit creation starts new attribution, never inherits an
+                # orphan row from a previously deleted object (issue #3838).
+                await relation_chunks_storage.upsert(
+                    {
+                        storage_key: {
+                            "chunk_ids": chunk_ids,
+                            "count": len(chunk_ids),
                         }
-                    )
-                    logger.info(
-                        f"Relation Create: tracked {len(chunk_ids)} chunks for `{vdb_src}`~`{vdb_tgt}`"
-                    )
+                    }
+                )
+                logger.info(
+                    f"Relation Create: tracked {len(chunk_ids)} chunks for `{vdb_src}`~`{vdb_tgt}`"
+                )
 
             # Save changes
             await _persist_graph_updates(

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1694,6 +1694,8 @@ async def acreate_entity(
     Replaces entity chunk tracking with the distinct real source IDs supplied
     for this creation, or an explicit empty row when there are none. Historical
     no-source placeholders do not count as evidence.
+    Manual creation does not protect the entity or its description from deletion:
+    once documents mention it, purging its last real source may delete it entirely.
 
     Args:
         chunk_entity_relation_graph: Graph storage instance
@@ -1863,6 +1865,8 @@ async def acreate_relation(
     Replaces relation chunk tracking with the distinct real source IDs supplied
     for this creation, or an explicit empty row when there are none. Orphan rows
     from a previous relation are never inherited.
+    Manual creation does not protect the relation or its description from deletion:
+    once documents mention it, purging its last real source may delete it entirely.
 
     Args:
         chunk_entity_relation_graph: Graph storage instance

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 import asyncio
-from typing import Any, cast
+from typing import Any, Awaitable, Callable, cast
 
 from .base import DeletionResult
 from .kg.shared_storage import get_storage_keyed_lock
@@ -1685,6 +1685,8 @@ async def acreate_entity(
     entity_data: dict[str, Any],
     entity_chunks_storage=None,
     relation_chunks_storage=None,
+    *,
+    before_create: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Asynchronously create a new entity.
 
@@ -1701,6 +1703,7 @@ async def acreate_entity(
         entity_data: Dictionary containing entity attributes, e.g. {"description": "description", "entity_type": "type"}
         entity_chunks_storage: Optional KV storage for tracking chunks that reference this entity
         relation_chunks_storage: Optional KV storage for tracking chunks that reference relations
+        before_create: Optional migration hook, awaited after validation and before writes
 
     Returns:
         Dictionary containing created entity information
@@ -1788,6 +1791,9 @@ async def acreate_entity(
                 }
             }
 
+            if before_create is not None:
+                await before_create()
+
             # Add entity to knowledge graph
             await chunk_entity_relation_graph.upsert_node(entity_name, node_data)
 
@@ -1848,6 +1854,8 @@ async def acreate_relation(
     target_entity: str,
     relation_data: dict[str, Any],
     relation_chunks_storage=None,
+    *,
+    before_create: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Asynchronously create a new relation between entities.
 
@@ -1867,6 +1875,7 @@ async def acreate_relation(
             values in ``source_id``. An omitted ``source_id`` is stored as an
             empty string and permits a non-negative fractional weight.
         relation_chunks_storage: Optional KV storage for tracking chunks that reference this relation
+        before_create: Optional migration hook, awaited after validation and before writes
 
     Returns:
         Dictionary containing created relation information
@@ -1974,6 +1983,9 @@ async def acreate_relation(
                     "file_path": relation_data.get("file_path", "manual_creation"),
                 }
             }
+
+            if before_create is not None:
+                await before_create()
 
             # Add relation to knowledge graph
             await chunk_entity_relation_graph.upsert_edge(

--- a/tests/api/routes/test_graph_attribute_validation.py
+++ b/tests/api/routes/test_graph_attribute_validation.py
@@ -291,7 +291,9 @@ class TestRelationWeightEvidenceFloor:
         edge = await rag.graph.get_edge("REL_A", "REL_B")
         assert edge["source_id"] == ""
         assert edge["weight"] == 0.25
-        assert rag.relation_chunks.records == {}
+        assert rag.relation_chunks.records == {
+            make_relation_chunk_key("REL_A", "REL_B"): {"chunk_ids": [], "count": 0}
+        }
 
     @pytest.mark.asyncio
     async def test_create_rejects_negative_source_less_weight(self, rag):

--- a/tests/pipeline/test_graph_deletion_tracking.py
+++ b/tests/pipeline/test_graph_deletion_tracking.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 import numpy as np
 import pytest
 
-from lightrag import LightRAG
+from lightrag import LightRAG, utils_graph
 from lightrag.constants import GRAPH_FIELD_SEP
 from lightrag.utils import EmbeddingFunc, Tokenizer, make_relation_chunk_key
 
@@ -159,3 +159,132 @@ async def test_delete_removes_tracking_before_reinsert(
             ]
     finally:
         await rag.finalize_storages()
+
+
+@pytest.fixture
+async def creation_rag(tmp_path):
+    rag = LightRAG(
+        working_dir=str(tmp_path),
+        workspace=f"creation_{uuid4().hex}",
+        llm_model_func=_no_llm,
+        embedding_func=EmbeddingFunc(embedding_dim=8, func=_embed),
+        tokenizer=Tokenizer("characters", _Characters()),
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    rag._process_extract_entities = _extract
+    try:
+        yield rag
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entrypoint", ["sdk", "helper"])
+@pytest.mark.parametrize("kind", ["entity", "relation"])
+@pytest.mark.parametrize(
+    "source_id,expected",
+    [
+        (None, []),
+        ("", []),
+        ("manual_creation", []),
+        ("UNKNOWN", []),
+        (
+            GRAPH_FIELD_SEP.join(
+                ["manual_creation", "chunk-new", "UNKNOWN", "", "chunk-new", "chunk-2"]
+            ),
+            ["chunk-new", "chunk-2"],
+        ),
+    ],
+)
+async def test_explicit_creation_replaces_orphan_evidence(
+    creation_rag, monkeypatch, kind, source_id, expected, entrypoint
+):
+    rag = creation_rag
+    await rag.ainsert("Atlas and Borealis: old harbor", ids=["old"])
+    tracking = rag.entity_chunks if kind == "entity" else rag.relation_chunks
+    key = "Atlas" if kind == "entity" else make_relation_chunk_key("Atlas", "Borealis")
+    old_row = await tracking.get_by_id(key)
+    assert old_row["chunk_ids"]
+
+    # Real JSON storage: a failed cleanup leaves durable orphan evidence after
+    # graph deletion. Explicit creation must replace it, even without sources.
+    async def fail_cleanup(ids):
+        raise OSError("injected tracking cleanup failure")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(tracking, "delete", fail_cleanup)
+        result = (
+            await rag.adelete_by_entity("Atlas")
+            if kind == "entity"
+            else await rag.adelete_by_relation("Atlas", "Borealis")
+        )
+    assert result.status == "fail"
+    assert (
+        json.loads(Path(tracking._file_name).read_text())[key]["chunk_ids"]
+        == old_row["chunk_ids"]
+    )
+
+    data = {"description": "Manually recreated"}
+    if source_id is not None:
+        data["source_id"] = source_id
+    if kind == "entity":
+        if entrypoint == "sdk":
+            await rag.acreate_entity("Atlas", data)
+        else:
+            await utils_graph.acreate_entity(
+                rag.chunk_entity_relation_graph,
+                rag.entities_vdb,
+                rag.relationships_vdb,
+                "Atlas",
+                data,
+                entity_chunks_storage=rag.entity_chunks,
+            )
+    else:
+        data["weight"] = max(1, len(expected))
+        if entrypoint == "sdk":
+            await rag.acreate_relation("Atlas", "Borealis", data)
+        else:
+            await utils_graph.acreate_relation(
+                rag.chunk_entity_relation_graph,
+                rag.entities_vdb,
+                rag.relationships_vdb,
+                "Atlas",
+                "Borealis",
+                data,
+                relation_chunks_storage=rag.relation_chunks,
+            )
+
+    row = await tracking.get_by_id(key)
+    assert row["chunk_ids"] == expected
+    assert row["count"] == len(expected)
+    persisted = json.loads(Path(tracking._file_name).read_text())[key]
+    assert persisted["chunk_ids"] == expected
+    assert persisted["count"] == len(expected)
+
+
+@pytest.mark.asyncio
+async def test_manual_entity_then_document_is_deleted_without_rebuild(
+    creation_rag, monkeypatch
+):
+    rag = creation_rag
+    await rag.acreate_entity("Atlas", {"description": "Atlas company"})
+    row = await rag.entity_chunks.get_by_id("Atlas")
+    assert row["chunk_ids"] == []
+    assert row["count"] == 0
+
+    await rag.ainsert("Atlas and Borealis: new mountain", ids=["new"])
+    chunk = (await rag.doc_status.get_by_id("new"))["chunks_list"][0]
+    assert (await rag.entity_chunks.get_by_id("Atlas"))["chunk_ids"] == [chunk]
+    assert "Atlas" in (await rag.full_entities.get_by_id("new"))["entity_names"]
+
+    async def unexpected_rebuild(*args, **kwargs):
+        raise AssertionError("The document owns all evidence; delete outright")
+
+    monkeypatch.setattr(
+        "lightrag.lightrag.rebuild_knowledge_from_chunks", unexpected_rebuild
+    )
+    result = await rag.adelete_by_doc_id("new")
+    assert result.status == "success", result.message
+    assert not await rag.chunk_entity_relation_graph.has_node("Atlas")
+    assert await rag.entity_chunks.get_by_id("Atlas") is None

--- a/tests/pipeline/test_graph_deletion_tracking.py
+++ b/tests/pipeline/test_graph_deletion_tracking.py
@@ -410,3 +410,72 @@ async def test_invalid_sdk_creation_does_not_start_migration(
             )
     assert await rag.entity_chunks.is_empty()
     assert await rag.relation_chunks.is_empty()
+
+
+@pytest.mark.asyncio
+async def test_creation_skips_migration_lock_after_success(creation_rag, monkeypatch):
+    rag = creation_rag
+    await rag.acreate_entity("First", {"description": "first"})
+    # No relations were created: is_empty() cannot prove this namespace has
+    # already been checked, even though another full graph scan is unnecessary.
+    assert await rag.relation_chunks.is_empty()
+
+    def unexpected_lock():
+        raise AssertionError("A successful migration check must bypass the lock")
+
+    monkeypatch.setattr(
+        "lightrag.storage_migrations.get_data_init_lock", unexpected_lock
+    )
+    await rag.acreate_entity("Second", {"description": "second"})
+    await rag.acreate_relation("First", "Second", {"description": "manual"})
+    assert await rag.chunk_entity_relation_graph.has_edge("First", "Second")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_creation_migration_checks_run_once(creation_rag, monkeypatch):
+    import asyncio
+    from contextlib import asynccontextmanager
+    from lightrag import storage_migrations
+
+    rag = creation_rag
+    original_lock = storage_migrations.get_data_init_lock
+    first_migrating = asyncio.Event()
+    second_waiting = asyncio.Event()
+    finish_migration = asyncio.Event()
+    acquisitions = 0
+    migrations = 0
+
+    @asynccontextmanager
+    async def observed_lock():
+        nonlocal acquisitions
+        acquisitions += 1
+        if acquisitions == 2:
+            second_waiting.set()
+        async with original_lock():
+            yield
+
+    async def blocked_migration():
+        nonlocal migrations
+        migrations += 1
+        first_migrating.set()
+        await finish_migration.wait()
+
+    monkeypatch.setattr(storage_migrations, "get_data_init_lock", observed_lock)
+    monkeypatch.setattr(rag, "_migrate_chunk_tracking_storage", blocked_migration)
+    first = asyncio.create_task(rag._migrate_chunk_tracking_before_creation())
+    second = None
+    try:
+        await asyncio.wait_for(first_migrating.wait(), timeout=5)
+        second = asyncio.create_task(rag._migrate_chunk_tracking_before_creation())
+        await asyncio.wait_for(second_waiting.wait(), timeout=5)
+        finish_migration.set()
+        await asyncio.wait_for(asyncio.gather(first, second), timeout=5)
+        assert migrations == 1
+    finally:
+        for task in (first, second):
+            if task is not None:
+                task.cancel()
+        await asyncio.gather(
+            *(task for task in (first, second) if task is not None),
+            return_exceptions=True,
+        )

--- a/tests/pipeline/test_graph_deletion_tracking.py
+++ b/tests/pipeline/test_graph_deletion_tracking.py
@@ -288,3 +288,125 @@ async def test_manual_entity_then_document_is_deleted_without_rebuild(
     assert result.status == "success", result.message
     assert not await rag.chunk_entity_relation_graph.has_node("Atlas")
     assert await rag.entity_chunks.get_by_id("Atlas") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["entity", "relation"])
+@pytest.mark.parametrize("fail_migration", [False, True])
+async def test_sdk_creation_migrates_legacy_tracking_first(
+    creation_rag, monkeypatch, kind, fail_migration
+):
+    rag = creation_rag
+    graph = rag.chunk_entity_relation_graph
+    # Model an upgraded working directory: graph provenance exists on disk,
+    # but neither tracking namespace has been seeded yet.
+    for name in ("LegacyA", "LegacyB"):
+        await graph.upsert_node(
+            name,
+            {"entity_id": name, "description": name, "source_id": "legacy-chunk"},
+        )
+    await graph.upsert_edge(
+        "LegacyA",
+        "LegacyB",
+        {"description": "legacy", "source_id": "legacy-chunk", "weight": 1.0},
+    )
+    await graph.index_done_callback()
+    assert await rag.entity_chunks.is_empty()
+    assert await rag.relation_chunks.is_empty()
+
+    async def create():
+        if kind == "entity":
+            await rag.acreate_entity("Manual", {"description": "manual"})
+        else:
+            await rag.acreate_relation(
+                "LegacyA", "ManualTarget", {"description": "manual"}
+            )
+
+    if kind == "relation":
+        await graph.upsert_node(
+            "ManualTarget",
+            {"entity_id": "ManualTarget", "description": "target", "source_id": ""},
+        )
+        await graph.index_done_callback()
+
+    if fail_migration:
+
+        async def fail_read():
+            raise OSError("legacy graph read unavailable")
+
+        with monkeypatch.context() as patch:
+            patch.setattr(graph, "get_all_nodes", fail_read)
+            with pytest.raises(OSError, match="legacy graph read unavailable"):
+                await create()
+        assert not await graph.has_node("Manual")
+        assert not await graph.has_edge("LegacyA", "ManualTarget")
+        assert await rag.entity_chunks.is_empty()
+        assert await rag.relation_chunks.is_empty()
+
+    await create()
+    # Reopening the stores and invoking the same migration as server startup
+    # must preserve both historical provenance and the new authoritative empty row.
+    await rag.finalize_storages()
+    reopened = LightRAG(
+        working_dir=rag.working_dir,
+        workspace=rag.workspace,
+        llm_model_func=_no_llm,
+        embedding_func=EmbeddingFunc(embedding_dim=8, func=_embed),
+        tokenizer=Tokenizer("characters", _Characters()),
+    )
+    await reopened.initialize_storages()
+    try:
+        await reopened.check_and_migrate_data()
+        for name in ("LegacyA", "LegacyB"):
+            assert (await reopened.entity_chunks.get_by_id(name))["chunk_ids"] == [
+                "legacy-chunk"
+            ]
+        key = make_relation_chunk_key("LegacyA", "LegacyB")
+        assert (await reopened.relation_chunks.get_by_id(key))["chunk_ids"] == [
+            "legacy-chunk"
+        ]
+        tracking = (
+            reopened.entity_chunks if kind == "entity" else reopened.relation_chunks
+        )
+        new_key = (
+            "Manual"
+            if kind == "entity"
+            else make_relation_chunk_key("LegacyA", "ManualTarget")
+        )
+        row = await tracking.get_by_id(new_key)
+        assert row["chunk_ids"] == []
+        assert row["count"] == 0
+        persisted = json.loads(Path(tracking._file_name).read_text())
+        assert persisted[new_key]["chunk_ids"] == []
+    finally:
+        await reopened.finalize_storages()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["entity", "relation"])
+async def test_invalid_sdk_creation_does_not_start_migration(
+    creation_rag, monkeypatch, kind
+):
+    rag = creation_rag
+    for name in ("LegacyA", "LegacyB"):
+        await rag.chunk_entity_relation_graph.upsert_node(
+            name, {"entity_id": name, "description": name, "source_id": "legacy-chunk"}
+        )
+
+    async def unexpected_migration():
+        raise AssertionError("Invalid input must be rejected before migration writes")
+
+    monkeypatch.setattr(
+        rag, "_migrate_chunk_tracking_before_creation", unexpected_migration
+    )
+    with pytest.raises(ValueError):
+        if kind == "entity":
+            await rag.acreate_entity(
+                "Manual", {"description": "manual", "source_id": []}
+            )
+        else:
+            await rag.acreate_relation(
+                "LegacyA", "LegacyB", {"description": "manual", "weight": -1}
+            )
+    assert await rag.entity_chunks.is_empty()
+    assert await rag.relation_chunks.is_empty()


### PR DESCRIPTION
## Description

Explicit admin creation can inherit orphaned chunk-tracking rows left by a failed deletion. Entity creation can also record `manual_creation` as evidence. Both paths now replace tracking with the distinct real source IDs supplied for the new object, including an authoritative empty row when no evidence is supplied.

SDK creation also runs the existing empty-namespace chunk-tracking migration before publishing a new tracking row. Otherwise, creating one manual object in a legacy working directory would suppress the server's later backfill for all historical objects in that namespace. The migration runs after creation validation, under the same initialization lock used by server startup; failures abort creation. Successful checks are cached per instance, with a second check under the initialization lock so concurrent callers do not repeat migration. Failed checks remain retryable; subsequent creations bypass the lock and storage queries even when a tracking namespace stays empty.

## Related Issues

Implements **R1a and R1b** of #3838. R2–R5 remain open; this PR does not close the issue.

## Changes Made

- Filter empty IDs and the shared no-evidence placeholders from entity creation, matching relation evidence semantics.
- Always upsert creation tracking, including `{"chunk_ids": [], "count": 0}`, so a previous object's provenance cannot survive recreation.
- Pass tracking stores through the public `LightRAG` creation wrappers used by the REST endpoints; these arguments were previously omitted, bypassing helper tracking updates entirely.
- Add SDK pre-creation chunk-tracking migration, without running unrelated document-anchor migrations or changing the existing non-empty namespace gate.
- Cover legacy graph → SDK creation → reopened stores/server migration for entities and relations, migration read failure/retry, and invalid requests that must not start migration.
- Add real NetworkX/JSON lifecycle regressions for deletion cleanup failures followed by explicit recreation through both SDK and helper entry points. Cover omitted, empty, placeholder-only, and mixed/duplicate sources, checking in-memory and persisted rows.
- Verify that a manually created entity later mentioned by a document is deleted outright when that document is purged, without rebuilding from placeholder evidence. Document creation tracking semantics and the lifecycle consequence: manual creation does not independently protect the object or its description when its last document source is purged.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

The purge classifier, ingestion/rebuild authority rules, commit failure handling, and locking behavior are unchanged. Existing polluted rows are only replaced on explicit creation; global repair remains R4.

Validation:
- Final implementation: `./scripts/test.sh tests/pipeline/test_graph_deletion_tracking.py tests/api/routes tests/extraction tests/test_storage_migrations_strict_read.py` — **928 passed, 5 skipped**.
- The original R1 validation covered pipeline, utils, API routes, and extraction (1948 passing cases after updating the old empty-row expectation).
- Added **29 regression cases** across the PR, including six for the SDK migration follow-up. The four legacy migration scenarios were verified failing before this follow-up fix.
- Verified the two new once-check regressions fail before the fix: subsequent creation bypasses the initialization lock, and concurrent waiting callers run migration only once. Existing migration failure/retry regressions remain green.
- Changed-file Ruff lint/format checks and `git diff --check` passed.
- No live external services or browser E2E were used.

