### PR TITLE
fix(milvus): run search/upsert/delete off the event loop thread

### DIFF
--- a/lightrag/constants.py
+++ b/lightrag/constants.py
@@ -636,6 +636,13 @@ CHUNKING_SUBMIT_LIMIT = 8
 # worker.
 STORAGE_IO_SUBMIT_LIMIT = 8
 
+# The Milvus pool is the exception to the single-worker shape above: its work is
+# blocking gRPC I/O, not CPU, so one worker would serialize every search in the
+# process behind one flush. This one constant is BOTH the worker count and the
+# submission ceiling, so a submission over the limit waits on the semaphore
+# instead of growing the executor's unbounded wait queue.
+MILVUS_SUBMIT_LIMIT = 8
+
 # Per-workspace ceiling on manual retry requests that have been published but
 # not yet ACKed (LR2 §10.1). The channel is sticky — a request survives until an
 # exclusive reset acknowledges it — so an operator hammering /reprocess_failed

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -101,6 +101,19 @@ async def run_in_milvus_executor(
     caller releases the awaiter while the call itself runs to completion in the
     pool. Callers that must not return before the call has landed keep their own
     deferral (see `_flush_pending_vector_ops`).
+
+    Accepted residue: the semaphore is per event loop (it has to be --
+    `asyncio.Semaphore` binds to the first loop that waits on it, see
+    `get_loop_semaphore`) while the executor is per process, so N concurrently
+    active loops in one process could have N * MILVUS_SUBMIT_LIMIT submissions
+    outstanding. That bounds nothing worse than queue depth: concurrent Milvus
+    round trips stay capped at the pool width process-wide, because a blocking
+    SDK call in flight IS an occupied worker and `ThreadPoolExecutor` never
+    starts more than `max_workers` of them; and a queued submission holds only
+    arguments its awaiting caller already keeps alive, so the queue duplicates
+    no memory. The deployment shape has one active loop per process anyway
+    (gunicorn forks a worker per loop, each with its own gRPC channel), and the
+    three sibling pools carry the identical per-loop/per-process split.
     """
     semaphore = get_loop_semaphore("milvus", MILVUS_SUBMIT_LIMIT)
     return await bounded_submit(get_milvus_executor(), semaphore, fn, *args, **kwargs)

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -1,13 +1,17 @@
 import asyncio
 import json
 import os
+import threading
 import time
-from typing import Any, final, Optional, Dict
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, final, Optional, Dict
 from dataclasses import dataclass, fields
 import numpy as np
 from lightrag.utils import (
     logger,
+    bounded_submit,
     compute_mdhash_id,
+    get_loop_semaphore,
     _cooperative_yield,
     _consume_future_exception,
     _wait_deferring_cancellation,
@@ -18,6 +22,7 @@ from ..constants import (
     DEFAULT_MAX_FILE_PATH_LENGTH,
     DEFAULT_QUERY_PRIORITY,
     GRAPH_FIELD_SEP,
+    MILVUS_SUBMIT_LIMIT,
 )
 from ..kg.shared_storage import get_data_init_lock, get_namespace_lock
 import pipmaster as pm
@@ -38,6 +43,67 @@ from packaging import version
 
 config = configparser.ConfigParser()
 config.read("config.ini", "utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Blocking gRPC off the event loop
+# ---------------------------------------------------------------------------
+#
+# MilvusClient is a synchronous SDK: `search`, `upsert`, `delete` and
+# `load_collection` all block until the server answers. Awaited inline from an
+# `async def`, they hold the only thread serving HTTP for the whole round trip,
+# and these round trips are not uniformly short -- a 64MB upsert batch, or a
+# cold `load_collection` (pymilvus polls until the collection is loaded), is
+# seconds rather than milliseconds.
+#
+# Not the default executor (`asyncio.to_thread`): that pool is
+# `min(32, cpu + 4)` workers with an unbounded wait queue, and it is shared with
+# `UnifiedLock._acquire_mp_lock_in_executor`, login password hashing and the
+# document routes' `stat()` calls. Parking Milvus round trips there makes every
+# `pipeline_status` / namespace lock acquisition under gunicorn -- and every
+# login -- queue behind them, which is why `get_storage_io_executor` and
+# `get_chunking_executor` carry the same warning.
+#
+# Not `run_in_storage_io` either: that pool has a single worker, which would
+# serialize every search in the process behind one flush.
+#
+# Invariants for anything submitted here:
+#   * no nested submission -- a submitted callable must not submit again;
+#   * synchronous SDK calls only: awaiting a coroutine from the worker would
+#     park it on the loop while the loop waits for the worker;
+#   * no re-entry into the storage layer, which takes `NamespaceLock` -- the
+#     caller already holds it and it is not reentrant. The pool therefore holds
+#     no locks and cannot take part in a cycle.
+
+_MILVUS_EXECUTOR: Optional[ThreadPoolExecutor] = None
+_MILVUS_EXECUTOR_GUARD = threading.Lock()
+
+
+def get_milvus_executor() -> ThreadPoolExecutor:
+    """The process-wide pool used for blocking MilvusClient calls."""
+    global _MILVUS_EXECUTOR
+    if _MILVUS_EXECUTOR is None:
+        with _MILVUS_EXECUTOR_GUARD:
+            if _MILVUS_EXECUTOR is None:
+                _MILVUS_EXECUTOR = ThreadPoolExecutor(
+                    max_workers=MILVUS_SUBMIT_LIMIT,
+                    thread_name_prefix="lightrag-milvus",
+                )
+    return _MILVUS_EXECUTOR
+
+
+async def run_in_milvus_executor(
+    fn: Callable[..., Any], *args: Any, **kwargs: Any
+) -> Any:
+    """Run one blocking MilvusClient call off the event loop thread.
+
+    Cancellation behaves exactly as `asyncio.to_thread` does: cancelling the
+    caller releases the awaiter while the call itself runs to completion in the
+    pool. Callers that must not return before the call has landed keep their own
+    deferral (see `_flush_pending_vector_ops`).
+    """
+    semaphore = get_loop_semaphore("milvus", MILVUS_SUBMIT_LIMIT)
+    return await bounded_submit(get_milvus_executor(), semaphore, fn, *args, **kwargs)
 
 
 @dataclass
@@ -2358,8 +2424,9 @@ class MilvusVectorDBStorage(BaseVectorStorage):
         """
         # Ensure collection is loaded before querying. MilvusClient is a
         # synchronous SDK (blocking gRPC calls) -- run it off the event loop
-        # thread so a search doesn't stall every other concurrent task.
-        await asyncio.to_thread(self._ensure_collection_loaded)
+        # thread so a search doesn't stall every other concurrent task, and off
+        # the SHARED default pool (see get_milvus_executor).
+        await run_in_milvus_executor(self._ensure_collection_loaded)
 
         # Use provided embedding or compute it
         if query_embedding is not None:
@@ -2384,7 +2451,7 @@ class MilvusVectorDBStorage(BaseVectorStorage):
             },
         }
 
