### PR TITLE
fix(kg): extend the reload fence to the vector backends

### DIFF
--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -129,12 +129,16 @@ class FaissVectorDBStorage(BaseVectorStorage):
           ``(st_mtime_ns, st_size)`` of **both** files against what this
           process recorded when it last loaded or wrote them
           (``_loaded_fingerprint``). State, not an event: nothing consumes
-          it and a failed notification cannot lose it. Sampling the pair
-          together matters more here than for the single-file backends —
-          cross-file atomicity is best-effort (see above), so a pair where
-          only one file moved is a real state this fence must not read as
-          "unchanged". Blind spot: two commits inside one filesystem
-          timestamp tick with identical sizes.
+          it and a failed notification cannot lose it. **Both files must
+          have moved** for the change to count: the publication renames them
+          one at a time, so a pair where only one moved does not describe a
+          single state, and reloading THAT is the corruption vector —
+          ``_load_faiss_index`` binds every in-range metadata row to whatever
+          vector the other file now holds. A partial change therefore reports
+          "no change" and this process keeps the older self-consistent
+          snapshot until the writer's retry completes the set (see
+          ``file_fingerprint.peer_commit_detected``). Blind spot: two
+          commits inside one filesystem timestamp tick with identical sizes.
         * **Accelerator channel — the ``storage_updated`` flag.** Read
           first, because a ``True`` value already answers the question.
           ``set_all_update_flags`` publishes it with one Manager RPC per
@@ -165,6 +169,11 @@ class FaissVectorDBStorage(BaseVectorStorage):
             ``NetworkXStorage``, which invalidates its fingerprint after a
             failed save *in order to* reload: it has no redo log, so its
             in-memory graph is the untrustworthy side.
+
+            Adoption covers the failing writer only. Every OTHER process is
+            covered by the both-files-must-move rule above — they never
+            recorded this pair, so nothing local tells them the publication
+            was interrupted; only the shape of the change on disk does.
         Reader and writer side (everything through
         ``_reload_index_from_disk_locked``):
             1. Inside ``_storage_lock``, test the flag; if it is ``False``,

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -424,13 +424,20 @@ class FaissVectorDBStorage(BaseVectorStorage):
         )
 
     def _fingerprint_paths(self) -> tuple[str, str]:
-        """Both files this storage's state spans.
+        """Both files this storage's state spans, **in publication order**.
 
-        Sampled together: either one changing means a peer wrote, and a
-        partially readable pair is "cannot tell" rather than a change (see
-        ``kg.file_fingerprint``). That matters here more than for the
-        single-file backends — cross-file atomicity is best-effort, so a
-        mismatched pair is a state this fence must not read as "unchanged".
+        Index first, metadata last, matching ``_save_faiss_index``'s write
+        order. ``file_fingerprint`` treats the last path as the commit
+        marker: a complete publication leaves it no older than the files it
+        commits, so a torn pair (the index newer than the metadata that is
+        supposed to describe it) is recognisable from the files alone, by any
+        process, without having seen the previous generation.
+
+        Watching the marker ALONE would not do: a peer several generations
+        behind sees the marker changed even when a later publication has
+        already laid down a new index beside it. Reordering this pair, or
+        reordering the writes, silently breaks the test — see
+        ``file_fingerprint.publication_complete``.
         """
         return (self._faiss_index_file, self._meta_file)
 
@@ -1442,6 +1449,15 @@ class FaissVectorDBStorage(BaseVectorStorage):
         def _write_both() -> None:
             # One submission for both files: two would take two permits and
             # could interleave another namespace's commit between the halves.
+            #
+            # ORDER IS PART OF THE CONTRACT: index first, metadata LAST.
+            # The metadata rename is this storage's commit point, which is
+            # what lets ANY process recognise a complete publication from the
+            # files alone -- a complete pair has the metadata no older than
+            # the index it describes, an interrupted one leaves the index
+            # newer. See ``_fingerprint_paths`` and
+            # ``file_fingerprint.publication_complete``. Reversing this makes
+            # a torn pair indistinguishable from a committed one.
             atomic_write(
                 index_file,
                 lambda tmp: faiss.write_index(index, tmp),

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -154,6 +154,17 @@ class FaissVectorDBStorage(BaseVectorStorage):
             3. ``set_all_update_flags`` flips every process's
                ``storage_updated`` flag (including the writer's own), then
                reset the writer's own flag to ``False``.
+            On a FAILED save the pair is adopted too. Step 1 is two
+            ``atomic_write`` calls, so a failure between them publishes a
+            MISMATCHED pair (a new ``.index`` beside the previous
+            ``.meta.json``) — this process's own doing, not a peer's. The
+            in-memory index plus the redo logs are the authority the retry
+            writes from; reloading the mismatched pair instead would bind one
+            row's metadata to another's vector and the replay would then
+            delete the wrong one. Opposite direction from
+            ``NetworkXStorage``, which invalidates its fingerprint after a
+            failed save *in order to* reload: it has no redo log, so its
+            in-memory graph is the untrustworthy side.
         Reader and writer side (everything through
         ``_reload_index_from_disk_locked``):
             1. Inside ``_storage_lock``, test the flag; if it is ``False``,
@@ -1444,7 +1455,37 @@ class FaissVectorDBStorage(BaseVectorStorage):
                 self._record_fingerprint()
                 await on_committed()
 
-            await commit_in_storage_io(_write_both, _committed)
+            try:
+                await commit_in_storage_io(_write_both, _committed)
+            except CommitBookkeepingError:
+                raise
+            except BaseException:
+                # A FAILED save still leaves the files on disk as THIS
+                # process's doing, so adopt them: the fingerprint fence must
+                # not read this process's own half-finished write as a peer
+                # commit.
+                #
+                # Unlike the single-file backends, ``_write_both`` is two
+                # ``atomic_write`` calls, so a failure between them publishes a
+                # MISMATCHED pair (a new ``.index`` beside the previous
+                # ``.meta.json``). ``self._index`` / ``self._id_to_meta`` still
+                # hold the complete post-flush snapshot, and the retry's job is
+                # to write both files from it. Reloading instead would replace
+                # that snapshot with the mismatched pair -- binding one row's
+                # metadata to another's vector (``_load_faiss_index`` keeps
+                # every metadata row whose fid is inside the shorter index and
+                # reconstructs its vector from there) -- and the redo replay
+                # would then delete the wrong vector and the next save would
+                # make that permanent, losing rows the operation never touched.
+                #
+                # Adopting hides nothing: a genuine peer commit after this
+                # moves the pair again, away from what was adopted here. The
+                # mismatched pair on disk is a pre-existing residue of the
+                # best-effort cross-file write (see the class docstring's
+                # storage model and ``_load_faiss_index``'s skew detection),
+                # not something this fence can repair.
+                self._record_fingerprint()
+                raise
         except CommitBookkeepingError as e:
             # Both files are already renamed into place, so the rows ARE durable
             # and the caller must not hear otherwise: `index_done_callback`'s

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -20,6 +20,7 @@ from lightrag.utils import (
 from lightrag.base import BaseVectorStorage
 from lightrag.constants import DEFAULT_QUERY_PRIORITY
 
+from . import file_fingerprint
 from .shared_storage import (
     get_namespace_lock,
     get_update_flag,
@@ -116,33 +117,77 @@ class FaissVectorDBStorage(BaseVectorStorage):
            unsnapshotted dict iteration) into the pool would break the
            invariant and would require widening the lock scope instead.
 
-    Cross-process sync protocol (flag-only — see #3854):
-        This protocol has ONE channel, and it can fail: the
-        ``storage_updated`` flag is published with one Manager RPC per
-        process, so a partial publication leaves a peer unnotified. That
-        peer does not reload here and, on the ``for_write=True`` path,
-        saves its stale snapshot over the durable rows. ``NetworkXStorage``
-        already pairs the flag with a file fingerprint that cannot be lost
-        with the manager (see its *Cross-process sync protocol*); phase 2
-        of #3854 brings the same fence here. Until then the redo logs
-        retained past the publication (#3858) downgrade a peer overwrite
-        from lost to recovered-on-the-next-commit; they do not close it.
-        Writer side (``index_done_callback``):
+    Cross-process sync protocol (two channels — see #3854):
+        Two independent tests decide whether this process holds a current
+        snapshot, OR-ed at the one place that asks
+        (``_reload_index_from_disk_locked``). They are not redundant — their
+        blind spots do not overlap. The mechanism lives in
+        ``lightrag.kg.file_fingerprint``; the canonical prose contract is
+        ``NetworkXStorage``'s section of the same name.
+
+        * **Authoritative channel — the file fingerprint.**
+          ``(st_mtime_ns, st_size)`` of **both** files against what this
+          process recorded when it last loaded or wrote them
+          (``_loaded_fingerprint``). State, not an event: nothing consumes
+          it and a failed notification cannot lose it. Sampling the pair
+          together matters more here than for the single-file backends —
+          cross-file atomicity is best-effort (see above), so a pair where
+          only one file moved is a real state this fence must not read as
+          "unchanged". Blind spot: two commits inside one filesystem
+          timestamp tick with identical sizes.
+        * **Accelerator channel — the ``storage_updated`` flag.** Read
+          first, because a ``True`` value already answers the question.
+          ``set_all_update_flags`` publishes it with one Manager RPC per
+          process, so a partial publication leaves a peer unnotified —
+          that loss is its blind spot, and it is what the file channel
+          exists for. In exchange it covers the fingerprint's tick
+          collision, which needs a healthy, fast-committing system.
+
+        Writer side (``index_done_callback`` / ``finalize``):
             1. ``_save_faiss_index`` writes both files atomically (per
                file; cross-file atomicity is best-effort, see above).
-            2. ``set_all_update_flags`` flips every process's
-               ``storage_updated`` flag (including the writer's own).
-            3. Reset the writer's own flag to ``False`` so the next
-               ``_get_index`` does not trigger a self-reload of what we
-               just wrote.
-        Reader side (any method that goes through ``_get_index``):
-            1. Inside ``_storage_lock``, observe
-               ``storage_updated.value is True``.
-            2. **Fully reload**: re-init ``self._index`` from
+            2. Record the fingerprint of the pair just written, so this
+               process does not later read its own save as a peer's. Done
+               inside ``_save_faiss_index`` — before the caller's
+               bookkeeping, because that publishes through the manager and
+               can fail, while this is a local ``stat``.
+            3. ``set_all_update_flags`` flips every process's
+               ``storage_updated`` flag (including the writer's own), then
+               reset the writer's own flag to ``False``.
+        Reader and writer side (everything through
+        ``_reload_index_from_disk_locked``):
+            1. Inside ``_storage_lock``, test the flag; if it is ``False``,
+               test the fingerprint.
+            2. On either, **fully reload**: re-init ``self._index`` from
                ``IndexFlatIP``, clear ``self._id_to_meta``, then call
                ``_load_faiss_index`` to re-parse both files. Faiss has no
                incremental sync API.
-            3. Reset the reader's own flag.
+            3. Record the new fingerprint **and** reset the flag, whichever
+               channel fired.
+
+        **This backend does not decline a stale write, and must not.**
+        ``NetworkXStorage`` refuses to save when the file has moved past its
+        snapshot, because it has no way to keep the mutation. Here the write
+        path is *reload-then-replay*: ``index_done_callback`` reloads the
+        peer's snapshot and ``_flush_pending_locked`` replays the pending
+        buffer and the ``_unsaved_upserts`` / ``_unsaved_deletes`` redo logs
+        on top of it (issue #3688), so both sides survive and there is
+        nothing to report as a failure. Consequently the flush-failure
+        propagation NetworkX needs (a declined commit must not be
+        acknowledged as durable, see ``LightRAG._flush_storages``) has no
+        counterpart here.
+
+        Accepted residues (see *Consistency without transactions* in
+        ``AGENTS.md``):
+            * The tick collision above, **and** the notification lost for
+              this process: the peer commit is not observed. Recovery: the
+              next commit by any process flips the flag and changes the
+              fingerprint; the redo logs mean this process's own rows are
+              replayed rather than lost either way.
+            * A ``stat`` this process cannot perform on either file: the
+              file channel reports "no change" and the fence degrades to
+              the flag alone, i.e. to the behaviour that predates it. See
+              ``kg.file_fingerprint`` for why the other direction is worse.
 
     Lock scope:
         ``_storage_lock`` is a per-``(namespace, workspace)`` keyed lock
@@ -286,6 +331,15 @@ class FaissVectorDBStorage(BaseVectorStorage):
         # Keep a local store for metadata, IDs, etc.
         # Maps <int faiss_id> → metadata (including your original ID).
         self._id_to_meta = {}
+        # ``(st_mtime_ns, st_size)`` per file -- BOTH files, since either one
+        # changing means a peer wrote. The authoritative half of the
+        # cross-process fence; see *Cross-process sync protocol*. Adopted
+        # after the load below, sampled before it (``kg.file_fingerprint``).
+        self._loaded_fingerprint = None
+        # How many times the file channel caught a commit the flag channel
+        # never announced, so a deployment can tell whether the
+        # lost-notification window in #3854 actually occurs.
+        self._missed_notification_reloads = 0
 
         # Minimal pending area for deferred embedding: custom-id -> _PendingFaissDoc.
         # Holds only records not yet embedded+materialized into self._index;
@@ -333,7 +387,10 @@ class FaissVectorDBStorage(BaseVectorStorage):
             extra_patterns=(glob.escape(self._meta_file) + ".tmp",),
         )
 
+        # Sampled BEFORE the load, never after -- see ``kg.file_fingerprint``.
+        fingerprint = self._stat_fingerprint()
         self._load_faiss_index()
+        self._adopt_fingerprint(fingerprint)
 
     async def initialize(self):
         """Initialize storage data"""
@@ -346,6 +403,49 @@ class FaissVectorDBStorage(BaseVectorStorage):
             self.namespace, workspace=self.workspace
         )
 
+    def _fingerprint_paths(self) -> tuple[str, str]:
+        """Both files this storage's state spans.
+
+        Sampled together: either one changing means a peer wrote, and a
+        partially readable pair is "cannot tell" rather than a change (see
+        ``kg.file_fingerprint``). That matters here more than for the
+        single-file backends — cross-file atomicity is best-effort, so a
+        mismatched pair is a state this fence must not read as "unchanged".
+        """
+        return (self._faiss_index_file, self._meta_file)
+
+    def _stat_fingerprint(self) -> file_fingerprint.Fingerprint | object:
+        """Sample both files' identity. See ``kg.file_fingerprint``."""
+        return file_fingerprint.sample(
+            self._fingerprint_paths(), workspace=self.workspace
+        )
+
+    def _adopt_fingerprint(
+        self, fingerprint: file_fingerprint.Fingerprint | object
+    ) -> None:
+        """Record ``fingerprint`` as the file pair this process now holds."""
+        self._loaded_fingerprint = file_fingerprint.adopted(fingerprint)
+
+    def _record_fingerprint(self) -> None:
+        """Adopt the files currently on disk without reloading from them.
+
+        For the writer: after its own save the in-memory index already *is*
+        their content.
+        """
+        self._adopt_fingerprint(self._stat_fingerprint())
+
+    def _peer_commit_detected(self) -> bool:
+        """Whether the files on disk differ from the ones this process loaded.
+
+        The fence's authoritative test — the one a failed notification cannot
+        disable. See ``kg.file_fingerprint``.
+        """
+        return file_fingerprint.peer_commit_detected(
+            self._fingerprint_paths(),
+            self._loaded_fingerprint,
+            workspace=self.workspace,
+        )
+
     def _reload_index_from_disk_locked(self, *, for_write: bool = False) -> bool:
         """Reload ``self._index`` + ``self._id_to_meta`` if another process committed newer data.
 
@@ -356,22 +456,45 @@ class FaissVectorDBStorage(BaseVectorStorage):
 
         Returns True if a reload happened, False if the local snapshot was
         already current.
+
+        Two tests, per *Cross-process sync protocol*: this process's
+        ``storage_updated`` flag, read first, and the files' fingerprint
+        against what this process recorded. The second is what survives a lost
+        notification.
         """
