### PR TITLE
fix(storage): make a landed write distinguishable from a failed one (#3838 R2)

### DIFF
--- a/lightrag/exceptions.py
+++ b/lightrag/exceptions.py
@@ -426,6 +426,41 @@ class IndexFlushError(Exception):
         super().__init__(f"{storage_name}[{namespace}] index flush failed: {cause}")
 
 
+class CommitBookkeepingError(RuntimeError):
+    """The offloaded write LANDED; the bookkeeping that had to follow it did not.
+
+    Raised by ``_bounded_submit_impl`` (``lightrag/utils.py``) when the callable
+    handed to ``commit_in_storage_io`` succeeded and its ``on_committed`` hook
+    then failed. The hook is publication, not persistence — flipping the other
+    processes' ``storage_updated`` flags, clearing the dirty bit, reloading a
+    sanitized file — so what it reports is a **visibility lag**, never a lost
+    write.
+
+    It exists because those two outcomes used to be indistinguishable: the hook's
+    own exception was re-raised as-is, landed in the call site's ``except
+    Exception``, and was handled by reasoning that only holds for a write that
+    never happened (roll the in-memory state back to the file, report failure).
+    Every caller inherited that lie — the deletion paths in ``utils_graph``
+    skipped the chunk-tracking retirement they still owed for an object that is
+    durably gone, and ``_insert_done`` marked a document FAILED whose writes were
+    on disk.
+
+    Contract for a handler: **treat the write as committed.** Log the deferred
+    visibility (an unknown remainder of the other workers keeps serving the
+    previous snapshot until the next commit anywhere notifies them, and this
+    process may redundantly reload the file it just wrote), then continue.
+    Reporting it as a failed write is forbidden; so is swallowing it silently.
+
+    ``result`` carries whatever the write callable returned, so a handler that
+    needs the write's own answer does not have to re-run it. The hook's failure
+    is preserved as ``__cause__`` (set via ``raise ... from``).
+    """
+
+    def __init__(self, message: str, *, result: Any = None) -> None:
+        super().__init__(message)
+        self.result = result
+
+
 class ChunkTokenLimitExceededError(ValueError):
     """Raised when a chunk exceeds the configured token limit."""
 

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -1313,13 +1313,14 @@ class FaissVectorDBStorage(BaseVectorStorage):
             # an unnotified peer saves its older snapshot over these rows first,
             # the next flush replays them back rather than losing them (#3854 is
             # the fence gap itself; this only makes it recoverable).
-            logger.error(
+            log_without_raising(
+                logger.error,
                 f"[{self.workspace}] FAISS index {self.namespace} was saved to "
                 f"{self._faiss_index_file}, but publishing that write failed: "
                 f"{e.__cause__}. An unknown remainder of the other processes "
                 "keeps reading the previous snapshot until the next commit "
                 "notifies them; this process may also reload the files it just "
-                "wrote."
+                "wrote.",
             )
 
     def _load_faiss_index(self):

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -1309,8 +1309,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
             # visibility lag that heals: `_index_dirty` stays True, so the next
             # commit rewrites this snapshot and notifies again; an unreset
             # `storage_updated` only makes this process reload the files it just
-            # wrote. The redo logs are cleared first inside the hook, which is
-            # correct in either case — the rows they would replay are on disk.
+            # wrote. The hook also keeps its redo logs when it fails here, so if
+            # an unnotified peer saves its older snapshot over these rows first,
+            # the next flush replays them back rather than losing them (#3854 is
+            # the fence gap itself; this only makes it recoverable).
             logger.error(
                 f"[{self.workspace}] FAISS index {self.namespace} was saved to "
                 f"{self._faiss_index_file}, but publishing that write failed: "
@@ -1458,7 +1460,9 @@ class FaissVectorDBStorage(BaseVectorStorage):
                next call to ``_get_index``. A failure here does **not**
                raise: step 3 already made the rows durable, so this is a
                visibility lag, logged and healed by the next commit —
-               ``_save_faiss_index`` catches it.
+               ``_save_faiss_index`` catches it. The redo logs are retired only
+               past this step, so rows an unnotified peer overwrites are
+               replayed back by the next flush.
 
         Either failure surfaces loudly through ``_insert_done`` so the
         caller can abort the document batch instead of silently losing
@@ -1475,10 +1479,21 @@ class FaissVectorDBStorage(BaseVectorStorage):
             await self._flush_pending_locked()
 
             async def _committed() -> None:
-                self._unsaved_deletes.clear()  # the removals are durable now
-                self._unsaved_upserts.clear()  # the rows are durable now
                 await set_all_update_flags(self.namespace, workspace=self.workspace)
                 self.storage_updated.value = False
+                # Retired only PAST the publication, never before it. The rows
+                # are durable either way, but a publication that failed leaves
+                # an unnotified peer holding an older whole-file snapshot, and
+                # that peer can become the next writer and save it over these
+                # rows. Keeping the redo logs makes that recoverable: this
+                # process's next flush reloads the foreign snapshot and replays
+                # them on top (the same path issue #3688 built), so the rows
+                # come back instead of being lost silently. Retiring them first
+                # threw away the only copy. Replay is idempotent -- an
+                # unchanged file matches by fingerprint and writes nothing, and
+                # a genuinely newer row under the same id supersedes ours.
+                self._unsaved_deletes.clear()  # the removals are durable now
+                self._unsaved_upserts.clear()  # the rows are durable now
                 self._index_dirty = False
 
             await self._save_faiss_index(_committed)
@@ -1992,10 +2007,21 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 return
 
             async def _committed() -> None:
-                self._unsaved_deletes.clear()  # the removals are durable now
-                self._unsaved_upserts.clear()  # the rows are durable now
                 await set_all_update_flags(self.namespace, workspace=self.workspace)
                 self.storage_updated.value = False
+                # Retired only PAST the publication, never before it. The rows
+                # are durable either way, but a publication that failed leaves
+                # an unnotified peer holding an older whole-file snapshot, and
+                # that peer can become the next writer and save it over these
+                # rows. Keeping the redo logs makes that recoverable: this
+                # process's next flush reloads the foreign snapshot and replays
+                # them on top (the same path issue #3688 built), so the rows
+                # come back instead of being lost silently. Retiring them first
+                # threw away the only copy. Replay is idempotent -- an
+                # unchanged file matches by fingerprint and writes nothing, and
+                # a genuinely newer row under the same id supersedes ours.
+                self._unsaved_deletes.clear()  # the removals are durable now
+                self._unsaved_upserts.clear()  # the rows are durable now
                 self._index_dirty = False
 
             await self._save_faiss_index(_committed)

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -8,6 +8,7 @@ import json
 import numpy as np
 from dataclasses import dataclass
 
+from lightrag.exceptions import CommitBookkeepingError
 from lightrag.file_atomic import atomic_write, reap_orphan_tmp_files
 from lightrag.utils import (
     commit_in_storage_io,
@@ -1265,7 +1266,9 @@ class FaissVectorDBStorage(BaseVectorStorage):
         call: a cancel delivered in between would leave both files published
         with the other processes never told to reload them. It runs only if the
         write succeeded — running it without a write would retire redo entries
-        for rows that were never persisted.
+        for rows that were never persisted. Its own failure is caught here as
+        ``CommitBookkeepingError`` and logged: both files are renamed into place
+        by then, so raising would tell the caller the vectors were never written.
         """
         # Save metadata dict to JSON, excluding __vector__ since vectors are
         # already stored in the Faiss index file and can be reconstructed on load.
@@ -1293,7 +1296,29 @@ class FaissVectorDBStorage(BaseVectorStorage):
             )
             atomic_write(meta_file, _write_meta, workspace)
 
-        await commit_in_storage_io(_write_both, on_committed)
+        try:
+            await commit_in_storage_io(_write_both, on_committed)
+        except CommitBookkeepingError as e:
+            # Both files are already renamed into place, so the rows ARE durable
+            # and the caller must not hear otherwise: `index_done_callback`'s
+            # contract is that a raise means the vectors were not written, which
+            # aborts the document batch in `_insert_done`.
+            #
+            # What did not complete is the publication — flagging the other
+            # processes and clearing this writer's dirty bit. The residue is a
+            # visibility lag that heals: `_index_dirty` stays True, so the next
+            # commit rewrites this snapshot and notifies again; an unreset
+            # `storage_updated` only makes this process reload the files it just
+            # wrote. The redo logs are cleared first inside the hook, which is
+            # correct in either case — the rows they would replay are on disk.
+            logger.error(
+                f"[{self.workspace}] FAISS index {self.namespace} was saved to "
+                f"{self._faiss_index_file}, but publishing that write failed: "
+                f"{e.__cause__}. An unknown remainder of the other processes "
+                "keeps reading the previous snapshot until the next commit "
+                "notifies them; this process may also reload the files it just "
+                "wrote."
+            )
 
     def _load_faiss_index(self):
         """
@@ -1430,7 +1455,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
             4. ``set_all_update_flags`` flips every registered process's
                ``storage_updated`` flag, then we immediately reset our own
                flag to ``False`` so the writer does not self-reload on the
-               next call to ``_get_index``.
+               next call to ``_get_index``. A failure here does **not**
+               raise: step 3 already made the rows durable, so this is a
+               visibility lag, logged and healed by the next commit —
+               ``_save_faiss_index`` catches it.
 
         Either failure surfaces loudly through ``_insert_done`` so the
         caller can abort the document batch instead of silently losing
@@ -1873,6 +1901,17 @@ class FaissVectorDBStorage(BaseVectorStorage):
         try:
             async with self._storage_lock:
                 await commit_in_storage_io(_delete_files, _committed)
+        except CommitBookkeepingError as e:
+            # The files are already gone; only the post-removal bookkeeping
+            # failed. Every step of `_committed` guards itself, so nothing raises
+            # this today -- it is the standing answer for a future step that
+            # forgets to, because "error" for a completed destruction is
+            # precisely the misreport those guards exist to prevent.
+            log_without_raising(
+                logger.error,
+                f"[{self.workspace}] Dropped FAISS index {self.namespace}, but "
+                f"its post-removal bookkeeping failed: {e.__cause__}",
+            )
         except Exception as e:
             log_without_raising(
                 logger.error,

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -297,6 +297,7 @@ class JsonDocStatusStorage(DocStatusStorage):
                 # -- `data_dict` is snapshotted above, on the loop, under the
                 # lock, so the worker thread touches nothing shared.
                 write_outcome: dict[str, bool] = {}
+                reconcile_failure: list[Exception] = []
 
                 def _write() -> None:
                     write_outcome["needs_reload"] = write_json(
@@ -321,8 +322,23 @@ class JsonDocStatusStorage(DocStatusStorage):
                         )
                         cleaned_data = load_json(self._file_name)
                         if cleaned_data is not None:
-                            self._data.clear()
-                            self._data.update(cleaned_data)
+                            try:
+                                self._data.clear()
+                                self._data.update(cleaned_data)
+                            except Exception as exc:
+                                # NOT publication, and not absorbable. On a
+                                # shared ``Manager().dict()`` these are two
+                                # separate RPCs, so a failure between them
+                                # leaves the shared dict EMPTY while the file on
+                                # disk holds the correct sanitized snapshot —
+                                # and the dirty flags are still set, so the next
+                                # flush would write that empty dict straight
+                                # over it, losing every row in the namespace.
+                                # Recorded so the handler below re-raises
+                                # instead of reporting a healthy deferred
+                                # publication.
+                                reconcile_failure.append(exc)
+                                raise
 
                     await clear_all_update_flags(
                         self.namespace, workspace=self.workspace
@@ -331,12 +347,22 @@ class JsonDocStatusStorage(DocStatusStorage):
                 try:
                     await commit_in_storage_io(_write, _committed)
                 except CommitBookkeepingError as e:
-                    # The file is already published; what failed is the
-                    # post-write reconciliation — reloading the sanitized data
-                    # and clearing every process's dirty flag. Neither is a lost
-                    # write, and both heal on the next flush: the flags stay set,
-                    # so the next index_done_callback rewrites this same snapshot
-                    # (sanitizing it again) and retries the clear.
+                    if reconcile_failure:
+                        # Fail loud. What is unreliable now is the shared
+                        # in-memory view, and no later flush heals it — a later
+                        # flush is what would PUBLISH it. The file on disk is
+                        # the correct snapshot, so the recovery is to stop
+                        # writing to this workspace and restart the workers,
+                        # which reload it. Re-raised as the original failure
+                        # rather than as CommitBookkeepingError: callers read
+                        # that type as "committed, only publication deferred"
+                        # and some deliberately absorb it.
+                        raise reconcile_failure[0]
+                    # Past the guard above, the only thing that can have
+                    # failed is the dirty-flag clear — the file is published and
+                    # the shared dict matches it. That heals on the next flush:
+                    # the flags stay set, so the next index_done_callback
+                    # rewrites this same snapshot and retries the clear.
                     #
                     # Not re-raising matters more here than anywhere else:
                     # `upsert` flushes synchronously precisely so the doc-status

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -29,6 +29,7 @@ from lightrag.file_atomic import reap_orphan_tmp_files
 from lightrag.utils import (
     _cooperative_yield,
     load_json,
+    log_without_raising,
     logger,
     validate_workspace,
     commit_in_storage_io,
@@ -342,12 +343,13 @@ class JsonDocStatusStorage(DocStatusStorage):
                     # row is durable before it returns, so reporting that landed
                     # write as a failure would abort an ingest whose recovery
                     # anchor is already on disk.
-                    logger.error(
+                    log_without_raising(
+                        logger.error,
                         f"[{self.workspace}] Doc status for {self.namespace} was "
                         f"written to {self._file_name}, but its post-write "
                         f"bookkeeping failed: {e.__cause__}. The dirty flags stay "
                         "set, so the next commit rewrites this snapshot and "
-                        "retries them."
+                        "retries them.",
                     )
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:

--- a/lightrag/kg/json_doc_status_impl.py
+++ b/lightrag/kg/json_doc_status_impl.py
@@ -36,6 +36,7 @@ from lightrag.utils import (
     get_pinyin_sort_key,
 )
 from lightrag.exceptions import (
+    CommitBookkeepingError,
     SourceConflictRepairCASError,
     StorageControlPlaneError,
     StorageNotInitializedError,
@@ -326,7 +327,28 @@ class JsonDocStatusStorage(DocStatusStorage):
                         self.namespace, workspace=self.workspace
                     )
 
-                await commit_in_storage_io(_write, _committed)
+                try:
+                    await commit_in_storage_io(_write, _committed)
+                except CommitBookkeepingError as e:
+                    # The file is already published; what failed is the
+                    # post-write reconciliation — reloading the sanitized data
+                    # and clearing every process's dirty flag. Neither is a lost
+                    # write, and both heal on the next flush: the flags stay set,
+                    # so the next index_done_callback rewrites this same snapshot
+                    # (sanitizing it again) and retries the clear.
+                    #
+                    # Not re-raising matters more here than anywhere else:
+                    # `upsert` flushes synchronously precisely so the doc-status
+                    # row is durable before it returns, so reporting that landed
+                    # write as a failure would abort an ingest whose recovery
+                    # anchor is already on disk.
+                    logger.error(
+                        f"[{self.workspace}] Doc status for {self.namespace} was "
+                        f"written to {self._file_name}, but its post-write "
+                        f"bookkeeping failed: {e.__cause__}. The dirty flags stay "
+                        "set, so the next commit rewrites this snapshot and "
+                        "retries them."
+                    )
 
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         """Insert/update doc-status records and **persist immediately**.

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -10,6 +10,7 @@ from lightrag.file_atomic import reap_orphan_tmp_files
 from lightrag.utils import (
     _cooperative_yield,
     load_json,
+    log_without_raising,
     logger,
     validate_workspace,
     commit_in_storage_io,
@@ -296,12 +297,13 @@ class JsonKVStorage(BaseKVStorage):
                     # marks a document FAILED whose rows are on disk, and
                     # utils_graph's deletion paths turn a chunk-tracking cleanup
                     # they have already completed into fail/500.
-                    logger.error(
+                    log_without_raising(
+                        logger.error,
                         f"[{self.workspace}] KV data for {self.namespace} was "
                         f"written to {self._file_name}, but its post-write "
                         f"bookkeeping failed: {e.__cause__}. The dirty flags stay "
                         "set, so the next commit rewrites this snapshot and "
-                        "retries them."
+                        "retries them.",
                     )
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -251,6 +251,7 @@ class JsonKVStorage(BaseKVStorage):
                 # -- `data_dict` is snapshotted above, on the loop, under the
                 # lock, so the worker thread touches nothing shared.
                 write_outcome: dict[str, bool] = {}
+                reconcile_failure: list[Exception] = []
 
                 def _write() -> None:
                     write_outcome["needs_reload"] = write_json(
@@ -275,8 +276,23 @@ class JsonKVStorage(BaseKVStorage):
                         )
                         cleaned_data = load_json(self._file_name)
                         if cleaned_data is not None:
-                            self._data.clear()
-                            self._data.update(cleaned_data)
+                            try:
+                                self._data.clear()
+                                self._data.update(cleaned_data)
+                            except Exception as exc:
+                                # NOT publication, and not absorbable. On a
+                                # shared ``Manager().dict()`` these are two
+                                # separate RPCs, so a failure between them
+                                # leaves the shared dict EMPTY while the file on
+                                # disk holds the correct sanitized snapshot —
+                                # and the dirty flags are still set, so the next
+                                # flush would write that empty dict straight
+                                # over it, losing every row in the namespace.
+                                # Recorded so the handler below re-raises
+                                # instead of reporting a healthy deferred
+                                # publication.
+                                reconcile_failure.append(exc)
+                                raise
 
                     await clear_all_update_flags(
                         self.namespace, workspace=self.workspace
@@ -285,12 +301,22 @@ class JsonKVStorage(BaseKVStorage):
                 try:
                     await commit_in_storage_io(_write, _committed)
                 except CommitBookkeepingError as e:
-                    # The file is already published; what failed is the
-                    # post-write reconciliation — reloading the sanitized data
-                    # and clearing every process's dirty flag. Neither is a lost
-                    # write, and both heal on the next flush: the flags stay set,
-                    # so the next index_done_callback rewrites this same snapshot
-                    # (sanitizing it again) and retries the clear.
+                    if reconcile_failure:
+                        # Fail loud. What is unreliable now is the shared
+                        # in-memory view, and no later flush heals it — a later
+                        # flush is what would PUBLISH it. The file on disk is
+                        # the correct snapshot, so the recovery is to stop
+                        # writing to this workspace and restart the workers,
+                        # which reload it. Re-raised as the original failure
+                        # rather than as CommitBookkeepingError: callers read
+                        # that type as "committed, only publication deferred"
+                        # and some deliberately absorb it.
+                        raise reconcile_failure[0]
+                    # Past the guard above, the only thing that can have
+                    # failed is the dirty-flag clear — the file is published and
+                    # the shared dict matches it. That heals on the next flush:
+                    # the flags stay set, so the next index_done_callback
+                    # rewrites this same snapshot and retries the clear.
                     #
                     # Re-raising instead would report a durable write as one that
                     # never happened, and every caller inherits that: _insert_done

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -15,7 +15,7 @@ from lightrag.utils import (
     commit_in_storage_io,
     write_json,
 )
-from lightrag.exceptions import StorageNotInitializedError
+from lightrag.exceptions import CommitBookkeepingError, StorageNotInitializedError
 from .shared_storage import (
     get_namespace_data,
     get_namespace_lock,
@@ -281,7 +281,28 @@ class JsonKVStorage(BaseKVStorage):
                         self.namespace, workspace=self.workspace
                     )
 
-                await commit_in_storage_io(_write, _committed)
+                try:
+                    await commit_in_storage_io(_write, _committed)
+                except CommitBookkeepingError as e:
+                    # The file is already published; what failed is the
+                    # post-write reconciliation — reloading the sanitized data
+                    # and clearing every process's dirty flag. Neither is a lost
+                    # write, and both heal on the next flush: the flags stay set,
+                    # so the next index_done_callback rewrites this same snapshot
+                    # (sanitizing it again) and retries the clear.
+                    #
+                    # Re-raising instead would report a durable write as one that
+                    # never happened, and every caller inherits that: _insert_done
+                    # marks a document FAILED whose rows are on disk, and
+                    # utils_graph's deletion paths turn a chunk-tracking cleanup
+                    # they have already completed into fail/500.
+                    logger.error(
+                        f"[{self.workspace}] KV data for {self.namespace} was "
+                        f"written to {self._file_name}, but its post-write "
+                        f"bookkeeping failed: {e.__cause__}. The dirty flags stay "
+                        "set, so the next commit rewrites this snapshot and "
+                        "retries them."
+                    )
 
     async def get_by_id(self, id: str) -> dict[str, Any] | None:
         async with self._storage_lock:

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -766,8 +766,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
             # visibility lag that heals: `_client_dirty` stays True, so the next
             # commit rewrites this snapshot and notifies again; an unreset
             # `storage_updated` only makes this process reload the file it just
-            # wrote. The redo logs are cleared first inside the hook, which is
-            # correct in either case — the rows they would replay are on disk.
+            # wrote. The hook also keeps its redo logs when it fails here, so if
+            # an unnotified peer saves its older snapshot over these rows first,
+            # the next flush replays them back rather than losing them (#3854 is
+            # the fence gap itself; this only makes it recoverable).
             logger.error(
                 f"[{self.workspace}] Vector data for {self.namespace} was saved "
                 f"to {self._client_file_name}, but publishing that write failed: "
@@ -1109,7 +1111,9 @@ class NanoVectorDBStorage(BaseVectorStorage):
                next call to ``_get_client``. A failure here does **not**
                raise: step 3 already made the rows durable, so this is a
                visibility lag, logged and healed by the next commit —
-               ``_save_to_disk_locked`` catches it.
+               ``_save_to_disk_locked`` catches it. The redo logs are retired only
+               past this step, so rows an unnotified peer overwrites are
+               replayed back by the next flush.
 
         Either failure surfaces loudly through ``_insert_done`` so the caller
         can abort the document batch instead of silently losing vectors. The
@@ -1126,10 +1130,21 @@ class NanoVectorDBStorage(BaseVectorStorage):
             await self._flush_pending_locked()
 
             async def _committed() -> None:
-                self._unsaved_deletes.clear()  # the removals are durable now
-                self._unsaved_upserts.clear()  # the rows are durable now
                 await set_all_update_flags(self.namespace, workspace=self.workspace)
                 self.storage_updated.value = False
+                # Retired only PAST the publication, never before it. The rows
+                # are durable either way, but a publication that failed leaves
+                # an unnotified peer holding an older whole-file snapshot, and
+                # that peer can become the next writer and save it over these
+                # rows. Keeping the redo logs makes that recoverable: this
+                # process's next flush reloads the foreign snapshot and replays
+                # them on top (the same path issue #3688 built), so the rows
+                # come back instead of being lost silently. Retiring them first
+                # threw away the only copy. Replay is idempotent -- an
+                # unchanged file matches by fingerprint and writes nothing, and
+                # a genuinely newer row under the same id supersedes ours.
+                self._unsaved_deletes.clear()  # the removals are durable now
+                self._unsaved_upserts.clear()  # the rows are durable now
                 self._client_dirty = False
 
             await self._save_to_disk_locked(_committed)
@@ -1626,10 +1641,21 @@ class NanoVectorDBStorage(BaseVectorStorage):
                 return
 
             async def _committed() -> None:
-                self._unsaved_deletes.clear()  # the removals are durable now
-                self._unsaved_upserts.clear()  # the rows are durable now
                 await set_all_update_flags(self.namespace, workspace=self.workspace)
                 self.storage_updated.value = False
+                # Retired only PAST the publication, never before it. The rows
+                # are durable either way, but a publication that failed leaves
+                # an unnotified peer holding an older whole-file snapshot, and
+                # that peer can become the next writer and save it over these
+                # rows. Keeping the redo logs makes that recoverable: this
+                # process's next flush reloads the foreign snapshot and replays
+                # them on top (the same path issue #3688 built), so the rows
+                # come back instead of being lost silently. Retiring them first
+                # threw away the only copy. Replay is idempotent -- an
+                # unchanged file matches by fingerprint and writes nothing, and
+                # a genuinely newer row under the same id supersedes ours.
+                self._unsaved_deletes.clear()  # the removals are durable now
+                self._unsaved_upserts.clear()  # the rows are durable now
                 self._client_dirty = False
 
             await self._save_to_disk_locked(_committed)

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 import numpy as np
 import time
 
+from lightrag.exceptions import CommitBookkeepingError
 from lightrag.file_atomic import atomic_write, reap_orphan_tmp_files
 from lightrag.utils import (
     commit_in_storage_io,
@@ -723,7 +724,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
         delivered in between would leave the file published with the other
         processes never told to reload it, and would strand the redo logs. It
         runs only if the write succeeded — running it without a write would
-        retire redo entries for rows that were never persisted.
+        retire redo entries for rows that were never persisted. Its own failure
+        is caught here as ``CommitBookkeepingError`` and logged: the file is
+        renamed into place by then, so raising would tell the caller the vectors
+        were never written.
 
         Only PART of the stall goes away. ``NanoVectorDB.save()`` base64-encodes
         the entire matrix through ``tobytes()`` and ``b64encode()``, two single C
@@ -741,15 +745,37 @@ class NanoVectorDBStorage(BaseVectorStorage):
             finally:
                 self._client.storage_file = original
 
-        await commit_in_storage_io(
-            partial(
-                atomic_write,
-                self._client_file_name,
-                _save_atomic,
-                self.workspace or "_",
-            ),
-            on_committed,
-        )
+        try:
+            await commit_in_storage_io(
+                partial(
+                    atomic_write,
+                    self._client_file_name,
+                    _save_atomic,
+                    self.workspace or "_",
+                ),
+                on_committed,
+            )
+        except CommitBookkeepingError as e:
+            # The file is already renamed into place, so the rows ARE durable
+            # and the caller must not hear otherwise: `index_done_callback`'s
+            # contract is that a raise means the vectors were not written, which
+            # aborts the document batch in `_insert_done`.
+            #
+            # What did not complete is the publication — flagging the other
+            # processes and clearing this writer's dirty bit. The residue is a
+            # visibility lag that heals: `_client_dirty` stays True, so the next
+            # commit rewrites this snapshot and notifies again; an unreset
+            # `storage_updated` only makes this process reload the file it just
+            # wrote. The redo logs are cleared first inside the hook, which is
+            # correct in either case — the rows they would replay are on disk.
+            logger.error(
+                f"[{self.workspace}] Vector data for {self.namespace} was saved "
+                f"to {self._client_file_name}, but publishing that write failed: "
+                f"{e.__cause__}. An unknown remainder of the other processes "
+                "keeps reading the previous snapshot until the next commit "
+                "notifies them; this process may also reload the file it just "
+                "wrote."
+            )
 
     async def query(
         self, query: str, top_k: int, query_embedding: list[float] = None
@@ -1080,7 +1106,10 @@ class NanoVectorDBStorage(BaseVectorStorage):
             4. ``set_all_update_flags`` flips every registered process's
                ``storage_updated`` flag, then we immediately reset our own
                flag to ``False`` so the writer does not self-reload on the
-               next call to ``_get_client``.
+               next call to ``_get_client``. A failure here does **not**
+               raise: step 3 already made the rows durable, so this is a
+               visibility lag, logged and healed by the next commit —
+               ``_save_to_disk_locked`` catches it.
 
         Either failure surfaces loudly through ``_insert_done`` so the caller
         can abort the document batch instead of silently losing vectors. The
@@ -1506,6 +1535,18 @@ class NanoVectorDBStorage(BaseVectorStorage):
         try:
             async with self._storage_lock:
                 await commit_in_storage_io(_delete_file, _committed)
+        except CommitBookkeepingError as e:
+            # The file is already gone; only the post-removal bookkeeping failed.
+            # Every step of `_committed` guards itself, so nothing raises this
+            # today -- it is the standing answer for a future step that forgets
+            # to, because "error" for a completed destruction is precisely the
+            # misreport those guards exist to prevent.
+            log_without_raising(
+                logger.error,
+                f"[{self.workspace}] Dropped {self.namespace}(file:"
+                f"{self._client_file_name}), but its post-removal bookkeeping "
+                f"failed: {e.__cause__}",
+            )
         except Exception as e:
             log_without_raising(
                 logger.error, f"[{self.workspace}] Error dropping {self.namespace}: {e}"

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -770,13 +770,14 @@ class NanoVectorDBStorage(BaseVectorStorage):
             # an unnotified peer saves its older snapshot over these rows first,
             # the next flush replays them back rather than losing them (#3854 is
             # the fence gap itself; this only makes it recoverable).
-            logger.error(
+            log_without_raising(
+                logger.error,
                 f"[{self.workspace}] Vector data for {self.namespace} was saved "
                 f"to {self._client_file_name}, but publishing that write failed: "
                 f"{e.__cause__}. An unknown remainder of the other processes "
                 "keeps reading the previous snapshot until the next commit "
                 "notifies them; this process may also reload the file it just "
-                "wrote."
+                "wrote.",
             )
 
     async def query(

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from operator import itemgetter
 from typing import final
 
+from lightrag.exceptions import CommitBookkeepingError
 from lightrag.file_atomic import atomic_write, reap_orphan_tmp_files
 from lightrag.types import KnowledgeGraph, KnowledgeGraphNode, KnowledgeGraphEdge
 from lightrag.utils import (
@@ -969,11 +970,6 @@ class NetworkXStorage(BaseGraphStorage):
             gate = self._gate()
             gate.clear()
             try:
-                # Save data to disk, off the event loop. The name is resolved at
-                # call time on purpose: test_networkx_index_done.py monkeypatches
-                # write_nx_graph, and hoisting the reference would leave that
-                # test green while testing nothing.
-                publish_error: list[Exception] = []
 
                 async def _committed() -> None:
                     # Runs inside the same uncancellable region as the write,
@@ -981,45 +977,43 @@ class NetworkXStorage(BaseGraphStorage):
                     # would be skippable by a cancel, leaving the new GraphML
                     # published while every other process keeps reading the
                     # previous one until some later commit happens to notify it.
-                    try:
-                        await set_all_update_flags(
-                            self.namespace, workspace=self.workspace
-                        )
-                        # Reset own update flag to avoid self-reloading. Inside
-                        # the same guard on purpose: in multiprocess mode this
-                        # flag is a `Manager().Value` proxy, so the assignment
-                        # is another RPC to the very process whose outage makes
-                        # the call above fail. Guarding only the first one lets
-                        # the identical failure escape one line later.
-                        self.storage_updated.value = False
-                    except Exception as e:
-                        # Recorded, never raised. Reaching this line means the
-                        # write already landed (`on_committed` runs only after
-                        # `fn` succeeded), so what failed is the publication of
-                        # that write, not the write: other workers keep reading
-                        # the previous snapshot until the next commit anywhere
-                        # flips their flags, and this process may redundantly
-                        # reload the file it just wrote. Both are visibility
-                        # effects, not a lost write. Raising them would report a
-                        # durable mutation as a failed one, and every caller
-                        # inherits that lie -- the deletion paths in utils_graph
-                        # skip the tracking retirement they still owe (leaving a
-                        # vanished object's authoritative rows behind), and
-                        # _insert_done marks a document FAILED whose graph
-                        # writes are on disk.
-                        publish_error.append(e)
+                    await set_all_update_flags(self.namespace, workspace=self.workspace)
+                    # Reset own update flag to avoid self-reloading. Inside the
+                    # same publication step on purpose: in multiprocess mode this
+                    # flag is a `Manager().Value` proxy, so the assignment is
+                    # another RPC to the very process whose outage makes the call
+                    # above fail. Separating them would let the identical failure
+                    # take a different path one line later.
+                    self.storage_updated.value = False
 
-                await commit_in_storage_io(
-                    lambda: NetworkXStorage.write_nx_graph(
-                        self._graph, self._graphml_xml_file, self.workspace
-                    ),
-                    _committed,
-                )
-                if publish_error:
+                try:
+                    # Save data to disk, off the event loop. The name is resolved
+                    # at call time on purpose: test_networkx_index_done.py
+                    # monkeypatches write_nx_graph, and hoisting the reference
+                    # would leave that test green while testing nothing.
+                    await commit_in_storage_io(
+                        lambda: NetworkXStorage.write_nx_graph(
+                            self._graph, self._graphml_xml_file, self.workspace
+                        ),
+                        _committed,
+                    )
+                except CommitBookkeepingError as e:
+                    # The write already landed (`on_committed` runs only after
+                    # `fn` succeeded), so what failed is the publication of that
+                    # write, not the write: other workers keep reading the
+                    # previous snapshot until the next commit anywhere flips
+                    # their flags, and this process may redundantly reload the
+                    # file it just wrote. Both are visibility effects, not a lost
+                    # write. Letting this reach the handler below would report a
+                    # durable mutation as a failed one, and every caller inherits
+                    # that lie -- the deletion paths in utils_graph skip the
+                    # tracking retirement they still owe (leaving a vanished
+                    # object's authoritative rows behind), and _insert_done marks
+                    # a document FAILED whose graph writes are on disk.
                     logger.error(
                         f"[{self.workspace}] Graph saved to "
                         f"{self._graphml_xml_file}, but publishing that write "
-                        f"failed: {publish_error[0]}. The notification flips "
+                        f"failed: {e.__cause__}. The notification flips "
                         "one flag per process, so an unknown remainder of them "
                         "keeps reading the previous snapshot until the next "
                         "commit notifies them; this process may also reload "
@@ -1028,10 +1022,11 @@ class NetworkXStorage(BaseGraphStorage):
                 return True  # Return success
             except Exception as e:
                 # Only a genuine write failure reaches here. A failure of the
-                # publication hook is recorded above and does not raise: the
-                # file is already on disk by the time that hook runs, so the
-                # recovery reload below -- and the "the write did not land"
-                # reasoning it rests on -- would both be wrong for it.
+                # publication hook is caught above as CommitBookkeepingError and
+                # does not reach this handler: the file is already on disk by the
+                # time that hook runs, so the recovery reload below -- and the
+                # "the write did not land" reasoning it rests on -- would both be
+                # wrong for it.
                 #
                 # Raise (do NOT swallow + return False): _insert_done's
                 # _flush_one only detects failures via exceptions, so a
@@ -1174,6 +1169,17 @@ class NetworkXStorage(BaseGraphStorage):
         try:
             async with self._storage_lock:
                 await commit_in_storage_io(_delete_file, _committed)
+        except CommitBookkeepingError as e:
+            # The file is already gone; only the post-removal bookkeeping failed.
+            # Every step of `_committed` guards itself, so nothing raises this
+            # today -- it is the standing answer for a future step that forgets
+            # to, because "error" for a completed destruction is precisely the
+            # misreport those guards exist to prevent.
+            log_without_raising(
+                logger.error,
+                f"[{self.workspace}] Dropped graph file:{self._graphml_xml_file}, "
+                f"but its post-removal bookkeeping failed: {e.__cause__}",
+            )
         except Exception as e:
             log_without_raising(
                 logger.error,

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -1010,14 +1010,15 @@ class NetworkXStorage(BaseGraphStorage):
                     # tracking retirement they still owe (leaving a vanished
                     # object's authoritative rows behind), and _insert_done marks
                     # a document FAILED whose graph writes are on disk.
-                    logger.error(
+                    log_without_raising(
+                        logger.error,
                         f"[{self.workspace}] Graph saved to "
                         f"{self._graphml_xml_file}, but publishing that write "
                         f"failed: {e.__cause__}. The notification flips "
                         "one flag per process, so an unknown remainder of them "
                         "keeps reading the previous snapshot until the next "
                         "commit notifies them; this process may also reload "
-                        "the file it just wrote."
+                        "the file it just wrote.",
                     )
                 return True  # Return success
             except Exception as e:

--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -41,7 +41,11 @@ import numpy as np
 from dotenv import load_dotenv
 import json_repair
 
-from lightrag.exceptions import ChunkBlockMatchError, EmptyTruncatedResponseError
+from lightrag.exceptions import (
+    ChunkBlockMatchError,
+    CommitBookkeepingError,
+    EmptyTruncatedResponseError,
+)
 from lightrag.constants import (
     DEFAULT_LOG_MAX_BYTES,
     DEFAULT_LOG_BACKUP_COUNT,
@@ -2861,6 +2865,11 @@ async def _bounded_submit_impl(
       because nothing was ever submitted. That is load-bearing, not tidiness:
       Nano's bookkeeping retires the redo log, and running it without a write
       would discard rows that were never persisted.
+    * ``on_committed`` raised → the write is already durable, so the failure is
+      re-raised as :class:`CommitBookkeepingError`, which says exactly that. The
+      hook's own exception must NOT reach the caller unwrapped: it is then
+      indistinguishable from a write that never landed, and every call site's
+      ``except Exception`` handles it by reasoning that only holds for that case.
     """
     await semaphore.acquire()
     try:
@@ -2920,6 +2929,23 @@ async def _bounded_submit_impl(
                 logger.error(f"{label} failed while its caller was cancelled: {exc}")
         raise pending_cancel
     if commit_exc is not None:
+        if isinstance(commit_exc, Exception):
+            # Typed, because the two failures this function can report want
+            # opposite handling and used to look identical: ``fn`` raising means
+            # nothing was persisted, while reaching HERE means the write is on
+            # disk and only its publication failed. A caller that cannot tell
+            # them apart rolls back in-memory state the file already has, and
+            # reports a durable mutation as one that never happened.
+            raise CommitBookkeepingError(
+                f"The offloaded write landed, but its commit bookkeeping "
+                f"failed: {commit_exc}",
+                result=async_future.result(),
+            ) from commit_exc
+        # A BaseException that is not an Exception (SystemExit, KeyboardInterrupt)
+        # is interpreter-level control flow, not a bookkeeping failure, and
+        # wrapping it would demote a shutdown request into a storage error. A
+        # cancelled hook never arrives here — ``commit_future.cancelled()`` is
+        # tested above, and that case is the caller's cancellation path.
         raise commit_exc
     return async_future.result()
 
@@ -3192,6 +3218,15 @@ async def commit_in_storage_io(
     this signature clear of the keyword-forwarding hazard ``run_in_storage_io``
     has to live with. ``on_committed`` runs ONLY if ``fn`` succeeded — see
     ``_bounded_submit_impl`` for why running it otherwise would lose data.
+
+    Raises:
+        CommitBookkeepingError: ``fn`` succeeded and ``on_committed`` did not.
+            The write is DURABLE; only its publication failed. Every call site
+            must handle this separately from a write failure and report the
+            commit as landed — see the exception's own docstring for the
+            contract, and ``NetworkXStorage.index_done_callback`` for the
+            reference handler.
+        Exception: whatever ``fn`` raised. Nothing was persisted.
     """
     from lightrag.constants import STORAGE_IO_SUBMIT_LIMIT
 

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -5,6 +5,7 @@ import asyncio
 from typing import Any, Awaitable, Callable, cast
 
 from .base import DeletionResult
+from .exceptions import CommitBookkeepingError
 from .kg.shared_storage import get_storage_keyed_lock
 from .constants import GRAPH_FIELD_SEP, RELATION_NO_EVIDENCE_SOURCE_IDS
 from .operate import _truncate_vdb_content
@@ -280,6 +281,13 @@ async def _persist_graph_updates(
     Ensures all relevant storage instances are properly persisted after
     operations like delete, edit, create, or merge.
 
+    A ``CommitBookkeepingError`` from any of them is logged, not propagated: it
+    says that store's write is durable and only its publication failed, so
+    raising it would fold a flush that DID land into the caller's failure
+    handling — reporting a completed deletion as ``fail``/500, and stranding the
+    tracking rows the retry would then believe it still owed. Every other
+    exception still propagates: those mean the flush did not happen.
+
     Args:
         entities_vdb: Entity vector database storage (optional)
         relationships_vdb: Relationship vector database storage (optional)
@@ -301,14 +309,20 @@ async def _persist_graph_updates(
     if relation_chunks_storage is not None:
         storages.append(relation_chunks_storage)
 
+    async def _flush(storage_inst) -> None:
+        try:
+            await cast(StorageNameSpace, storage_inst).index_done_callback()
+        except CommitBookkeepingError as e:
+            logger.error(
+                f"Persisting {getattr(storage_inst, 'namespace', storage_inst)} "
+                f"landed, but publishing it failed: {e.__cause__}. The data is "
+                "durable; cross-process visibility is deferred to the next "
+                "commit."
+            )
+
     # Persist all storage instances in parallel
     if storages:
-        await asyncio.gather(
-            *[
-                cast(StorageNameSpace, storage_inst).index_done_callback()
-                for storage_inst in storages  # type: ignore
-            ]
-        )
+        await asyncio.gather(*[_flush(storage_inst) for storage_inst in storages])
 
 
 async def _finish_deferring_cancellation(coro, description: str) -> None:
@@ -358,8 +372,27 @@ async def _commit_graph_or_raise(chunk_entity_relation_graph, context: str) -> N
 
     Only an explicit ``False`` counts as "did not commit". The base signature is
     ``-> None``, so backends that simply return nothing are unaffected.
+
+    ``CommitBookkeepingError`` is the opposite answer and is caught here: it
+    means the write DID land and only its publication failed. Letting it out
+    would reach the caller's generic ``except Exception`` and be reported as a
+    deletion that did not happen, so the tracking rows of an object that is
+    durably gone would be left behind — and for an entity the incident relation
+    rows are then unreachable, since the edges that named them are gone with the
+    node. ``NetworkXStorage`` already absorbs its own publication failure, so no
+    shipped backend raises this today; this is the standing answer for any graph
+    backend that hands the decision to its caller instead, because the default
+    (treat it as a declined commit) is the one that loses data.
     """
-    committed = await chunk_entity_relation_graph.index_done_callback()
+    try:
+        committed = await chunk_entity_relation_graph.index_done_callback()
+    except CommitBookkeepingError as e:
+        logger.error(
+            f"{context}: the graph write is durable, but publishing it failed: "
+            f"{e.__cause__}. Continuing with the tracking cleanup this removal "
+            "owes; cross-process visibility is deferred to the next commit."
+        )
+        return
     if committed is False:
         raise RuntimeError(
             f"{context}: the graph commit was skipped because another process "
@@ -429,6 +462,17 @@ async def adelete_by_entity(
     deletion whose node is already durably gone and strand rows the sweep cannot
     reach. A stale vector record is the recoverable, rebuildable residue this
     codebase already accepts elsewhere.
+
+    A commit whose WRITE landed and whose PUBLICATION failed is not a failed
+    commit, and this function does not treat it as one: the file backends absorb
+    it themselves, and :func:`_commit_graph_or_raise` /
+    :func:`_persist_graph_updates` absorb a ``CommitBookkeepingError`` from any
+    backend that hands it up instead. The cleanup is attempted either way. If it
+    then fails for a real reason, the handling is unchanged — the orphaned
+    relation keys are named in the log and the call answers ``fail``/500. If it
+    succeeds, the deletion answers ``success``; what the publication failure cost
+    is cross-process visibility, deferred to the next commit and logged there,
+    not the removal itself.
 
     Args:
         chunk_entity_relation_graph: Graph storage instance

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -15,6 +15,7 @@ from .utils import (
     _wait_deferring_cancellation,
     compute_mdhash_id,
     graph_attribute_value_rejection,
+    log_without_raising,
     logger,
     make_relation_vdb_ids,
     normalize_entity_name,
@@ -313,11 +314,12 @@ async def _persist_graph_updates(
         try:
             await cast(StorageNameSpace, storage_inst).index_done_callback()
         except CommitBookkeepingError as e:
-            logger.error(
+            log_without_raising(
+                logger.error,
                 f"Persisting {getattr(storage_inst, 'namespace', storage_inst)} "
                 f"landed, but publishing it failed: {e.__cause__}. The data is "
                 "durable; cross-process visibility is deferred to the next "
-                "commit."
+                "commit.",
             )
 
     # Persist all storage instances in parallel
@@ -387,10 +389,11 @@ async def _commit_graph_or_raise(chunk_entity_relation_graph, context: str) -> N
     try:
         committed = await chunk_entity_relation_graph.index_done_callback()
     except CommitBookkeepingError as e:
-        logger.error(
+        log_without_raising(
+            logger.error,
             f"{context}: the graph write is durable, but publishing it failed: "
             f"{e.__cause__}. Continuing with the tracking cleanup this removal "
-            "owes; cross-process visibility is deferred to the next commit."
+            "owes; cross-process visibility is deferred to the next commit.",
         )
         return
     if committed is False:

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -1764,3 +1764,93 @@ async def test_a_backward_clock_step_does_not_revert_a_newer_commit(
         "the replay reverted a commit the clock step made look older"
     )
     _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_a_failed_publication_keeps_the_redo_log(tmp_path, monkeypatch):
+    """The rows are durable, but the peers were not told — keep the redo log.
+
+    ``set_all_update_flags`` can fail partway, leaving a peer holding an older
+    whole-file snapshot that it may later save over these rows (the fence gap
+    tracked in #3854). Retiring the redo entries as the hook's first step threw
+    away the only remaining copy, making that loss permanent and silent.
+
+    Fix-proof: clear ``_unsaved_upserts`` before the notification instead, and
+    the entry is gone here.
+    """
+    storage = _make_storage(tmp_path, _CountingEmbed())
+    await storage.initialize()
+    await storage.upsert({"idA": {"content": "alpha"}})
+
+    async def failing_set_all_update_flags(namespace, workspace=None):
+        raise RuntimeError("shared-storage manager is down")
+
+    monkeypatch.setattr(
+        "lightrag.kg.faiss_impl.set_all_update_flags", failing_set_all_update_flags
+    )
+    assert await storage.index_done_callback() is True, (
+        "a durable write must not be reported as a failed one"
+    )
+
+    assert "idA" in storage._unsaved_upserts
+    assert storage._index_dirty is True, "the dirty bit is what retries the publish"
+
+    # A publication that succeeds still retires it — the retention above is the
+    # failure branch, not a leak.
+    monkeypatch.undo()
+    assert await storage.index_done_callback() is True
+    assert storage._unsaved_upserts == {}
+    _assert_consistent(storage)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_rows_lost_to_an_unnotified_peer_are_replayed_back(tmp_path, monkeypatch):
+    """The recovery the retained redo log buys, end to end.
+
+    ``other`` never learns of ``writer``'s commit, so its own commit saves a
+    snapshot that has never seen ``idA`` over both files. That overwrite is
+    #3854's fence gap and no commit-status choice prevents it; what the retained
+    redo log decides is whether the rows come back. ``writer``'s next flush
+    reloads the foreign snapshot and replays them on top — the path #3688 built
+    for a failed save.
+
+    Fix-proof: retire the redo logs before ``set_all_update_flags`` and ``idA``
+    is gone from disk for good.
+    """
+    writer = _make_storage(tmp_path, _CountingEmbed())
+    other = _make_storage(tmp_path, _CountingEmbed())
+    await writer.initialize()
+    await other.initialize()
+
+    await writer.upsert({"idA": {"content": "ours"}})
+
+    async def failing_set_all_update_flags(namespace, workspace=None):
+        raise RuntimeError("shared-storage manager is down")
+
+    monkeypatch.setattr(
+        "lightrag.kg.faiss_impl.set_all_update_flags", failing_set_all_update_flags
+    )
+    assert await writer.index_done_callback() is True
+    monkeypatch.undo()
+
+    # `other` was never flagged, so it does not reload: its commit publishes a
+    # whole-file snapshot in which `idA` has never existed.
+    await other.upsert({"idB": {"content": "theirs"}})
+    assert await other.index_done_callback() is True
+    assert await other.get_by_id("idA") is None, (
+        "the peer was supposed to be unaware of idA; the scenario did not set up"
+    )
+
+    # `other`'s own commit notifies `writer`, so this flush reloads its snapshot.
+    assert await writer.index_done_callback() is True
+
+    reader = _make_storage(tmp_path, _CountingEmbed())
+    await reader.initialize()
+    assert (await reader.get_by_id("idA"))["content"] == "ours", (
+        "the row the peer overwrote was not replayed back; the loss would be "
+        "permanent and silent"
+    )
+    assert (await reader.get_by_id("idB"))["content"] == "theirs"
+    _assert_consistent(reader)

--- a/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
+++ b/tests/kg/faiss_impl/test_faiss_deferred_embedding.py
@@ -1854,3 +1854,41 @@ async def test_rows_lost_to_an_unnotified_peer_are_replayed_back(tmp_path, monke
     )
     assert (await reader.get_by_id("idB"))["content"] == "theirs"
     _assert_consistent(reader)
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_a_broken_sink_cannot_turn_a_landed_save_into_a_failure(
+    tmp_path, monkeypatch
+):
+    """The publication-failure diagnostic is past the point of no return.
+
+    Both files are renamed into place by the time that handler runs, so a
+    logging handler, formatter or output target that raises must not escape it:
+    ``index_done_callback`` would report a durable write as one that never
+    happened, and ``_insert_done`` marks the document FAILED and re-runs
+    mutations that already landed. Same reasoning, and same remedy
+    (``log_without_raising``), as the post-removal ``drop`` diagnostics.
+
+    Fix-proof: call ``logger.error`` directly in the handler and this raises.
+    """
+    storage = _make_storage(tmp_path, _CountingEmbed())
+    await storage.initialize()
+    await storage.upsert({"idA": {"content": "alpha"}})
+
+    async def failing_set_all_update_flags(namespace, workspace=None):
+        raise RuntimeError("shared-storage manager is down")
+
+    def log_boom(msg):
+        raise RuntimeError("log sink boom")
+
+    monkeypatch.setattr(
+        "lightrag.kg.faiss_impl.set_all_update_flags", failing_set_all_update_flags
+    )
+    monkeypatch.setattr("lightrag.kg.faiss_impl.logger.error", log_boom)
+
+    assert await storage.index_done_callback() is True
+    assert os.path.exists(storage._faiss_index_file)
+    assert os.path.exists(storage._meta_file)
+    assert "idA" in storage._unsaved_upserts
+    _assert_consistent(storage)

--- a/tests/kg/faiss_impl/test_faiss_write_off_event_loop.py
+++ b/tests/kg/faiss_impl/test_faiss_write_off_event_loop.py
@@ -306,14 +306,12 @@ async def test_a_failed_notification_is_not_reported_as_a_failed_save(
             "the save did not land, so this proves nothing"
         )
         assert os.path.exists(storage._meta_file)
-        # The dirty bit stays set, which is what retries the publication...
+        # The dirty bit stays set, which is what retries the publication.
         assert storage._index_dirty is True
-        # ...and the redo log is NOT retired, because an unnotified peer can
-        # still save its older snapshot over these rows; keeping it lets the
-        # next flush replay them back on top of that snapshot instead of losing
-        # them silently. `tests/kg/nano_impl/` proves the recovery end to end on
-        # the backend this sandbox can run.
-        assert set(storage._unsaved_upserts) == {"v1"}
+        # The redo log is not asserted here: `_seed` materializes rows straight
+        # into the index, so nothing ever passed through the pending buffer.
+        # Its retention past a failed publication is pinned in
+        # test_faiss_deferred_embedding.py, on the real upsert path.
         assert any(
             "publishing that write failed" in record.getMessage()
             for record in caplog.records

--- a/tests/kg/faiss_impl/test_faiss_write_off_event_loop.py
+++ b/tests/kg/faiss_impl/test_faiss_write_off_event_loop.py
@@ -17,6 +17,7 @@ Two properties are pinned here:
 
 import asyncio
 import json
+import logging
 import os
 import threading
 import time
@@ -258,5 +259,60 @@ async def test_cancelled_commit_still_notifies_and_retires_the_redo_logs(
         )
         assert storage._index_dirty is False, "dirty bit survived a durable save"
         assert storage._unsaved_upserts == {}, "redo log kept rows that are on disk"
+    finally:
+        finalize_share_data()
+
+
+async def test_a_failed_notification_is_not_reported_as_a_failed_save(
+    tmp_path, monkeypatch, caplog
+):
+    """A publication failure must not be raised as a save failure.
+
+    `index_done_callback`'s contract is that a raise means the vectors were NOT
+    written, and `_insert_done` aborts the document batch on it. But the hook
+    runs only after both files are renamed into place, so an exception out of
+    `set_all_update_flags` reports a durable write as a lost one.
+
+    What failed is the cross-process reload notification. The residue heals:
+    `_index_dirty` stays True, so the next commit rewrites this snapshot and
+    notifies again.
+    """
+    from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+
+    finalize_share_data()
+    initialize_share_data()
+    try:
+        storage = _make_storage(tmp_path)
+        await storage.initialize()
+        _seed(storage, "v1")
+        storage._index_dirty = True
+
+        async def failing_set_all_update_flags(namespace, workspace=None):
+            raise RuntimeError("shared-storage manager is down")
+
+        monkeypatch.setattr(
+            faiss_impl, "set_all_update_flags", failing_set_all_update_flags
+        )
+
+        # lightrag's logger does not propagate, so caplog cannot see it otherwise.
+        logger = logging.getLogger("lightrag")
+        monkeypatch.setattr(logger, "propagate", True)
+
+        with caplog.at_level(logging.ERROR, logger="lightrag"):
+            committed = await storage.index_done_callback()
+
+        assert committed is True
+        assert os.path.exists(storage._faiss_index_file), (
+            "the save did not land, so this proves nothing"
+        )
+        assert os.path.exists(storage._meta_file)
+        # The rows are durable, so the redo log must not keep replaying them...
+        assert storage._unsaved_upserts == {}
+        # ...while the dirty bit stays set, which is what retries the publication.
+        assert storage._index_dirty is True
+        assert any(
+            "publishing that write failed" in record.getMessage()
+            for record in caplog.records
+        ), f"the deferred publication was not logged: {caplog.text}"
     finally:
         finalize_share_data()

--- a/tests/kg/faiss_impl/test_faiss_write_off_event_loop.py
+++ b/tests/kg/faiss_impl/test_faiss_write_off_event_loop.py
@@ -306,10 +306,14 @@ async def test_a_failed_notification_is_not_reported_as_a_failed_save(
             "the save did not land, so this proves nothing"
         )
         assert os.path.exists(storage._meta_file)
-        # The rows are durable, so the redo log must not keep replaying them...
-        assert storage._unsaved_upserts == {}
-        # ...while the dirty bit stays set, which is what retries the publication.
+        # The dirty bit stays set, which is what retries the publication...
         assert storage._index_dirty is True
+        # ...and the redo log is NOT retired, because an unnotified peer can
+        # still save its older snapshot over these rows; keeping it lets the
+        # next flush replay them back on top of that snapshot instead of losing
+        # them silently. `tests/kg/nano_impl/` proves the recovery end to end on
+        # the backend this sandbox can run.
+        assert set(storage._unsaved_upserts) == {"v1"}
         assert any(
             "publishing that write failed" in record.getMessage()
             for record in caplog.records

--- a/tests/kg/json_impl/test_json_commit_reconciliation.py
+++ b/tests/kg/json_impl/test_json_commit_reconciliation.py
@@ -256,3 +256,60 @@ async def test_a_broken_sink_cannot_turn_a_landed_write_into_a_failure(
     with open(storage._file_name, encoding="utf-8") as f:
         persisted = json.load(f)
     assert "id1" in persisted, "the write did not land, so this proves nothing"
+
+
+@pytest.mark.parametrize(
+    "factory, row",
+    [
+        (_make_kv, {"content": "alpha"}),
+        (_make_doc_status, {"status": "processed", "file_path": "a.pdf"}),
+    ],
+    ids=["kv", "doc_status"],
+)
+async def test_a_failed_sanitize_reload_is_not_absorbed(
+    tmp_path, monkeypatch, factory, row
+):
+    """A reconciliation failure is not a deferred publication — it must raise.
+
+    ``self._data.clear()`` and ``self._data.update()`` are two separate RPCs on
+    the shared ``Manager().dict()``, so a failure between them leaves the shared
+    dict EMPTY while the file on disk holds the correct sanitized snapshot. The
+    dirty flags are still set, so the next flush would write that empty dict
+    straight over a good file and lose every row in the namespace.
+
+    Absorbing it — as the dirty-flag clear beside it legitimately is — would make
+    that loss silent. Nothing about it heals: the shared in-memory view is what a
+    later flush PUBLISHES, so the failure has to reach a caller.
+
+    Fix-proof: drop the ``reconcile_failure`` guard from the handler and this
+    returns normally with the store emptied.
+    """
+    storage = await factory(tmp_path)
+    await storage.upsert({"id1": row})
+
+    module = type(storage).__module__
+
+    class _BrokenUpdate(dict):
+        def update(self, *args, **kwargs):
+            raise RuntimeError("shared-dict RPC failed")
+
+    def _sanitizing_write(data_dict, file_name):
+        with open(file_name, "w", encoding="utf-8") as f:
+            json.dump({"id1": dict(row, content_was="sanitized")}, f)
+        return True  # sanitization happened -> caller must reload
+
+    monkeypatch.setattr(f"{module}.write_json", _sanitizing_write)
+    storage._data = _BrokenUpdate(storage._data)
+    storage.storage_updated.value = True
+
+    with pytest.raises(RuntimeError, match="shared-dict RPC failed"):
+        await storage.index_done_callback()
+
+    # The file is the correct sanitized snapshot; it is memory that is now
+    # unreliable, which is why the recovery is a restart, not a retry.
+    with open(storage._file_name, encoding="utf-8") as f:
+        assert json.load(f)["id1"]["content_was"] == "sanitized"
+    assert dict(storage._data) == {}, (
+        "the scenario under test is the emptied shared dict; if it is intact "
+        "this test proves nothing"
+    )

--- a/tests/kg/json_impl/test_json_commit_reconciliation.py
+++ b/tests/kg/json_impl/test_json_commit_reconciliation.py
@@ -16,6 +16,7 @@ uncancellable region, which is what these tests pin.
 
 import asyncio
 import json
+import logging
 import threading
 
 import pytest
@@ -153,3 +154,60 @@ async def test_reconciliation_is_skipped_when_the_write_fails(
         await storage.index_done_callback()
 
     assert reloads == [], "reconciled a write that never landed"
+
+
+@pytest.mark.parametrize(
+    "factory, row",
+    [
+        (_make_kv, {"content": "alpha"}),
+        (_make_doc_status, {"status": "processed", "file_path": "a.pdf"}),
+    ],
+    ids=["kv", "doc_status"],
+)
+async def test_a_failed_flag_clear_is_not_reported_as_a_failed_write(
+    tmp_path, monkeypatch, caplog, factory, row
+):
+    """A publication failure must not be raised as a save failure.
+
+    ``on_committed`` runs only after ``write_json`` succeeded, so an exception
+    out of ``clear_all_update_flags`` means the file is already on disk. Letting
+    it propagate reported a durable write as a lost one, and every caller
+    inherited that: ``_insert_done`` marked a document FAILED whose rows are
+    persisted, and ``utils_graph``'s deletion paths turned a chunk-tracking
+    cleanup they had already completed into ``fail``/500 — stranding, on the
+    retry that followed, rows the sweep can no longer reach.
+
+    What failed is only the dirty-flag reset, and it heals: the flags stay set,
+    so the next commit rewrites this same snapshot and retries them.
+    """
+    storage = await factory(tmp_path)
+    await storage.upsert({"id1": row})
+
+    module = type(storage).__module__
+
+    async def failing_clear_all_update_flags(namespace, workspace=None):
+        raise RuntimeError("shared-storage manager is down")
+
+    monkeypatch.setattr(
+        f"{module}.clear_all_update_flags", failing_clear_all_update_flags
+    )
+    storage.storage_updated.value = True
+
+    # lightrag's logger does not propagate, so caplog cannot see it otherwise.
+    logger = logging.getLogger("lightrag")
+    monkeypatch.setattr(logger, "propagate", True)
+
+    with caplog.at_level(logging.ERROR, logger="lightrag"):
+        await storage.index_done_callback()
+
+    with open(storage._file_name, encoding="utf-8") as f:
+        persisted = json.load(f)
+    assert "id1" in persisted, "the write did not land, so this proves nothing"
+    assert storage.storage_updated.value is True, (
+        "the dirty flag was cleared despite the failure, so the next commit "
+        "would not retry the publication"
+    )
+    assert any(
+        "post-write bookkeeping failed" in record.getMessage()
+        for record in caplog.records
+    ), f"the deferred publication was not logged: {caplog.text}"

--- a/tests/kg/json_impl/test_json_commit_reconciliation.py
+++ b/tests/kg/json_impl/test_json_commit_reconciliation.py
@@ -211,3 +211,48 @@ async def test_a_failed_flag_clear_is_not_reported_as_a_failed_write(
         "post-write bookkeeping failed" in record.getMessage()
         for record in caplog.records
     ), f"the deferred publication was not logged: {caplog.text}"
+
+
+@pytest.mark.parametrize(
+    "factory, row",
+    [
+        (_make_kv, {"content": "alpha"}),
+        (_make_doc_status, {"status": "processed", "file_path": "a.pdf"}),
+    ],
+    ids=["kv", "doc_status"],
+)
+async def test_a_broken_sink_cannot_turn_a_landed_write_into_a_failure(
+    tmp_path, monkeypatch, factory, row
+):
+    """The bookkeeping-failure diagnostic is past the point of no return.
+
+    The file is published by the time that handler runs, so a broken logging
+    handler, formatter or output target must not escape it — the caller would
+    then hear that a durable write never happened. For ``JsonDocStatusStorage``
+    that caller is ``upsert``, which flushes synchronously precisely to make the
+    recovery anchor durable before it returns.
+
+    Fix-proof: call ``logger.error`` directly in the handler and this raises.
+    """
+    storage = await factory(tmp_path)
+    await storage.upsert({"id1": row})
+
+    module = type(storage).__module__
+
+    async def failing_clear_all_update_flags(namespace, workspace=None):
+        raise RuntimeError("shared-storage manager is down")
+
+    def log_boom(msg):
+        raise RuntimeError("log sink boom")
+
+    monkeypatch.setattr(
+        f"{module}.clear_all_update_flags", failing_clear_all_update_flags
+    )
+    monkeypatch.setattr(f"{module}.logger.error", log_boom)
+    storage.storage_updated.value = True
+
+    await storage.index_done_callback()
+
+    with open(storage._file_name, encoding="utf-8") as f:
+        persisted = json.load(f)
+    assert "id1" in persisted, "the write did not land, so this proves nothing"

--- a/tests/kg/nano_impl/test_nano_save_off_event_loop.py
+++ b/tests/kg/nano_impl/test_nano_save_off_event_loop.py
@@ -16,6 +16,8 @@ could not be cancelled at all.
 """
 
 import asyncio
+import json
+import logging
 import threading
 import time
 
@@ -217,3 +219,47 @@ async def test_cancelled_commit_still_notifies_and_retires_the_redo_logs(
     )
     assert storage._client_dirty is False, "the dirty bit survived a durable save"
     assert storage._unsaved_upserts == {}, "redo log kept rows that are on disk"
+
+
+async def test_a_failed_notification_is_not_reported_as_a_failed_save(
+    tmp_path, monkeypatch, caplog
+):
+    """A publication failure must not be raised as a save failure.
+
+    ``index_done_callback``'s contract is that a raise means the vectors were
+    NOT written, and ``_insert_done`` aborts the document batch on it. But the
+    hook runs only after ``atomic_write`` renamed the file into place, so an
+    exception out of ``set_all_update_flags`` reports a durable write as a lost
+    one.
+
+    What failed is the cross-process reload notification. The residue heals:
+    ``_client_dirty`` stays True, so the next commit rewrites this snapshot and
+    notifies again.
+    """
+    storage = await _make_storage(tmp_path)
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    async def failing_set_all_update_flags(namespace, workspace=None):
+        raise RuntimeError("shared-storage manager is down")
+
+    monkeypatch.setattr(nano_impl, "set_all_update_flags", failing_set_all_update_flags)
+
+    # lightrag's logger does not propagate, so caplog cannot see it otherwise.
+    logger = logging.getLogger("lightrag")
+    monkeypatch.setattr(logger, "propagate", True)
+
+    with caplog.at_level(logging.ERROR, logger="lightrag"):
+        committed = await storage.index_done_callback()
+
+    assert committed is True
+    with open(storage._client_file_name, encoding="utf-8") as f:
+        persisted = json.load(f)
+    assert persisted["data"], "the save did not land, so this proves nothing"
+    # The rows are durable, so the redo log must not keep replaying them...
+    assert storage._unsaved_upserts == {}
+    # ...while the dirty bit stays set, which is what retries the publication.
+    assert storage._client_dirty is True
+    assert any(
+        "publishing that write failed" in record.getMessage()
+        for record in caplog.records
+    ), f"the deferred publication was not logged: {caplog.text}"

--- a/tests/kg/nano_impl/test_nano_save_off_event_loop.py
+++ b/tests/kg/nano_impl/test_nano_save_off_event_loop.py
@@ -18,6 +18,7 @@ could not be cancelled at all.
 import asyncio
 import json
 import logging
+import os
 import threading
 import time
 
@@ -255,11 +256,56 @@ async def test_a_failed_notification_is_not_reported_as_a_failed_save(
     with open(storage._client_file_name, encoding="utf-8") as f:
         persisted = json.load(f)
     assert persisted["data"], "the save did not land, so this proves nothing"
-    # The rows are durable, so the redo log must not keep replaying them...
-    assert storage._unsaved_upserts == {}
-    # ...while the dirty bit stays set, which is what retries the publication.
+    # The dirty bit stays set, which is what retries the publication...
     assert storage._client_dirty is True
+    # ...and the redo log is NOT retired, because an unnotified peer can still
+    # save its older snapshot over these rows. See the recovery test below.
+    assert set(storage._unsaved_upserts) == {"id1"}
     assert any(
         "publishing that write failed" in record.getMessage()
         for record in caplog.records
     ), f"the deferred publication was not logged: {caplog.text}"
+
+
+async def test_rows_lost_to_an_unnotified_peer_are_replayed_back(tmp_path, monkeypatch):
+    """The recovery the retained redo log buys, end to end.
+
+    A publication that fails partway leaves a peer holding an older whole-file
+    snapshot, and that peer can legitimately become the next writer and save it
+    over these rows -- the fence gap tracked in #3854, which no commit-status
+    change can close. What this pins is that the loss is RECOVERABLE rather than
+    silent and permanent: the redo log survives the failed publication, so this
+    process's next flush reloads the foreign snapshot and replays its rows on
+    top (the path issue #3688 built for a failed save).
+
+    Fix-proof: retire the redo logs before ``set_all_update_flags`` instead, and
+    ``id1`` never comes back. ``FaissVectorDBStorage`` has the same shape.
+    """
+    storage = await _make_storage(tmp_path)
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    async def failing_set_all_update_flags(namespace, workspace=None):
+        raise RuntimeError("shared-storage manager is down")
+
+    monkeypatch.setattr(nano_impl, "set_all_update_flags", failing_set_all_update_flags)
+    await storage.index_done_callback()
+
+    # A peer that never learned of the commit above writes its own snapshot --
+    # one that has never seen `id1` -- over the file.
+    os.remove(storage._client_file_name)
+    peer = nano_vectordb.NanoVectorDB(DIM, storage_file=storage._client_file_name)
+    peer.upsert(datas=[{"__id__": "peer-row", "__vector__": np.full(DIM, 3.0)}])
+    peer.save()
+
+    # The peer's own commit notifies us, so the next flush reloads its snapshot.
+    monkeypatch.undo()
+    storage.storage_updated.value = True
+    await storage.index_done_callback()
+
+    with open(storage._client_file_name, encoding="utf-8") as f:
+        persisted = json.load(f)
+    ids = {row["__id__"] for row in persisted["data"]}
+    assert ids == {"id1", "peer-row"}, (
+        "the rows the peer overwrote were not replayed back; the loss would be "
+        f"permanent and silent (persisted={ids})"
+    )

--- a/tests/kg/nano_impl/test_nano_save_off_event_loop.py
+++ b/tests/kg/nano_impl/test_nano_save_off_event_loop.py
@@ -310,3 +310,37 @@ async def test_rows_lost_to_an_unnotified_peer_are_replayed_back(tmp_path, monke
         "the row the peer overwrote was not replayed back; the loss would be "
         f"permanent and silent (persisted={ids})"
     )
+
+
+async def test_a_broken_sink_cannot_turn_a_landed_save_into_a_failure(
+    tmp_path, monkeypatch
+):
+    """The publication-failure diagnostic is past the point of no return.
+
+    The rows are on disk by the time that handler runs, so a logging handler,
+    formatter or output target that raises must not escape it: `index_done_callback`
+    would then report a durable write as one that never happened, and
+    `_insert_done` marks the document FAILED and re-runs mutations that already
+    landed. Same reasoning, and same remedy (`log_without_raising`), as the
+    post-removal `drop` diagnostics.
+
+    Fix-proof: call `logger.error` directly in the handler and this raises.
+    """
+    storage = await _make_storage(tmp_path)
+    await storage.upsert({"id1": {"content": "alpha"}})
+
+    async def failing_set_all_update_flags(namespace, workspace=None):
+        raise RuntimeError("shared-storage manager is down")
+
+    def log_boom(msg):
+        raise RuntimeError("log sink boom")
+
+    monkeypatch.setattr(nano_impl, "set_all_update_flags", failing_set_all_update_flags)
+    monkeypatch.setattr(nano_impl.logger, "error", log_boom)
+
+    assert await storage.index_done_callback() is True
+
+    with open(storage._client_file_name, encoding="utf-8") as f:
+        persisted = json.load(f)
+    assert persisted["data"], "the save did not land, so this proves nothing"
+    assert set(storage._unsaved_upserts) == {"id1"}

--- a/tests/kg/nano_impl/test_nano_save_off_event_loop.py
+++ b/tests/kg/nano_impl/test_nano_save_off_event_loop.py
@@ -18,7 +18,6 @@ could not be cancelled at all.
 import asyncio
 import json
 import logging
-import os
 import threading
 import time
 
@@ -270,42 +269,44 @@ async def test_a_failed_notification_is_not_reported_as_a_failed_save(
 async def test_rows_lost_to_an_unnotified_peer_are_replayed_back(tmp_path, monkeypatch):
     """The recovery the retained redo log buys, end to end.
 
-    A publication that fails partway leaves a peer holding an older whole-file
-    snapshot, and that peer can legitimately become the next writer and save it
-    over these rows -- the fence gap tracked in #3854, which no commit-status
-    change can close. What this pins is that the loss is RECOVERABLE rather than
-    silent and permanent: the redo log survives the failed publication, so this
-    process's next flush reloads the foreign snapshot and replays its rows on
-    top (the path issue #3688 built for a failed save).
+    ``other`` never learns of ``writer``'s commit, so its own commit saves a
+    whole-file snapshot that has never seen ``id1`` over this file. That
+    overwrite is the fence gap tracked in #3854 and no commit-status choice
+    prevents it; what the retained redo log decides is whether the rows come
+    back. ``writer``'s next flush reloads the foreign snapshot and replays them
+    on top -- the path issue #3688 built for a failed save.
 
     Fix-proof: retire the redo logs before ``set_all_update_flags`` instead, and
-    ``id1`` never comes back. ``FaissVectorDBStorage`` has the same shape.
+    ``id1`` is gone from disk for good. ``FaissVectorDBStorage`` has the same
+    shape; its mirror lives in tests/kg/faiss_impl/.
     """
-    storage = await _make_storage(tmp_path)
-    await storage.upsert({"id1": {"content": "alpha"}})
+    writer = await _make_storage(tmp_path)
+    other = await _make_storage(tmp_path)
+
+    await writer.upsert({"id1": {"content": "ours"}})
 
     async def failing_set_all_update_flags(namespace, workspace=None):
         raise RuntimeError("shared-storage manager is down")
 
     monkeypatch.setattr(nano_impl, "set_all_update_flags", failing_set_all_update_flags)
-    await storage.index_done_callback()
-
-    # A peer that never learned of the commit above writes its own snapshot --
-    # one that has never seen `id1` -- over the file.
-    os.remove(storage._client_file_name)
-    peer = nano_vectordb.NanoVectorDB(DIM, storage_file=storage._client_file_name)
-    peer.upsert(datas=[{"__id__": "peer-row", "__vector__": np.full(DIM, 3.0)}])
-    peer.save()
-
-    # The peer's own commit notifies us, so the next flush reloads its snapshot.
+    assert await writer.index_done_callback() is True
     monkeypatch.undo()
-    storage.storage_updated.value = True
-    await storage.index_done_callback()
 
-    with open(storage._client_file_name, encoding="utf-8") as f:
+    # `other` was never flagged, so it does not reload: its commit publishes a
+    # whole-file snapshot in which `id1` has never existed.
+    await other.upsert({"id2": {"content": "theirs"}})
+    assert await other.index_done_callback() is True
+    assert await other.get_by_id("id1") is None, (
+        "the peer was supposed to be unaware of id1; the scenario did not set up"
+    )
+
+    # `other`'s own commit notifies `writer`, so this flush reloads its snapshot.
+    assert await writer.index_done_callback() is True
+
+    with open(writer._client_file_name, encoding="utf-8") as f:
         persisted = json.load(f)
     ids = {row["__id__"] for row in persisted["data"]}
-    assert ids == {"id1", "peer-row"}, (
-        "the rows the peer overwrote were not replayed back; the loss would be "
+    assert ids == {"id1", "id2"}, (
+        "the row the peer overwrote was not replayed back; the loss would be "
         f"permanent and silent (persisted={ids})"
     )

--- a/tests/kg/networkx_impl/test_networkx_commit_gate.py
+++ b/tests/kg/networkx_impl/test_networkx_commit_gate.py
@@ -473,3 +473,43 @@ async def test_a_failed_writer_flag_reset_is_not_reported_as_a_failed_write(
         "publishing that write failed" in record.getMessage()
         for record in caplog.records
     ), f"the publication failure was not logged: {caplog.text}"
+
+
+async def test_a_broken_sink_cannot_turn_a_landed_commit_into_a_failure(
+    tmp_path, monkeypatch
+):
+    """The publication-failure diagnostic is past the point of no return.
+
+    The GraphML file is on disk by the time that handler runs, so a logging
+    handler, formatter or output target that raises must not escape it: the
+    exception would land in the outer "the write did not land" handler, which
+    restores ``self._graph`` from the file and re-raises. Every caller then
+    inherits the misreport this handler exists to prevent -- ``utils_graph``'s
+    deletion paths skip the tracking retirement they owe, and ``_insert_done``
+    marks a document FAILED whose graph writes are durable.
+
+    Fix-proof: call ``logger.error`` directly in the handler and this raises.
+    """
+    storage = await _make_storage(tmp_path)
+    await storage.upsert_node("A", {"entity_id": "A"})
+
+    async def failing_set_all_update_flags(namespace, workspace=None):
+        raise RuntimeError("shared-storage manager is down")
+
+    def log_boom(msg):
+        raise RuntimeError("log sink boom")
+
+    monkeypatch.setattr(
+        "lightrag.kg.networkx_impl.set_all_update_flags",
+        failing_set_all_update_flags,
+    )
+    monkeypatch.setattr("lightrag.kg.networkx_impl.logger.error", log_boom)
+
+    assert await storage.index_done_callback() is True
+
+    persisted = NetworkXStorage.load_nx_graph(storage._graphml_xml_file)
+    assert persisted is not None and persisted.has_node("A")
+    # The recovery reload of the "write failed" branch must not have run: the
+    # file has the node, so a reload would be a no-op here either way, which is
+    # exactly why the assertion above cannot stand alone.
+    assert await storage.has_node("A")

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -40,6 +40,7 @@ from copy import deepcopy
 import pytest
 
 from lightrag import utils_graph
+from lightrag.exceptions import CommitBookkeepingError
 from lightrag.kg.networkx_impl import NetworkXStorage
 from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
 from lightrag.utils import make_relation_chunk_key
@@ -883,3 +884,108 @@ class TestDirectCancellationBeforeTheCommit:
 
         assert rag.persisted_graph().has_edge(ENTITY, OTHER)
         assert rag.relation_chunks.records[RELATION_KEY] == CHUNKS
+
+
+class TestPublishedCommitIsNotAFailure:
+    """The three answers a graph commit can give, and the one middle case.
+
+    ``commit_in_storage_io`` runs its bookkeeping hook only after the write
+    succeeded, so a hook failure means the mutation is already on disk. It
+    arrives as ``CommitBookkeepingError``, which says exactly that, and this
+    deletion must go on to retire the tracking rows a durably removed node owes:
+    the entity's own row is reachable by the ``not_found`` sweep on a retry, but
+    its incident relation rows are not — the edges that named them are gone with
+    the node.
+
+    The two neighbours are the contrast, and both keep today's handling:
+
+    * ``_Boom`` — the write never landed, so the object is still live and its
+      provenance must stay with it;
+    * ``CancelledError`` — carries no evidence either way, so the cleanup is
+      deliberately given up rather than guessed at (see ``adelete_by_entity``).
+
+    Fix-proof: drop the ``except CommitBookkeepingError`` from
+    ``_commit_graph_or_raise`` and the middle case answers ``fail`` with the
+    relation row left behind for a node that is gone.
+    """
+
+    @staticmethod
+    def _commit_raises(fixture, monkeypatch, exc, *, land_the_write: bool):
+        original = fixture.graph.index_done_callback
+
+        async def _commit():
+            if land_the_write:
+                await original()
+            raise exc
+
+        monkeypatch.setattr(fixture.graph, "index_done_callback", _commit)
+
+    @pytest.mark.asyncio
+    async def test_a_published_write_that_failed_to_notify_still_cleans_up(
+        self, rag, monkeypatch
+    ):
+        self._commit_raises(
+            rag,
+            monkeypatch,
+            CommitBookkeepingError(
+                "the offloaded write landed, but its commit bookkeeping failed",
+                result=True,
+            ),
+            land_the_write=True,
+        )
+
+        result = await rag.delete_entity()
+
+        assert result.status == "success"
+        assert not rag.persisted_graph().has_node(ENTITY)
+        assert ENTITY not in rag.entity_chunks.records
+        assert RELATION_KEY not in rag.relation_chunks.records
+        # Only this entity's rows: the sweep must not widen on a publication
+        # failure any more than on a clean commit.
+        assert rag.entity_chunks.records[OTHER] == CHUNKS
+
+    @pytest.mark.asyncio
+    async def test_a_write_that_never_landed_keeps_every_row(self, rag, monkeypatch):
+        self._commit_raises(
+            rag, monkeypatch, _Boom("graph commit failed"), land_the_write=False
+        )
+
+        result = await rag.delete_entity()
+
+        assert result.status == "fail"
+        assert rag.persisted_graph().has_node(ENTITY)
+        assert rag.entity_chunks.records[ENTITY] == CHUNKS
+        assert rag.relation_chunks.records[RELATION_KEY] == CHUNKS
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_commit_keeps_every_row(self, rag, monkeypatch):
+        self._commit_raises(
+            rag, monkeypatch, asyncio.CancelledError(), land_the_write=False
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await rag.delete_entity()
+
+        # Nothing was submitted, so an immediate-write tracking store must not
+        # have its row put in the grave while the node survives on disk.
+        assert rag.persisted_graph().has_node(ENTITY)
+        assert rag.entity_chunks.records[ENTITY] == CHUNKS
+        assert rag.relation_chunks.records[RELATION_KEY] == CHUNKS
+
+    @pytest.mark.asyncio
+    async def test_a_published_relation_delete_still_cleans_up(self, rag, monkeypatch):
+        self._commit_raises(
+            rag,
+            monkeypatch,
+            CommitBookkeepingError(
+                "the offloaded write landed, but its commit bookkeeping failed",
+                result=True,
+            ),
+            land_the_write=True,
+        )
+
+        result = await rag.delete_relation()
+
+        assert result.status == "success"
+        assert not rag.persisted_graph().has_edge(ENTITY, OTHER)
+        assert RELATION_KEY not in rag.relation_chunks.records

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -989,3 +989,62 @@ class TestPublishedCommitIsNotAFailure:
         assert result.status == "success"
         assert not rag.persisted_graph().has_edge(ENTITY, OTHER)
         assert RELATION_KEY not in rag.relation_chunks.records
+
+
+class TestPublishedCommitSurvivesABrokenSink:
+    """The published-commit handler is past the point of no return.
+
+    ``_commit_graph_or_raise`` answers a ``CommitBookkeepingError`` with a log
+    line and continues, because the removal is durable. If that log call can
+    raise, the exception lands in ``adelete_by_entity``'s generic handler and
+    the deletion answers ``fail``/500 with its tracking rows stranded -- exactly
+    the misreport the handler exists to prevent, reached through the diagnostic
+    about it. ``_persist_graph_updates`` carries the same handler for the
+    tracking flush that follows.
+
+    Fix-proof: call ``logger.error`` directly in either handler and both cases
+    below report ``fail``.
+    """
+
+    @staticmethod
+    def _break_the_sink(monkeypatch):
+        def log_boom(msg):
+            raise RuntimeError("log sink boom")
+
+        monkeypatch.setattr(utils_graph.logger, "error", log_boom)
+
+    @pytest.mark.asyncio
+    async def test_entity_delete_still_succeeds_and_cleans_up(self, rag, monkeypatch):
+        original = rag.graph.index_done_callback
+
+        async def _commit():
+            await original()
+            raise CommitBookkeepingError("published, not notified", result=True)
+
+        monkeypatch.setattr(rag.graph, "index_done_callback", _commit)
+        self._break_the_sink(monkeypatch)
+
+        result = await rag.delete_entity()
+
+        assert result.status == "success"
+        assert not rag.persisted_graph().has_node(ENTITY)
+        assert ENTITY not in rag.entity_chunks.records
+        assert RELATION_KEY not in rag.relation_chunks.records
+
+    @pytest.mark.asyncio
+    async def test_a_tracking_flush_that_only_failed_to_publish_still_succeeds(
+        self, rag, monkeypatch
+    ):
+        original = rag.entity_chunks.index_done_callback
+
+        async def _flush():
+            await original()
+            raise CommitBookkeepingError("published, not notified", result=None)
+
+        monkeypatch.setattr(rag.entity_chunks, "index_done_callback", _flush)
+        self._break_the_sink(monkeypatch)
+
+        result = await rag.delete_entity()
+
+        assert result.status == "success"
+        assert ENTITY not in rag.entity_chunks.records

--- a/tests/utils/test_storage_io_offload.py
+++ b/tests/utils/test_storage_io_offload.py
@@ -17,7 +17,11 @@ Pinned here:
   contract: it still declares no keyword arguments of its own;
 * ``commit_in_storage_io`` keeps a landed write and its bookkeeping together:
   the hook runs inside the same uncancellable region, and only if the write
-  actually happened.
+  actually happened;
+* the three outcomes stay distinguishable: ``fn`` raising propagates as itself
+  (nothing persisted), a failing hook becomes ``CommitBookkeepingError`` (the
+  write is durable, only its publication failed), and a cancelled caller still
+  gets ``CancelledError``.
 """
 
 import asyncio
@@ -29,6 +33,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from lightrag import utils as lr_utils
+from lightrag.exceptions import CommitBookkeepingError
 from lightrag.utils import (
     _bounded_submit_impl,
     bounded_submit,
@@ -426,17 +431,76 @@ async def test_commit_hook_failure_surfaces_when_not_cancelled():
     """Bookkeeping that fails must be reported, not swallowed.
 
     The write landed but the namespace was never flagged, so the caller has to
-    hear about it — ``_insert_done`` only detects failures via exceptions.
+    hear about it. It hears about it as ``CommitBookkeepingError``, never as the
+    hook's own exception: re-raising that made "the write is on disk and its
+    publication failed" indistinguishable from "nothing was persisted", and
+    every call site's ``except Exception`` then handled it as the latter —
+    rolling in-memory state back to a file that already has the mutation, and
+    reporting a durable write as one that never happened.
+    """
+
+    cause = RuntimeError("flag update failed")
+
+    async def on_committed():
+        raise cause
+
+    work = _BlockingWork(result="written")
+    work.release.set()
+
+    with pytest.raises(CommitBookkeepingError) as excinfo:
+        await commit_in_storage_io(work, on_committed)
+
+    assert excinfo.value.__cause__ is cause
+    assert "flag update failed" in str(excinfo.value)
+    # The write's own answer travels with it, so a handler that needs it does
+    # not have to re-run the write to find out.
+    assert excinfo.value.result == "written"
+
+
+async def test_a_failed_write_is_not_reported_as_a_landed_one():
+    """The contrast that gives the typed error its meaning.
+
+    ``fn`` raising means nothing was persisted, and that must keep arriving as
+    the backend's own exception — a handler that treats it as
+    ``CommitBookkeepingError`` would skip the rollback the failure needs.
+    """
+    hook_ran = []
+
+    async def on_committed():  # pragma: no cover — must not run
+        hook_ran.append(1)
+
+    work = _BlockingWork(exc=OSError("disk full"))
+    work.release.set()
+
+    with pytest.raises(OSError) as excinfo:
+        await commit_in_storage_io(work, on_committed)
+
+    assert not isinstance(excinfo.value, CommitBookkeepingError)
+    assert hook_ran == []
+
+
+async def test_a_cancelled_caller_still_gets_cancelled_not_the_typed_error():
+    """R2 covers the hook-failure path only; cancellation is unchanged.
+
+    A deferred cancellation outranks the hook's failure, because a caller that
+    was cancelled must not be told a storage error happened instead. The
+    deletion paths in ``utils_graph`` depend on this: they give up their
+    tracking cleanup on ``CancelledError`` (it carries no evidence about what
+    landed) and proceed on ``CommitBookkeepingError`` (which does).
     """
 
     async def on_committed():
         raise RuntimeError("flag update failed")
 
     work = _BlockingWork()
+    task = asyncio.create_task(commit_in_storage_io(work, on_committed))
+
+    await _wait_for(work.started.is_set)
+    task.cancel()
     work.release.set()
 
-    with pytest.raises(RuntimeError, match="flag update failed"):
-        await commit_in_storage_io(work, on_committed)
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 async def test_on_committed_requires_wait_for_completion():


### PR DESCRIPTION
## Description

R2 of #3838 — *"Make a landed write distinguishable from a failed one"*, which closes **M4**.

`commit_in_storage_io` runs its `on_committed` hook only after the write succeeded, so an exception out of that hook means the file is **already on disk**. It was re-raised as-is, landed in every call site's generic `except Exception`, and was handled there by reasoning that only holds for a write that never happened: roll the in-memory state back to the file, and report the mutation as lost.

`NetworkXStorage` worked around that with a list its hook appended to instead of raising (bc7ed9e9, 1608750e). The other four file backends had no such workaround, so a failing publication still reported a durable write as a failed one:

* `_insert_done` marks a document FAILED whose rows are persisted;
* `utils_graph`'s deletion paths turn a chunk-tracking cleanup they have **already completed** into `fail`/500 — which strands, on the retry that follows, the incident relation rows the `not_found` sweep can no longer reach (the edges that named them are gone with the node).

The fix types the failure rather than working around it per backend.

## Related Issues

Implements R2 of #3838. R1 landed in #3856; R3–R5 are still open. Findings from review that belong to #3854 are recorded there rather than fixed here — see *Review rounds* below.

## Changes Made

**`lightrag/exceptions.py`** — new `CommitBookkeepingError(RuntimeError)`: *the write LANDED, the bookkeeping that had to follow it did not*. Carries `result` (the write callable's own return value) and the hook's failure as `__cause__`. Its docstring states the handler contract: treat the write as committed, log the deferred visibility, never report it as a failed write and never swallow it silently.

**`lightrag/utils.py`** — `_bounded_submit_impl` raises it in place of the hook's own exception. A `BaseException` that is not an `Exception` still propagates unwrapped (a `SystemExit` is a shutdown request, not a storage error). The cancellation path is untouched, as R2 requires: a deferred `CancelledError` still wins, because it carries no evidence about what landed and `adelete_by_entity` deliberately gives up its cleanup on it (fad3316).

**Every `commit_in_storage_io` call site** now handles the typed error as a committed write:

| site | before | after |
| --- | --- | --- |
| `networkx_impl.index_done_callback` | `publish_error` list appended inside the hook | same behaviour, expressed through the typed handler |
| `json_kv_impl` / `json_doc_status_impl.index_done_callback` | hook failure raised → durable write reported lost | logged, commit reported as landed |
| `nano_vector_db_impl._save_to_disk_locked`, `faiss_impl._save_faiss_index` | same | logged, `index_done_callback` returns `True` |
| the three `drop()` paths | `except Exception` → `{"status": "error"}` for a completed destruction | reported as the success it is |

Each residue heals on its own and the log says so: the dirty flags stay set, so the next commit rewrites the same snapshot and notifies again; an unreset `storage_updated` only makes this process reload the file it just wrote.

Every one of these diagnostics goes through `log_without_raising`. They sit past a point of no return, so a logging handler, formatter or output target that raises must not escape and re-create the misreport the handler exists to prevent.

**`lightrag/utils_graph.py`** — `_commit_graph_or_raise` and `_persist_graph_updates` absorb it too, so a graph backend that hands the decision up instead of absorbing it is not read as a declined commit. The deletion then proceeds with the tracking cleanup it owes and answers `success`, with the lost cross-process visibility in the log — the behaviour R2 specifies (attempt the cleanup; a real failure keeps today's `fail`/500 with the orphaned keys named; success returns success).

**Two limits on what is absorbed**, both from review and both load-bearing:

* **Nano / FAISS retire their redo logs only past the publication.** They used to clear `_unsaved_upserts` / `_unsaved_deletes` as the hook's first step. A peer that never learned of the commit can save its older snapshot over these rows (the fence gap tracked in #3854, which no commit-status choice closes), and with the redo log already cleared those rows were gone from disk *and* from memory: permanent, and silent. Retiring them past the publication means the next flush reloads the foreign snapshot and replays them on top, through the path #3688 built for a failed save. Replay is idempotent — an unchanged file matches by fingerprint and writes nothing; a genuinely newer row under the same id is declined by `_resident_supersedes_redo`.
* **A failed JSON sanitize-reload is not absorbed.** That hook does two unlike things and only one is publication. `self._data.clear()` and `self._data.update()` are separate RPCs on a `Manager().dict()`, so a failure between them leaves the shared dict EMPTY while the file on disk is correct — and the dirty flags are still set, so the next flush would write that empty dict straight over it. Absorbing belongs to `clear_all_update_flags` alone; a reconciliation failure is re-raised as its own exception, deliberately not as `CommitBookkeepingError` (callers read that type as "committed, only publication deferred", and `_persist_graph_updates` absorbs it).

## What's broken / behaviour changes

* A JSON, Nano or FAISS commit whose **publication** fails now completes instead of raising. A document whose writes landed but whose notification failed is PROCESSED, not FAILED — the same direction bc7ed9e9 already took for NetworkX, and correct: the data is on disk and reprocessing would re-merge what is already there.
* An entity/relation deletion whose graph commit published but failed to notify now answers `success` and retires its tracking rows, instead of `fail`/500 with the rows stranded.
* A file-backed `drop()` whose post-removal bookkeeping fails reports `success`, not `error`.
* Nano / FAISS keep their redo logs across a failed publication, so those entries survive one extra commit cycle and the read paths keep serving them until the next flush retires or supersedes them.
* What is **not** changed: a write that never landed still raises the backend's own exception; a cancelled caller still gets `CancelledError`; and a JSON reconciliation failure still raises.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed — three Codex rounds, all findings addressed or scoped (below)
- [x] Documentation updated (if necessary) — docstrings and the contract on the new exception; R5 covers the class-docstring/`ProgramingWithCore.md` work
- [x] Unit tests added (if applicable)

## Review rounds

| finding | outcome |
| --- | --- |
| **P1** An unnotified peer can overwrite this commit | The window is #3854's — the reload fence is gated solely on `storage_updated.value` in NetworkX, Nano *and* FAISS, and raising flips no flags either, so no commit-status choice closes it. Recorded on #3854 (which asked for exactly this check on Nano), with the durable `mtime`/`size` fence left to it. What *was* in reach — the loss being unrecoverable — is fixed here by the redo-log ordering above. |
| **P2** The committed-write log is unguarded | Fixed. All seven handlers now use `log_without_raising`. |
| **P1** JSON reconciliation failures must not be absorbed | Fixed. The absorb is narrowed to the flag clear; see above. The window itself predates this PR (the reconciliation was never restored on failure) — what this PR had added was silence over it. |

## Additional Notes

**Tests** (acceptance: *"distinguish the three outcomes: write failed, write landed with a failing hook, and caller cancelled — and assert `adelete_by_entity` cleans up its tracking rows in the middle case only"*):

* `tests/utils/test_storage_io_offload.py` — the three outcomes at the helper level, plus `result` / `__cause__`;
* `tests/pipeline/test_graph_deletion_tracking_ordering.py::TestPublishedCommitIsNotAFailure` — the same three at the `adelete_by_entity` level: rows cleaned in the middle case only, kept in the other two;
* `tests/kg/{json,nano,faiss,networkx}_impl/` — a failing notification is not reported as a failed write, the data is on disk, and the dirty bit stays set so the publication is retried;
* the review-round additions: redo-log retention plus an end-to-end recovery case on both vector backends (commit → fail the notification → let a peer publish a snapshot that never saw the row → flush → the row is back), a broken-sink case on every handler this sandbox can run, and `test_a_failed_sanitize_reload_is_not_absorbed`.

Every new test was verified to go red with its fix reverted.

**Suites run:** `tests/utils`, `tests/kg`, `tests/pipeline`. The full suite was run before and after the change and produced an **identical** failure set — all of them pre-existing in this sandbox (optional backends such as `faiss`/`qdrant` and the spaCy models are not installable here), so the FAISS tests are skipped locally and CI is the first place they run.

**Design note worth a reviewer's eye:** `_commit_graph_or_raise`'s `except CommitBookkeepingError` is unreachable with today's backends, since `NetworkXStorage` absorbs its own publication failure and no other graph backend uses `commit_in_storage_io`. It is deliberate defensive scaffolding, labelled as such in the docstring: the default behaviour without it (treat the typed error as a declined commit) is the data-losing one, and R2 names this catch explicitly.

**Follow-up worth its own issue, not done here:** *eliminating* the JSON reconciliation window rather than reporting it. There is no atomic way to replace a `DictProxy`'s contents, but an update-then-prune ordering would leave a superset in every failure position instead of an empty dict, which converges on the next flush. That changes the reconciliation algorithm, which R2 does not otherwise touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FcH1nQSTieHWuEcCw3hHJ