### PR TITLE
fix(parser): preserve text in nested PPTX groups

### DIFF
--- a/lightrag/parser/legacy/extractors.py
+++ b/lightrag/parser/legacy/extractors.py
@@ -81,17 +81,25 @@ def _extract_docx(file_bytes: bytes) -> str:
 
 
 def _extract_pptx(file_bytes: bytes) -> str:
-    """Extract PPTX content (synchronous)."""
+    """Extract PPTX text, including nested groups, in shape order (synchronous)."""
+    from collections.abc import Iterator
+
     from pptx import Presentation  # type: ignore
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+    from pptx.shapes.shapetree import GroupShapes, SlideShapes
 
     pptx_file = BytesIO(file_bytes)
     prs = Presentation(pptx_file)
-    content = ""
-    for slide in prs.slides:
-        for shape in slide.shapes:
-            if hasattr(shape, "text"):
-                content += shape.text + "\n"
-    return content
+
+    def iter_text(shapes: SlideShapes | GroupShapes) -> Iterator[str]:
+        for shape in shapes:
+            # Groups have no text of their own; their children can include groups.
+            if shape.shape_type == MSO_SHAPE_TYPE.GROUP:
+                yield from iter_text(shape.shapes)
+            elif hasattr(shape, "text"):
+                yield shape.text + "\n"
+
+    return "".join(text for slide in prs.slides for text in iter_text(slide.shapes))
 
 
 def _extract_xlsx(file_bytes: bytes) -> str:

--- a/tests/parser/test_legacy_extractors.py
+++ b/tests/parser/test_legacy_extractors.py
@@ -8,6 +8,9 @@ from xml.etree import ElementTree as ET
 
 import pytest
 from openpyxl import Workbook
+from pptx import Presentation
+from pptx.enum.shapes import MSO_CONNECTOR
+from pptx.util import Inches
 
 from lightrag.parser.legacy.extractors import extract_text
 
@@ -150,3 +153,33 @@ def test_extract_text_xlsx_handles_multiple_sheets_and_string_results():
     # String cached result preferred over the concatenation formula text.
     assert "foobar" in text
     assert '=A1&"bar"' not in text
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("group_depth", [0, 1, 2])
+def test_extract_text_pptx_preserves_grouped_text_and_order(group_depth):
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+
+    def add_text(shapes, text):
+        shapes.add_textbox(0, 0, Inches(2), Inches(1)).text = text
+
+    add_text(slide.shapes, "Before")
+    shapes = slide.shapes
+    for _ in range(group_depth):
+        shapes = shapes.add_group_shape().shapes
+    add_text(shapes, "Grouped paragraph\nSecond paragraph\vSoft break")
+    shapes.add_connector(MSO_CONNECTOR.STRAIGHT, 0, 0, Inches(1), Inches(1))
+    shapes.add_group_shape()  # Empty groups must not add spurious newlines.
+    add_text(shapes, "")  # Keep the existing empty-textbox newline behavior.
+    add_text(shapes, "Group sibling")
+    add_text(slide.shapes, "After")
+    next_slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    add_text(next_slide.shapes, "Next slide")
+    file_bytes = BytesIO()
+    presentation.save(file_bytes)
+
+    assert extract_text(file_bytes.getvalue(), "pptx") == (
+        "Before\nGrouped paragraph\nSecond paragraph\vSoft break\n\n"
+        "Group sibling\nAfter\nNext slide\n"
+    )

--- a/tests/parser/test_legacy_parser.py
+++ b/tests/parser/test_legacy_parser.py
@@ -67,6 +67,28 @@ async def test_legacy_parse_txt_persists_and_archives(tmp_path, archived):
     assert "parse_stage_skipped" not in result.to_dict()
 
 
+async def test_legacy_parse_pptx_with_only_grouped_text(tmp_path, archived):
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[6])
+    group = slide.shapes.add_group_shape()
+    group.shapes.add_textbox(0, 0, Inches(2), Inches(1)).text = "Grouped evidence"
+    source = tmp_path / "grouped.pptx"
+    presentation.save(source)
+    rag = _FakeRag()
+
+    result = await LegacyParser().parse(_ctx(rag, source))
+
+    assert result.content == "Grouped evidence\n"
+    assert result.parse_format == FULL_DOCS_FORMAT_RAW
+    assert result.parse_engine == "legacy"
+    assert len(rag.persisted) == 1
+    assert rag.persisted[0][1]["content"] == result.content
+    assert archived == [str(source)]
+
+
 async def test_legacy_parse_unsupported_suffix_raises(tmp_path, archived):
     source = tmp_path / "image.xyz"
     source.write_bytes(b"not parseable")


### PR DESCRIPTION
## Description

The legacy PPTX extractor drops text inside grouped shapes. `slide.shapes` exposes the group container, but the container has no `text` property, so its text-bearing children are never visited. A deck with grouped content can be indexed incompletely; a deck containing only grouped text fails parsing with `extracted no usable text`.

This change visits nested group children in shape-tree order while preserving the existing handling of leaf text and newlines.

## Related Issues

Found and reproduced on current main (`7eb87008`). I did not find an existing issue or PR covering legacy PPTX group traversal in the related open/closed PR and issue searches. #3378 concerns remote MinerU parsing and is not addressed here.

## Changes Made

- Recurse into PPTX group shapes, including nested groups, using python-pptx's existing shape API.
- Preserve slide/shape order, paragraph and soft-break text, and empty-textbox newline behavior; ignore empty groups and non-text shapes as before.
- Add serialized PPTX regressions for ungrouped, grouped and nested text, plus a group-only document test through `LegacyParser.parse` that verifies persisted content and the archive handoff.

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation updated (extractor docstring)
- [x] Unit tests added

## Additional Notes

Validation on Python 3.13.13 / python-pptx 1.0.2:

- Before the fix: **3 failed, 8 passed** across the two affected test files. The ungrouped control passed; grouped/nested content disappeared, and the group-only document was rejected as empty.
- After the fix: **11 passed** across those files.
- `tests/parser`: **1534 passed, 45 skipped**. Optional pinned spaCy models are not installed. Localhost fixtures and tokenizer cache downloads required network-enabled execution; macOS SVG tests additionally needed the installed Homebrew Cairo path (`DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib`) with a direct Python invocation.
- `_extract_pptx` and its traversal helper: all 13 statements and all 6 measured branches covered.
- Repository-pinned pre-commit checks passed for the three changed files; `git diff --check` passed.

No new dependency, public API, ZIP-budget change, or parser-routing change. This does not add table/chart extraction, OCR, notes/master-slide text, or geometric reading-order inference. Tests generate actual PPTX files locally; external LLM services and desktop PowerPoint rendering were not exercised. Previously indexed documents are not automatically reprocessed.