-        if not self.storage_updated.value:
+        notified = bool(self.storage_updated.value)
+        if not notified and not self._peer_commit_detected():
             return False
 
-        log_message = (
-            f"[{self.workspace}] Process {os.getpid()} FAISS reloading {self.namespace} "
-            "due to update by another process"
-        )
-        if for_write:
-            logger.warning(log_message)
+        if notified:
+            log_message = (
+                f"[{self.workspace}] Process {os.getpid()} FAISS reloading {self.namespace} "
+                "due to update by another process"
+            )
+            if for_write:
+                logger.warning(log_message)
+            else:
+                logger.info(log_message)
         else:
-            logger.info(log_message)
+            # The lost-notification case the file channel exists for. Always a
+            # warning, on the read path too: unlike a notified reload this one
+            # says a publication failed somewhere.
+            self._missed_notification_reloads += 1
+            logger.warning(
+                f"[{self.workspace}] Process {os.getpid()} FAISS reloading "
+                f"{self.namespace}: {self._faiss_index_file} is not the file "
+                "pair this process loaded and no reload notification arrived "
+                "for it, so a notification was lost. Recovering through the "
+                f"file channel (occurrence #{self._missed_notification_reloads} "
+                "in this process)."
+            )
 
+        # Sampled BEFORE the read, never after -- see ``kg.file_fingerprint``.
+        fingerprint = self._stat_fingerprint()
         self._index = faiss.IndexFlatIP(self._dim)
         self._id_to_meta = {}
         self._load_faiss_index()
+        self._adopt_fingerprint(fingerprint)
         self.storage_updated.value = False
         return True
 
@@ -1307,7 +1430,21 @@ class FaissVectorDBStorage(BaseVectorStorage):
             atomic_write(meta_file, _write_meta, workspace)
 
         try:
-            await commit_in_storage_io(_write_both, on_committed)
+            async def _committed() -> None:
+                # Adopt the pair this process just wrote BEFORE the caller's
+                # bookkeeping, which publishes through the manager and can
+                # fail. A local stat, so it cannot fail with it -- and doing it
+                # first means a failed publication does not additionally leave
+                # this process treating its own save as a peer's, which would
+                # cost a full reload of both files on the next call for
+                # nothing.
+                #
+                # Here rather than in each caller's hook so no save path can
+                # forget it: ``finalize`` reuses this same method.
+                self._record_fingerprint()
+                await on_committed()
+
+            await commit_in_storage_io(_write_both, _committed)
         except CommitBookkeepingError as e:
             # Both files are already renamed into place, so the rows ARE durable
             # and the caller must not hear otherwise: `index_done_callback`'s
@@ -1876,6 +2013,19 @@ class FaissVectorDBStorage(BaseVectorStorage):
                     "is left set below so the next read rebuilds it from the "
                     f"removed files: {snapshot_error}",
                 )
+
+            # Mirror that decision on the file channel, and BEFORE the
+            # fallible manager writes below: a plain attribute assignment
+            # cannot fail with the manager, so the fence holds even when the
+            # flag write does not. Adopting the files' absence when the
+            # allocation installed the post-drop index; invalidating (``None``
+            # differs from any real pair, present or absent) when it did not,
+            # so the next read rebuilds the stale index through this channel
+            # too.
+            if snapshot_reset:
+                self._record_fingerprint()
+            else:
+                self._loaded_fingerprint = None
 
             # Keep publication under the storage lock. Once deletion starts,
             # commit_in_storage_io defers caller cancellation through this hook

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -1441,6 +1441,7 @@ class FaissVectorDBStorage(BaseVectorStorage):
             atomic_write(meta_file, _write_meta, workspace)
 
         try:
+
             async def _committed() -> None:
                 # Adopt the pair this process just wrote BEFORE the caller's
                 # bookkeeping, which publishes through the manager and can

--- a/lightrag/kg/file_fingerprint.py
+++ b/lightrag/kg/file_fingerprint.py
@@ -41,10 +41,12 @@ than the shape, and three copies of them is how it rots:
 * **Single-process mode has no peer that could have committed**, so the test is
   skipped there: a divergent file means an external edit, and reloading for it
   would discard the process's own uncommitted mutations.
-* **A multi-file storage must have moved ALL of its files** for the change to
-  count. A subset is an interrupted publication whose files do not describe one
-  state, and reloading that is the corruption vector -- see
-  :func:`peer_commit_detected`.
+* **A multi-file storage must look completely published**, judged from the
+  files themselves: it publishes them in a fixed order and renames the last one
+  -- the commit marker -- LAST, so a completed publication leaves the marker no
+  older than the files it commits. Reloading a torn set is the corruption
+  vector. ``paths`` is therefore given in PUBLICATION ORDER. See
+  :func:`publication_complete`.
 
 Each storage keeps its own recorded value and wires these into its reload,
 commit and drop paths; see ``NetworkXStorage``'s *Cross-process sync protocol*
