### PR TITLE
fix(hf): run generate() and embedding forward pass off the event loop thread

### DIFF
--- a/lightrag/llm/hf.py
+++ b/lightrag/llm/hf.py
@@ -47,6 +47,17 @@ def initialize_hf_model(model_name):
     return hf_model, hf_tokenizer
 
 
+# initialize_hf_model caches a single model instance (maxsize=1), and the
+# same instance backs every concurrent hf_model_if_cache call. PyTorch's
+# generate() is not safe to call concurrently against one model from
+# multiple threads (shared KV-cache/internal buffers can corrupt output),
+# and concurrent generations multiply GPU memory usage per call. Blocking
+# the event loop used to serialize this by accident -- asyncio.to_thread
+# does not, so this lock keeps only one generate() call in flight at a
+# time without blocking unrelated async work.
+_generate_lock = asyncio.Lock()
+
+
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=4, max=10),
@@ -127,13 +138,14 @@ async def hf_model_if_cache(
     # of bridging synchronous PyTorch inference through asyncio.to_thread,
     # not something fixable at this call site.
     try:
-        output = await asyncio.to_thread(
-            hf_model.generate,
-            **inputs,
-            max_new_tokens=max_new_tokens,
-            num_return_sequences=1,
-            early_stopping=True,
-        )
+        async with _generate_lock:
+            output = await asyncio.to_thread(
+                hf_model.generate,
+                **inputs,
+                max_new_tokens=max_new_tokens,
+                num_return_sequences=1,
+                early_stopping=True,
+            )
     except asyncio.CancelledError:
         logger.warning(
             "hf_model_if_cache: cancelled while awaiting generate(); "

--- a/lightrag/llm/hf.py
+++ b/lightrag/llm/hf.py
@@ -287,13 +287,22 @@ async def hf_embed(
             hidden_fp32 = outputs.last_hidden_state.to(torch.float32)
             summed = (hidden_fp32 * mask).sum(dim=1)
             counts = mask.sum(dim=1).clamp_min(1)
-            return (summed / counts).to(outputs.last_hidden_state.dtype)
+            embeddings = (summed / counts).to(outputs.last_hidden_state.dtype)
+
+        # Convert to NumPy in the same thread: .cpu() on a CUDA tensor
+        # synchronizes the device (waits for pending GPU work to finish),
+        # which can block just as long as the forward pass itself -- doing
+        # it back on the event loop thread would defeat the point of
+        # offloading generate()/the forward pass in the first place.
+        if embeddings.dtype == torch.bfloat16:
+            return embeddings.detach().to(torch.float32).cpu().numpy()
+        return embeddings.detach().cpu().numpy()
 
     # Same cancellation caveat as hf_model_if_cache's generate() call: a
     # timeout here cannot stop the forward pass early, only stop waiting
     # for it.
     try:
-        embeddings = await asyncio.to_thread(_run_forward)
+        return await asyncio.to_thread(_run_forward)
     except asyncio.CancelledError:
         logger.warning(
             "hf_embed: cancelled while awaiting the forward pass; the "
@@ -301,9 +310,3 @@ async def hf_embed(
             "completes on its own"
         )
         raise
-
-    # Convert embeddings to NumPy
-    if embeddings.dtype == torch.bfloat16:
-        return embeddings.detach().to(torch.float32).cpu().numpy()
-    else:
-        return embeddings.detach().cpu().numpy()

--- a/lightrag/llm/hf.py
+++ b/lightrag/llm/hf.py
@@ -54,6 +54,28 @@ _HF_INFERENCE_EXECUTOR = None
 _HF_INFERENCE_EXECUTOR_GUARD = threading.Lock()
 
 
+def _reset_hf_inference_executor_after_fork() -> None:
+    """A forked child (e.g. a gunicorn pre-fork worker) inherits a copy of
+    the parent's ThreadPoolExecutor object, but fork() only carries the
+    calling thread into the child -- the pool's own worker thread does not
+    exist there. Submitting through the stale executor would hang forever
+    (the job sits queued with no live worker to pick it up). The guard lock
+    is just as unsafe to inherit: if fork happens while some other thread
+    holds it, the child sees it permanently locked, since only the forking
+    thread survives to ever release it. Reset both so the next call in the
+    child lazily builds a fresh executor and lock instead.
+    """
+    global _HF_INFERENCE_EXECUTOR, _HF_INFERENCE_EXECUTOR_GUARD
+    _HF_INFERENCE_EXECUTOR = None
+    _HF_INFERENCE_EXECUTOR_GUARD = threading.Lock()
+
+
+# os.fork() (and therefore os.register_at_fork) doesn't exist on Windows --
+# there is no post-fork state to repair there.
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_hf_inference_executor_after_fork)
+
+
 def _get_hf_inference_executor() -> ThreadPoolExecutor:
     """Return the process-wide worker used for local HF inference."""
     global _HF_INFERENCE_EXECUTOR

--- a/lightrag/llm/hf.py
+++ b/lightrag/llm/hf.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import os
 import warnings
@@ -117,7 +118,11 @@ async def hf_model_if_cache(
     # hf_model is loaded with device_map="auto" (see initialize_hf_model),
     # so hf_model.device already reflects accelerate's placement.
     inputs = {k: v.to(hf_model.device) for k, v in input_ids.items()}
-    output = hf_model.generate(
+    # generate() runs the actual model inference synchronously and can take
+    # seconds to minutes -- calling it directly here would block the whole
+    # event loop for that duration, stalling every other concurrent task.
+    output = await asyncio.to_thread(
+        hf_model.generate,
         **inputs,
         max_new_tokens=max_new_tokens,
         num_return_sequences=1,
@@ -244,28 +249,34 @@ async def hf_embed(
         texts, return_tensors="pt", padding=True, truncation=True
     ).to(device)
 
-    # Perform inference
-    with torch.no_grad():
-        attention_mask = encoded_texts["attention_mask"]
-        outputs = embed_model(
-            input_ids=encoded_texts["input_ids"],
-            attention_mask=attention_mask,
-        )
-        # Plain .mean(dim=1) counts padding-token hidden states, so the same
-        # text's embedding shifts depending on what else is in the batch.
-        # Weight by attention_mask instead. The reduction runs in float32
-        # regardless of the model's own dtype: accumulating in fp16/bf16
-        # risks the summed hidden states overflowing to infinity on long
-        # inputs, and token counts above ~2048 (fp16) or ~256 (bf16) can't
-        # be represented exactly, biasing the mean. clamp_min(1) keeps a
-        # fully-masked row finite (all-padding input) rather than dividing
-        # by zero. The result is cast back to the original hidden-state
-        # dtype so output dtype behaviour is unchanged.
-        mask = attention_mask.unsqueeze(-1).to(torch.float32)
-        hidden_fp32 = outputs.last_hidden_state.to(torch.float32)
-        summed = (hidden_fp32 * mask).sum(dim=1)
-        counts = mask.sum(dim=1).clamp_min(1)
-        embeddings = (summed / counts).to(outputs.last_hidden_state.dtype)
+    # Perform inference. The forward pass is synchronous model compute that
+    # can take seconds -- run it off the event loop thread, same reasoning
+    # as hf_model_if_cache's generate() call.
+    def _run_forward():
+        with torch.no_grad():
+            attention_mask = encoded_texts["attention_mask"]
+            outputs = embed_model(
+                input_ids=encoded_texts["input_ids"],
+                attention_mask=attention_mask,
+            )
+            # Plain .mean(dim=1) counts padding-token hidden states, so the
+            # same text's embedding shifts depending on what else is in the
+            # batch. Weight by attention_mask instead. The reduction runs in
+            # float32 regardless of the model's own dtype: accumulating in
+            # fp16/bf16 risks the summed hidden states overflowing to
+            # infinity on long inputs, and token counts above ~2048 (fp16)
+            # or ~256 (bf16) can't be represented exactly, biasing the mean.
+            # clamp_min(1) keeps a fully-masked row finite (all-padding
+            # input) rather than dividing by zero. The result is cast back
+            # to the original hidden-state dtype so output dtype behaviour
+            # is unchanged.
+            mask = attention_mask.unsqueeze(-1).to(torch.float32)
+            hidden_fp32 = outputs.last_hidden_state.to(torch.float32)
+            summed = (hidden_fp32 * mask).sum(dim=1)
+            counts = mask.sum(dim=1).clamp_min(1)
+            return (summed / counts).to(outputs.last_hidden_state.dtype)
+
+    embeddings = await asyncio.to_thread(_run_forward)
 
     # Convert embeddings to NumPy
     if embeddings.dtype == torch.bfloat16:

--- a/lightrag/llm/hf.py
+++ b/lightrag/llm/hf.py
@@ -28,7 +28,7 @@ from lightrag.exceptions import (
 )
 import torch
 import numpy as np
-from lightrag.utils import TruncatedResponse, wrap_embedding_func_with_attrs
+from lightrag.utils import TruncatedResponse, logger, wrap_embedding_func_with_attrs
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -63,8 +63,6 @@ async def hf_model_if_cache(
     **kwargs,
 ) -> str:
     if enable_cot:
-        from lightrag.utils import logger
-
         logger.debug(
             "enable_cot=True is not supported for Hugging Face local models and will be ignored."
         )
@@ -121,13 +119,28 @@ async def hf_model_if_cache(
     # generate() runs the actual model inference synchronously and can take
     # seconds to minutes -- calling it directly here would block the whole
     # event loop for that duration, stalling every other concurrent task.
-    output = await asyncio.to_thread(
-        hf_model.generate,
-        **inputs,
-        max_new_tokens=max_new_tokens,
-        num_return_sequences=1,
-        early_stopping=True,
-    )
+    #
+    # Cancelling this await (e.g. an outer execution timeout) only cancels
+    # the asyncio wrapper: CPython cannot forcibly stop a running thread, so
+    # generate() keeps running -- and keeps holding whatever GPU memory it
+    # allocated -- until it finishes on its own. This is an inherent limit
+    # of bridging synchronous PyTorch inference through asyncio.to_thread,
+    # not something fixable at this call site.
+    try:
+        output = await asyncio.to_thread(
+            hf_model.generate,
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            num_return_sequences=1,
+            early_stopping=True,
+        )
+    except asyncio.CancelledError:
+        logger.warning(
+            "hf_model_if_cache: cancelled while awaiting generate(); "
+            "the model keeps running in the background thread, still "
+            "holding its allocated memory, until it completes on its own"
+        )
+        raise
     generated_ids = output[0][len(inputs["input_ids"][0]) :]
     response_text = hf_tokenizer.decode(generated_ids, skip_special_tokens=True)
 
@@ -276,7 +289,18 @@ async def hf_embed(
             counts = mask.sum(dim=1).clamp_min(1)
             return (summed / counts).to(outputs.last_hidden_state.dtype)
 
-    embeddings = await asyncio.to_thread(_run_forward)
+    # Same cancellation caveat as hf_model_if_cache's generate() call: a
+    # timeout here cannot stop the forward pass early, only stop waiting
+    # for it.
+    try:
+        embeddings = await asyncio.to_thread(_run_forward)
+    except asyncio.CancelledError:
+        logger.warning(
+            "hf_embed: cancelled while awaiting the forward pass; the "
+            "model keeps running in the background thread until it "
+            "completes on its own"
+        )
+        raise
 
     # Convert embeddings to NumPy
     if embeddings.dtype == torch.bfloat16:

--- a/lightrag/llm/hf.py
+++ b/lightrag/llm/hf.py
@@ -1,7 +1,10 @@
 import asyncio
 import copy
+import contextvars
 import os
+import threading
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 
 import pipmaster as pm  # Pipmaster for dynamic library install
@@ -47,15 +50,38 @@ def initialize_hf_model(model_name):
     return hf_model, hf_tokenizer
 
 
-# initialize_hf_model caches a single model instance (maxsize=1), and the
-# same instance backs every concurrent hf_model_if_cache call. PyTorch's
-# generate() is not safe to call concurrently against one model from
-# multiple threads (shared KV-cache/internal buffers can corrupt output),
-# and concurrent generations multiply GPU memory usage per call. Blocking
-# the event loop used to serialize this by accident -- asyncio.to_thread
-# does not, so this lock keeps only one generate() call in flight at a
-# time without blocking unrelated async work.
-_generate_lock = asyncio.Lock()
+_HF_INFERENCE_EXECUTOR = None
+_HF_INFERENCE_EXECUTOR_GUARD = threading.Lock()
+
+
+def _get_hf_inference_executor() -> ThreadPoolExecutor:
+    """Return the process-wide worker used for local HF inference."""
+    global _HF_INFERENCE_EXECUTOR
+    if _HF_INFERENCE_EXECUTOR is None:
+        with _HF_INFERENCE_EXECUTOR_GUARD:
+            if _HF_INFERENCE_EXECUTOR is None:
+                _HF_INFERENCE_EXECUTOR = ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="lightrag-hf-inference"
+                )
+    return _HF_INFERENCE_EXECUTOR
+
+
+async def _run_hf_inference(fn, /, *args, **kwargs):
+    """Run one inference job without binding synchronisation to an event loop."""
+    concurrent_future = _get_hf_inference_executor().submit(
+        contextvars.copy_context().run, lambda: fn(*args, **kwargs)
+    )
+    async_future = asyncio.wrap_future(concurrent_future)
+    async_future.add_done_callback(
+        lambda future: None if future.cancelled() else future.exception()
+    )
+    try:
+        return await asyncio.shield(async_future)
+    except asyncio.CancelledError:
+        # This succeeds only while the job is still queued. A running job keeps
+        # occupying the sole worker until the underlying model call returns.
+        concurrent_future.cancel()
+        raise
 
 
 @retry(
@@ -135,22 +161,21 @@ async def hf_model_if_cache(
     # the asyncio wrapper: CPython cannot forcibly stop a running thread, so
     # generate() keeps running -- and keeps holding whatever GPU memory it
     # allocated -- until it finishes on its own. This is an inherent limit
-    # of bridging synchronous PyTorch inference through asyncio.to_thread,
+    # of bridging synchronous PyTorch inference through a worker thread,
     # not something fixable at this call site.
     try:
-        async with _generate_lock:
-            output = await asyncio.to_thread(
-                hf_model.generate,
-                **inputs,
-                max_new_tokens=max_new_tokens,
-                num_return_sequences=1,
-                early_stopping=True,
-            )
+        output = await _run_hf_inference(
+            hf_model.generate,
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            num_return_sequences=1,
+            early_stopping=True,
+        )
     except asyncio.CancelledError:
         logger.warning(
             "hf_model_if_cache: cancelled while awaiting generate(); "
-            "the model keeps running in the background thread, still "
-            "holding its allocated memory, until it completes on its own"
+            "if generation already started, the model keeps running in "
+            "the background thread until it completes"
         )
         raise
     generated_ids = output[0][len(inputs["input_ids"][0]) :]
@@ -314,11 +339,11 @@ async def hf_embed(
     # timeout here cannot stop the forward pass early, only stop waiting
     # for it.
     try:
-        return await asyncio.to_thread(_run_forward)
+        return await _run_hf_inference(_run_forward)
     except asyncio.CancelledError:
         logger.warning(
             "hf_embed: cancelled while awaiting the forward pass; the "
-            "model keeps running in the background thread until it "
-            "completes on its own"
+            "model keeps running in the background thread if inference "
+            "already started"
         )
         raise

--- a/tests/llm/hf_impl/test_hf_off_event_loop.py
+++ b/tests/llm/hf_impl/test_hf_off_event_loop.py
@@ -11,6 +11,7 @@ sibling hf tests in this directory.
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import threading
 import types
@@ -127,6 +128,71 @@ async def test_hf_model_if_cache_runs_generate_off_the_event_loop_thread(
 
 
 @pytest.mark.asyncio
+async def test_hf_model_if_cache_logs_and_repropagates_cancellation(
+    hf_module, monkeypatch
+):
+    """Cancelling the outer await (e.g. an execution timeout) still has to
+    propagate CancelledError, with a warning noting generate() keeps
+    running -- and keeps holding its allocated memory -- in the background
+    thread until it completes on its own."""
+    call_started = threading.Event()
+    release_call = threading.Event()
+    warnings_logged = []
+
+    class FakeModel:
+        def __init__(self):
+            self.device = FakeDevice("cpu")
+            self.generation_config = types.SimpleNamespace(eos_token_id=0)
+
+        def generate(self, **kwargs):
+            call_started.set()
+            release_call.wait(timeout=5)
+            input_ids = kwargs["input_ids"]
+            return FakeTensor([input_ids.data[0] + [901, 902]], "cpu")
+
+    class FakeTokenizer:
+        eos_token_id = 0
+
+        def apply_chat_template(
+            self, messages, tokenize=False, add_generation_prompt=True
+        ):
+            return "<prompt>"
+
+        def __call__(self, text, return_tensors="pt", padding=True, truncation=True):
+            return {
+                "input_ids": FakeTensor([[1, 2, 3]]),
+                "attention_mask": FakeTensor([[1, 1, 1]]),
+            }
+
+        def decode(self, tensor, skip_special_tokens=True):
+            return f"decoded:{tensor.data}"
+
+    monkeypatch.setattr(
+        hf_module, "initialize_hf_model", lambda name: (FakeModel(), FakeTokenizer())
+    )
+    monkeypatch.setattr(
+        hf_module.logger, "warning", lambda msg: warnings_logged.append(msg)
+    )
+
+    task = asyncio.ensure_future(
+        hf_module.hf_model_if_cache("fake-model", "hello world")
+    )
+    for _ in range(500):
+        if call_started.is_set():
+            break
+        await asyncio.sleep(0.01)
+    assert call_started.is_set()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    release_call.set()
+    assert len(warnings_logged) == 1
+    assert "cancelled while awaiting generate()" in warnings_logged[0]
+
+
+@pytest.mark.asyncio
 async def test_hf_embed_runs_forward_pass_off_the_event_loop_thread(hf_module):
     main_thread_id = threading.get_ident()
     call_thread_id = {}
@@ -190,3 +256,87 @@ async def test_hf_embed_runs_forward_pass_off_the_event_loop_thread(hf_module):
 
     assert result.shape == (1, 1024)
     assert call_thread_id["id"] != main_thread_id
+
+
+@pytest.mark.asyncio
+async def test_hf_embed_logs_and_repropagates_cancellation(hf_module, monkeypatch):
+    call_started = threading.Event()
+    release_call = threading.Event()
+    warnings_logged = []
+
+    class _FakeModelOutput:
+        def __init__(self, last_hidden_state):
+            self.last_hidden_state = last_hidden_state
+
+    class _FakeHidden:
+        dtype = "float32"
+
+        def unsqueeze(self, dim):
+            return self
+
+        def to(self, target):
+            return self
+
+        def __mul__(self, other):
+            return self
+
+        def sum(self, dim):
+            return self
+
+        def clamp_min(self, value):
+            return self
+
+        def __truediv__(self, other):
+            return self
+
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def numpy(self):
+            return np.zeros((1, 1024), dtype=np.float32)
+
+    class _FakeEmbedModel:
+        def to(self, device):
+            return self
+
+        def __call__(self, input_ids, attention_mask):
+            call_started.set()
+            release_call.wait(timeout=5)
+            return _FakeModelOutput(_FakeHidden())
+
+        def parameters(self):
+            yield _FakeHidden()
+
+    class _FakeTokenizerOutput(dict):
+        def to(self, device):
+            return self
+
+    class _FakeTokenizer:
+        def __call__(self, texts, return_tensors="pt", padding=True, truncation=True):
+            return _FakeTokenizerOutput(
+                {"input_ids": _FakeHidden(), "attention_mask": _FakeHidden()}
+            )
+
+    monkeypatch.setattr(
+        hf_module.logger, "warning", lambda msg: warnings_logged.append(msg)
+    )
+
+    task = asyncio.ensure_future(
+        hf_module.hf_embed(["hello"], _FakeTokenizer(), _FakeEmbedModel())
+    )
+    for _ in range(500):
+        if call_started.is_set():
+            break
+        await asyncio.sleep(0.01)
+    assert call_started.is_set()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    release_call.set()
+    assert len(warnings_logged) == 1
+    assert "cancelled while awaiting the forward pass" in warnings_logged[0]

--- a/tests/llm/hf_impl/test_hf_off_event_loop.py
+++ b/tests/llm/hf_impl/test_hf_off_event_loop.py
@@ -259,6 +259,75 @@ async def test_hf_embed_runs_forward_pass_off_the_event_loop_thread(hf_module):
 
 
 @pytest.mark.asyncio
+async def test_hf_embed_runs_cpu_conversion_off_the_event_loop_thread(hf_module):
+    """.cpu() on a CUDA tensor synchronizes the device (blocks until
+    pending GPU work finishes), which can take as long as the forward pass
+    itself -- it must run in the same background thread, not back on the
+    event loop after the forward pass returns."""
+    main_thread_id = threading.get_ident()
+    cpu_call_thread_id = {}
+
+    class _FakeModelOutput:
+        def __init__(self, last_hidden_state):
+            self.last_hidden_state = last_hidden_state
+
+    class _FakeHidden:
+        dtype = "float32"
+
+        def unsqueeze(self, dim):
+            return self
+
+        def to(self, target):
+            return self
+
+        def __mul__(self, other):
+            return self
+
+        def sum(self, dim):
+            return self
+
+        def clamp_min(self, value):
+            return self
+
+        def __truediv__(self, other):
+            return self
+
+        def detach(self):
+            return self
+
+        def cpu(self):
+            cpu_call_thread_id["id"] = threading.get_ident()
+            return self
+
+        def numpy(self):
+            return np.zeros((1, 1024), dtype=np.float32)
+
+    class _FakeEmbedModel:
+        def to(self, device):
+            return self
+
+        def __call__(self, input_ids, attention_mask):
+            return _FakeModelOutput(_FakeHidden())
+
+        def parameters(self):
+            yield _FakeHidden()
+
+    class _FakeTokenizerOutput(dict):
+        def to(self, device):
+            return self
+
+    class _FakeTokenizer:
+        def __call__(self, texts, return_tensors="pt", padding=True, truncation=True):
+            return _FakeTokenizerOutput(
+                {"input_ids": _FakeHidden(), "attention_mask": _FakeHidden()}
+            )
+
+    await hf_module.hf_embed(["hello"], _FakeTokenizer(), _FakeEmbedModel())
+
+    assert cpu_call_thread_id["id"] != main_thread_id
+
+
+@pytest.mark.asyncio
 async def test_hf_embed_logs_and_repropagates_cancellation(hf_module, monkeypatch):
     call_started = threading.Event()
     release_call = threading.Event()

--- a/tests/llm/hf_impl/test_hf_off_event_loop.py
+++ b/tests/llm/hf_impl/test_hf_off_event_loop.py
@@ -128,6 +128,88 @@ async def test_hf_model_if_cache_runs_generate_off_the_event_loop_thread(
 
 
 @pytest.mark.asyncio
+async def test_hf_model_if_cache_serializes_concurrent_generate_calls(
+    hf_module, monkeypatch
+):
+    """initialize_hf_model caches a single model instance shared by every
+    concurrent hf_model_if_cache call (e.g. extract_entities() fanning out
+    up to llm_model_max_async chunks). generate() is not safe to call
+    concurrently against one model from multiple threads -- blocking the
+    event loop used to serialize this by accident; asyncio.to_thread does
+    not, so only one generate() call must ever be in flight at a time."""
+    in_generate = threading.Event()
+    release_generate = threading.Event()
+    concurrent_calls = {"count": 0, "max": 0}
+    lock = threading.Lock()
+
+    class FakeModel:
+        def __init__(self):
+            self.device = FakeDevice("cpu")
+            self.generation_config = types.SimpleNamespace(eos_token_id=0)
+
+        def generate(self, **kwargs):
+            with lock:
+                concurrent_calls["count"] += 1
+                concurrent_calls["max"] = max(
+                    concurrent_calls["max"], concurrent_calls["count"]
+                )
+            in_generate.set()
+            release_generate.wait(timeout=5)
+            with lock:
+                concurrent_calls["count"] -= 1
+            input_ids = kwargs["input_ids"]
+            return FakeTensor([input_ids.data[0] + [901, 902]], "cpu")
+
+    class FakeTokenizer:
+        eos_token_id = 0
+
+        def apply_chat_template(
+            self, messages, tokenize=False, add_generation_prompt=True
+        ):
+            return "<prompt>"
+
+        def __call__(self, text, return_tensors="pt", padding=True, truncation=True):
+            return {
+                "input_ids": FakeTensor([[1, 2, 3]]),
+                "attention_mask": FakeTensor([[1, 1, 1]]),
+            }
+
+        def decode(self, tensor, skip_special_tokens=True):
+            return f"decoded:{tensor.data}"
+
+    monkeypatch.setattr(
+        hf_module, "initialize_hf_model", lambda name: (FakeModel(), FakeTokenizer())
+    )
+
+    task1 = asyncio.ensure_future(
+        hf_module.hf_model_if_cache("fake-model", "hello world")
+    )
+    for _ in range(500):
+        if in_generate.is_set():
+            break
+        await asyncio.sleep(0.01)
+    assert in_generate.is_set()
+
+    # A second call must queue behind the lock instead of starting a
+    # second concurrent generate().
+    task2 = asyncio.ensure_future(
+        hf_module.hf_model_if_cache("fake-model", "hello again")
+    )
+    await asyncio.sleep(0.05)
+    assert concurrent_calls["count"] == 1
+
+    # release_generate is a one-shot latch: once set it stays set, so
+    # task2's own generate() call (once it gets the lock) will not block
+    # on it either -- that's fine, the queueing behavior was already
+    # proven by the count==1 check above.
+    release_generate.set()
+    await task1
+    await task2
+
+    assert concurrent_calls["max"] == 1
+
+
+@pytest.mark.asyncio
 async def test_hf_model_if_cache_logs_and_repropagates_cancellation(
     hf_module, monkeypatch
 ):

--- a/tests/llm/hf_impl/test_hf_off_event_loop.py
+++ b/tests/llm/hf_impl/test_hf_off_event_loop.py
@@ -12,6 +12,7 @@ sibling hf tests in this directory.
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import threading
 import types
@@ -81,6 +82,31 @@ def test_hf_inference_executor_works_across_successive_event_loops(hf_module):
 
     assert asyncio.run(run_once()) == "ok"
     assert asyncio.run(run_once()) == "ok"
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="fork() is POSIX-only")
+def test_inference_executor_resets_after_fork(hf_module):
+    """A forked child (e.g. a gunicorn pre-fork worker) inherits a COPY of
+    the parent's ThreadPoolExecutor object and its guard lock, but fork()
+    only carries the calling thread into the child -- the pool's own
+    worker thread (and, if some other thread held the guard lock at fork
+    time, the thread that would release it) do not exist there. Submitting
+    through the stale executor would hang forever. os.register_at_fork
+    must reset both so the child lazily builds a fresh pair."""
+    hf_module._get_hf_inference_executor()
+    assert hf_module._HF_INFERENCE_EXECUTOR is not None
+
+    pid = os.fork()
+    if pid == 0:
+        # Child: exit immediately via os._exit so control never returns to
+        # pytest's own machinery here (fixture teardown, etc. must run
+        # exactly once, in the parent only).
+        ok = hf_module._HF_INFERENCE_EXECUTOR is None
+        os._exit(0 if ok else 1)
+
+    _, status = os.waitpid(pid, 0)
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0
 
 
 def test_cancelled_queued_hf_inference_does_not_run(hf_module):

--- a/tests/llm/hf_impl/test_hf_off_event_loop.py
+++ b/tests/llm/hf_impl/test_hf_off_event_loop.py
@@ -1,0 +1,192 @@
+"""hf_model_if_cache() and hf_embed() run real, synchronous PyTorch compute
+(hf_model.generate() / a forward pass) that can take seconds to minutes.
+Calling either directly from these async functions would block the whole
+event loop for that duration, stalling every other concurrent task. Both
+must run their blocking call on a worker thread instead.
+
+lightrag/llm/hf.py imports transformers and torch at module level. Neither
+is a project dependency, so both are stubbed here, same approach as the
+sibling hf tests in this directory.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+import importlib
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.offline
+
+
+class FakeDevice:
+    def __init__(self, name):
+        self.type = name
+
+
+class FakeTensor:
+    def __init__(self, data, device="cpu"):
+        self.data = data
+        self.device = FakeDevice(device)
+
+    def to(self, device):
+        return FakeTensor(self.data, device)
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        return FakeTensor(self.data[idx], self.device.type)
+
+    def item(self):
+        return self.data
+
+
+def install_fake_transformers_and_torch(monkeypatch):
+    fake_transformers = types.ModuleType("transformers")
+    fake_transformers.AutoTokenizer = object
+    fake_transformers.AutoModelForCausalLM = object
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+    class _NullContext:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *exc):
+            return False
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.float32 = "float32"
+    fake_torch.bfloat16 = "bfloat16"
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    fake_torch.backends = types.SimpleNamespace(
+        mps=types.SimpleNamespace(is_available=lambda: False)
+    )
+    fake_torch.device = lambda name: name
+    fake_torch.no_grad = _NullContext
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    import pipmaster as pm
+
+    monkeypatch.setattr(pm, "is_installed", lambda name: True)
+
+
+@pytest.fixture
+def hf_module(monkeypatch):
+    install_fake_transformers_and_torch(monkeypatch)
+    sys.modules.pop("lightrag.llm.hf", None)
+    return importlib.import_module("lightrag.llm.hf")
+
+
+@pytest.mark.asyncio
+async def test_hf_model_if_cache_runs_generate_off_the_event_loop_thread(
+    hf_module, monkeypatch
+):
+    main_thread_id = threading.get_ident()
+    call_thread_id = {}
+
+    class FakeModel:
+        def __init__(self):
+            self.device = FakeDevice("cpu")
+            self.generation_config = types.SimpleNamespace(eos_token_id=0)
+
+        def generate(self, **kwargs):
+            call_thread_id["id"] = threading.get_ident()
+            input_ids = kwargs["input_ids"]
+            return FakeTensor([input_ids.data[0] + [901, 902]], "cpu")
+
+    class FakeTokenizer:
+        eos_token_id = 0
+
+        def apply_chat_template(
+            self, messages, tokenize=False, add_generation_prompt=True
+        ):
+            return "<prompt>"
+
+        def __call__(self, text, return_tensors="pt", padding=True, truncation=True):
+            return {
+                "input_ids": FakeTensor([[1, 2, 3]]),
+                "attention_mask": FakeTensor([[1, 1, 1]]),
+            }
+
+        def decode(self, tensor, skip_special_tokens=True):
+            return f"decoded:{tensor.data}"
+
+    fake_model = FakeModel()
+    monkeypatch.setattr(
+        hf_module, "initialize_hf_model", lambda name: (fake_model, FakeTokenizer())
+    )
+
+    result = await hf_module.hf_model_if_cache("fake-model", "hello world")
+
+    assert result == "decoded:[901, 902]"
+    assert call_thread_id["id"] != main_thread_id
+
+
+@pytest.mark.asyncio
+async def test_hf_embed_runs_forward_pass_off_the_event_loop_thread(hf_module):
+    main_thread_id = threading.get_ident()
+    call_thread_id = {}
+
+    class _FakeModelOutput:
+        def __init__(self, last_hidden_state):
+            self.last_hidden_state = last_hidden_state
+
+    class _FakeHidden:
+        dtype = "float32"
+
+        def unsqueeze(self, dim):
+            return self
+
+        def to(self, target):
+            return self
+
+        def __mul__(self, other):
+            return self
+
+        def sum(self, dim):
+            return self
+
+        def clamp_min(self, value):
+            return self
+
+        def __truediv__(self, other):
+            return self
+
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def numpy(self):
+            return np.zeros((1, 1024), dtype=np.float32)
+
+    class _FakeEmbedModel:
+        def to(self, device):
+            return self
+
+        def __call__(self, input_ids, attention_mask):
+            call_thread_id["id"] = threading.get_ident()
+            return _FakeModelOutput(_FakeHidden())
+
+        def parameters(self):
+            yield _FakeHidden()
+
+    class _FakeTokenizerOutput(dict):
+        def to(self, device):
+            return self
+
+    class _FakeTokenizer:
+        def __call__(self, texts, return_tensors="pt", padding=True, truncation=True):
+            return _FakeTokenizerOutput(
+                {"input_ids": _FakeHidden(), "attention_mask": _FakeHidden()}
+            )
+
+    result = await hf_module.hf_embed(["hello"], _FakeTokenizer(), _FakeEmbedModel())
+
+    assert result.shape == (1, 1024)
+    assert call_thread_id["id"] != main_thread_id

--- a/tests/llm/hf_impl/test_hf_off_event_loop.py
+++ b/tests/llm/hf_impl/test_hf_off_event_loop.py
@@ -75,6 +75,41 @@ def install_fake_transformers_and_torch(monkeypatch):
     monkeypatch.setattr(pm, "is_installed", lambda name: True)
 
 
+def test_hf_inference_executor_works_across_successive_event_loops(hf_module):
+    async def run_once():
+        return await hf_module._run_hf_inference(lambda: "ok")
+
+    assert asyncio.run(run_once()) == "ok"
+    assert asyncio.run(run_once()) == "ok"
+
+
+def test_cancelled_queued_hf_inference_does_not_run(hf_module):
+    first_started = threading.Event()
+    release_first = threading.Event()
+    calls = []
+
+    def run(marker):
+        calls.append(marker)
+        if marker == "first":
+            first_started.set()
+            release_first.wait(timeout=5)
+        return marker
+
+    async def exercise():
+        first = asyncio.create_task(hf_module._run_hf_inference(run, "first"))
+        assert await asyncio.to_thread(first_started.wait, 5)
+        queued = asyncio.create_task(hf_module._run_hf_inference(run, "queued"))
+        await asyncio.sleep(0)
+        queued.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await queued
+        release_first.set()
+        assert await first == "first"
+
+    asyncio.run(exercise())
+    assert calls == ["first"]
+
+
 @pytest.fixture
 def hf_module(monkeypatch):
     install_fake_transformers_and_torch(monkeypatch)
@@ -272,6 +307,61 @@ async def test_hf_model_if_cache_logs_and_repropagates_cancellation(
     release_call.set()
     assert len(warnings_logged) == 1
     assert "cancelled while awaiting generate()" in warnings_logged[0]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_generate_remains_serialized_until_worker_finishes(
+    hf_module, monkeypatch
+):
+    first_started = threading.Event()
+    second_started = threading.Event()
+    release_first = threading.Event()
+    calls = 0
+
+    class FakeModel:
+        device = FakeDevice("cpu")
+        generation_config = types.SimpleNamespace(eos_token_id=0)
+
+        def generate(self, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                first_started.set()
+                release_first.wait(timeout=5)
+            else:
+                second_started.set()
+            return FakeTensor([kwargs["input_ids"].data[0] + [901]], "cpu")
+
+    class FakeTokenizer:
+        eos_token_id = 0
+
+        def apply_chat_template(self, *args, **kwargs):
+            return "<prompt>"
+
+        def __call__(self, *args, **kwargs):
+            return {"input_ids": FakeTensor([[1]]), "attention_mask": FakeTensor([[1]])}
+
+        def decode(self, tensor, skip_special_tokens=True):
+            return "decoded"
+
+    model = FakeModel()
+    tokenizer = FakeTokenizer()
+    monkeypatch.setattr(
+        hf_module, "initialize_hf_model", lambda name: (model, tokenizer)
+    )
+
+    first = asyncio.create_task(hf_module.hf_model_if_cache("model", "first"))
+    assert await asyncio.to_thread(first_started.wait, 5)
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+    second = asyncio.create_task(hf_module.hf_model_if_cache("model", "second"))
+    await asyncio.sleep(0.05)
+    assert not second_started.is_set()
+
+    release_first.set()
+    assert await second == "decoded"
 
 
 @pytest.mark.asyncio
@@ -491,3 +581,77 @@ async def test_hf_embed_logs_and_repropagates_cancellation(hf_module, monkeypatc
     release_call.set()
     assert len(warnings_logged) == 1
     assert "cancelled while awaiting the forward pass" in warnings_logged[0]
+
+
+@pytest.mark.asyncio
+async def test_hf_embed_serializes_concurrent_forward_passes(hf_module):
+    first_started = threading.Event()
+    second_started = threading.Event()
+    release_first = threading.Event()
+    calls = 0
+
+    class FakeHidden:
+        dtype = "float32"
+
+        def unsqueeze(self, dim):
+            return self
+
+        def to(self, target):
+            return self
+
+        def __mul__(self, other):
+            return self
+
+        def sum(self, dim):
+            return self
+
+        def clamp_min(self, value):
+            return self
+
+        def __truediv__(self, other):
+            return self
+
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def numpy(self):
+            return np.zeros((1, 1024), dtype=np.float32)
+
+    class FakeModel:
+        def to(self, device):
+            return self
+
+        def parameters(self):
+            yield FakeHidden()
+
+        def __call__(self, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                first_started.set()
+                release_first.wait(timeout=5)
+            else:
+                second_started.set()
+            return types.SimpleNamespace(last_hidden_state=FakeHidden())
+
+    class FakeEncoded(dict):
+        def to(self, device):
+            return self
+
+    class FakeTokenizer:
+        def __call__(self, *args, **kwargs):
+            return FakeEncoded(input_ids=FakeHidden(), attention_mask=FakeHidden())
+
+    model = FakeModel()
+    tokenizer = FakeTokenizer()
+    first = asyncio.create_task(hf_module.hf_embed(["first"], tokenizer, model))
+    assert await asyncio.to_thread(first_started.wait, 5)
+    second = asyncio.create_task(hf_module.hf_embed(["second"], tokenizer, model))
+    await asyncio.sleep(0.05)
+    assert not second_started.is_set()
+
+    release_first.set()
+    await asyncio.gather(first, second)


### PR DESCRIPTION
## Problem

hf_model_if_cache() and hf_embed() call PyTorch's generate() and the model's forward pass directly inside async def functions. Both are synchronous, CPU/GPU-bound calls that can take seconds to minutes, blocking the whole event loop for that duration and stalling every other concurrent task.

## Change

Wrap both calls in asyncio.to_thread() so local HF inference runs on a worker thread instead of the event loop.

## Tests

tests/llm/hf_impl: 20 passed

## Related Issue

No related issue.