### PR TITLE
fix(api): prefix Swagger UI asset URLs with ASGI root_path

### DIFF
--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -1662,19 +1662,20 @@ def create_app(args):
     # create_app working for callers that build args programmatically.
     ai_content_notice_enabled = bool(getattr(args, "enable_ai_content_notice", False))
 
+    # The WebUI mount path is fixed at "/webui" — see
+    # docs/MultiSiteDeployment.md for the rationale. Computed before
+    # swagger_description below, which embeds it in the ReDoc link.
+    api_prefix = normalize_api_prefix(getattr(args, "api_prefix", None))
+    webui_path = WEBUI_PATH
+
     base_description = (
         "Providing API for LightRAG core, Web UI and Ollama Model Emulation"
     )
     swagger_description = (
         base_description
         + (" (API-Key Enabled)" if api_key else "")
-        + "\n\n[View ReDoc documentation](/redoc)"
+        + f"\n\n[View ReDoc documentation]({api_prefix}/redoc)"
     )
-
-    # The WebUI mount path is fixed at "/webui" — see
-    # docs/MultiSiteDeployment.md for the rationale.
-    api_prefix = normalize_api_prefix(getattr(args, "api_prefix", None))
-    webui_path = WEBUI_PATH
 
     app_kwargs = {
         "title": "LightRAG Server API",

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -2557,13 +2557,14 @@ def create_app(args):
         @app.get("/docs", include_in_schema=False)
         async def custom_swagger_ui_html(request: Request):
             """Custom Swagger UI HTML with local static files"""
+            root = request.scope.get("root_path", "").rstrip("/")
             response = get_swagger_ui_html(
-                openapi_url=app.openapi_url,
+                openapi_url=f"{root}{app.openapi_url}",
                 title=app.title + " - Swagger UI",
-                oauth2_redirect_url="/docs/oauth2-redirect",
-                swagger_js_url="/static/swagger-ui/swagger-ui-bundle.js",
-                swagger_css_url="/static/swagger-ui/swagger-ui.css",
-                swagger_favicon_url="/static/swagger-ui/favicon-32x32.png",
+                oauth2_redirect_url=f"{root}/docs/oauth2-redirect",
+                swagger_js_url=f"{root}/static/swagger-ui/swagger-ui-bundle.js",
+                swagger_css_url=f"{root}/static/swagger-ui/swagger-ui.css",
+                swagger_favicon_url=f"{root}/static/swagger-ui/favicon-32x32.png",
                 swagger_ui_parameters=app.swagger_ui_parameters,
             )
             html = response.body.decode("utf-8")

--- a/tests/api/test_path_prefixes.py
+++ b/tests/api/test_path_prefixes.py
@@ -722,6 +722,44 @@ class TestSwaggerUIAssetURLs:
             assert "'/docs/oauth2-redirect'" in html
             assert "'/openapi.json'" in html
 
+    def test_redoc_link_in_description_prefixed_with_api_prefix(
+        self, mock_args_api_prefix
+    ):
+        """The [View ReDoc documentation](...) link in the OpenAPI info
+        description (rendered in the Swagger UI info panel) must also carry
+        root_path -- raised in review on PR #3864: this link was still
+        hardcoded to /redoc even after the asset-URL fix, so it 404s behind
+        a proxy the same way the assets did."""
+        with patch("lightrag.api.lightrag_server.LightRAG") as mock_rag:
+            mock_rag.return_value = MagicMock()
+            from lightrag.api.lightrag_server import create_app
+
+            app = create_app(mock_args_api_prefix)
+            client = TestClient(app)
+
+            response = client.get("/test-api/openapi.json")
+            assert response.status_code == 200
+            description = response.json()["info"]["description"]
+
+            assert "[View ReDoc documentation](/test-api/redoc)" in description
+            assert "(/redoc)" not in description
+
+    def test_redoc_link_in_description_unprefixed_without_api_prefix(
+        self, mock_args_no_prefix
+    ):
+        with patch("lightrag.api.lightrag_server.LightRAG") as mock_rag:
+            mock_rag.return_value = MagicMock()
+            from lightrag.api.lightrag_server import create_app
+
+            app = create_app(mock_args_no_prefix)
+            client = TestClient(app)
+
+            response = client.get("/openapi.json")
+            assert response.status_code == 200
+            description = response.json()["info"]["description"]
+
+            assert "[View ReDoc documentation](/redoc)" in description
+
 
 class TestWhitelistUnderApiPrefix:
     """WHITELIST_PATHS is matched against route paths, on the real application.

--- a/tests/api/test_path_prefixes.py
+++ b/tests/api/test_path_prefixes.py
@@ -668,6 +668,61 @@ class TestUvicornRootPathSemantics:
         )
 
 
+class TestSwaggerUIAssetURLs:
+    """custom_swagger_ui_html must prefix its asset URLs with root_path.
+
+    TestRoutesAtNaturalPaths above only pins that /docs returns 200 — that
+    alone doesn't catch this bug, because the /docs route itself always
+    answers 200 regardless of root_path; it's the *asset URLs embedded in
+    its HTML* (swagger-ui-bundle.js, swagger-ui.css, favicon, the
+    oauth2-redirect link, and the openapi_url) that were previously emitted
+    as fixed absolute paths, 404ing behind a proxy that strips the prefix
+    before forwarding. Mirrors the root_path handling already covered for
+    service_info_response / workspace_unavailable_response /
+    redirect_to_default_ui.
+    """
+
+    def test_asset_urls_prefixed_with_api_prefix(self, mock_args_api_prefix):
+        with patch("lightrag.api.lightrag_server.LightRAG") as mock_rag:
+            mock_rag.return_value = MagicMock()
+            from lightrag.api.lightrag_server import create_app
+
+            app = create_app(mock_args_api_prefix)
+            client = TestClient(app)
+
+            response = client.get("/test-api/docs")
+            assert response.status_code == 200
+            html = response.text
+
+            assert 'src="/test-api/static/swagger-ui/swagger-ui-bundle.js"' in html
+            assert 'href="/test-api/static/swagger-ui/swagger-ui.css"' in html
+            assert 'href="/test-api/static/swagger-ui/favicon-32x32.png"' in html
+            assert "'/test-api/docs/oauth2-redirect'" in html
+            assert "'/test-api/openapi.json'" in html
+
+            # The un-prefixed form must not appear — that's exactly what
+            # 404s behind a proxy that strips /test-api before forwarding.
+            assert 'src="/static/swagger-ui/swagger-ui-bundle.js"' not in html
+
+    def test_asset_urls_unprefixed_without_api_prefix(self, mock_args_no_prefix):
+        with patch("lightrag.api.lightrag_server.LightRAG") as mock_rag:
+            mock_rag.return_value = MagicMock()
+            from lightrag.api.lightrag_server import create_app
+
+            app = create_app(mock_args_no_prefix)
+            client = TestClient(app)
+
+            response = client.get("/docs")
+            assert response.status_code == 200
+            html = response.text
+
+            assert 'src="/static/swagger-ui/swagger-ui-bundle.js"' in html
+            assert 'href="/static/swagger-ui/swagger-ui.css"' in html
+            assert 'href="/static/swagger-ui/favicon-32x32.png"' in html
+            assert "'/docs/oauth2-redirect'" in html
+            assert "'/openapi.json'" in html
+
+
 class TestWhitelistUnderApiPrefix:
     """WHITELIST_PATHS is matched against route paths, on the real application.
 


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

> Fixes `/docs` (Swagger UI) rendering broken behind a path-prefix reverse proxy: asset URLs were built as fixed absolute paths instead of respecting the ASGI `root_path` that `LIGHTRAG_API_PREFIX` sets, so JS/CSS/favicon requests 404 through the proxy.

## Related Issues

> Fixes #3863

## Changes Made

> - [`custom_swagger_ui_html`](https://github.com/HKUDS/LightRAG/blob/7eb87008dd84bd26fd69e1459ddb4f19ec1e9784/lightrag/api/lightrag_server.py#L2558) now prepends `request.scope["root_path"]` to `openapi_url`, `oauth2_redirect_url`, `swagger_js_url`, `swagger_css_url`, `swagger_favicon_url`.
> - Mirrors the existing pattern in [`service_info_response`](https://github.com/HKUDS/LightRAG/blob/7eb87008dd84bd26fd69e1459ddb4f19ec1e9784/lightrag/api/lightrag_server.py#L2580), [`workspace_unavailable_response`](https://github.com/HKUDS/LightRAG/blob/7eb87008dd84bd26fd69e1459ddb4f19ec1e9784/lightrag/api/lightrag_server.py#L2600), and [`redirect_to_default_ui`](https://github.com/HKUDS/LightRAG/blob/7eb87008dd84bd26fd69e1459ddb4f19ec1e9784/lightrag/api/lightrag_server.py#L2624) in the same file.

## Checklist

- [x] Changes tested locally
- [ ]  Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

[]