@@ -130,21 +132,21 @@ def peer_commit_detected(
     The fence's authoritative test -- the one a failed notification cannot
     disable. ``False`` in single-process mode and on an unreadable ``stat``.
 
-    **A multi-file storage must have moved ALL of its files.** A publication
-    that renames its files one at a time is only complete once every rename
-    has landed; a subset having moved means the files on disk do not describe
-    one state, and reloading THAT is what corrupts -- FAISS pairs a new
-    ``.index`` with the previous ``.meta.json`` and binds one row's metadata
-    to another's vector. So a partial change reports "no change": keeping an
-    older self-consistent snapshot is always better than adopting an
-    inconsistent one, and it is what this process did before the fence
-    existed. The writer completes or retries the publication (its in-memory
-    state plus its redo logs are the authority), and the next check sees both
-    files moved.
+    **A multi-file storage must look completely published**, judged by
+    :func:`publication_complete` from the files themselves. A publication
+    renames its files one at a time, so there is a window in which they do not
+    describe one state, and reloading THAT is what corrupts -- FAISS would pair
+    one generation's ``.index`` with another's ``.meta.json`` and bind one
+    row's metadata to another's vector. A pair that does not look complete
+    reports "no change": keeping an older self-consistent snapshot is always
+    better than adopting an inconsistent one, and it is what this process did
+    before the fence existed. The writer completes or retries the publication
+    (its in-memory state plus its redo logs are the authority), and the next
+    check sees a complete set.
 
     ``recorded is None`` means "nothing recorded, or deliberately
-    invalidated" and always reports a change -- it is how a storage arms the
-    fence after a failure it must reload out of.
+    invalidated" and reports a change for any complete state -- it is how a
+    storage arms the fence after a failure it must reload out of.
     """
     if not fence_enabled():
         return False
@@ -153,18 +155,43 @@ def peer_commit_detected(
         return False
     if sampled == recorded:
         return False
-    if (
-        len(paths) > 1
-        and isinstance(recorded, tuple)
-        and len(recorded) == len(sampled)
-        and any(new == old for new, old in zip(sampled, recorded))
-    ):
+    if len(paths) > 1 and not publication_complete(sampled):
         log_without_raising(
             logger.warning,
-            f"[{workspace}] Only part of {len(paths)} storage files changed "
-            f"({', '.join(paths)}) — an incomplete publication, not a peer "
-            "commit. Keeping the snapshot this process already holds; the "
-            "writer's retry completes the file set.",
+            f"[{workspace}] The storage files ({', '.join(paths)}) do not look "
+            "completely published — the commit marker is older than the files "
+            "it commits, or the set is partial. Treating this as an "
+            "interrupted publication, not a peer commit, and keeping the "
+            "snapshot this process already holds; the writer's retry "
+            "completes the set.",
         )
         return False
     return True
+
+
+def publication_complete(sampled: Fingerprint) -> bool:
+    """Whether a multi-file sample looks like one completed publication.
+
+    **The last path is the commit marker.** A storage whose state spans
+    several files publishes them in a fixed order and renames the marker
+    LAST, so a completed publication leaves the marker no older than every
+    file it commits, and an interrupted one leaves some file NEWER than the
+    marker. That test is what makes completeness judgeable from the files
+    alone -- by any process, at any generation of staleness.
+
+    Comparing per-file changes against what a reader last recorded cannot do
+    that: a reader several generations behind sees every file changed even
+    when the newest publication is half-landed, so it would take a torn pair
+    for a commit. Ordering is a property of the files; a recorded fingerprint
+    is a property of one reader.
+
+    Everything absent is complete (the post-``drop`` state, which peers must
+    be able to converge on). A present marker with any file missing is not.
+    """
+    *committed, marker = sampled
+    if marker is None:
+        return all(entry is None for entry in committed)
+    if any(entry is None for entry in committed):
+        return False
+    marker_mtime = marker[0]
+    return all(entry[0] <= marker_mtime for entry in committed)

--- a/lightrag/kg/file_fingerprint.py
+++ b/lightrag/kg/file_fingerprint.py
@@ -43,10 +43,11 @@ than the shape, and three copies of them is how it rots:
   would discard the process's own uncommitted mutations.
 * **A multi-file storage must look completely published**, judged from the
   files themselves: it publishes them in a fixed order and renames the last one
-  -- the commit marker -- LAST, so a completed publication leaves the marker no
-  older than the files it commits. Reloading a torn set is the corruption
-  vector. ``paths`` is therefore given in PUBLICATION ORDER. See
-  :func:`publication_complete`.
+  -- the commit marker -- LAST, so a completed publication leaves the marker
+  STRICTLY newer than the files it commits. Reloading a torn set is the
+  corruption vector, and strictness is what keeps a coarse filesystem clock
+  from passing one off as complete. ``paths`` is therefore given in PUBLICATION
+  ORDER. See :func:`publication_complete`.
 
 Each storage keeps its own recorded value and wires these into its reload,
 commit and drop paths; see ``NetworkXStorage``'s *Cross-process sync protocol*
@@ -174,10 +175,25 @@ def publication_complete(sampled: Fingerprint) -> bool:
 
     **The last path is the commit marker.** A storage whose state spans
     several files publishes them in a fixed order and renames the marker
-    LAST, so a completed publication leaves the marker no older than every
-    file it commits, and an interrupted one leaves some file NEWER than the
-    marker. That test is what makes completeness judgeable from the files
-    alone -- by any process, at any generation of staleness.
+    LAST, so a completed publication leaves the marker STRICTLY newer than
+    every file it commits, and an interrupted one leaves some file at or
+    after the marker. That test is what makes completeness judgeable from the
+    files alone -- by any process, at any generation of staleness.
+
+    **Strictly**, not "no older", and that is the whole guard against coarse
+    filesystem timestamps. A torn set can land its next file inside the same
+    timestamp tick as the previous publication's marker, making the two
+    mtimes equal; ``<=`` would call that complete and hand back a set whose
+    files describe different generations. ``<`` refuses it.
+
+    The cost is in the safe direction: a COMPLETE publication whose writes all
+    land inside one tick is also refused, so its commit goes unnoticed by this
+    channel. That is a missed reload, not a torn one -- the process keeps a
+    self-consistent snapshot, the flag channel carries that commit (a
+    same-tick publication means a healthy, fast-committing writer, which is
+    exactly when the flag works), and the next publication that spans a tick
+    is seen. Compare the mirror residue on the change-detection side, where
+    the same tick collision also costs a detection rather than correctness.
 
     Comparing per-file changes against what a reader last recorded cannot do
     that: a reader several generations behind sees every file changed even
@@ -194,4 +210,4 @@ def publication_complete(sampled: Fingerprint) -> bool:
     if any(entry is None for entry in committed):
         return False
     marker_mtime = marker[0]
-    return all(entry[0] <= marker_mtime for entry in committed)
+    return all(entry[0] < marker_mtime for entry in committed)

--- a/lightrag/kg/file_fingerprint.py
+++ b/lightrag/kg/file_fingerprint.py
@@ -41,6 +41,10 @@ than the shape, and three copies of them is how it rots:
 * **Single-process mode has no peer that could have committed**, so the test is
   skipped there: a divergent file means an external edit, and reloading for it
   would discard the process's own uncommitted mutations.
+* **A multi-file storage must have moved ALL of its files** for the change to
+  count. A subset is an interrupted publication whose files do not describe one
+  state, and reloading that is the corruption vector -- see
+  :func:`peer_commit_detected`.
 
 Each storage keeps its own recorded value and wires these into its reload,
 commit and drop paths; see ``NetworkXStorage``'s *Cross-process sync protocol*
@@ -125,10 +129,42 @@ def peer_commit_detected(
 
     The fence's authoritative test -- the one a failed notification cannot
     disable. ``False`` in single-process mode and on an unreadable ``stat``.
+
+    **A multi-file storage must have moved ALL of its files.** A publication
+    that renames its files one at a time is only complete once every rename
+    has landed; a subset having moved means the files on disk do not describe
+    one state, and reloading THAT is what corrupts -- FAISS pairs a new
+    ``.index`` with the previous ``.meta.json`` and binds one row's metadata
+    to another's vector. So a partial change reports "no change": keeping an
+    older self-consistent snapshot is always better than adopting an
+    inconsistent one, and it is what this process did before the fence
+    existed. The writer completes or retries the publication (its in-memory
+    state plus its redo logs are the authority), and the next check sees both
+    files moved.
+
+    ``recorded is None`` means "nothing recorded, or deliberately
+    invalidated" and always reports a change -- it is how a storage arms the
+    fence after a failure it must reload out of.
     """
     if not fence_enabled():
         return False
     sampled = sample(paths, workspace=workspace)
     if sampled is UNREADABLE:
         return False
-    return sampled != recorded
+    if sampled == recorded:
+        return False
+    if (
+        len(paths) > 1
+        and isinstance(recorded, tuple)
+        and len(recorded) == len(sampled)
+        and any(new == old for new, old in zip(sampled, recorded))
+    ):
+        log_without_raising(
+            logger.warning,
+            f"[{workspace}] Only part of {len(paths)} storage files changed "
+            f"({', '.join(paths)}) — an incomplete publication, not a peer "
+            "commit. Keeping the snapshot this process already holds; the "
+            "writer's retry completes the file set.",
+        )
+        return False
+    return True

--- a/lightrag/kg/file_fingerprint.py
+++ b/lightrag/kg/file_fingerprint.py
@@ -1,0 +1,134 @@
+"""The file half of the file-backed storages' cross-process fence (#3854).
+
+``NetworkXStorage``, ``NanoVectorDBStorage`` and ``FaissVectorDBStorage`` all
+coordinate through a file plus a ``storage_updated`` flag distributed by
+``lightrag.kg.shared_storage``. The flag is published with one Manager RPC per
+process, so it can be lost -- for one process, for several, or for all -- and a
+process that misses it keeps a stale snapshot and, on its write path, saves
+that snapshot over the peer's durable rows.
+
+This module is the second channel: the file's own ``(st_mtime_ns, st_size)``,
+compared against what the process recorded when it last loaded or wrote it.
+Unlike the flag it is *state* rather than a consumable event, so a failed
+notification cannot disable it.
+
+The two channels are OR-ed and both are kept, permanently: their blind spots do
+not overlap. The flag fails on a transient manager outage, where the commits
+are far apart in time and the fingerprint sees them; the fingerprint fails when
+two commits land inside one filesystem timestamp tick with an identical size,
+which needs a healthy, fast-committing system -- exactly when the flag works.
+
+The mechanism lives here, once, because its hazards are in the details rather
+than the shape, and three copies of them is how it rots:
+
+* **Sample BEFORE reading the file, never after.** A fingerprint taken after
+  the parse can belong to a newer file than the one now in memory, and
+  recording it would suppress the reload that newer file needs -- the one way
+  this fence could *introduce* a lost write. Sampling early can only cost a
+  redundant reload. Callers own this ordering; the functions cannot enforce it.
+* **An unreadable ``stat`` is not an absent file.** ``UNREADABLE`` reports "no
+  change" so the fence degrades to the flag alone, i.e. to the behaviour that
+  predates it. Failing towards a reload instead would install an empty
+  snapshot from a file it cannot read, and the next commit would serialize that
+  over the real one.
+* **``st_ino`` is deliberately excluded.** ``atomic_write`` renames a tmp file
+  over the target, freeing the previous inode, and the allocator hands that
+  same inode straight back to the next tmp file in the directory -- measured at
+  28 reuses across 30 consecutive commits. It is near-constant across commits
+  and discriminates nothing. ``st_size`` is a helper that catches nothing on
+  its own (an equal-length attribute rewrite keeps it); ``mtime`` carries the
+  signal.
+* **Single-process mode has no peer that could have committed**, so the test is
+  skipped there: a divergent file means an external edit, and reloading for it
+  would discard the process's own uncommitted mutations.
+
+Each storage keeps its own recorded value and wires these into its reload,
+commit and drop paths; see ``NetworkXStorage``'s *Cross-process sync protocol*
+for the full contract, including the accepted residues.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Sequence
+
+from lightrag.utils import log_without_raising, logger
+
+from .shared_storage import is_multiprocess_mode
+
+# Returned by :func:`sample` when a path's metadata could not be read at all.
+# Distinct from ``None`` ("the file does not exist", a real state to converge
+# on) because the two must not lead to the same decision -- see the module
+# docstring.
+UNREADABLE = object()
+
+# What a readable sample yields: one ``(st_mtime_ns, st_size)`` per path, or
+# ``None`` for a path that does not exist.
+Fingerprint = tuple[tuple[int, int] | None, ...]
+
+
+def fence_enabled() -> bool:
+    """Whether the file channel is consulted at all.
+
+    Single-process mode has no peer that could have committed, so the file
+    test is skipped there -- see the module docstring. Exposed so the storages
+    (and their tests) consult the gate in exactly one place.
+    """
+    return is_multiprocess_mode()
+
+
+def sample(paths: Sequence[str], *, workspace: str) -> Fingerprint | object:
+    """Sample the identity of every path, or ``UNREADABLE`` if any stat fails.
+
+    All-or-nothing on purpose: a storage whose state spans two files (FAISS's
+    index + metadata) has to treat a partially readable pair as "cannot tell",
+    not as a change.
+
+    Routed through ``log_without_raising`` because a ``drop`` commit hook
+    reaches here after the files are already gone, and every step of such a
+    hook must be unable to report a completed destruction as an error -- a
+    broken log sink included.
+    """
+    fingerprints: list[tuple[int, int] | None] = []
+    for path in paths:
+        try:
+            st = os.stat(path)
+        except FileNotFoundError:
+            fingerprints.append(None)
+        except OSError as exc:
+            log_without_raising(
+                logger.warning,
+                f"[{workspace}] Could not stat {path} to check for peer "
+                "commits; the reload fence falls back to the notification "
+                f"flag alone: {exc}",
+            )
+            return UNREADABLE
+        else:
+            fingerprints.append((st.st_mtime_ns, st.st_size))
+    return tuple(fingerprints)
+
+
+def adopted(sampled: Fingerprint | object) -> Fingerprint | None:
+    """The value to record for ``sampled``.
+
+    ``UNREADABLE`` becomes ``None``, which differs from any real file: the next
+    check therefore re-samples and, if the ``stat`` works by then, reloads
+    once. That is the harmless direction.
+    """
+    return None if sampled is UNREADABLE else sampled  # type: ignore[return-value]
+
+
+def peer_commit_detected(
+    paths: Sequence[str], recorded: Fingerprint | None, *, workspace: str
+) -> bool:
+    """Whether the files on disk differ from the ones this process recorded.
+
+    The fence's authoritative test -- the one a failed notification cannot
+    disable. ``False`` in single-process mode and on an unreadable ``stat``.
+    """
+    if not fence_enabled():
+        return False
+    sampled = sample(paths, workspace=workspace)
+    if sampled is UNREADABLE:
+        return False
+    return sampled != recorded

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -23,6 +23,7 @@ from lightrag.utils import (
 from lightrag.base import BaseVectorStorage
 from lightrag.constants import DEFAULT_QUERY_PRIORITY
 from nano_vectordb import NanoVectorDB
+from . import file_fingerprint
 from .shared_storage import (
     get_namespace_lock,
     get_update_flag,
@@ -88,33 +89,76 @@ class NanoVectorDBStorage(BaseVectorStorage):
            don't have to hold ``_storage_lock`` while calling into
            ``client``.
 
-    Cross-process sync protocol (flag-only — see #3854):
-        This protocol has ONE channel, and it can fail: the
-        ``storage_updated`` flag is published with one Manager RPC per
-        process, so a partial publication leaves a peer unnotified. That
-        peer does not reload here and, on the ``for_write=True`` path,
-        saves its stale snapshot over the durable rows. ``NetworkXStorage``
-        already pairs the flag with a file fingerprint that cannot be lost
-        with the manager (see its *Cross-process sync protocol*); phase 2
-        of #3854 brings the same fence here. Until then the redo logs
-        retained past the publication (#3858) downgrade a peer overwrite
-        from lost to recovered-on-the-next-commit; they do not close it.
-        Writer side (``index_done_callback``):
+    Cross-process sync protocol (two channels — see #3854):
+        Two independent tests decide whether this process holds a current
+        snapshot, OR-ed at the one place that asks
+        (``_reload_client_from_disk_locked``). They are not redundant — their
+        blind spots do not overlap. The mechanism, and why each detail of it
+        is the way it is, lives in ``lightrag.kg.file_fingerprint``; the
+        canonical prose contract is ``NetworkXStorage``'s section of the same
+        name.
+
+        * **Authoritative channel — the file fingerprint.**
+          ``(st_mtime_ns, st_size)`` of the JSON file against what this
+          process recorded when it last loaded or wrote it
+          (``_loaded_fingerprint``). State, not an event: nothing consumes
+          it and a failed notification cannot lose it. Blind spot: two
+          commits inside one filesystem timestamp tick with an identical
+          file size.
+        * **Accelerator channel — the ``storage_updated`` flag.** Read
+          first, because a ``True`` value already answers the question.
+          ``set_all_update_flags`` publishes it with one Manager RPC per
+          process, so a partial publication leaves a peer unnotified —
+          that loss is its blind spot, and it is what the file channel
+          exists for. In exchange it covers the fingerprint's tick
+          collision, which needs a healthy, fast-committing system.
+
+        Writer side (``index_done_callback`` / ``finalize``):
             1. Atomically write the in-memory state to disk
                (``atomic_write`` swaps a tmp file into place).
-            2. Call ``set_all_update_flags`` to flip every process's
-               ``storage_updated`` flag (including the writer's own).
-            3. Immediately reset the writer's own flag to ``False`` so
-               the next call to ``_get_client`` does not trigger a
-               self-reload of the data this process just wrote.
-        Reader side (any method that goes through ``_get_client``):
-            1. Inside ``_storage_lock``, observe
-               ``storage_updated.value is True``.
-            2. **Fully reload** ``self._client`` from disk — NanoVectorDB
-               has no incremental sync API, so the entire JSON file is
-               re-parsed and a fresh in-memory matrix is rebuilt.
-            3. Reset the reader's own flag to ``False`` so concurrent
-               coroutines in the same process don't double-reload.
+            2. Record the fingerprint of the file just written, so this
+               process does not later read its own save as a peer's. Done
+               inside ``_save_to_disk_locked`` — before the caller's
+               bookkeeping, because that publishes through the manager and
+               can fail, while this is a local ``stat``.
+            3. ``set_all_update_flags`` flips every process's
+               ``storage_updated`` flag (including the writer's own), then
+               reset the writer's own flag to ``False``.
+        Reader and writer side (everything through
+        ``_reload_client_from_disk_locked``):
+            1. Inside ``_storage_lock``, test the flag; if it is ``False``,
+               test the fingerprint.
+            2. On either, **fully reload** ``self._client`` from disk —
+               NanoVectorDB has no incremental sync API, so the entire JSON
+               file is re-parsed and a fresh in-memory matrix is rebuilt.
+            3. Record the new fingerprint **and** reset the flag, whichever
+               channel fired.
+
+        **This backend does not decline a stale write, and must not.**
+        ``NetworkXStorage`` refuses to save when the file has moved past its
+        snapshot, because it has no way to keep the mutation. Here the write
+        path is *reload-then-replay*: ``index_done_callback`` reloads the
+        peer's snapshot and ``_flush_pending_locked`` replays the pending
+        buffer and the ``_unsaved_upserts`` / ``_unsaved_deletes`` redo logs
+        on top of it (issue #3688), so both sides survive and there is
+        nothing to report as a failure. Replay is idempotent: an unchanged
+        file matches by fingerprint and writes nothing, and a genuinely newer
+        row under the same id is declined by ``_resident_supersedes_redo``.
+        Consequently the flush-failure propagation NetworkX needs (a declined
+        commit must not be acknowledged as durable, see
+        ``LightRAG._flush_storages``) has no counterpart here.
+
+        Accepted residues (see *Consistency without transactions* in
+        ``AGENTS.md``):
+            * The tick collision above, **and** the notification lost for
+              this process: the peer commit is not observed. Recovery: the
+              next commit by any process flips the flag and changes the
+              fingerprint; the redo logs mean this process's own rows are
+              replayed rather than lost either way.
+            * A ``stat`` this process cannot perform: the file channel
+              reports "no change" and the fence degrades to the flag alone,
+              i.e. to the behaviour that predates it. See
+              ``kg.file_fingerprint`` for why the other direction is worse.
 
     Lock scope:
         ``_storage_lock`` is a per-``(namespace, workspace)`` keyed lock
@@ -326,10 +370,23 @@ class NanoVectorDBStorage(BaseVectorStorage):
         # NanoVectorDB opens the target file.
         reap_orphan_tmp_files(self._client_file_name, self.workspace or "_")
 
+        # ``(st_mtime_ns, st_size)`` of the JSON file this process last loaded
+        # or wrote -- the authoritative half of the cross-process fence (see
+        # *Cross-process sync protocol*). Sampled BEFORE the construction
+        # below, which reads the file; see ``kg.file_fingerprint`` for why the
+        # order matters.
+        fingerprint = self._stat_fingerprint()
+        self._loaded_fingerprint = None
+        # How many times the file channel caught a commit the flag channel
+        # never announced, so a deployment can tell whether the
+        # lost-notification window in #3854 actually occurs.
+        self._missed_notification_reloads = 0
+
         self._client = NanoVectorDB(
             self.embedding_func.embedding_dim,
             storage_file=self._client_file_name,
         )
+        self._adopt_fingerprint(fingerprint)
 
         # Minimal pending area for deferred embedding: id -> _PendingNanoDoc.
         # Holds only records not yet embedded+materialized into self._client;
@@ -369,6 +426,38 @@ class NanoVectorDBStorage(BaseVectorStorage):
             self.namespace, workspace=self.workspace
         )
 
+    def _stat_fingerprint(self) -> file_fingerprint.Fingerprint | object:
+        """Sample the JSON file's identity. See ``kg.file_fingerprint``."""
+        return file_fingerprint.sample(
+            (self._client_file_name,), workspace=self.workspace
+        )
+
+    def _adopt_fingerprint(
+        self, fingerprint: file_fingerprint.Fingerprint | object
+    ) -> None:
+        """Record ``fingerprint`` as the file this process now holds."""
+        self._loaded_fingerprint = file_fingerprint.adopted(fingerprint)
+
+    def _record_fingerprint(self) -> None:
+        """Adopt the file currently on disk without reloading from it.
+
+        For the writer: after its own save the in-memory client already *is*
+        the file's content.
+        """
+        self._adopt_fingerprint(self._stat_fingerprint())
+
+    def _peer_commit_detected(self) -> bool:
+        """Whether the file on disk differs from the one this process loaded.
+
+        The fence's authoritative test — the one a failed notification cannot
+        disable. See ``kg.file_fingerprint``.
+        """
+        return file_fingerprint.peer_commit_detected(
+            (self._client_file_name,),
+            self._loaded_fingerprint,
+            workspace=self.workspace,
+        )
+
     def _reload_client_from_disk_locked(self, *, for_write: bool = False) -> bool:
         """Reload ``self._client`` if another process committed newer data.
 
@@ -376,23 +465,46 @@ class NanoVectorDBStorage(BaseVectorStorage):
         used by write paths as well as reads because deferred upserts mean a
         stale writer must merge its pending buffer into the latest on-disk
         snapshot, not save over it or return without flushing.
+
+        Two tests, per *Cross-process sync protocol*: this process's
+        ``storage_updated`` flag, read first, and the file's fingerprint
+        against what this process recorded. The second is what survives a lost
+        notification.
         """
-        if not self.storage_updated.value:
+        notified = bool(self.storage_updated.value)
+        if not notified and not self._peer_commit_detected():
             return False
 
-        log_message = (
-            f"[{self.workspace}] Process {os.getpid()} reloading {self.namespace} "
-            "due to update by another process"
-        )
-        if for_write:
-            logger.warning(log_message)
+        if notified:
+            log_message = (
+                f"[{self.workspace}] Process {os.getpid()} reloading {self.namespace} "
+                "due to update by another process"
+            )
+            if for_write:
+                logger.warning(log_message)
+            else:
+                logger.info(log_message)
         else:
-            logger.info(log_message)
+            # The lost-notification case the file channel exists for. Always a
+            # warning, on the read path too: unlike a notified reload this one
+            # says a publication failed somewhere.
+            self._missed_notification_reloads += 1
+            logger.warning(
+                f"[{self.workspace}] Process {os.getpid()} reloading "
+                f"{self.namespace}: {self._client_file_name} is not the file "
+                "this process loaded and no reload notification arrived for "
+                "it, so a notification was lost. Recovering through the file "
+                f"channel (occurrence #{self._missed_notification_reloads} in "
+                "this process)."
+            )
 
+        # Sampled BEFORE the read, never after -- see ``kg.file_fingerprint``.
+        fingerprint = self._stat_fingerprint()
         self._client = NanoVectorDB(
             self.embedding_func.embedding_dim,
             storage_file=self._client_file_name,
         )
+        self._adopt_fingerprint(fingerprint)
         self.storage_updated.value = False
         return True
 
@@ -755,6 +867,19 @@ class NanoVectorDBStorage(BaseVectorStorage):
             finally:
                 self._client.storage_file = original
 
+        async def _committed() -> None:
+            # Adopt the file this process just wrote BEFORE the caller's
+            # bookkeeping, which publishes through the manager and can fail. A
+            # local stat, so it cannot fail with it -- and doing it first means
+            # a failed publication does not additionally leave this process
+            # treating its own save as a peer's, which would cost a full
+            # file reload on the next call for nothing.
+            #
+            # Here rather than in each caller's hook so no save path can forget
+            # it: ``finalize`` reuses this same method.
+            self._record_fingerprint()
+            await on_committed()
+
         try:
             await commit_in_storage_io(
                 partial(
@@ -763,7 +888,7 @@ class NanoVectorDBStorage(BaseVectorStorage):
                     _save_atomic,
                     self.workspace or "_",
                 ),
-                on_committed,
+                _committed,
             )
         except CommitBookkeepingError as e:
             # The file is already renamed into place, so the rows ARE durable
@@ -1507,6 +1632,18 @@ class NanoVectorDBStorage(BaseVectorStorage):
                     "writer reload flag is left set below so the next read "
                     f"rebuilds it from the removed file: {snapshot_error}",
                 )
