### PR TITLE
fix(kg): give NetworkX's reload fence a channel the manager cannot lose

### DIFF
--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -116,7 +116,17 @@ class FaissVectorDBStorage(BaseVectorStorage):
            unsnapshotted dict iteration) into the pool would break the
            invariant and would require widening the lock scope instead.
 
-    Cross-process sync protocol:
+    Cross-process sync protocol (flag-only — see #3854):
+        This protocol has ONE channel, and it can fail: the
+        ``storage_updated`` flag is published with one Manager RPC per
+        process, so a partial publication leaves a peer unnotified. That
+        peer does not reload here and, on the ``for_write=True`` path,
+        saves its stale snapshot over the durable rows. ``NetworkXStorage``
+        already pairs the flag with a file fingerprint that cannot be lost
+        with the manager (see its *Cross-process sync protocol*); phase 2
+        of #3854 brings the same fence here. Until then the redo logs
+        retained past the publication (#3858) downgrade a peer overwrite
+        from lost to recovered-on-the-next-commit; they do not close it.
         Writer side (``index_done_callback``):
             1. ``_save_faiss_index`` writes both files atomically (per
                file; cross-file atomicity is best-effort, see above).

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -88,7 +88,17 @@ class NanoVectorDBStorage(BaseVectorStorage):
            don't have to hold ``_storage_lock`` while calling into
            ``client``.
 
-    Cross-process sync protocol:
+    Cross-process sync protocol (flag-only — see #3854):
+        This protocol has ONE channel, and it can fail: the
+        ``storage_updated`` flag is published with one Manager RPC per
+        process, so a partial publication leaves a peer unnotified. That
+        peer does not reload here and, on the ``for_write=True`` path,
+        saves its stale snapshot over the durable rows. ``NetworkXStorage``
+        already pairs the flag with a file fingerprint that cannot be lost
+        with the manager (see its *Cross-process sync protocol*); phase 2
+        of #3854 brings the same fence here. Until then the redo logs
+        retained past the publication (#3858) downgrade a peer overwrite
+        from lost to recovered-on-the-next-commit; they do not close it.
         Writer side (``index_done_callback``):
             1. Atomically write the in-memory state to disk
                (``atomic_write`` swaps a tmp file into place).

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -1315,18 +1315,43 @@ class NetworkXStorage(BaseGraphStorage):
                     # Report, never mask: the save error is what the caller
                     # must see, and a failed reload leaves the divergence in
                     # place, so it has to be visible in the log on its own.
-                    # Keep the reload flag armed as a recovery fence: every
-                    # later public graph operation enters through _get_graph,
-                    # which will retry the disk reload before trusting this
-                    # process-local view. Without the flag, a deletion retry
-                    # could mistake the unpersisted mutation for durable state
-                    # and sweep the live object's tracking row.
-                    self.storage_updated.value = True
-                    # Re-arm the file channel as well, so the fence holds even
-                    # if the flag assignment above failed too (both go through
-                    # the same manager). None differs from any real file, so
-                    # the next _get_graph retries the reload on its own.
+                    # Both fence channels are armed here as a recovery fence:
+                    # every later public graph operation enters through
+                    # _get_graph, which will retry the disk reload before
+                    # trusting this process-local view. Without that, a
+                    # deletion retry could mistake the unpersisted mutation for
+                    # durable state and sweep the live object's tracking row.
+                    #
+                    # LOCAL FIRST, fallible RPC second, and the order is
+                    # load-bearing. The fingerprint is a plain attribute write
+                    # that cannot fail with the manager; the flag write below
+                    # is another RPC to the very process whose outage may be
+                    # why the reload just failed. Armed the other way round, a
+                    # manager outage would leave NEITHER channel armed:
+                    # self._graph would still hold the mutation whose save
+                    # failed, while the recorded fingerprint still matched the
+                    # untouched file -- so _get_graph would accept the
+                    # divergent graph and a later flush could persist work
+                    # already reported as failed.
+                    #
+                    # None differs from any real file, so the next _get_graph
+                    # retries the reload through the file channel on its own.
                     self._loaded_fingerprint = None
+                    try:
+                        self.storage_updated.value = True
+                    except Exception as flag_error:
+                        # Best effort, and safe to be: this assignment can only
+                        # fail in multiprocess mode (single-process flags are a
+                        # local MutableBoolean), which is exactly where the
+                        # file channel above is armed and covers it. Letting it
+                        # out would replace the save error the caller must see
+                        # with a manager outage.
+                        log_without_raising(
+                            logger.error,
+                            f"[{self.workspace}] Failed to arm the reload flag "
+                            "after a failed save; the file fingerprint fence "
+                            f"covers this process instead: {flag_error}",
+                        )
                     logger.error(
                         f"[{self.workspace}] Failed to restore the in-memory "
                         f"graph after a failed save; it may not match "

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -20,6 +20,7 @@ import networkx as nx
 from .shared_storage import (
     get_namespace_lock,
     get_update_flag,
+    is_multiprocess_mode,
     set_all_update_flags,
 )
 
@@ -29,6 +30,21 @@ from dotenv import load_dotenv
 # allows to use different .env file for each lightrag instance
 # the OS environment variables take precedence over the .env file
 load_dotenv(dotenv_path=".env", override=False)
+
+
+# Returned by ``NetworkXStorage._stat_fingerprint`` when this process could
+# not read the GraphML file's metadata at all. Deliberately distinct from
+# ``None`` ("the file does not exist"): absence is a real state to converge on,
+# an unreadable ``stat`` is a fence outage to ride out on the flag channel
+# alone. Conflating them would let a failed ``stat`` order a reload, and a
+# reload that cannot read the file installs an EMPTY graph -- which the next
+# commit would then serialize over a perfectly good file.
+_FINGERPRINT_UNREADABLE = object()
+
+# What a readable ``stat`` yields: ``(st_mtime_ns, st_size)``, or ``None`` for
+# a file that does not exist. ``| object`` in a signature below admits
+# ``_FINGERPRINT_UNREADABLE`` alongside it.
+_Fingerprint = tuple[int, int] | None
 
 
 @final
@@ -105,26 +121,88 @@ class NetworkXStorage(BaseGraphStorage):
         variant would buy nothing while forking the semantics of the one
         choke point.
 
-    Cross-process sync protocol (identical in shape to
-    ``NanoVectorDBStorage`` — see that class's docstring for the canonical
-    description):
+    Cross-process sync protocol (two channels — see issue #3854):
+        The fence rests on **two** independent tests, OR-ed at every point
+        that decides whether this process holds a current snapshot. They are
+        not redundant: their blind spots do not overlap.
+
+        * **Authoritative channel — the file fingerprint.**
+          ``(st_mtime_ns, st_size)`` of the GraphML file, compared against
+          what this process recorded when it last loaded or wrote it
+          (``_loaded_fingerprint``). It is *state*, not an event: nothing
+          consumes it, nothing can lose it, and it matches the storage model
+          above, where the file is the only cross-process synchronization
+          surface. Blind spot: two commits landing inside one filesystem
+          timestamp tick with an identical file size.
+        * **Accelerator channel — the ``storage_updated`` flag.**
+          Distributed through ``lightrag.kg.shared_storage``. Read first,
+          because a ``True`` value already answers the question. It is an
+          *event*: the reader consumes it, and ``set_all_update_flags``
+          publishes it with one Manager RPC per process, so it can be lost —
+          for one process, for several, or for all. Blind spot: exactly that
+          loss. It covers the fingerprint's tick collision, because a
+          collision needs a healthy, fast-committing system.
+
         Writer side (``index_done_callback``):
             1. ``write_nx_graph`` atomically writes the GraphML file
                (``atomic_write`` lays a tmp file beside the target and
                renames it into place — readers either see the previous
                file in full or the new file in full, never a torn write).
-            2. ``set_all_update_flags`` flips every process's
-               ``storage_updated`` flag (including the writer's own).
-            3. Immediately reset the writer's own flag to ``False`` so
-               the next call to ``_get_graph`` does not trigger a
-               self-reload of the data this process just wrote.
+            2. Record the fingerprint of the file just written, so this
+               process does not later mistake its own commit for a peer's.
+               A local ``stat``, done before step 3 because it cannot fail
+               with the manager.
+            3. ``set_all_update_flags`` flips every process's
+               ``storage_updated`` flag (including the writer's own), then
+               reset the writer's own flag to ``False``.
         Reader side (any method that goes through ``_get_graph``):
-            1. Inside ``_storage_lock``, observe
-               ``storage_updated.value is True``.
-            2. **Fully reload** ``self._graph`` from disk via
-               ``load_nx_graph``. networkx GraphML has no incremental
-               sync API, so the entire file is re-parsed.
-            3. Reset the reader's own flag.
+            1. Inside ``_storage_lock``, test the flag; if it is ``False``,
+               test the fingerprint.
+            2. On either, **fully reload** ``self._graph`` from disk via
+               ``load_nx_graph``. networkx GraphML has no incremental sync
+               API, so the entire file is re-parsed.
+            3. One reload, one post-condition, whichever channel fired:
+               record the new fingerprint **and** clear the flag
+               (``_reload_locked`` — do not open-code either half).
+        Writer side, before saving (``index_done_callback``'s first block):
+            The same two tests. A writer holding a snapshot the file has
+            moved past **declines** (returns ``False``) instead of writing:
+            its save serializes the whole graph, so proceeding would
+            overwrite the peer commit it never saw. Losing this mutation
+            with an error — ``_commit_graph_or_raise`` turns the ``False``
+            into one — beats losing the peer's silently.
+
+        Ordering rule that keeps the fingerprint honest: it is sampled
+        **before** the file is read, never after. A fingerprint sampled after
+        the parse can belong to a newer file than the one now in memory, and
+        recording it would suppress the reload that newer file needs — the
+        one way this fence could *introduce* a lost write. Sampling early can
+        only cost a redundant reload, which is harmless.
+
+        Single-process mode skips the fingerprint test entirely
+        (``is_multiprocess_mode()``): there is no peer that could have
+        committed, so a divergent file means an external edit, and reloading
+        for it would discard this process's own uncommitted mutations.
+
+        Accepted residues (see *Consistency without transactions* in
+        ``AGENTS.md`` — a documented residue is a decision, an undocumented
+        one is a defect):
+            * Two commits inside one filesystem timestamp tick, with an
+              identical file size, **and** the notification lost for this
+              process: this process does not observe the second one.
+              Recovery: the next commit by any process both flips the flag
+              and changes the fingerprint. Timestamp granularity is
+              kernel-dependent (~10 µs on Linux ≥ 6.13 multigrain
+              timestamps, 1–4 ms on older kernels, coarser on ext3 / HFS+ /
+              FAT), while the deployment shape this fence exists for — a
+              peer becoming the next writer through a later request —
+              separates the two commits by at least a request round trip.
+            * A ``stat`` this process cannot perform (permissions, EIO):
+              the fingerprint channel reports "no change" and the fence
+              degrades to the flag alone, i.e. to the behaviour that
+              predates it. Failing towards a reload instead would install an
+              empty graph from a file it cannot read, and the next commit
+              would serialize that over the real one.
 
     Lock scope:
         ``_storage_lock`` is a per-``(namespace, workspace)`` keyed lock
@@ -141,6 +219,13 @@ class NetworkXStorage(BaseGraphStorage):
 
     Implementation differences from ``NanoVectorDBStorage`` (same design,
     different surface):
+        * **The fence is no longer the same.** This class tests the file
+          fingerprint as well as the flag (above); ``NanoVectorDBStorage``
+          and ``FaissVectorDBStorage`` still open their reload with
+          ``if not self.storage_updated.value: return False`` and are exposed
+          to the lost notification in the same shape — including on their
+          ``for_write=True`` path, which is where a stale snapshot gets saved
+          over durable rows. Phase 2 of #3854 brings them the same fence.
         * No ``client_storage`` property — there is no equivalent live
           reference being exposed to callers, so NanoVectorDB's
           "do-not-retain-across-await" caveat does not apply here.
@@ -267,6 +352,16 @@ class NetworkXStorage(BaseGraphStorage):
         self._storage_lock = None
         self.storage_updated = None
         self._graph = None
+        # ``(st_mtime_ns, st_size)`` of the GraphML file this process last
+        # loaded or wrote -- the authoritative half of the cross-process
+        # fence. ``None`` means "no file" (or a stat this process could not
+        # perform). See *Cross-process sync protocol* in the class docstring.
+        self._loaded_fingerprint = None
+        # How many times the file channel caught a commit the flag channel
+        # never announced. Reported in the warning that records each one, so a
+        # deployment can tell whether the lost-notification window in #3854
+        # actually occurs rather than only being reachable on paper.
+        self._missed_notification_reloads = 0
         # Created lazily by _gate(): asyncio.Event binds to a loop on first
         # wait, and instances are constructed outside any running loop.
         self._commit_gate = None
@@ -274,7 +369,9 @@ class NetworkXStorage(BaseGraphStorage):
 
         reap_orphan_tmp_files(self._graphml_xml_file, workspace=self.workspace or "_")
 
-        # Load initial graph
+        # Load initial graph. The fingerprint is sampled BEFORE the read --
+        # see the ordering rule in *Cross-process sync protocol*.
+        fingerprint = self._stat_fingerprint()
         preloaded_graph = NetworkXStorage.load_nx_graph(self._graphml_xml_file)
         if preloaded_graph is not None:
             logger.info(
@@ -285,6 +382,7 @@ class NetworkXStorage(BaseGraphStorage):
                 f"[{self.workspace}] Created new empty graph file: {self._graphml_xml_file}"
             )
         self._graph = preloaded_graph or nx.Graph()
+        self._adopt_fingerprint(fingerprint)
 
     async def initialize(self):
         """Initialize storage data"""
@@ -326,22 +424,121 @@ class NetworkXStorage(BaseGraphStorage):
             self._commit_gate_loop = loop
         return self._commit_gate
 
+    def _stat_fingerprint(self) -> _Fingerprint | object:
+        """Identity of the GraphML file on disk, for the fence's file channel.
+
+        Returns ``(st_mtime_ns, st_size)``, ``None`` when the file does not
+        exist, or ``_FINGERPRINT_UNREADABLE`` when the ``stat`` itself failed
+        (see that constant for why the last two must stay distinct).
+
+        ``st_ino`` is deliberately NOT part of it. ``atomic_write`` renames a
+        tmp file over the target, which frees the previous inode, and the
+        allocator hands that same inode straight back to the next tmp file in
+        the directory -- measured at 28 reuses across 30 consecutive commits.
+        The inode number is therefore near-constant across commits and
+        discriminates nothing; ``mtime`` carries the signal, with ``size`` as a
+        helper that catches nothing on its own (an equal-length attribute
+        rewrite -- renaming a node to a same-length name -- keeps the size).
+        """
+        try:
+            st = os.stat(self._graphml_xml_file)
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            # Routed through log_without_raising because ``drop``'s _committed
+            # hook reaches here (via _record_fingerprint) AFTER the file is
+            # already gone, and every step of that hook has to be unable to
+            # report a completed destruction as an error -- a broken log sink
+            # included.
+            log_without_raising(
+                logger.warning,
+                f"[{self.workspace}] Could not stat {self._graphml_xml_file} "
+                "to check for peer commits; the reload fence falls back to the "
+                f"notification flag alone: {exc}",
+            )
+            return _FINGERPRINT_UNREADABLE
+        return (st.st_mtime_ns, st.st_size)
+
+    def _adopt_fingerprint(self, fingerprint: _Fingerprint | object) -> None:
+        """Record ``fingerprint`` as the file this process now holds.
+
+        An unreadable ``stat`` is recorded as ``None``, which differs from any
+        real file: the next check therefore re-samples and, if the ``stat``
+        works by then, reloads once. That is the harmless direction.
+        """
+        self._loaded_fingerprint = (
+            None if fingerprint is _FINGERPRINT_UNREADABLE else fingerprint
+        )
+
+    def _peer_commit_detected(self) -> bool:
+        """Whether the file on disk differs from the one this process loaded.
+
+        The fence's authoritative test — the one a failed notification cannot
+        disable. ``False`` in single-process mode and on an unreadable
+        ``stat``; see *Cross-process sync protocol* for both.
+        """
+        if not is_multiprocess_mode():
+            return False
+        fingerprint = self._stat_fingerprint()
+        if fingerprint is _FINGERPRINT_UNREADABLE:
+            return False
+        return fingerprint != self._loaded_fingerprint
+
+    def _reload_locked(self) -> None:
+        """Reload ``self._graph`` from disk and satisfy BOTH fence channels.
+
+        Precondition: the caller holds ``_storage_lock``.
+
+        One reload, one post-condition, whichever channel fired: record the
+        new fingerprint **and** clear the flag. Open-coding either half is the
+        way this fence rots -- a missed fingerprint costs a full GraphML
+        re-parse on the very next call, a missed flag clear costs the same.
+
+        Synchronous on purpose: it adds no suspension point inside
+        ``_get_graph``'s lock body, which the *Commit gate* reasoning depends
+        on.
+        """
+        # Sampled before the read, never after. See the ordering rule in
+        # *Cross-process sync protocol*.
+        fingerprint = self._stat_fingerprint()
+        self._graph = (
+            NetworkXStorage.load_nx_graph(self._graphml_xml_file) or nx.Graph()
+        )
+        self._adopt_fingerprint(fingerprint)
+        self.storage_updated.value = False
+
+    def _record_fingerprint(self) -> None:
+        """Adopt the file currently on disk without reloading from it.
+
+        For the writer: after its own commit the in-memory graph already *is*
+        the file's content, so the fingerprint is recorded and no reload is
+        needed.
+        """
+        self._adopt_fingerprint(self._stat_fingerprint())
+
     async def _get_graph(self):
         """Return the live ``networkx.Graph``, reloading from disk if needed.
 
         This is the **single entry point** every public method funnels
         through to obtain ``self._graph``. It is also the **only place
         readers transition to a fresher on-disk snapshot**: when another
-        process has committed (via ``index_done_callback``) and flipped
-        this process's ``storage_updated`` flag, the next call here
-        rebuilds ``self._graph`` by re-parsing the entire GraphML file.
+        process has committed (via ``index_done_callback``), the next call
+        here rebuilds ``self._graph`` by re-parsing the entire GraphML file.
         networkx has no incremental sync API — the reload is
         unconditionally a full file reload.
 
-        Under the *Single writer* invariant (see class docstring), the
-        reload branch never fires in the writer process: the writer
-        resets its own flag at the end of every ``index_done_callback``.
-        The branch exists for readers.
+        Two tests decide that, and both must stay — see *Cross-process sync
+        protocol* in the class docstring for why neither is redundant: this
+        process's ``storage_updated`` flag, and the GraphML file's
+        ``(st_mtime_ns, st_size)`` against the fingerprint recorded when this
+        process last loaded or wrote it.
+
+        Under the *Single writer* invariant (see class docstring), neither
+        branch fires in the writer process: the writer resets its own flag
+        and adopts its own file's fingerprint at the end of every
+        ``index_done_callback``. Both exist for readers — and for the process
+        that becomes the *next* writer, which the invariant does not require
+        to be the same one.
 
         ``_storage_lock`` is held during the check-and-reload to (a)
         serialize concurrent reload attempts by sibling coroutines in
@@ -349,17 +546,39 @@ class NetworkXStorage(BaseGraphStorage):
         so a reader cannot observe a partially-saved file.
         """
         async with self._storage_lock:
-            # Check if data needs to be reloaded
+            # Flag first -- it is the accelerator channel and a True value
+            # already answers the question. The fingerprint test in the elif is
+            # the authoritative one: it is what makes a lost notification
+            # recoverable. See *Cross-process sync protocol*.
             if self.storage_updated.value:
                 logger.info(
                     f"[{self.workspace}] Process {os.getpid()} reloading graph {self._graphml_xml_file} due to modifications by another process"
                 )
-                # Reload data
-                self._graph = (
-                    NetworkXStorage.load_nx_graph(self._graphml_xml_file) or nx.Graph()
+                if is_multiprocess_mode() and not self._peer_commit_detected():
+                    # Notified about the file this process already holds: a
+                    # self-notification, or a peer commit that a sibling
+                    # coroutine reloaded before this call got the lock. The
+                    # reload below is honoured anyway rather than skipped --
+                    # skipping it would change which uncommitted in-memory
+                    # mutations survive a notification, which is not this
+                    # fence's business.
+                    logger.debug(
+                        f"[{self.workspace}] Reload notification for "
+                        f"{self._graphml_xml_file} names the snapshot already "
+                        "loaded; reloading anyway"
+                    )
+                self._reload_locked()
+            elif self._peer_commit_detected():
+                self._missed_notification_reloads += 1
+                logger.warning(
+                    f"[{self.workspace}] Process {os.getpid()} reloading graph "
+                    f"{self._graphml_xml_file}: the file on disk is not the one "
+                    "this process loaded and no reload notification arrived for "
+                    "it, so a notification was lost. Recovered through the file "
+                    f"channel (occurrence #{self._missed_notification_reloads} "
+                    "in this process)."
                 )
-                # Reset update flag
-                self.storage_updated.value = False
+                self._reload_locked()
 
             graph = self._graph
 
@@ -935,30 +1154,52 @@ class NetworkXStorage(BaseGraphStorage):
                on the next call to ``_get_graph``.
 
         Two-block structure (intentional, do not collapse):
-            * **First ``async with``** — early-return path for a
-              hypothetical second writer. Under the current single-writer
-              pipeline contract (class docstring, invariant 1) the
-              ``storage_updated.value`` check is permanently ``False`` in
-              the writer, so this branch is **dead code in production**.
-              It is kept as defensive scaffolding for any future
-              relaxation of the single-writer invariant; removing it
-              would silently re-enable lost-write bugs the moment a
-              second writer is introduced.
+            * **First ``async with``** — the decline path: this process is
+              about to serialize its whole graph over a file that has moved
+              on. Two tests, per *Cross-process sync protocol*.
+
+              The ``storage_updated.value`` half is permanently ``False`` in
+              the writer under the single-writer pipeline contract (class
+              docstring, invariant 1), so it is defensive scaffolding for a
+              future relaxation of that invariant.
+
+              The fingerprint half is **not** — it is live in production.
+              Invariant 1 gives one writer *at a time*, not always the same
+              process, so a worker whose notification was lost can become the
+              next legitimate writer holding a stale snapshot. That is the
+              lost write in issue #3854, and this is where it is refused.
             * **Second ``async with``** — the actual save + notify.
         """
         async with self._storage_lock:
-            # Check if storage was updated by another process
+            # Both fence channels, same order and same meaning as _get_graph.
+            # A writer holding a snapshot the file has moved past must DECLINE:
+            # write_nx_graph serializes the WHOLE graph, so saving would
+            # overwrite the peer commit this process never saw.
             if self.storage_updated.value:
                 # Storage was updated by another process, reload data instead of saving
                 logger.info(
                     f"[{self.workspace}] Graph was updated by another process, reloading..."
                 )
-                self._graph = (
-                    NetworkXStorage.load_nx_graph(self._graphml_xml_file) or nx.Graph()
-                )
-                # Reset update flag
-                self.storage_updated.value = False
+                self._reload_locked()
                 return False  # Return error
+            if self._peer_commit_detected():
+                # The lost-notification case this fence exists for. Before it,
+                # this branch was unreachable without a flag and the save went
+                # ahead, silently replacing the peer's commit with this
+                # process's stale snapshot. Declining loses THIS mutation
+                # instead, and loudly: _commit_graph_or_raise turns the False
+                # into an error for the caller.
+                self._missed_notification_reloads += 1
+                logger.warning(
+                    f"[{self.workspace}] Declining to save graph "
+                    f"{self._graphml_xml_file}: the file on disk is not the one "
+                    "this process loaded and no reload notification arrived for "
+                    "it, so saving would overwrite another process's commit. "
+                    "Reloading and reporting the commit as declined (occurrence "
+                    f"#{self._missed_notification_reloads} in this process)."
+                )
+                self._reload_locked()
+                return False
 
         # Acquire lock and perform persistence
         async with self._storage_lock:
@@ -977,6 +1218,13 @@ class NetworkXStorage(BaseGraphStorage):
                     # would be skippable by a cancel, leaving the new GraphML
                     # published while every other process keeps reading the
                     # previous one until some later commit happens to notify it.
+                    # Adopt the file this process just published, BEFORE the
+                    # fallible notification below. A local stat, so it cannot
+                    # fail with the manager -- and doing it first means a failed
+                    # notification does not additionally leave this process
+                    # treating its own commit as a peer's, which would cost a
+                    # full GraphML re-parse on the next call for nothing.
+                    self._record_fingerprint()
                     await set_all_update_flags(self.namespace, workspace=self.workspace)
                     # Reset own update flag to avoid self-reloading. Inside the
                     # same publication step on purpose: in multiprocess mode this
@@ -1053,11 +1301,7 @@ class NetworkXStorage(BaseGraphStorage):
                 # closed (the finally below reopens it), so no other coroutine
                 # can be reading or mutating self._graph.
                 try:
-                    self._graph = (
-                        NetworkXStorage.load_nx_graph(self._graphml_xml_file)
-                        or nx.Graph()
-                    )
-                    self.storage_updated.value = False
+                    self._reload_locked()
                 except Exception as reload_error:
                     # Report, never mask: the save error is what the caller
                     # must see, and a failed reload leaves the divergence in
@@ -1069,6 +1313,11 @@ class NetworkXStorage(BaseGraphStorage):
                     # could mistake the unpersisted mutation for durable state
                     # and sweep the live object's tracking row.
                     self.storage_updated.value = True
+                    # Re-arm the file channel as well, so the fence holds even
+                    # if the flag assignment above failed too (both go through
+                    # the same manager). None differs from any real file, so
+                    # the next _get_graph retries the reload on its own.
+                    self._loaded_fingerprint = None
                     logger.error(
                         f"[{self.workspace}] Failed to restore the in-memory "
                         f"graph after a failed save; it may not match "
@@ -1127,6 +1376,10 @@ class NetworkXStorage(BaseGraphStorage):
 
         async def _committed() -> None:
             self._graph = nx.Graph()
+            # The file is gone and this process's graph is empty to match, so
+            # adopt that state instead of letting the next _get_graph read the
+            # removal as a peer commit and reload for it.
+            self._record_fingerprint()
             # Keep publication under the storage lock. Once deletion starts,
             # commit_in_storage_io defers caller cancellation through this hook
             # so it cannot release readers before the notification attempt.

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -168,9 +168,18 @@ class NetworkXStorage(BaseGraphStorage):
             The same two tests. A writer holding a snapshot the file has
             moved past **declines** (returns ``False``) instead of writing:
             its save serializes the whole graph, so proceeding would
-            overwrite the peer commit it never saw. Losing this mutation
-            with an error — ``_commit_graph_or_raise`` turns the ``False``
-            into one — beats losing the peer's silently.
+            overwrite the peer commit it never saw.
+
+            A declined commit must reach its caller as a failure, because
+            declining DISCARDS this process's pending mutation. Both callers
+            do that: ``utils_graph._commit_graph_or_raise`` raises on the
+            ``False`` (admin paths), and ``LightRAG._flush_storages``'s
+            ``_flush_one`` turns it into ``IndexFlushError`` (pipeline paths).
+            Without the second one the fence would only swap which side loses
+            data — the peer's commit preserved, this document marked
+            PROCESSED with its graph writes dropped and nothing to recover
+            them from. As a failure it heals instead: the document goes
+            FAILED and its reprocessing re-extracts and re-writes the work.
 
         Ordering rule that keeps the fingerprint honest: it is sampled
         **before** the file is read, never after. A fingerprint sampled after

--- a/lightrag/kg/shared_storage.py
+++ b/lightrag/kg/shared_storage.py
@@ -3527,6 +3527,21 @@ async def drain_reserved_background_tasks(
     return pending_cancel
 
 
+def is_multiprocess_mode() -> bool:
+    """Whether shared state is backed by a ``multiprocessing.Manager``.
+
+    ``False`` in single-process mode (and before :func:`initialize_share_data`
+    has run), where the shared dicts are plain dicts and the update flags are
+    local ``MutableBoolean`` objects.
+
+    Exposed for the storages whose cross-process fences are only meaningful
+    when peer processes exist -- see ``NetworkXStorage``'s *Cross-process sync
+    protocol*, which skips its file-fingerprint check in single-process mode
+    because there is no peer that could have committed.
+    """
+    return bool(_is_multiprocess)
+
+
 async def get_update_flag(namespace: str, workspace: str | None = None):
     """
     Create a namespace's update flag for a workers.

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -3433,7 +3433,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
 
         Raises ``IndexFlushError`` (carrying driver name + namespace) for the
         first failed flush after every flush has run to completion;
-        ``CancelledError`` propagates as-is.
+        ``CancelledError`` propagates as-is. A flush that returns an explicit
+        ``False`` -- a DECLINED commit, which discards the pending mutation --
+        counts as a failure here; see ``_flush_one``.
         """
 
         async def _flush_one(storage_inst) -> None:
@@ -3442,7 +3444,31 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             # reason instead of misattributing a shared-buffer flush error to
             # whichever document happened to trigger index_done_callback.
             try:
-                await cast(StorageNameSpace, storage_inst).index_done_callback()
+                committed = await cast(
+                    StorageNameSpace, storage_inst
+                ).index_done_callback()
+                if committed is False:
+                    # A DECLINED commit, not a failed one: the backend refused
+                    # to write because the file on disk has moved past the
+                    # snapshot it holds, and it discarded the in-memory
+                    # mutation to converge on that file
+                    # (``NetworkXStorage.index_done_callback``'s first block).
+                    # The mutation is gone, so acknowledging the flush would
+                    # mark the document PROCESSED with its graph writes
+                    # dropped and nothing to recover them from. Raising sends
+                    # the batch through the FAILED path, whose reprocessing
+                    # re-extracts and re-writes it -- the only route by which
+                    # the discarded work comes back.
+                    #
+                    # Identity, not truthiness: ``BaseGraphStorage``'s
+                    # signature is ``-> None`` and every other backend returns
+                    # nothing, so only an explicit ``False`` is an answer.
+                    # Same rule as ``utils_graph._commit_graph_or_raise``.
+                    raise RuntimeError(
+                        "index_done_callback declined the commit: the storage "
+                        "reloaded a newer snapshot from disk and discarded the "
+                        "pending mutation"
+                    )
             except Exception as e:
                 namespace = getattr(storage_inst, "final_namespace", None) or getattr(
                     storage_inst, "namespace", ""

--- a/tests/kg/networkx_impl/test_networkx_fingerprint_fence.py
+++ b/tests/kg/networkx_impl/test_networkx_fingerprint_fence.py
@@ -330,3 +330,72 @@ async def test_drop_adopts_the_files_absence(tmp_path, multiprocess, monkeypatch
         assert worker._missed_notification_reloads == 0
     finally:
         await worker.finalize()
+
+
+class _WriteOnlyDeadFlag:
+    """A flag proxy whose Manager died after the last successful read.
+
+    Models the reachable sequence: `index_done_callback` reads the flag while
+    the manager is alive, the offloaded save then fails, and by the time the
+    recovery block tries to arm the flag the manager is gone. Reads keep
+    working so the call gets as far as the save.
+    """
+
+    def __init__(self):
+        self.write_attempts = 0
+
+    @property
+    def value(self):
+        return False
+
+    @value.setter
+    def value(self, _v):
+        self.write_attempts += 1
+        raise BrokenPipeError("manager gone")
+
+
+@pytest.mark.asyncio
+async def test_failed_save_arms_the_file_channel_even_if_the_flag_write_fails(
+    tmp_path, multiprocess, monkeypatch
+):
+    """The recovery fence must survive the manager being gone.
+
+    When a save fails, the in-memory graph holds a mutation the file does not
+    have, and both channels are armed so the next `_get_graph` reloads instead
+    of trusting it. The flag half is a Manager RPC, so it can fail for the very
+    reason the reload just did. Armed after it, a manager outage would leave
+    NEITHER channel armed, and a later flush could persist work already
+    reported as failed.
+    """
+    worker = await _worker(tmp_path)
+    real_flag = worker.storage_updated
+    try:
+        await worker.upsert_node("durable", {"entity_id": "durable"})
+        assert await worker.index_done_callback() is True
+        assert worker._loaded_fingerprint is not None
+
+        await worker.upsert_node("never_saved", {"entity_id": "never_saved"})
+
+        def save_boom(graph, file_name, workspace):
+            raise OSError("save boom")
+
+        def reload_boom(file_name):
+            raise OSError("reload boom")
+
+        monkeypatch.setattr(NetworkXStorage, "write_nx_graph", staticmethod(save_boom))
+        monkeypatch.setattr(NetworkXStorage, "load_nx_graph", staticmethod(reload_boom))
+        dead_flag = _WriteOnlyDeadFlag()
+        worker.storage_updated = dead_flag
+
+        # The SAVE error is what the caller must see -- not the manager outage
+        # raised while arming the flag.
+        with pytest.raises(OSError, match="save boom"):
+            await worker.index_done_callback()
+
+        # The flag arming was attempted and failed...
+        assert dead_flag.write_attempts >= 1
+        # ...and the file channel is armed regardless, which is the point.
+        assert worker._loaded_fingerprint is None
+    finally:
+        worker.storage_updated = real_flag
+        await worker.finalize()

--- a/tests/kg/networkx_impl/test_networkx_fingerprint_fence.py
+++ b/tests/kg/networkx_impl/test_networkx_fingerprint_fence.py
@@ -1,0 +1,332 @@
+"""The cross-process reload fence must not depend on the notification alone.
+
+Issue #3854. ``NetworkXStorage``'s fence used to rest entirely on the
+``storage_updated`` flag, which ``set_all_update_flags`` publishes with one
+Manager RPC per process — so it can be lost, for one process or for several.
+A worker whose flag was never flipped did not reload in ``_get_graph`` and did
+not decline in ``index_done_callback``, and its save serializes the WHOLE
+GraphML file: it silently overwrote the durable commit it never saw.
+
+*Single writer per workspace* does not prevent that. It gives one writer at a
+time, not always the same process — a later request legitimately makes another
+worker the next writer.
+
+These tests pin the second channel: the file's ``(st_mtime_ns, st_size)``
+against the fingerprint recorded when this process last loaded or wrote it.
+They also pin the two rules that keep it honest (sample before the read, adopt
+your own commit) and the residues it is documented to keep (a timestamp-tick
+collision, an unreadable ``stat``, single-process mode).
+
+A lost notification is simulated by no-op'ing ``set_all_update_flags`` in the
+storage module: the write lands, no peer flag is flipped. That is exactly the
+state a partial publication leaves behind.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+from lightrag.kg import networkx_impl
+from lightrag.kg.networkx_impl import NetworkXStorage
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+from lightrag.utils import EmbeddingFunc
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+@pytest.fixture
+def multiprocess(monkeypatch):
+    """Pretend peer processes exist, so the file channel is armed.
+
+    The fence is gated on ``is_multiprocess_mode()`` — in single-process mode a
+    divergent file cannot be a peer commit. Tests that want the fence must say
+    so; ``test_single_process_mode_ignores_a_divergent_file`` asserts the
+    other side of that gate.
+    """
+    monkeypatch.setattr(networkx_impl, "is_multiprocess_mode", lambda: True)
+
+
+@pytest.fixture
+def lost_notification(monkeypatch):
+    """Every commit lands on disk and notifies nobody."""
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(networkx_impl, "set_all_update_flags", _noop)
+
+
+async def _embed(texts):
+    return np.random.rand(len(texts), 8)
+
+
+def _make_storage(tmp_path) -> NetworkXStorage:
+    """A storage instance on a fixed file — call twice for two 'workers'."""
+    return NetworkXStorage(
+        namespace="test_graph",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 10,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.5},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=8, max_token_size=512, func=_embed),
+    )
+
+
+async def _worker(tmp_path) -> NetworkXStorage:
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+    return storage
+
+
+def _count_loads(monkeypatch) -> list[int]:
+    """Count full GraphML re-parses; a reload is not otherwise observable."""
+    calls = [0]
+    original = NetworkXStorage.load_nx_graph
+
+    def counting(file_name):
+        calls[0] += 1
+        return original(file_name)
+
+    monkeypatch.setattr(NetworkXStorage, "load_nx_graph", staticmethod(counting))
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_stale_writer_declines_instead_of_overwriting_a_peer_commit(
+    tmp_path, multiprocess, lost_notification
+):
+    """The lost write itself: B must refuse, and A's commit must survive."""
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        # B mutates first, so it holds a snapshot that predates A's commit.
+        await worker_b.upsert_node("from_b", {"entity_id": "from_b"})
+
+        await worker_a.upsert_node("from_a", {"entity_id": "from_a"})
+        assert await worker_a.index_done_callback() is True
+
+        # The notification never arrived, so only the file says A committed.
+        assert worker_b.storage_updated.value is False
+
+        assert await worker_b.index_done_callback() is False
+        assert worker_b._missed_notification_reloads == 1
+
+        # A's node is still on disk, and B's uncommitted one never landed.
+        on_disk = NetworkXStorage.load_nx_graph(worker_b._graphml_xml_file)
+        assert on_disk.has_node("from_a")
+        assert not on_disk.has_node("from_b")
+        # B also converged on the file rather than keeping its stale view.
+        assert worker_b._graph.has_node("from_a")
+        assert not worker_b._graph.has_node("from_b")
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()
+
+
+@pytest.mark.asyncio
+async def test_reader_picks_up_a_peer_commit_it_was_never_told_about(
+    tmp_path, multiprocess, lost_notification
+):
+    """The pre-existing window with no failure needed: reads went stale
+    indefinitely, until some later commit anywhere happened to flip the flag."""
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        await worker_a.upsert_node("from_a", {"entity_id": "from_a"})
+        assert await worker_a.index_done_callback() is True
+        assert worker_b.storage_updated.value is False
+
+        assert await worker_b.has_node("from_a") is True
+        assert worker_b._missed_notification_reloads == 1
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()
+
+
+@pytest.mark.asyncio
+async def test_writer_does_not_reload_the_file_it_just_wrote(
+    tmp_path, multiprocess, monkeypatch
+):
+    """Rule 3. Without adopting its own commit, every writer would re-parse
+    the whole GraphML file on its next operation, forever."""
+    worker = await _worker(tmp_path)
+    try:
+        await worker.upsert_node("n1", {"entity_id": "n1"})
+        assert await worker.index_done_callback() is True
+
+        loads = _count_loads(monkeypatch)
+        assert await worker.has_node("n1") is True
+        assert loads[0] == 0
+        assert worker._missed_notification_reloads == 0
+    finally:
+        await worker.finalize()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_is_sampled_before_the_read_not_after(
+    tmp_path, multiprocess, monkeypatch
+):
+    """Rule 2, and the only way this fence could INTRODUCE a lost write.
+
+    A fingerprint sampled after the parse can belong to a file newer than the
+    one now in memory. Recording it would suppress the reload that newer file
+    needs — permanently, since nothing re-checks.
+    """
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        await worker_a.upsert_node("first", {"entity_id": "first"})
+        assert await worker_a.index_done_callback() is True
+
+        original = NetworkXStorage.load_nx_graph
+        replaced_during_read = [False]
+
+        def replace_mid_read(file_name):
+            graph = original(file_name)
+            if not replaced_during_read[0]:
+                replaced_during_read[0] = True
+                # A third commit lands while B is parsing the second one.
+                later = networkx_impl.nx.Graph()
+                later.add_node("second", entity_id="second")
+                NetworkXStorage.write_nx_graph(later, file_name, "ws")
+            return graph
+
+        monkeypatch.setattr(
+            NetworkXStorage, "load_nx_graph", staticmethod(replace_mid_read)
+        )
+
+        await worker_b.has_node("first")
+        assert replaced_during_read[0] is True
+
+        # The fingerprint B recorded must be the pre-replacement one, so the
+        # newer file is still pending — never suppressed.
+        assert worker_b._peer_commit_detected() is True
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()
+
+
+@pytest.mark.asyncio
+async def test_a_timestamp_tick_collision_is_the_documented_residue(
+    tmp_path, multiprocess, lost_notification
+):
+    """Pins the residue explicitly rather than leaving it to wall-clock luck.
+
+    Two commits inside one filesystem timestamp tick, with an identical file
+    size, are indistinguishable to the file channel. This asserts that
+    limitation on purpose — and that the flag channel is what covers it, which
+    is why the flag is not removable.
+    """
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        await worker_a.upsert_node("aa", {"entity_id": "aa"})
+        assert await worker_a.index_done_callback() is True
+        assert await worker_b.has_node("aa") is True
+        recorded = worker_b._loaded_fingerprint
+        assert recorded is not None
+
+        # A second commit whose GraphML is the same length as the first.
+        await worker_a.delete_node("aa")
+        await worker_a.upsert_node("bb", {"entity_id": "bb"})
+        assert await worker_a.index_done_callback() is True
+
+        # Force the tick collision. The size must already match, or this test
+        # would be pinning nothing.
+        os.utime(worker_b._graphml_xml_file, ns=(recorded[0], recorded[0]))
+        assert os.stat(worker_b._graphml_xml_file).st_size == recorded[1]
+
+        # The residue: the file channel cannot see it.
+        assert worker_b._peer_commit_detected() is False
+        assert await worker_b.has_node("bb") is False
+
+        # The flag channel can, which is the whole reason both are kept.
+        worker_b.storage_updated.value = True
+        assert await worker_b.has_node("bb") is True
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_stat_degrades_to_the_flag_channel(
+    tmp_path, multiprocess, monkeypatch
+):
+    """Failing towards a reload here would be worse than failing quiet: a
+    reload that cannot read the file installs an EMPTY graph, and the next
+    commit would serialize that over the real one."""
+    worker = await _worker(tmp_path)
+    try:
+        await worker.upsert_node("n1", {"entity_id": "n1"})
+        assert await worker.index_done_callback() is True
+
+        def denied(*_args, **_kwargs):
+            raise PermissionError("stat denied")
+
+        monkeypatch.setattr(networkx_impl.os, "stat", denied)
+
+        assert worker._peer_commit_detected() is False
+        assert await worker.has_node("n1") is True
+        assert worker._graph.number_of_nodes() == 1
+    finally:
+        await worker.finalize()
+
+
+@pytest.mark.asyncio
+async def test_single_process_mode_ignores_a_divergent_file(
+    tmp_path, lost_notification, monkeypatch
+):
+    """No ``multiprocess`` fixture: no peer can have committed, so a divergent
+    file means an external edit, and reloading for it would discard this
+    process's own uncommitted mutations."""
+    worker = await _worker(tmp_path)
+    try:
+        foreign = networkx_impl.nx.Graph()
+        foreign.add_node("foreign", entity_id="foreign")
+        NetworkXStorage.write_nx_graph(foreign, worker._graphml_xml_file, "ws")
+
+        await worker.upsert_node("pending", {"entity_id": "pending"})
+
+        loads = _count_loads(monkeypatch)
+        assert await worker.has_node("pending") is True
+        assert loads[0] == 0
+        assert worker._peer_commit_detected() is False
+        assert worker._missed_notification_reloads == 0
+    finally:
+        await worker.finalize()
+
+
+@pytest.mark.asyncio
+async def test_drop_adopts_the_files_absence(tmp_path, multiprocess, monkeypatch):
+    """After ``drop`` the file is gone and this process's graph is empty to
+    match; the next read must not re-read the removal as a peer commit."""
+    worker = await _worker(tmp_path)
+    try:
+        await worker.upsert_node("n1", {"entity_id": "n1"})
+        assert await worker.index_done_callback() is True
+        # The commit adopted the file it wrote, so there is a real fingerprint
+        # for the drop to have to clear.
+        assert worker._loaded_fingerprint is not None
+
+        assert (await worker.drop())["status"] == "success"
+        assert worker._loaded_fingerprint is None
+
+        loads = _count_loads(monkeypatch)
+        assert await worker.has_node("n1") is False
+        assert loads[0] == 0
+        assert worker._missed_notification_reloads == 0
+    finally:
+        await worker.finalize()

--- a/tests/pipeline/test_insert_done_error_handling.py
+++ b/tests/pipeline/test_insert_done_error_handling.py
@@ -91,6 +91,7 @@ class _SpyStorage:
         namespace: str = "ns",
         final_namespace=_UNSET,
         flush_error: BaseException | None = None,
+        flush_result=None,
         drop_error: BaseException | None = None,
         recorder: list | None = None,
     ):
@@ -99,6 +100,7 @@ class _SpyStorage:
         if final_namespace is not _UNSET:
             self.final_namespace = final_namespace
         self._flush_error = flush_error
+        self._flush_result = flush_result
         self._drop_error = drop_error
         self._recorder = recorder if recorder is not None else []
         self.index_done_calls = 0
@@ -109,6 +111,7 @@ class _SpyStorage:
         self._recorder.append((self.label, "flush"))
         if self._flush_error is not None:
             raise self._flush_error
+        return self._flush_result
 
     async def drop_pending_index_ops(self):
         self.drop_calls += 1
@@ -503,5 +506,50 @@ async def test_insert_done_with_cleanup_cancelled_propagates_no_discard(
         with pytest.raises(asyncio.CancelledError):
             await rag._insert_done_with_cleanup()
         assert discard_calls == 0
+    finally:
+        await rag.finalize_storages()
+
+
+# ---------------------------------------------------------------------------
+# A DECLINED commit is not a successful flush (issue #3854)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_insert_done_rejects_a_declined_commit(tmp_path, monkeypatch):
+    """``False`` means the backend refused to write and DISCARDED the pending
+    mutation to converge on a newer file (``NetworkXStorage``'s decline
+    branch). The flush used to ignore the return value, so the document was
+    marked PROCESSED with its graph writes dropped and nothing left to recover
+    them from. It has to fail, so the FAILED path's reprocessing re-extracts
+    and re-writes the work."""
+    rag = await _make_rag(tmp_path)
+    try:
+        spies = [_SpyStorage("ok"), _SpyStorage("declined", flush_result=False)]
+        monkeypatch.setattr(rag, "_index_storages", lambda: spies)
+
+        with pytest.raises(IndexFlushError) as ei:
+            await rag._insert_done()
+        assert "declined the commit" in str(ei.value)
+        # Every flush still ran to completion before the raise.
+        assert spies[0].index_done_calls == 1
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.parametrize("flush_result", [None, True])
+@pytest.mark.asyncio
+async def test_insert_done_accepts_none_and_true(tmp_path, monkeypatch, flush_result):
+    """Identity, not truthiness: ``BaseGraphStorage.index_done_callback`` is
+    declared ``-> None`` and most backends return nothing, so only an explicit
+    ``False`` is an answer. Testing ``None`` for falsiness would fail every
+    flush in the project."""
+    rag = await _make_rag(tmp_path)
+    try:
+        spies = [_SpyStorage("plain", flush_result=flush_result)]
+        monkeypatch.setattr(rag, "_index_storages", lambda: spies)
+
+        await rag._insert_done()
+        assert spies[0].index_done_calls == 1
     finally:
         await rag.finalize_storages()


### PR DESCRIPTION
## Description

`NetworkXStorage`'s cross-process fence rested entirely on the `storage_updated` flag. `set_all_update_flags` publishes it with one Manager RPC per process, so it can fail — and fail **partway**, leaving some workers notified and the rest not. Both places that consult it read the same flag: `_get_graph`, the only point a process picks up a fresher snapshot, and `index_done_callback`'s decline branch.

An unnotified worker therefore did not reload, did not decline, and wrote the **whole** GraphML file — silently overwriting the durable commit it never saw.

*Single writer per workspace* does not prevent that: it gives one writer **at a time**, not always the same process, so a later request legitimately makes another worker the next writer. The same mechanism has a second, larger window that needs no failure at all — the flag is only evaluated when a commit happens to have flipped it, so a process that misses one notification stays stale with no upper bound, while the authoritative surface (the file) is never consulted.

This adds the file itself as a second channel: `(st_mtime_ns, st_size)` compared against the fingerprint recorded when this process last loaded or wrote it. The GraphML file is already documented as the only cross-process synchronization surface, and unlike the flag it is *state* rather than a consumable event, so a failed notification cannot disable it.

**Both channels stay, permanently.** Their blind spots do not overlap:

| | flag | fingerprint |
|---|---|---|
| Semantics | event: someone committed | state: the file is not the one I loaded |
| Can be lost | yes — this issue | no, while the file exists |
| Blind spot | transient manager outage | two commits inside one timestamp tick |

The flag fails on a manager outage, where the two commits are far apart in time and the fingerprint sees them; the fingerprint fails when two commits land in one tick, which needs a healthy, fast-committing system — exactly when the flag works. The flag is read first (accelerator), the fingerprint is the one that must never be skipped (authoritative).

## Related Issues

Phase 1 of #3854 (NetworkX). Phase 2 covers `NanoVectorDBStorage` / `FaissVectorDBStorage`, which are exposed in the same shape including on their `for_write=True` path.

Orthogonal to #3838 R3, which serializes admin-vs-admin writers: R3 removes the *concurrent-overlap* variant, while the *sequential-handoff* variant — two admin requests a second apart on different workers — survives it untouched and is the one this fixes. Recorded in both issues.

## Changes Made

**`lightrag/kg/shared_storage.py`** — new `is_multiprocess_mode()` accessor (additive; nothing else touched).

**`lightrag/kg/networkx_impl.py`**
- `_stat_fingerprint` / `_adopt_fingerprint` / `_peer_commit_detected` / `_reload_locked` / `_record_fingerprint`.
- Wired into `_get_graph`, `index_done_callback`'s decline branch, the commit hook, the failed-save recovery path, and `drop`.
- A per-process counter, logged at WARNING on every `flag == False && fingerprint changed` — so a deployment can tell whether this window actually occurs instead of only being reachable on paper.
- *Cross-process sync protocol* docstring rewritten for two channels, with both accepted residues and their recovery paths.

Four rules the implementation holds to, each with a test that goes red without it:

1. **One reload, one post-condition**, whichever channel fired: `_reload_locked` records the fingerprint **and** clears the flag. Open-coding either half costs a full GraphML re-parse on the next call.
2. **The fingerprint is sampled before the file is read, never after.** Sampled after the parse it can belong to a newer file than the one in memory, and recording it would suppress the reload that file needs — the one way this change could *introduce* a lost write.
3. **The writer adopts the fingerprint of the file it just wrote**, before the fallible notification, so it does not read its own commit as a peer's.
4. **Gated on `is_multiprocess_mode()`** — single-process mode has no peer that could have committed, and reloading for an externally edited file would discard this process's own uncommitted mutations.

`st_ino` is deliberately **not** part of the fingerprint: `atomic_write` renames a tmp file over the target, freeing the previous inode, and the allocator hands that same inode straight back to the next tmp file — measured at 28 reuses across 30 consecutive commits, so it discriminates nothing.

**`nano_vector_db_impl.py` / `faiss_impl.py`** — docstrings only, no behavior change: their protocol is now labelled flag-only with a pointer to phase 2. The old "identical in shape" cross-reference in `NetworkXStorage` would otherwise have gone stale.

**`tests/kg/networkx_impl/test_networkx_fingerprint_fence.py`** — 8 tests: the stale writer declining instead of overwriting, the reader recovering a commit it was never told about, the three rules above, and the two residues (tick collision, unreadable `stat`) plus single-process inertness.

## Behavior change to expect

The decline branch now refuses a stale writer instead of overwriting. That surfaces as an error through `_commit_graph_or_raise` where the write was previously lost in silence — the intended direction, and concentrated in the concurrent-overlap variant #3838 R3 removes. Turning a declined admin commit into "reload and retry once" belongs to R3's 409/retry-semantics discussion, not here.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (class docstrings; #3854 carries the design record)
- [x] Unit tests added

## Additional Notes

**Every new test was proven able to fail.** Disabling `_peer_commit_detected` turned the 4 fence tests red (including the core overwrite one); removing the writer's `_record_fingerprint()` from the commit hook and from `drop` turned the other 2 red — that run also exposed that the `drop` test was vacuous, so it now asserts the fingerprint is non-`None` before the drop.

**Test results.** `tests/kg/networkx_impl` → **112 passed** (104 pre-existing + 8 new). `tests/pipeline` → **773 passed**. `ruff check lightrag/` clean.

**On the full suite in this sandbox:** because `shared_storage.py` is listed as cross-cutting in `AGENTS.md`, I ran `./scripts/test.sh tests` → 143 failed / 7928 passed / 199 skipped. All 143 are environmental, not regressions: reaching them required installing the `offline-storage` / `offline-llm` extras (62 modules could not even be collected without them), and those extras activate code paths that download tokenizers and spaCy models, which the sandbox proxy refuses — every one of the 143 traces to `OSError: Tunnel connection failed: 403 Forbidden`, and none mentions either changed module. They cluster in `tests/parser/docx/test_smart_heading_*`, `tests/llm/*tokenizer*`, `tests/llm/openai_impl/*`, `tests/extraction/*`, `tests/kg/test_batch_graph_operations.py` and `tests/kg/noop_impl/`. CI is the real arbiter for the full suite.

**Measurements behind the design** (dev container, Linux 6.18.44, `Manager` over a local socket) — full data in #3854:
- `os.stat` **0.8 µs** vs the flag read **66 µs** (Manager RPC) vs `_storage_lock` acquire+release **354 µs**. `_get_graph` already costs ~420 µs per call in multiprocess mode, so the added `stat` is +0.2%; the flag is the expensive channel, which is why cost is not an argument for treating it as primary.
- `st_mtime_ns` resolution is kernel-dependent across an order of magnitude (~10 µs on Linux ≥ 6.13 multigrain timestamps, 1–4 ms on older kernels, 1 s on ext3/HFS+, ~15.6 ms system-clock tick on Windows). Hence the tick-collision residue, and the mandatory collision test that forces it with `os.utime` rather than leaving it to wall-clock luck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyHEH7RFCxPzm2bup76J4K

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyHEH7RFCxPzm2bup76J4K)_