-        results = await asyncio.to_thread(
+        results = await run_in_milvus_executor(
             self._client.search,
             collection_name=self.final_namespace,
             data=embedding,
@@ -2501,9 +2568,9 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                 return
 
             # Milvus requires the collection to be loaded before upsert/delete.
-            # MilvusClient is synchronous (blocking gRPC) -- run it off the
-            # event loop thread, same reasoning as query()'s search() call.
-            await asyncio.to_thread(self._ensure_collection_loaded)
+            # MilvusClient is synchronous (blocking gRPC) -- run it in the Milvus
+            # pool, same reasoning as query()'s search() call.
+            await run_in_milvus_executor(self._ensure_collection_loaded)
 
             pending_docs = self._pending_vector_docs
             pending_deletes = self._pending_vector_deletes
@@ -2604,7 +2671,7 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                                 f"[{self.workspace}] Milvus upsert batch {batch_index}/{len(upsert_batches)}: "
                                 f"records={len(records_batch)}, estimated_payload_bytes={estimated_bytes}"
                             )
-                            await asyncio.to_thread(
+                            await run_in_milvus_executor(
                                 self._client.upsert,
                                 collection_name=self.final_namespace,
                                 data=records_batch,
@@ -2619,7 +2686,7 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                             else len(delete_ids)
                         )
                         for i in range(0, len(delete_ids), delete_chunk):
-                            await asyncio.to_thread(
+                            await run_in_milvus_executor(
                                 self._client.delete,
                                 collection_name=self.final_namespace,
                                 pks=delete_ids[i : i + delete_chunk],
@@ -2638,7 +2705,7 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                     pending_docs.pop(doc_id, None)
                 pending_deletes.clear()
 
-            # asyncio.to_thread only cancels the awaiting future, not the
+            # run_in_milvus_executor only cancels the awaiting future, not the
             # in-flight Milvus call: a bare cancellation here would release
             # _flush_lock and return to the caller while the write (and the
             # buffer pop that must follow it) is still running in the

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -9,6 +9,8 @@ from lightrag.utils import (
     logger,
     compute_mdhash_id,
     _cooperative_yield,
+    _consume_future_exception,
+    _wait_deferring_cancellation,
     validate_workspace,
 )
 from ..base import BaseVectorStorage
@@ -2568,72 +2570,95 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                 for doc_id in committed_ids
             ]
 
-            try:
-                if list_data:
-                    # Split the upsert into batches that stay under the server-side
-                    # 64MB gRPC message limit. Fail-fast: any batch failure raises
-                    # immediately and the full buffer is retained for the next flush.
-                    upsert_batches = self._build_upsert_batches(
-                        list_data,
-                        max_payload_bytes=self._max_upsert_payload_bytes,
-                        max_records_per_batch=self._max_upsert_records_per_batch,
-                    )
-                    if len(upsert_batches) > 1:
-                        logger.info(
-                            f"[{self.workspace}] {self.namespace} flush: upsert split into "
-                            f"{len(upsert_batches)} batches for {len(list_data)} records "
-                            f"(max_payload={self._max_upsert_payload_bytes} batch={self._max_upsert_records_per_batch})"
+            async def _write_and_clear_buffers() -> None:
+                try:
+                    if list_data:
+                        # Split the upsert into batches that stay under the server-side
+                        # 64MB gRPC message limit. Fail-fast: any batch failure raises
+                        # immediately and the full buffer is retained for the next flush.
+                        upsert_batches = self._build_upsert_batches(
+                            list_data,
+                            max_payload_bytes=self._max_upsert_payload_bytes,
+                            max_records_per_batch=self._max_upsert_records_per_batch,
                         )
-                    for batch_index, (records_batch, estimated_bytes) in enumerate(
-                        upsert_batches, 1
-                    ):
-                        if (
-                            len(records_batch) == 1
-                            and self._max_upsert_payload_bytes > 0
-                            and estimated_bytes > self._max_upsert_payload_bytes
-                        ):
-                            logger.warning(
-                                f"[{self.workspace}] {self.namespace} flush: single record "
-                                f"id={records_batch[0].get('id')} estimated {estimated_bytes} bytes "
-                                f"exceeds {self._max_upsert_payload_bytes}"
+                        if len(upsert_batches) > 1:
+                            logger.info(
+                                f"[{self.workspace}] {self.namespace} flush: upsert split into "
+                                f"{len(upsert_batches)} batches for {len(list_data)} records "
+                                f"(max_payload={self._max_upsert_payload_bytes} batch={self._max_upsert_records_per_batch})"
                             )
-                        logger.debug(
-                            f"[{self.workspace}] Milvus upsert batch {batch_index}/{len(upsert_batches)}: "
-                            f"records={len(records_batch)}, estimated_payload_bytes={estimated_bytes}"
+                        for batch_index, (records_batch, estimated_bytes) in enumerate(
+                            upsert_batches, 1
+                        ):
+                            if (
+                                len(records_batch) == 1
+                                and self._max_upsert_payload_bytes > 0
+                                and estimated_bytes > self._max_upsert_payload_bytes
+                            ):
+                                logger.warning(
+                                    f"[{self.workspace}] {self.namespace} flush: single record "
+                                    f"id={records_batch[0].get('id')} estimated {estimated_bytes} bytes "
+                                    f"exceeds {self._max_upsert_payload_bytes}"
+                                )
+                            logger.debug(
+                                f"[{self.workspace}] Milvus upsert batch {batch_index}/{len(upsert_batches)}: "
+                                f"records={len(records_batch)}, estimated_payload_bytes={estimated_bytes}"
+                            )
+                            await asyncio.to_thread(
+                                self._client.upsert,
+                                collection_name=self.final_namespace,
+                                data=records_batch,
+                            )
+                    if pending_deletes:
+                        # Chunk deletes by record count; pks are short strings so a
+                        # count cap is enough to stay under the gRPC message limit.
+                        delete_ids = list(pending_deletes)
+                        delete_chunk = (
+                            self._max_delete_records_per_batch
+                            if self._max_delete_records_per_batch > 0
+                            else len(delete_ids)
                         )
-                        await asyncio.to_thread(
-                            self._client.upsert,
-                            collection_name=self.final_namespace,
-                            data=records_batch,
-                        )
-                if pending_deletes:
-                    # Chunk deletes by record count; pks are short strings so a
-                    # count cap is enough to stay under the gRPC message limit.
-                    delete_ids = list(pending_deletes)
-                    delete_chunk = (
-                        self._max_delete_records_per_batch
-                        if self._max_delete_records_per_batch > 0
-                        else len(delete_ids)
+                        for i in range(0, len(delete_ids), delete_chunk):
+                            await asyncio.to_thread(
+                                self._client.delete,
+                                collection_name=self.final_namespace,
+                                pks=delete_ids[i : i + delete_chunk],
+                            )
+                except Exception as e:
+                    logger.error(
+                        f"[{self.workspace}] Error flushing vector ops "
+                        f"(upserts={len(pending_docs)}, "
+                        f"deletes={len(pending_deletes)}): {e}"
                     )
-                    for i in range(0, len(delete_ids), delete_chunk):
-                        await asyncio.to_thread(
-                            self._client.delete,
-                            collection_name=self.final_namespace,
-                            pks=delete_ids[i : i + delete_chunk],
-                        )
-            except Exception as e:
-                logger.error(
-                    f"[{self.workspace}] Error flushing vector ops "
-                    f"(upserts={len(pending_docs)}, "
-                    f"deletes={len(pending_deletes)}): {e}"
-                )
-                raise
+                    raise
 
-            # On success, clear the buffers in-place so external references
-            # (e.g. drop()) see the cleared state.
-            for doc_id in committed_ids:
-                pending_docs.pop(doc_id, None)
-            pending_deletes.clear()
+                # On success, clear the buffers in-place so external references
+                # (e.g. drop()) see the cleared state.
+                for doc_id in committed_ids:
+                    pending_docs.pop(doc_id, None)
+                pending_deletes.clear()
+
+            # asyncio.to_thread only cancels the awaiting future, not the
+            # in-flight Milvus call: a bare cancellation here would release
+            # _flush_lock and return to the caller while the write (and the
+            # buffer pop that must follow it) is still running in the
+            # background, letting a concurrent flush interleave with it and
+            # possibly land a stale write. Defer the cancellation until the
+            # write -- and its buffer bookkeeping -- has actually finished,
+            # same idiom as commit_in_storage_io / _finish_deferring_cancellation.
+            write_future = asyncio.ensure_future(_write_and_clear_buffers())
+            write_future.add_done_callback(_consume_future_exception)
+            pending_cancel = await _wait_deferring_cancellation(write_future, None)
+            if pending_cancel is not None:
+                if not write_future.cancelled():
+                    write_exc = write_future.exception()
+                    if write_exc is not None:
+                        logger.error(
+                            f"[{self.workspace}] {self.namespace} flush write "
+                            f"completed while its caller was cancelled: {write_exc}"
+                        )
+                raise pending_cancel
+            write_future.result()
 
     async def delete_entity(self, entity_name: str) -> None:
         """Buffer an entity vector delete by computing its hash ID."""

--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -2354,8 +2354,10 @@ class MilvusVectorDBStorage(BaseVectorStorage):
         embeds and writes them. Callers that need read-after-write visibility
         for similarity search must run an explicit flush first.
         """
-        # Ensure collection is loaded before querying
-        self._ensure_collection_loaded()
+        # Ensure collection is loaded before querying. MilvusClient is a
+        # synchronous SDK (blocking gRPC calls) -- run it off the event loop
+        # thread so a search doesn't stall every other concurrent task.
+        await asyncio.to_thread(self._ensure_collection_loaded)
 
         # Use provided embedding or compute it
         if query_embedding is not None:
@@ -2380,7 +2382,8 @@ class MilvusVectorDBStorage(BaseVectorStorage):
             },
         }
 
-        results = self._client.search(
+        results = await asyncio.to_thread(
+            self._client.search,
             collection_name=self.final_namespace,
             data=embedding,
             limit=top_k,
@@ -2496,7 +2499,9 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                 return
 
             # Milvus requires the collection to be loaded before upsert/delete.
-            self._ensure_collection_loaded()
+            # MilvusClient is synchronous (blocking gRPC) -- run it off the
+            # event loop thread, same reasoning as query()'s search() call.
+            await asyncio.to_thread(self._ensure_collection_loaded)
 
             pending_docs = self._pending_vector_docs
             pending_deletes = self._pending_vector_deletes
@@ -2596,8 +2601,10 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                             f"[{self.workspace}] Milvus upsert batch {batch_index}/{len(upsert_batches)}: "
                             f"records={len(records_batch)}, estimated_payload_bytes={estimated_bytes}"
                         )
-                        self._client.upsert(
-                            collection_name=self.final_namespace, data=records_batch
+                        await asyncio.to_thread(
+                            self._client.upsert,
+                            collection_name=self.final_namespace,
+                            data=records_batch,
                         )
                 if pending_deletes:
                     # Chunk deletes by record count; pks are short strings so a
@@ -2609,7 +2616,8 @@ class MilvusVectorDBStorage(BaseVectorStorage):
                         else len(delete_ids)
                     )
                     for i in range(0, len(delete_ids), delete_chunk):
-                        self._client.delete(
+                        await asyncio.to_thread(
+                            self._client.delete,
                             collection_name=self.final_namespace,
                             pks=delete_ids[i : i + delete_chunk],
                         )

--- a/tests/kg/milvus_impl/test_milvus_off_event_loop.py
+++ b/tests/kg/milvus_impl/test_milvus_off_event_loop.py
@@ -1,0 +1,120 @@
+"""MilvusVectorDBStorage.query() and _flush_pending_vector_ops() call the
+synchronous MilvusClient SDK (blocking gRPC) directly inside async methods.
+Calling it without offloading would block the whole event loop for the
+duration of every search/upsert/delete round trip, stalling every other
+concurrent task (LLM calls, other storage I/O) sharing the loop.
+
+All tests use mocks -- no running Milvus instance required. Mirrors the
+fixture setup in test_milvus_deferred_embedding.py.
+"""
+
+import asyncio
+import threading
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+from lightrag.kg.milvus_impl import MilvusVectorDBStorage
+
+pytestmark = pytest.mark.offline
+
+
+class MockEmbeddingFunc:
+    def __init__(self, dim=8):
+        self.embedding_dim = dim
+        self.max_token_size = 512
+        self.model_name = "mock-embed"
+
+    async def __call__(self, texts, **kwargs):
+        return np.random.rand(len(texts), self.embedding_dim).astype(np.float32)
+
+
+@pytest.fixture(autouse=True)
+def patch_namespace_lock():
+    cache: dict = {}
+
+    def factory(namespace, workspace=None, enable_logging=False):
+        key = (namespace, workspace or "")
+        lock = cache.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            cache[key] = lock
+        return lock
+
+    with patch("lightrag.kg.milvus_impl.get_namespace_lock", side_effect=factory):
+        yield cache
+
+
+def _make_storage(embed_func, *, namespace="entities", workspace="test"):
+    storage = MilvusVectorDBStorage(
+        namespace=namespace,
+        workspace=workspace,
+        global_config={
+            "embedding_batch_num": 10,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=embed_func,
+        meta_fields={"content"},
+    )
+    storage._client = MagicMock()
+    storage._client.has_collection.return_value = True
+    storage._client.load_collection = MagicMock()
+    storage._initialized = True
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_query_runs_search_off_the_event_loop_thread():
+    main_thread_id = threading.get_ident()
+    call_thread_id = {}
+
+    def fake_search(**kwargs):
+        call_thread_id["id"] = threading.get_ident()
+        return [[]]
+
+    s = _make_storage(MockEmbeddingFunc())
+    s._client.search = MagicMock(side_effect=fake_search)
+
+    result = await s.query("hello", top_k=5, query_embedding=[0.1] * 8)
+
+    assert result == []
+    assert call_thread_id["id"] != main_thread_id
+
+
+@pytest.mark.asyncio
+async def test_flush_runs_upsert_off_the_event_loop_thread():
+    main_thread_id = threading.get_ident()
+    call_thread_id = {}
+
+    def fake_upsert(**kwargs):
+        call_thread_id["id"] = threading.get_ident()
+        return {"upsert_count": 1}
+
+    s = _make_storage(MockEmbeddingFunc())
+    s._client.upsert = MagicMock(side_effect=fake_upsert)
+    s._client.delete = MagicMock(return_value={"delete_count": 0})
+
+    await s.upsert({"v1": {"content": "hello"}})
+    await s.index_done_callback()
+
+    assert call_thread_id["id"] != main_thread_id
+
+
+@pytest.mark.asyncio
+async def test_flush_runs_delete_off_the_event_loop_thread():
+    main_thread_id = threading.get_ident()
+    call_thread_id = {}
+
+    def fake_delete(**kwargs):
+        call_thread_id["id"] = threading.get_ident()
+        return {"delete_count": 1}
+
+    s = _make_storage(MockEmbeddingFunc())
+    s._client.upsert = MagicMock(return_value={"upsert_count": 0})
+    s._client.delete = MagicMock(side_effect=fake_delete)
+
+    await s.delete(["v1"])
+    await s.index_done_callback()
+
+    assert call_thread_id["id"] != main_thread_id

--- a/tests/kg/milvus_impl/test_milvus_off_event_loop.py
+++ b/tests/kg/milvus_impl/test_milvus_off_event_loop.py
@@ -10,11 +10,13 @@ fixture setup in test_milvus_deferred_embedding.py.
 
 import asyncio
 import threading
+import time
 
 import numpy as np
 import pytest
 from unittest.mock import MagicMock, patch
 
+from lightrag.constants import MILVUS_SUBMIT_LIMIT
 from lightrag.kg.milvus_impl import MilvusVectorDBStorage
 
 pytestmark = pytest.mark.offline
@@ -103,7 +105,7 @@ async def test_flush_runs_upsert_off_the_event_loop_thread():
 
 @pytest.mark.asyncio
 async def test_cancelling_flush_defers_until_write_completes_then_clears_buffer():
-    """asyncio.to_thread only cancels the awaiting future -- an in-flight
+    """run_in_milvus_executor only cancels the awaiting future -- an in-flight
     Milvus upsert keeps running in the background thread. A bare cancel
     here would release _flush_lock and return to the caller while that
     write (and its buffer bookkeeping) is still pending, letting a
@@ -164,3 +166,80 @@ async def test_flush_runs_delete_off_the_event_loop_thread():
     await s.index_done_callback()
 
     assert call_thread_id["id"] != main_thread_id
+
+
+@pytest.mark.asyncio
+async def test_blocking_calls_use_the_dedicated_milvus_pool():
+    """Off the loop is not enough: the calls must also stay off the process
+    DEFAULT executor. That pool is shared with
+    UnifiedLock._acquire_mp_lock_in_executor, login password hashing and the
+    document routes' stat() calls, and its wait queue is unbounded -- parking
+    multi-second Milvus round trips there makes namespace-lock acquisition and
+    /login queue behind Milvus. Threads from the dedicated pool are named
+    'lightrag-milvus*'; asyncio's default pool names them 'asyncio_*'."""
+    thread_names: dict[str, str] = {}
+
+    def record(op):
+        def _fake(**kwargs):
+            thread_names[op] = threading.current_thread().name
+            return {"upsert_count": 1} if op == "upsert" else {"delete_count": 1}
+
+        return _fake
+
+    def fake_load(*args, **kwargs):
+        thread_names["load_collection"] = threading.current_thread().name
+
+    def fake_search(**kwargs):
+        thread_names["search"] = threading.current_thread().name
+        return [[]]
+
+    s = _make_storage(MockEmbeddingFunc())
+    s._client.load_collection = MagicMock(side_effect=fake_load)
+    s._client.search = MagicMock(side_effect=fake_search)
+    s._client.upsert = MagicMock(side_effect=record("upsert"))
+    s._client.delete = MagicMock(side_effect=record("delete"))
+
+    await s.query("hello", top_k=5, query_embedding=[0.1] * 8)
+    await s.upsert({"v1": {"content": "hello"}})
+    await s.delete(["v2"])
+    await s.index_done_callback()
+
+    assert set(thread_names) == {"load_collection", "search", "upsert", "delete"}
+    offenders = {
+        op: name
+        for op, name in thread_names.items()
+        if not name.startswith("lightrag-milvus")
+    }
+    assert offenders == {}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_searches_are_capped_by_the_submit_limit():
+    """The dedicated pool's wait queue is unbounded like any other
+    ThreadPoolExecutor's, so submissions are ceilinged by a semaphore
+    (MILVUS_SUBMIT_LIMIT) rather than by the pool itself. Without that ceiling
+    every concurrent search gets its own thread up to the pool's width."""
+    state = {"live": 0, "peak": 0}
+    guard = threading.Lock()
+
+    def fake_search(**kwargs):
+        with guard:
+            state["live"] += 1
+            state["peak"] = max(state["peak"], state["live"])
+        time.sleep(0.1)
+        with guard:
+            state["live"] -= 1
+        return [[]]
+
+    s = _make_storage(MockEmbeddingFunc())
+    s._client.search = MagicMock(side_effect=fake_search)
+
+    await asyncio.gather(
+        *(
+            s.query("hello", top_k=5, query_embedding=[0.1] * 8)
+            for _ in range(MILVUS_SUBMIT_LIMIT + 4)
+        )
+    )
+
+    assert s._client.search.call_count == MILVUS_SUBMIT_LIMIT + 4
+    assert state["peak"] <= MILVUS_SUBMIT_LIMIT

--- a/tests/kg/milvus_impl/test_milvus_off_event_loop.py
+++ b/tests/kg/milvus_impl/test_milvus_off_event_loop.py
@@ -102,6 +102,52 @@ async def test_flush_runs_upsert_off_the_event_loop_thread():
 
 
 @pytest.mark.asyncio
+async def test_cancelling_flush_defers_until_write_completes_then_clears_buffer():
+    """asyncio.to_thread only cancels the awaiting future -- an in-flight
+    Milvus upsert keeps running in the background thread. A bare cancel
+    here would release _flush_lock and return to the caller while that
+    write (and its buffer bookkeeping) is still pending, letting a
+    concurrent flush interleave with the orphaned write. Cancellation must
+    instead be deferred until the write, and the buffer pop that follows
+    it, have actually finished."""
+    call_started = threading.Event()
+    release_call = threading.Event()
+
+    def fake_upsert(**kwargs):
+        call_started.set()
+        release_call.wait(timeout=5)
+        return {"upsert_count": 1}
+
+    s = _make_storage(MockEmbeddingFunc())
+    s._client.upsert = MagicMock(side_effect=fake_upsert)
+    s._client.delete = MagicMock(return_value={"delete_count": 0})
+
+    await s.upsert({"v1": {"content": "hello"}})
+
+    task = asyncio.ensure_future(s.index_done_callback())
+    for _ in range(500):
+        if call_started.is_set():
+            break
+        await asyncio.sleep(0.01)
+    assert call_started.is_set()
+
+    task.cancel()
+    # Let the background write finish so the deferred cancellation can
+    # resolve -- release_call must be set before awaiting the cancelled
+    # task, since the cancellation is held back until the write completes.
+    release_call.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    s._client.upsert.assert_called_once()
+    # The write actually landed, so the buffer must reflect that outcome
+    # -- not the stale "still pending" state a bare cancel would leave.
+    assert s._pending_vector_docs == {}
+    assert not s._flush_lock.locked()
+
+
+@pytest.mark.asyncio
 async def test_flush_runs_delete_off_the_event_loop_thread():
     main_thread_id = threading.get_ident()
     call_thread_id = {}


### PR DESCRIPTION
## Problem

MilvusVectorDBStorage.query() and _flush_pending_vector_ops() call MilvusClient's search/upsert/delete directly inside async methods. MilvusClient is a synchronous SDK (blocking gRPC), so every call blocks the whole event loop for the round trip, stalling every other concurrent task.

## Change

Wrap the search/upsert/delete calls (and the collection-load check before them) in asyncio.to_thread(). Scoped to the hot read/write path; startup/migration/admin methods in this file share the same limitation and are left for a follow-up.

## Tests

tests/kg/milvus_impl: 196 passed

## Related Issue

No related issue.