+
+            # Mirror that decision on the file channel, and BEFORE the
+            # fallible manager writes below: a plain attribute assignment
+            # cannot fail with the manager, so the fence holds even when the
+            # flag write does not. Adopting the file's absence when the reset
+            # installed the post-drop client; invalidating (``None`` differs
+            # from any real file, present or absent) when it did not, so the
+            # next read rebuilds the stale client through this channel too.
+            if snapshot_reset:
+                self._record_fingerprint()
+            else:
+                self._loaded_fingerprint = None
 
             # Keep publication under the storage lock. Once deletion starts,
             # commit_in_storage_io defers caller cancellation through this hook

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -880,6 +880,20 @@ class NanoVectorDBStorage(BaseVectorStorage):
             self._record_fingerprint()
             await on_committed()
 
+        # No fingerprint handling on the FAILURE path, unlike
+        # ``FaissVectorDBStorage._save_faiss_index``: this is ONE
+        # ``atomic_write``, so a failed save leaves the previous file in place
+        # and its fingerprint unchanged, and the fence correctly sees no
+        # change. FAISS writes two files and can publish a mismatched pair, so
+        # it has to adopt them explicitly to keep the fence from reading its
+        # own partial write as a peer commit.
+        #
+        # And note the direction differs from ``NetworkXStorage``, which
+        # INVALIDATES its fingerprint after a failed save to force a reload:
+        # it has no redo log, so its in-memory graph is untrustworthy and the
+        # file is the only authority. Here the in-memory client plus the redo
+        # logs ARE the authority to retry from, so the snapshot must be kept.
+
         try:
             await commit_in_storage_io(
                 partial(

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -17,10 +17,10 @@ from lightrag.utils import (
 )
 from lightrag.base import BaseGraphStorage
 import networkx as nx
+from . import file_fingerprint
 from .shared_storage import (
     get_namespace_lock,
     get_update_flag,
-    is_multiprocess_mode,
     set_all_update_flags,
 )
 
@@ -30,21 +30,6 @@ from dotenv import load_dotenv
 # allows to use different .env file for each lightrag instance
 # the OS environment variables take precedence over the .env file
 load_dotenv(dotenv_path=".env", override=False)
-
-
-# Returned by ``NetworkXStorage._stat_fingerprint`` when this process could
-# not read the GraphML file's metadata at all. Deliberately distinct from
-# ``None`` ("the file does not exist"): absence is a real state to converge on,
-# an unreadable ``stat`` is a fence outage to ride out on the flag channel
-# alone. Conflating them would let a failed ``stat`` order a reload, and a
-# reload that cannot read the file installs an EMPTY graph -- which the next
-# commit would then serialize over a perfectly good file.
-_FINGERPRINT_UNREADABLE = object()
-
-# What a readable ``stat`` yields: ``(st_mtime_ns, st_size)``, or ``None`` for
-# a file that does not exist. ``| object`` in a signature below admits
-# ``_FINGERPRINT_UNREADABLE`` alongside it.
-_Fingerprint = tuple[int, int] | None
 
 
 @final
@@ -189,7 +174,7 @@ class NetworkXStorage(BaseGraphStorage):
         only cost a redundant reload, which is harmless.
 
         Single-process mode skips the fingerprint test entirely
-        (``is_multiprocess_mode()``): there is no peer that could have
+        (``file_fingerprint.fence_enabled()``): there is no peer that could have
         committed, so a divergent file means an external edit, and reloading
         for it would discard this process's own uncommitted mutations.
 
@@ -228,13 +213,16 @@ class NetworkXStorage(BaseGraphStorage):
 
     Implementation differences from ``NanoVectorDBStorage`` (same design,
     different surface):
-        * **The fence is no longer the same.** This class tests the file
-          fingerprint as well as the flag (above); ``NanoVectorDBStorage``
-          and ``FaissVectorDBStorage`` still open their reload with
-          ``if not self.storage_updated.value: return False`` and are exposed
-          to the lost notification in the same shape — including on their
-          ``for_write=True`` path, which is where a stale snapshot gets saved
-          over durable rows. Phase 2 of #3854 brings them the same fence.
+        * **The fence is shared, its verdict is not.** All three test the
+          file fingerprint as well as the flag, through the same
+          ``lightrag.kg.file_fingerprint`` helpers. What differs is what
+          happens once a peer commit is detected on a WRITE path: this class
+          **declines** the save (it has no way to keep the mutation), while
+          the vector backends reload the peer snapshot and replay their
+          pending buffer and redo logs on top (issue #3688) — so they lose
+          nothing and report nothing. The flush-failure propagation a decline
+          requires (``LightRAG._flush_storages``) is therefore this class's
+          concern alone.
         * No ``client_storage`` property — there is no equivalent live
           reference being exposed to callers, so NanoVectorDB's
           "do-not-retain-across-await" caveat does not apply here.
@@ -433,65 +421,30 @@ class NetworkXStorage(BaseGraphStorage):
             self._commit_gate_loop = loop
         return self._commit_gate
 
-    def _stat_fingerprint(self) -> _Fingerprint | object:
-        """Identity of the GraphML file on disk, for the fence's file channel.
-
-        Returns ``(st_mtime_ns, st_size)``, ``None`` when the file does not
-        exist, or ``_FINGERPRINT_UNREADABLE`` when the ``stat`` itself failed
-        (see that constant for why the last two must stay distinct).
-
-        ``st_ino`` is deliberately NOT part of it. ``atomic_write`` renames a
-        tmp file over the target, which frees the previous inode, and the
-        allocator hands that same inode straight back to the next tmp file in
-        the directory -- measured at 28 reuses across 30 consecutive commits.
-        The inode number is therefore near-constant across commits and
-        discriminates nothing; ``mtime`` carries the signal, with ``size`` as a
-        helper that catches nothing on its own (an equal-length attribute
-        rewrite -- renaming a node to a same-length name -- keeps the size).
-        """
-        try:
-            st = os.stat(self._graphml_xml_file)
-        except FileNotFoundError:
-            return None
-        except OSError as exc:
-            # Routed through log_without_raising because ``drop``'s _committed
-            # hook reaches here (via _record_fingerprint) AFTER the file is
-            # already gone, and every step of that hook has to be unable to
-            # report a completed destruction as an error -- a broken log sink
-            # included.
-            log_without_raising(
-                logger.warning,
-                f"[{self.workspace}] Could not stat {self._graphml_xml_file} "
-                "to check for peer commits; the reload fence falls back to the "
-                f"notification flag alone: {exc}",
-            )
-            return _FINGERPRINT_UNREADABLE
-        return (st.st_mtime_ns, st.st_size)
-
-    def _adopt_fingerprint(self, fingerprint: _Fingerprint | object) -> None:
-        """Record ``fingerprint`` as the file this process now holds.
-
-        An unreadable ``stat`` is recorded as ``None``, which differs from any
-        real file: the next check therefore re-samples and, if the ``stat``
-        works by then, reloads once. That is the harmless direction.
-        """
-        self._loaded_fingerprint = (
-            None if fingerprint is _FINGERPRINT_UNREADABLE else fingerprint
+    def _stat_fingerprint(self) -> file_fingerprint.Fingerprint | object:
+        """Sample the GraphML file's identity. See ``kg.file_fingerprint``."""
+        return file_fingerprint.sample(
+            (self._graphml_xml_file,), workspace=self.workspace
         )
+
+    def _adopt_fingerprint(
+        self, fingerprint: file_fingerprint.Fingerprint | object
+    ) -> None:
+        """Record ``fingerprint`` as the file this process now holds."""
+        self._loaded_fingerprint = file_fingerprint.adopted(fingerprint)
 
     def _peer_commit_detected(self) -> bool:
         """Whether the file on disk differs from the one this process loaded.
 
         The fence's authoritative test — the one a failed notification cannot
         disable. ``False`` in single-process mode and on an unreadable
-        ``stat``; see *Cross-process sync protocol* for both.
+        ``stat``; see ``kg.file_fingerprint`` for both.
         """
-        if not is_multiprocess_mode():
-            return False
-        fingerprint = self._stat_fingerprint()
-        if fingerprint is _FINGERPRINT_UNREADABLE:
-            return False
-        return fingerprint != self._loaded_fingerprint
+        return file_fingerprint.peer_commit_detected(
+            (self._graphml_xml_file,),
+            self._loaded_fingerprint,
+            workspace=self.workspace,
+        )
 
     def _reload_locked(self) -> None:
         """Reload ``self._graph`` from disk and satisfy BOTH fence channels.
@@ -563,7 +516,10 @@ class NetworkXStorage(BaseGraphStorage):
                 logger.info(
                     f"[{self.workspace}] Process {os.getpid()} reloading graph {self._graphml_xml_file} due to modifications by another process"
                 )
-                if is_multiprocess_mode() and not self._peer_commit_detected():
+                if (
+                    file_fingerprint.fence_enabled()
+                    and not self._peer_commit_detected()
+                ):
                     # Notified about the file this process already holds: a
                     # self-notification, or a peer commit that a sibling
                     # coroutine reloaded before this call got the lock. The

--- a/tests/kg/faiss_impl/test_faiss_fingerprint_fence.py
+++ b/tests/kg/faiss_impl/test_faiss_fingerprint_fence.py
@@ -73,7 +73,9 @@ async def _worker(tmp_path) -> FaissVectorDBStorage:
             "embedding_batch_num": 32,
             "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
         },
-        embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=_embed),
+        embedding_func=EmbeddingFunc(
+            embedding_dim=DIM, max_token_size=512, func=_embed
+        ),
         meta_fields={"content"},
     )
     await storage.initialize()
@@ -133,9 +135,7 @@ async def test_reader_picks_up_a_peer_commit_it_was_never_told_about(
 
 
 @pytest.mark.asyncio
-async def test_a_change_to_the_meta_file_alone_is_a_peer_commit(
-    tmp_path, multiprocess
-):
+async def test_a_change_to_the_meta_file_alone_is_a_peer_commit(tmp_path, multiprocess):
     """The pair is sampled, not just the index file. Cross-file atomicity is
     best-effort, so a pair where only the metadata moved is a real state — and
     reading it as "unchanged" would serve rows the metadata no longer has."""

--- a/tests/kg/faiss_impl/test_faiss_fingerprint_fence.py
+++ b/tests/kg/faiss_impl/test_faiss_fingerprint_fence.py
@@ -134,25 +134,89 @@ async def test_reader_picks_up_a_peer_commit_it_was_never_told_about(
         await worker_b.finalize()
 
 
+@pytest.mark.parametrize("moved", ["index", "meta"])
 @pytest.mark.asyncio
-async def test_a_change_to_the_meta_file_alone_is_a_peer_commit(tmp_path, multiprocess):
-    """The pair is sampled, not just the index file. Cross-file atomicity is
-    best-effort, so a pair where only the metadata moved is a real state — and
-    reading it as "unchanged" would serve rows the metadata no longer has."""
+async def test_a_half_published_pair_is_not_a_peer_commit(
+    tmp_path, multiprocess, moved
+):
+    """Both files are sampled, and BOTH must have moved to count.
+
+    A publication renames the two files one at a time, so a pair where only
+    one moved does not describe a single state. Reloading it is the corruption
+    vector — ``_load_faiss_index`` binds in-range metadata rows to whatever
+    vectors the other file now holds. Keeping the older self-consistent
+    snapshot is the safe direction, and it is what this process did before the
+    fence existed.
+    """
     worker = await _worker(tmp_path)
     try:
         await worker.upsert({"n1": {"content": "x"}})
         assert await worker.index_done_callback() is True
         assert worker._peer_commit_detected() is False
 
-        with open(worker._meta_file, encoding="utf-8") as fh:
-            meta = fh.read()
-        with open(worker._meta_file, "w", encoding="utf-8") as fh:
-            fh.write(meta + " ")  # same index file, different metadata
+        target = worker._meta_file if moved == "meta" else worker._faiss_index_file
+        with open(target, "rb") as fh:
+            payload = fh.read()
+        with open(target, "wb") as fh:
+            fh.write(payload + b" ")  # one file of the pair moves, not both
 
-        assert worker._peer_commit_detected() is True
+        assert worker._peer_commit_detected() is False
     finally:
         await worker.finalize()
+
+
+@pytest.mark.asyncio
+async def test_a_peer_does_not_reload_another_workers_half_published_pair(
+    tmp_path, multiprocess, lost_notification, monkeypatch
+):
+    """The finding the failure-path adoption did not cover.
+
+    Adopting the pair protects the writer that failed. A PEER sees the moved
+    ``.index``, has no flag to tell it otherwise, and — before the
+    all-files-must-move rule — read that as a peer commit: it reloaded the
+    mismatched pair and, as the next writer, persisted the corruption. Codex
+    review on #3867 traced it as losing untouched row B.
+    """
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        await worker_a.upsert({"A": {"content": "a"}, "B": {"content": "b"}})
+        assert await worker_a.index_done_callback() is True
+        # B adopts the complete pair by reading through it. That read is
+        # itself a lost-notification recovery (the fixture publishes nothing),
+        # so the counter is already 1 — what matters below is that the
+        # half-published pair does not add to it.
+        assert await worker_b.get_by_id("B") is not None
+        recoveries = worker_b._missed_notification_reloads
+
+        # A deletes A and fails the metadata half of its save.
+        await worker_a.delete(["A"])
+        real_atomic_write = faiss_impl.atomic_write
+
+        def fail_on_meta(file_name, write_fn, workspace="_", *args, **kwargs):
+            if file_name == worker_a._meta_file:
+                raise OSError("meta write boom")
+            return real_atomic_write(file_name, write_fn, workspace, *args, **kwargs)
+
+        with monkeypatch.context() as patched:
+            patched.setattr(faiss_impl, "atomic_write", fail_on_meta)
+            with pytest.raises(OSError, match="meta write boom"):
+                await worker_a.index_done_callback()
+
+        # The peer must NOT take the half-published pair for a commit.
+        assert worker_b._peer_commit_detected() is False
+        assert worker_b._missed_notification_reloads == recoveries
+        # It keeps serving its own consistent snapshot.
+        assert await worker_b.get_by_id("B") is not None
+
+        # Once A's retry completes the pair, the peer does converge on it.
+        assert await worker_a.index_done_callback() is True
+        assert worker_b._peer_commit_detected() is True
+        assert await worker_b.get_by_id("A") is None
+        assert await worker_b.get_by_id("B") is not None
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()
 
 
 @pytest.mark.asyncio

--- a/tests/kg/faiss_impl/test_faiss_fingerprint_fence.py
+++ b/tests/kg/faiss_impl/test_faiss_fingerprint_fence.py
@@ -14,6 +14,7 @@ reloads the peer snapshot and replays this process's pending buffer and
 from __future__ import annotations
 
 import json
+import os
 
 import numpy as np
 import pytest
@@ -134,19 +135,18 @@ async def test_reader_picks_up_a_peer_commit_it_was_never_told_about(
         await worker_b.finalize()
 
 
-@pytest.mark.parametrize("moved", ["index", "meta"])
 @pytest.mark.asyncio
-async def test_a_half_published_pair_is_not_a_peer_commit(
-    tmp_path, multiprocess, moved
+async def test_an_index_newer_than_its_metadata_is_an_interrupted_publication(
+    tmp_path, multiprocess
 ):
-    """Both files are sampled, and BOTH must have moved to count.
+    """The completeness test, judged from the files alone.
 
-    A publication renames the two files one at a time, so a pair where only
-    one moved does not describe a single state. Reloading it is the corruption
-    vector — ``_load_faiss_index`` binds in-range metadata rows to whatever
-    vectors the other file now holds. Keeping the older self-consistent
-    snapshot is the safe direction, and it is what this process did before the
-    fence existed.
+    ``_save_faiss_index`` writes the index first and renames the metadata
+    LAST, so the metadata is this storage's commit marker: a completed
+    publication leaves it no older than the index it describes. An index
+    newer than its metadata therefore means a publication that did not
+    finish, and reloading it is the corruption vector — ``_load_faiss_index``
+    binds in-range metadata rows to whatever vectors the index now holds.
     """
     worker = await _worker(tmp_path)
     try:
@@ -154,15 +154,64 @@ async def test_a_half_published_pair_is_not_a_peer_commit(
         assert await worker.index_done_callback() is True
         assert worker._peer_commit_detected() is False
 
-        target = worker._meta_file if moved == "meta" else worker._faiss_index_file
-        with open(target, "rb") as fh:
-            payload = fh.read()
-        with open(target, "wb") as fh:
-            fh.write(payload + b" ")  # one file of the pair moves, not both
+        # The index moves past the commit marker: an unfinished publication.
+        meta_mtime = os.stat(worker._meta_file).st_mtime_ns
+        os.utime(worker._faiss_index_file, ns=(meta_mtime + 1000, meta_mtime + 1000))
 
         assert worker._peer_commit_detected() is False
     finally:
         await worker.finalize()
+
+
+@pytest.mark.asyncio
+async def test_a_peer_generations_behind_still_rejects_a_torn_pair(
+    tmp_path, multiprocess, lost_notification, monkeypatch
+):
+    """The case a per-file "did it change" comparison cannot catch.
+
+    Codex review on #3867: a peer that recorded pair A, missed the
+    notification for a COMPLETE pair B, and then meets a half-landed C sees
+    every file changed relative to A — so comparing per-file changes against
+    its own recorded fingerprint takes the torn pair for a commit. The
+    completeness test does not depend on what the reader recorded: the marker
+    being older than the file it commits is a property of the files.
+    """
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        # Generation A, which B records.
+        await worker_a.upsert({"A": {"content": "a"}})
+        assert await worker_a.index_done_callback() is True
+        assert await worker_b.get_by_id("A") is not None
+        recorded_a = worker_b._loaded_fingerprint
+
+        # Generation B lands completely; B is never told.
+        await worker_a.upsert({"B": {"content": "b"}})
+        assert await worker_a.index_done_callback() is True
+
+        # Generation C tears: its index lands, its metadata does not.
+        await worker_a.upsert({"C": {"content": "c"}})
+        real_atomic_write = faiss_impl.atomic_write
+
+        def fail_on_meta(file_name, write_fn, workspace="_", *args, **kwargs):
+            if file_name == worker_a._meta_file:
+                raise OSError("meta write boom")
+            return real_atomic_write(file_name, write_fn, workspace, *args, **kwargs)
+
+        with monkeypatch.context() as patched:
+            patched.setattr(faiss_impl, "atomic_write", fail_on_meta)
+            with pytest.raises(OSError, match="meta write boom"):
+                await worker_a.index_done_callback()
+
+        # Both of B's recorded entries differ from what is on disk now...
+        current = worker_b._stat_fingerprint()
+        assert all(new != old for new, old in zip(current, recorded_a))
+        # ...and it must still refuse, because the pair is torn.
+        assert worker_b._peer_commit_detected() is False
+        assert await worker_b.get_by_id("C") is None
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()
 
 
 @pytest.mark.asyncio
@@ -189,7 +238,8 @@ async def test_a_peer_does_not_reload_another_workers_half_published_pair(
         assert await worker_b.get_by_id("B") is not None
         recoveries = worker_b._missed_notification_reloads
 
-        # A deletes A and fails the metadata half of its save.
+        # A deletes A and fails the metadata half of its save — the commit
+        # marker never lands, so the publication is visibly unfinished.
         await worker_a.delete(["A"])
         real_atomic_write = faiss_impl.atomic_write
 

--- a/tests/kg/faiss_impl/test_faiss_fingerprint_fence.py
+++ b/tests/kg/faiss_impl/test_faiss_fingerprint_fence.py
@@ -1,0 +1,190 @@
+"""FAISS's reload fence must not depend on the notification alone.
+
+Phase 2 of issue #3854 — the same fence as `tests/kg/nano_impl/`, plus the one
+property specific to this backend: its state spans TWO files (`.index` and
+`.meta.json`), so the fingerprint samples both and a change to either is a peer
+commit. Cross-file atomicity is best-effort here, which is exactly why the pair
+must not be readable as "unchanged" when only one of them moved.
+
+Like nano and unlike NetworkX, a stale write is not declined: the write path
+reloads the peer snapshot and replays this process's pending buffer and
+`_unsaved_*` redo logs on top, so both sides survive.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+pytest.importorskip("faiss")
+
+from lightrag.kg import faiss_impl, file_fingerprint  # noqa: E402
+from lightrag.kg.faiss_impl import FaissVectorDBStorage  # noqa: E402
+from lightrag.kg.shared_storage import (  # noqa: E402
+    finalize_share_data,
+    initialize_share_data,
+)
+from lightrag.utils import EmbeddingFunc  # noqa: E402
+
+pytestmark = pytest.mark.offline
+
+DIM = 8
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+@pytest.fixture
+def multiprocess(monkeypatch):
+    """Pretend peer processes exist, so the file channel is armed."""
+    monkeypatch.setattr(file_fingerprint, "is_multiprocess_mode", lambda: True)
+
+
+@pytest.fixture
+def lost_notification(monkeypatch):
+    """Every commit lands on disk and notifies nobody."""
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(faiss_impl, "set_all_update_flags", _noop)
+
+
+async def _embed(texts, **_kwargs):
+    return np.array(
+        [np.full(DIM, (abs(hash(t)) % 97) + 1, dtype=np.float32) for t in texts]
+    )
+
+
+async def _worker(tmp_path) -> FaissVectorDBStorage:
+    """A storage instance on a fixed file pair — call twice for two 'workers'."""
+    storage = FaissVectorDBStorage(
+        namespace="test_vectors",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 32,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=_embed),
+        meta_fields={"content"},
+    )
+    await storage.initialize()
+    return storage
+
+
+def _ids_on_disk(worker) -> set[str]:
+    """The ids a fresh reader would see — the durable state, not memory."""
+    with open(worker._meta_file, encoding="utf-8") as fh:
+        meta = json.load(fh)
+    rows = meta["data"] if isinstance(meta, dict) and "data" in meta else meta
+    if isinstance(rows, dict):
+        rows = rows.values()
+    return {row["__id__"] for row in rows}
+
+
+@pytest.mark.asyncio
+async def test_a_stale_writer_replays_instead_of_overwriting_a_peer_commit(
+    tmp_path, multiprocess, lost_notification
+):
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        await worker_b.upsert({"from_b": {"content": "b"}})
+
+        await worker_a.upsert({"from_a": {"content": "a"}})
+        assert await worker_a.index_done_callback() is True
+
+        assert worker_b.storage_updated.value is False
+
+        assert await worker_b.index_done_callback() is True
+        assert worker_b._missed_notification_reloads == 1
+
+        # No decline, no loss: A's row was reloaded and B's replayed on top.
+        assert _ids_on_disk(worker_b) == {"from_a", "from_b"}
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()
+
+
+@pytest.mark.asyncio
+async def test_reader_picks_up_a_peer_commit_it_was_never_told_about(
+    tmp_path, multiprocess, lost_notification
+):
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        await worker_a.upsert({"from_a": {"content": "a"}})
+        assert await worker_a.index_done_callback() is True
+        assert worker_b.storage_updated.value is False
+
+        assert await worker_b.get_by_id("from_a") is not None
+        assert worker_b._missed_notification_reloads == 1
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()
+
+
+@pytest.mark.asyncio
+async def test_a_change_to_the_meta_file_alone_is_a_peer_commit(
+    tmp_path, multiprocess
+):
+    """The pair is sampled, not just the index file. Cross-file atomicity is
+    best-effort, so a pair where only the metadata moved is a real state — and
+    reading it as "unchanged" would serve rows the metadata no longer has."""
+    worker = await _worker(tmp_path)
+    try:
+        await worker.upsert({"n1": {"content": "x"}})
+        assert await worker.index_done_callback() is True
+        assert worker._peer_commit_detected() is False
+
+        with open(worker._meta_file, encoding="utf-8") as fh:
+            meta = fh.read()
+        with open(worker._meta_file, "w", encoding="utf-8") as fh:
+            fh.write(meta + " ")  # same index file, different metadata
+
+        assert worker._peer_commit_detected() is True
+    finally:
+        await worker.finalize()
+
+
+@pytest.mark.asyncio
+async def test_single_process_mode_ignores_a_divergent_file_pair(
+    tmp_path, lost_notification
+):
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        await worker_a.upsert({"from_a": {"content": "a"}})
+        assert await worker_a.index_done_callback() is True
+
+        assert worker_b._peer_commit_detected() is False
+        assert await worker_b.get_by_id("from_a") is None
+        assert worker_b._missed_notification_reloads == 0
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()
+
+
+@pytest.mark.asyncio
+async def test_drop_adopts_the_files_absence(tmp_path, multiprocess):
+    worker = await _worker(tmp_path)
+    try:
+        await worker.upsert({"n1": {"content": "x"}})
+        assert await worker.index_done_callback() is True
+        assert worker._loaded_fingerprint is not None
+
+        assert (await worker.drop())["status"] == "success"
+        # Both files' ABSENCE, adopted — not ``None``, which means "nothing
+        # recorded" and would order a reload on the next call.
+        assert worker._loaded_fingerprint == (None, None)
+        assert worker._peer_commit_detected() is False
+    finally:
+        await worker.finalize()

--- a/tests/kg/faiss_impl/test_faiss_fingerprint_fence.py
+++ b/tests/kg/faiss_impl/test_faiss_fingerprint_fence.py
@@ -352,3 +352,57 @@ async def test_a_partial_two_file_save_is_not_read_as_a_peer_commit(
         assert await worker.get_by_id("B") is not None
     finally:
         await worker.finalize()
+
+
+@pytest.mark.asyncio
+async def test_a_torn_pair_inside_one_timestamp_tick_is_still_refused(
+    tmp_path, multiprocess, lost_notification, monkeypatch
+):
+    """The completeness test must not depend on the clock's resolution.
+
+    Codex review on #3867: on a coarse-granularity filesystem the next
+    publication's index can land in the same timestamp tick as the previous
+    one's metadata, making the two mtimes equal. A "no older than" test calls
+    that complete and hands back a pair whose files describe different
+    generations. The comparison is therefore STRICT.
+
+    The tick is forced with ``os.utime`` rather than hoped for, so this holds
+    on the fine-grained filesystems CI runs on too.
+    """
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        await worker_a.upsert({"A": {"content": "a"}, "B": {"content": "b"}})
+        assert await worker_a.index_done_callback() is True
+        assert await worker_b.get_by_id("B") is not None
+
+        # Tear the pair: the index lands, the metadata does not.
+        await worker_a.delete(["A"])
+        real_atomic_write = faiss_impl.atomic_write
+
+        def fail_on_meta(file_name, write_fn, workspace="_", *args, **kwargs):
+            if file_name == worker_a._meta_file:
+                raise OSError("meta write boom")
+            return real_atomic_write(file_name, write_fn, workspace, *args, **kwargs)
+
+        with monkeypatch.context() as patched:
+            patched.setattr(faiss_impl, "atomic_write", fail_on_meta)
+            with pytest.raises(OSError, match="meta write boom"):
+                await worker_a.index_done_callback()
+
+        # Collapse the two writes into one tick, as a coarse clock would.
+        meta_mtime = os.stat(worker_b._meta_file).st_mtime_ns
+        os.utime(worker_b._faiss_index_file, ns=(meta_mtime, meta_mtime))
+        assert (
+            os.stat(worker_b._faiss_index_file).st_mtime_ns
+            == os.stat(worker_b._meta_file).st_mtime_ns
+        )
+
+        # The pair still differs from what the peer recorded (the index's size
+        # moved), so only the completeness test can refuse it.
+        assert worker_b._stat_fingerprint() != worker_b._loaded_fingerprint
+        assert worker_b._peer_commit_detected() is False
+        assert await worker_b.get_by_id("B") is not None
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()

--- a/tests/kg/faiss_impl/test_faiss_fingerprint_fence.py
+++ b/tests/kg/faiss_impl/test_faiss_fingerprint_fence.py
@@ -188,3 +188,53 @@ async def test_drop_adopts_the_files_absence(tmp_path, multiprocess):
         assert worker._peer_commit_detected() is False
     finally:
         await worker.finalize()
+
+
+@pytest.mark.asyncio
+async def test_a_partial_two_file_save_is_not_read_as_a_peer_commit(
+    tmp_path, multiprocess, monkeypatch
+):
+    """The one hazard the fence adds to a TWO-file backend.
+
+    ``_write_both`` is two ``atomic_write`` calls, so a failure between them
+    publishes a MISMATCHED pair: a new ``.index`` beside the previous
+    ``.meta.json``. The pair's fingerprint has moved, so a fence that took that
+    at face value would reload this process's own half-finished write as if it
+    were a peer commit — replacing the complete in-memory snapshot with a pair
+    that binds one row's metadata to another's vector, after which the redo
+    replay deletes the wrong vector and the next save makes it permanent.
+
+    Codex review on #3867 traced it as: delete A from ``[A, B]`` and lose B.
+    """
+    worker = await _worker(tmp_path)
+    try:
+        await worker.upsert({"A": {"content": "a"}, "B": {"content": "b"}})
+        assert await worker.index_done_callback() is True
+        assert _ids_on_disk(worker) == {"A", "B"}
+
+        # Delete A, then fail the metadata half of the save.
+        await worker.delete(["A"])
+
+        real_atomic_write = faiss_impl.atomic_write
+
+        def fail_on_meta(file_name, write_fn, workspace="_", *args, **kwargs):
+            if file_name == worker._meta_file:
+                raise OSError("meta write boom")
+            return real_atomic_write(file_name, write_fn, workspace, *args, **kwargs)
+
+        with monkeypatch.context() as patched:
+            patched.setattr(faiss_impl, "atomic_write", fail_on_meta)
+            with pytest.raises(OSError, match="meta write boom"):
+                await worker.index_done_callback()
+
+        # The pair on disk is this process's own partial write, so the fence
+        # must NOT offer to reload it.
+        assert worker._peer_commit_detected() is False
+
+        # The retry writes both files from the snapshot still held in memory:
+        # A is gone, and B — which the operation never touched — survives.
+        assert await worker.index_done_callback() is True
+        assert _ids_on_disk(worker) == {"B"}
+        assert await worker.get_by_id("B") is not None
+    finally:
+        await worker.finalize()

--- a/tests/kg/nano_impl/test_nano_fingerprint_fence.py
+++ b/tests/kg/nano_impl/test_nano_fingerprint_fence.py
@@ -74,7 +74,9 @@ async def _worker(tmp_path) -> NanoVectorDBStorage:
             "embedding_batch_num": 32,
             "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
         },
-        embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=_embed),
+        embedding_func=EmbeddingFunc(
+            embedding_dim=DIM, max_token_size=512, func=_embed
+        ),
         meta_fields={"content"},
     )
     await storage.initialize()

--- a/tests/kg/nano_impl/test_nano_fingerprint_fence.py
+++ b/tests/kg/nano_impl/test_nano_fingerprint_fence.py
@@ -1,0 +1,202 @@
+"""The vector backends' reload fence must not depend on the notification alone.
+
+Phase 2 of issue #3854, mirroring `tests/kg/networkx_impl/`. Before it,
+`_reload_client_from_disk_locked` opened with
+`if not self.storage_updated.value: return False`, and that flag is published
+with one Manager RPC per process. A peer whose flag was never flipped kept a
+stale matrix and, on the `for_write=True` path, saved it over the durable rows.
+
+The outcome differs from `NetworkXStorage` in a way worth pinning: this backend
+does not DECLINE a stale write, it reload-then-replays. The peer's snapshot is
+loaded and this process's pending buffer plus its `_unsaved_*` redo logs are
+replayed on top (issue #3688), so both sides survive — which is why the
+flush-failure propagation NetworkX needs has no counterpart here.
+
+A lost notification is simulated by no-op'ing `set_all_update_flags` in the
+storage module: the write lands, no peer flag is flipped. That is exactly the
+state a partial publication leaves behind.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from lightrag.kg import file_fingerprint, nano_vector_db_impl
+from lightrag.kg.nano_vector_db_impl import NanoVectorDBStorage
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+from lightrag.utils import EmbeddingFunc
+
+pytestmark = pytest.mark.offline
+
+DIM = 8
+
+
+@pytest.fixture(autouse=True)
+def _shared_data():
+    finalize_share_data()
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+@pytest.fixture
+def multiprocess(monkeypatch):
+    """Pretend peer processes exist, so the file channel is armed."""
+    monkeypatch.setattr(file_fingerprint, "is_multiprocess_mode", lambda: True)
+
+
+@pytest.fixture
+def lost_notification(monkeypatch):
+    """Every commit lands on disk and notifies nobody."""
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(nano_vector_db_impl, "set_all_update_flags", _noop)
+
+
+async def _embed(texts, **_kwargs):
+    return np.array(
+        [np.full(DIM, (abs(hash(t)) % 97) + 1, dtype=np.float32) for t in texts]
+    )
+
+
+async def _worker(tmp_path) -> NanoVectorDBStorage:
+    """A storage instance on a fixed file — call twice for two 'workers'."""
+    storage = NanoVectorDBStorage(
+        namespace="test_vectors",
+        workspace="ws",
+        global_config={
+            "working_dir": str(tmp_path),
+            "embedding_batch_num": 32,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=EmbeddingFunc(embedding_dim=DIM, max_token_size=512, func=_embed),
+        meta_fields={"content"},
+    )
+    await storage.initialize()
+    return storage
+
+
+def _ids_on_disk(worker) -> set[str]:
+    """The ids a fresh reader would see — the durable state, not memory.
+
+    Read through the JSON file rather than a second ``NanoVectorDB``, so the
+    assertion does not depend on that class's private storage attribute.
+    """
+    with open(worker._client_file_name, encoding="utf-8") as fh:
+        return {row["__id__"] for row in json.load(fh)["data"]}
+
+
+@pytest.mark.asyncio
+async def test_a_stale_writer_replays_instead_of_overwriting_a_peer_commit(
+    tmp_path, multiprocess, lost_notification
+):
+    """The lost write itself — and here BOTH sides survive it."""
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        await worker_b.upsert({"from_b": {"content": "b"}})
+
+        await worker_a.upsert({"from_a": {"content": "a"}})
+        assert await worker_a.index_done_callback() is True
+
+        # The notification never arrived, so only the file says A committed.
+        assert worker_b.storage_updated.value is False
+
+        assert await worker_b.index_done_callback() is True
+        assert worker_b._missed_notification_reloads == 1
+
+        # No decline, no loss: A's row was reloaded and B's replayed on top.
+        assert _ids_on_disk(worker_b) == {"from_a", "from_b"}
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()
+
+
+@pytest.mark.asyncio
+async def test_reader_picks_up_a_peer_commit_it_was_never_told_about(
+    tmp_path, multiprocess, lost_notification
+):
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        await worker_a.upsert({"from_a": {"content": "a"}})
+        assert await worker_a.index_done_callback() is True
+        assert worker_b.storage_updated.value is False
+
+        assert await worker_b.get_by_id("from_a") is not None
+        assert worker_b._missed_notification_reloads == 1
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()
+
+
+@pytest.mark.asyncio
+async def test_writer_does_not_reload_the_file_it_just_wrote(
+    tmp_path, multiprocess, monkeypatch
+):
+    """Without adopting its own save, every writer would re-parse the whole
+    JSON file and rebuild the matrix on its next operation, forever."""
+    worker = await _worker(tmp_path)
+    try:
+        await worker.upsert({"n1": {"content": "x"}})
+        assert await worker.index_done_callback() is True
+
+        reloads = [0]
+        original = NanoVectorDBStorage._reload_client_from_disk_locked
+
+        def counting(self, **kwargs):
+            did = original(self, **kwargs)
+            reloads[0] += int(bool(did))
+            return did
+
+        monkeypatch.setattr(
+            NanoVectorDBStorage, "_reload_client_from_disk_locked", counting
+        )
+        assert await worker.get_by_id("n1") is not None
+        assert reloads[0] == 0
+        assert worker._missed_notification_reloads == 0
+    finally:
+        await worker.finalize()
+
+
+@pytest.mark.asyncio
+async def test_single_process_mode_ignores_a_divergent_file(
+    tmp_path, lost_notification
+):
+    """No ``multiprocess`` fixture: no peer can have committed, so a divergent
+    file means an external edit, and reloading for it would discard this
+    process's own pending rows."""
+    worker_a = await _worker(tmp_path)
+    worker_b = await _worker(tmp_path)
+    try:
+        await worker_a.upsert({"from_a": {"content": "a"}})
+        assert await worker_a.index_done_callback() is True
+
+        assert worker_b._peer_commit_detected() is False
+        assert await worker_b.get_by_id("from_a") is None
+        assert worker_b._missed_notification_reloads == 0
+    finally:
+        await worker_a.finalize()
+        await worker_b.finalize()
+
+
+@pytest.mark.asyncio
+async def test_drop_adopts_the_files_absence(tmp_path, multiprocess, monkeypatch):
+    worker = await _worker(tmp_path)
+    try:
+        await worker.upsert({"n1": {"content": "x"}})
+        assert await worker.index_done_callback() is True
+        assert worker._loaded_fingerprint is not None
+
+        assert (await worker.drop())["status"] == "success"
+        # The file's ABSENCE, adopted — not ``None``, which means "nothing
+        # recorded" and would order a reload on the next call.
+        assert worker._loaded_fingerprint == (None,)
+        assert worker._peer_commit_detected() is False
+    finally:
+        await worker.finalize()

--- a/tests/kg/networkx_impl/test_networkx_fingerprint_fence.py
+++ b/tests/kg/networkx_impl/test_networkx_fingerprint_fence.py
@@ -29,7 +29,7 @@ import os
 import numpy as np
 import pytest
 
-from lightrag.kg import networkx_impl
+from lightrag.kg import file_fingerprint, networkx_impl
 from lightrag.kg.networkx_impl import NetworkXStorage
 from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
 from lightrag.utils import EmbeddingFunc
@@ -49,12 +49,12 @@ def _shared_data():
 def multiprocess(monkeypatch):
     """Pretend peer processes exist, so the file channel is armed.
 
-    The fence is gated on ``is_multiprocess_mode()`` — in single-process mode a
-    divergent file cannot be a peer commit. Tests that want the fence must say
-    so; ``test_single_process_mode_ignores_a_divergent_file`` asserts the
-    other side of that gate.
+    The fence is gated on ``file_fingerprint.fence_enabled()`` — in
+    single-process mode a divergent file cannot be a peer commit. Tests that
+    want the fence must say so; the gate's other side is asserted by
+    ``test_single_process_mode_ignores_a_divergent_file``.
     """
-    monkeypatch.setattr(networkx_impl, "is_multiprocess_mode", lambda: True)
+    monkeypatch.setattr(file_fingerprint, "is_multiprocess_mode", lambda: True)
 
 
 @pytest.fixture
@@ -238,6 +238,8 @@ async def test_a_timestamp_tick_collision_is_the_documented_residue(
         assert await worker_b.has_node("aa") is True
         recorded = worker_b._loaded_fingerprint
         assert recorded is not None
+        # One entry per path; this storage has a single file.
+        recorded_mtime, recorded_size = recorded[0]
 
         # A second commit whose GraphML is the same length as the first.
         await worker_a.delete_node("aa")
@@ -246,8 +248,8 @@ async def test_a_timestamp_tick_collision_is_the_documented_residue(
 
         # Force the tick collision. The size must already match, or this test
         # would be pinning nothing.
-        os.utime(worker_b._graphml_xml_file, ns=(recorded[0], recorded[0]))
-        assert os.stat(worker_b._graphml_xml_file).st_size == recorded[1]
+        os.utime(worker_b._graphml_xml_file, ns=(recorded_mtime, recorded_mtime))
+        assert os.stat(worker_b._graphml_xml_file).st_size == recorded_size
 
         # The residue: the file channel cannot see it.
         assert worker_b._peer_commit_detected() is False
@@ -322,7 +324,9 @@ async def test_drop_adopts_the_files_absence(tmp_path, multiprocess, monkeypatch
         assert worker._loaded_fingerprint is not None
 
         assert (await worker.drop())["status"] == "success"
-        assert worker._loaded_fingerprint is None
+        # The file's ABSENCE, adopted — not ``None``, which means "nothing
+        # recorded" and would order a reload on the next call.
+        assert worker._loaded_fingerprint == (None,)
 
         loads = _count_loads(monkeypatch)
         assert await worker.has_node("n1") is False


### PR DESCRIPTION
## Description

Phase 2 of #3854. `NanoVectorDBStorage._reload_client_from_disk_locked` and `FaissVectorDBStorage._reload_index_from_disk_locked` both opened with `if not self.storage_updated.value: return False`, and that flag is published with one Manager RPC per process. A peer whose flag was never flipped kept a stale snapshot and — on the `for_write=True` path that **both write paths take** — saved it over the peer's durable rows.

Both now test the file's `(st_mtime_ns, st_size)` against the fingerprint recorded when the process last loaded or wrote it, OR-ed with the flag, exactly as NetworkX has since phase 1.

**Phase 1 ([#3861](https://github.com/HKUDS/LightRAG/pull/3861)) is merged, so this PR targets `main` and its diff is phase 2 only.** It was opened stacked on the phase-1 branch to keep the diff readable; note for future stacked PRs that a non-`main` base gets **no CI at all** here — `tests.yml`, `pg-smoke.yml` and `webui-tests.yml` all filter `pull_request: branches: [main, dev, dev-*]` — and GitHub does not retarget automatically while the base branch still exists. The base was moved once phase 1 landed, and `main` was merged in.

## Related Issues

Phase 2 of #3854. Answers the question that issue's [phase 2 note](https://github.com/HKUDS/LightRAG/issues/3854#issuecomment-5572570319) left open — see *The decline is not extended* below.

## Changes Made

**`lightrag/kg/file_fingerprint.py` (new)** — the mechanism, once, with the reasoning that only exists in the details: sample **before** the read, an unreadable `stat` is not an absent file, `st_ino` is excluded because `atomic_write`'s rename hands the freed inode straight back to the next tmp file (28 reuses across 30 commits), and single-process mode has no peer to detect. `fence_enabled()` is the one place the multiprocess gate is consulted.

**`networkx_impl.py`** — migrated onto the shared helpers, same method names and same behaviour (its 9 phase-1 tests pass unchanged). One ordering slip in phase 1 already cost a review round; three copies of this is how it rots.

**`nano_vector_db_impl.py` / `faiss_impl.py`** — the fence wired into:
- the reload (both channels, flag first, fingerprint sampled before the read, one post-condition: record fingerprint **and** clear flag);
- `__post_init__`, sampling before the initial load;
- every save, adopting the file it just wrote **before** the fallible publication — placed inside `_save_to_disk_locked` / `_save_faiss_index` rather than each caller's hook, so `finalize` cannot forget it;
- `drop`, adopting the files' absence, or **invalidating** the fingerprint when its snapshot reset failed — mirroring what that path already does with the flag, and done before the manager writes that can fail (the phase-1 P2 lesson);
- a `_missed_notification_reloads` counter, logged at WARNING whenever the file channel catches a commit the flag never announced.

Both class docstrings' *Cross-process sync protocol* sections are rewritten from the phase-1 "flag-only — see #3854" placeholder, including their accepted residues.

## FAISS spans two files, so it needs a completeness test

This is the load-bearing part of the change and it took four review rounds to get right — the three earlier attempts each covered only part of the population, so the reasoning is worth stating in full.

`_save_faiss_index` publishes `.index` and `.meta.json` with one `atomic_write` each, so there is a window in which the two files describe **different generations**. Reloading such a pair is worse than not reloading at all: `_load_faiss_index` keeps every metadata row whose fid falls inside the shorter index and reconstructs its vector from there, so a torn pair binds one row's metadata to another's vector, the redo replay then deletes the wrong vector, and the next save makes that permanent — losing rows the operation never touched.

**The invariant:** the write order *is* the generation marker. The index is written first and the metadata renamed **last**, so a completed publication leaves `meta.st_mtime_ns` **strictly greater** than the index's, and an interrupted one does not. `file_fingerprint.publication_complete` tests exactly that — `paths` is given in publication order and the last one is the commit marker — and a set that fails it reports "no change", so the process keeps its older self-consistent snapshot until the writer's retry completes the set.

Two properties this has and the earlier attempts did not:

- **It never consults the reader's recorded fingerprint.** Ordering is a property of the files; a recorded fingerprint is a property of one reader. A peer several generations behind sees every file changed even when the newest publication is half-landed, so any per-file "did this change" comparison takes a torn pair for a commit.
- **Strict, not "no older".** Equality can only mean two writes landed in one filesystem timestamp tick, and a torn set reaches equality the same way a complete one does. `<` refuses it; the cost is that a *complete* same-tick publication is refused too, which is a missed detection rather than a torn read — and the flag channel carries that commit, since a same-tick publication means a healthy, fast-committing writer.

Alongside it, `_save_faiss_index`'s **failure path adopts the pair**: whatever is on disk is that process's own doing, and its in-memory index plus redo logs are the authority its retry writes from. The single-file backends need neither piece — one `atomic_write` is all-or-nothing — and NetworkX needs the *opposite* failure handling, invalidating its fingerprint in order to force a reload, having no redo log to retry from. All three asymmetries are documented where someone would otherwise "fix" them, including the two comments saying that reversing either the write order or the pair order silently disables the test.

## The decline is not extended — deliberately

NetworkX **declines** a stale save because it has no way to keep the mutation, which is why phase 1 also had to make `LightRAG._flush_storages` reject a declined commit.

These two do not decline and must not: their write path is *reload-then-replay* — `index_done_callback` reloads the peer snapshot and `_flush_pending_locked` replays the pending buffer plus the `_unsaved_upserts` / `_unsaved_deletes` redo logs on top (issue #3688). Both sides survive, so there is nothing to report as a failure and the flush-failure propagation has no counterpart here. `test_a_stale_writer_replays_instead_of_overwriting_a_peer_commit` pins that outcome in both backends: after a lost notification the file ends up holding **both** workers' rows.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (class docstrings + the new module's contract)
- [x] Unit tests added

## Additional Notes

**Every new test was proven able to fail**, by breaking the behaviour it pins and watching it go red: disabling each backend's fingerprint test, removing the failure-path adoption, disabling the completeness gate, reducing the fingerprint to the commit marker alone, and relaxing `<` back to `<=` each turn a specific test red. The remaining tests pin the *absence* of a reload, which those mutations cannot break.

**Test results** on the current head: `tests/kg/faiss_impl` + `tests/kg/nano_impl` + `tests/kg/networkx_impl` + `tests/pipeline` → **1065 passed** · `ruff check --ignore=E402` and `ruff format --check` clean across `lightrag/` and `tests/` (712 files) · CI green (pre-commit, PostgreSQL 18, Offline Tests 3.12 and 3.14).

`faiss-cpu` is not in the default dev install here, and without it the FAISS tests **skip silently** rather than fail — worth knowing when validating this locally.

**Left for a follow-up, not needed here:** an explicit generation key in `meta.json` or an atomic pair publication (a directory rename) would make FAISS's completeness test independent of timestamps entirely. Both are storage-format changes for backends the project scopes as test-only, and neither buys anything the ordering invariant does not already give at tick resolution — but they are the right answer if these backends ever become production storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyHEH7RFCxPzm2bup76J4K