### PR TITLE
feat: select installed custom chunkers at server startup

### DIFF
--- a/docs/FileProcessingPipeline-zh.md
+++ b/docs/FileProcessingPipeline-zh.md
@@ -249,6 +249,10 @@ LIGHTRAG_PARSER=pdf:legacy-R(chunk_ts=800,chunk_ol=80);*:legacy-R  # 规则
 
 文本 API 以 `chunking.strategy="custom"` 暴露同一路径；`params` 使用完整的 fixed-token/legacy 参数契约（`chunk_token_size`、`chunk_overlap_token_size`、`split_by_character`、`split_by_character_only`）。如果没有替换 `LightRAG.chunking_func`，`/documents/text` 与 `/documents/texts` 会返回 422。
 
+Server 部署可以通过 `CUSTOM_CHUNKER=<注册名>`（或 `--custom-chunker`）在启动时选择已安装的 `lightrag.chunkers` 插件，见 [ThirdPartyChunker-zh.md](./ThirdPartyChunker-zh.md)。注入作用于**整个实例**：不带分块 selector 的插入也调用它，不限于 `C`。显式 F/R/V/P 仍调用内置策略。未配置时保持现有准入和回退行为；配置错误则启动失败，不会悄悄换回默认回调。
+
+`doc_status.metadata.custom_chunker` 独立记录最近一次尝试的注册名/版本及 `authoritative: false`，不改变 `chunk_method` 与 `chunk_opts`。该观察值跨重试/重置保留，仅供诊断，不是执行指令。持久化 C 文档在配置身份变化或移除后重处理，每次尝试告警一次并按**当前配置**继续。已有的逐次 fallback 告警独立保留；作者提供的版本号无法检测同名同版本背后的实现变化。
+
 > `drop_references` 检测调参 `CHUNK_P_REFERENCES_TAIL_N`（默认 `0`：扫描全部内容块；正数表示只扫描文末最后 N 块）/ `CHUNK_P_REFERENCES_HEADINGS`（竖线分隔，默认 `References\|Bibliography\|参考文献`）仅经环境变量、运行时实时读取。drop_references可以通过环境变量 `CHUNK_P_DROP_REFERENCES` 设置为全局默认值.
 
 ### 2.7 校验、优先级与回退
@@ -1117,7 +1121,7 @@ PENDING ─►├─ parse_queues["mineru"]  ─► [mineru 池  × N2] ─┼�
 4. **task 上限与请求上限不同**：`MAX_ASYNC_LLM` 设置 N5 单文档 chunk 抽取的 task 上限，以及其两倍的合并 task 上限。实际抽取和合并摘要请求使用 Extract 角色的上限：设置了 `EXTRACT_MAX_ASYNC_LLM` 时使用它，否则使用 `MAX_ASYNC_LLM`。缓存、图的 keyed lock 和角色上限都会让观测到的实际请求并发低于 task 并发。
 5. **queue size 与背压**：`QUEUE_SIZE_INSERT=4` 这个偏小的默认值是有意为之——process 阶段慢且占内存，让 analyze 阶段在队列写满时阻塞、再反压到 parse 阶段，避免一次性把成千上万份解析结果堆在内存里。
 6. **改后生效方式**：所有参数通过 `.env`（或环境变量）传入，仅在 `LightRAG` 实例构造时读取一次；改完需要重启服务。
-7. **分块不随并发增长**：分块在一个专用的单 worker 线程池里执行，目的是不阻塞事件循环，并发度不随 `MAX_PARALLEL_INSERT` 提高，调大并发不会让分块更快。自定义 `chunking_func` 仍在事件循环上执行（它的契约允许触碰运行中的事件循环），CPU 密集的实现应自行 `asyncio.to_thread`。
+7. **分块不随并发增长**：分块在一个专用的单 worker 线程池里执行，目的是不阻塞事件循环，并发度不随 `MAX_PARALLEL_INSERT` 提高，调大并发不会让分块更快。自定义 `chunking_func` 默认仍在事件循环上执行（它的契约允许触碰运行中的事件循环）。CPU 密集的实现应自行 offload，或由同步注册插件声明 `executor_safe=True` 复用有界分块线程池；异步插件不能启用此选项。
 
 **典型调优场景：**
 

--- a/docs/FileProcessingPipeline.md
+++ b/docs/FileProcessingPipeline.md
@@ -249,6 +249,10 @@ Currently supported parameters (canonical name / short alias):
 
 The text APIs expose the same path as `chunking.strategy="custom"`. Its `params` object uses the complete fixed-token/legacy contract (`chunk_token_size`, `chunk_overlap_token_size`, `split_by_character`, and `split_by_character_only`). `/documents/text` and `/documents/texts` return 422 unless `LightRAG.chunking_func` was replaced with a non-default callback.
 
+For Server deployments, `CUSTOM_CHUNKER=<registered-name>` (or `--custom-chunker`) selects an installed `lightrag.chunkers` plugin at startup; see [ThirdPartyChunker.md](./ThirdPartyChunker.md). This injection is **instance-wide**: no-selector inserts also use the callback, not just `C`. Explicit F/R/V/P still use built-ins. With the key unset, existing admission and fallback behavior is unchanged. Invalid selections fail startup rather than silently reverting to the built-in callback.
+
+`doc_status.metadata.custom_chunker` records the last attempted registered name/version with `authoritative: false`, separately from the unchanged `chunk_method` and `chunk_opts`. It survives retry/reset for diagnosis, not as an instruction. Reprocessing a persisted `C` document after changing/removing the configured identity warns once per attempt and proceeds under the current configuration. The existing per-attempt fallback warning is separate and unchanged. Author-supplied versions cannot detect implementation changes behind unchanged identities.
+
 > `drop_references` detection knobs `CHUNK_P_REFERENCES_TAIL_N` (default `0`: scan all content blocks; a positive value scans only the last N) / `CHUNK_P_REFERENCES_HEADINGS` (pipe-separated, default `References\|Bibliography\|参考文献`) are env-only and read live at run time. Global default can be set via env var `CHUNK_P_DROP_REFERENCES`.
 
 ### 2.7 Validation, Priority, and Fallback
@@ -1117,7 +1121,7 @@ Parse queues are **created dynamically from the registry's `ParserSpec.queue_gro
 4. **Task limits and request limits are distinct**: `MAX_ASYNC_LLM` sets N5's per-document chunk-extraction task limit and its `2 ×` merge-task limit. Actual extraction and merge-summary requests use the Extract role's limit, `EXTRACT_MAX_ASYNC_LLM` when set or `MAX_ASYNC_LLM` otherwise. Caches, keyed graph locks, and a role limit can make observed request concurrency lower than task concurrency.
 5. **Queue size and back-pressure**: the small `QUEUE_SIZE_INSERT=4` default is deliberate — process is slow and memory-hungry, so a full queue blocks the analyze stage and back-pressures parse, instead of piling tens of thousands of parse results into memory at once.
 6. **How changes take effect**: every parameter comes from `.env` (or the environment) and is read once when the `LightRAG` instance is constructed; restart the service after changing one.
-7. **Chunking does not scale with concurrency**: chunking runs in a dedicated single-worker thread pool so it does not block the event loop, and its concurrency does not grow with `MAX_PARALLEL_INSERT` — raising that will not make chunking faster. A custom `chunking_func` still runs on the event loop (its contract allows touching the running loop), so CPU-heavy implementations should call `asyncio.to_thread` themselves.
+7. **Chunking does not scale with concurrency**: chunking runs in a dedicated single-worker thread pool so it does not block the event loop, and its concurrency does not grow with `MAX_PARALLEL_INSERT` — raising that will not make chunking faster. A custom `chunking_func` still runs on the event loop by default (its contract allows touching the running loop). CPU-heavy implementations should offload themselves, or a synchronous registered plugin may declare `executor_safe=True` to use the bounded chunking pool; async plugins cannot opt into that offload.
 
 **Typical tuning scenarios:**
 

--- a/docs/ThirdPartyChunker-zh.md
+++ b/docs/ThirdPartyChunker-zh.md
@@ -1,0 +1,84 @@
+# 第三方分块器
+
+已安装的 Python 包可以注册六参数分块回调，无需修改 LightRAG。Server 启动时发现注册信息并注入选中的一个回调。本功能对应 [#3868](https://github.com/HKUDS/LightRAG/issues/3868)，不包含 `C(name=...)`、上下文契约、身份强制校验、多活动分块器或 F/R/V/P 的 transform hook。
+
+## 发布轻量注册入口
+
+在插件包的 `pyproject.toml` 中声明：
+
+```toml
+[project.entry-points."lightrag.chunkers"]
+acme = "acme_chunker.plugin:register"
+```
+
+包的 `__init__.py` 和注册模块均不要导入分块实现：
+
+```python
+# acme_chunker/plugin.py
+from lightrag.chunker.registry import ChunkerSpec, register_chunker
+
+def register():
+    register_chunker(ChunkerSpec(
+        name="acme",
+        impl="acme_chunker.implementation:chunk",
+        version="1",
+        description="Organization-specific document splitting",
+        executor_safe=False,
+    ))
+```
+
+一个零参数入口函数可以注册多个 spec。注册仅保存元数据，只有选中的 `impl` 才被加载。插件是受信任的已安装 Python 代码，不是沙箱；作者不得在注册入口提前导入实现、访问网络或初始化进程/线程资源。
+
+名称必须满足 `[a-z0-9][a-z0-9_-]{0,63}`，保留名为 `fixed_token`、`recursive_character`、`semantic_vector`、`paragraph_semantic` 以及 `f/r/v/p/c`。`version` 是仅用于诊断的不透明字符串，不能作为兼容性保证；`description` 必须为非空单行说明。以后可增加可选 spec 字段而不改变 entry-point 契约。
+
+发现过程每进程一次；Gunicorn preload 在 fork 前完成解析，worker 继承同一注册/选择快照。实现模块导入也应兼容 preload：与事件循环、网络绑定的资源在回调中创建，不在导入时创建。安装/升级插件或更改选择后需重启部署。入口按发行包及 entry-point 来源确定性排序。重名记录包含双方来源的 ERROR；选中重名则启动失败，未选中重名保留最后一项。失败的注册入口会连同其部分注册结果一起丢弃并记录来源；若它未能提供所选名称，后续校验以未知名称拒绝启动。
+
+## 实现原有六参数契约
+
+```python
+def chunk(tokenizer, content, split_by_character, split_by_character_only,
+          chunk_overlap_token_size, chunk_token_size):
+    # Return ordered dictionaries with tokens, content and chunk_order_index.
+    ...
+```
+
+支持同步和异步函数，始终传入这六个位置参数，不传 `_emit_source_span` 等内置私有参数。默认在事件循环上调用，包含返回 awaitable 的同步工厂函数。异常导致文档 FAILED，不会静默改用其它算法。现有下游块校验与 embedding 大小处理仍适用；自定义输出不进行 source-span sidecar 回填。
+
+CPU 密集、同步且线程安全的实现可以声明 `executor_safe=True`，复用 LightRAG 有界分块线程池。该实现不得依赖当前事件循环或返回 awaitable。异步函数/异步可调用对象声明该选项会在启动时被拒绝。依赖事件循环的实现保持默认，或在异步回调中自行 offload；这个声明是作者承诺，不是线程安全证明或隔离机制。
+
+## Server 选择
+
+将插件安装进运行 LightRAG 的同一环境，配置：
+
+```dotenv
+CUSTOM_CHUNKER=acme
+```
+
+也可使用 `lightrag-server --custom-chunker acme` 或 `lightrag-gunicorn --custom-chunker acme`，CLI 优先于 `.env`。值只能是已注册的裸名称，不能是 Python 导入路径、文件路径或代码，HTTP 请求也不能指定实现。
+
+未知/有歧义的名称、导入/属性错误、不可调用对象、可检查但不能接受六个位置参数的签名均导致启动失败。没有可检查签名的原生可调用对象仍允许加载，但运行与输出契约不变。
+
+注入等同于 `LightRAG(chunking_func=...)`，作用于**显式 C 和不带分块 selector 的插入**，不是 C 专用。F/R/V/P 仍选内置策略并保留现有 bypass 告警。文本 API 用 `chunking.strategy="custom"`，文件/路由 hint 用 C。未设置时不覆盖默认回调：新 C 请求仍返回 422，已持久化/后台 C 仍逐次告警并回退精确定长分块。仅安装插件并不会选中它。
+
+## SDK 嵌入
+
+```python
+from lightrag import LightRAG
+from lightrag.chunker.plugins import load_and_resolve_chunker
+
+callback = load_and_resolve_chunker("acme")
+rag = LightRAG(chunking_func=callback)  # Add storage/LLM configuration.
+# await rag.initialize_storages() before inserts; finalize on completion.
+```
+
+SDK 也可直接 `register_chunker(spec, origin="my-application")`。未配置的解析结果为 `None`：此时应省略构造参数，而非传入 `chunking_func=None`。
+
+若仅需发现插件，可调用 `load_third_party_chunkers()`，再使用 registry 中的 `registered_chunker_names()` 或 `resolve_chunker(name)`。仅发现的接口会记录失败，但不会声称选择已通过校验。
+
+## 诊断与重处理
+
+一条启动 INFO 列出名称、版本、说明、来源和选择结果，并说明不带 selector 的插入也受影响。注册失败是 ERROR，不影响无关的有效选择。Server 的每条失败日志会注明选择校验后的结果：指定的分块器仍可用于 C/无 selector 插入、选择失败导致启动中止，或未配置时维持现有 C 接纳/回退行为。启动校验成功不保证插件之后的运行或输出一定正确。
+
+`doc_status.metadata.custom_chunker` 独立于 `chunk_opts` 保存最近一次尝试的观察值，例如 `{"name": "acme", "version": "1", "authoritative": false}`；`chunk_method` 原有字符串不变。旧观察值被没有注册回调的一次尝试替换时，名称/版本记为 null。
+
+观察值跨重置保留仅供比较：持久化 C 文档的旧名称/版本与当前配置不同时，每次处理尝试记录一条 drift WARNING，随后按**当前**回调执行，或在移除配置后按原有规则告警回退。fallback 告警独立保留原有逐文档/逐次频率。记录中的身份不参与选择或阻止执行；同名同版本无法证明实现未变，包版本及部署可重现性需另外管理。改变配置不会自动重处理已完成文档。

--- a/docs/ThirdPartyChunker.md
+++ b/docs/ThirdPartyChunker.md
@@ -1,0 +1,85 @@
+# Third-party chunkers
+
+An installed package can publish a legacy six-argument chunker without modifying LightRAG. The Server discovers registrations at startup and injects one selected callback. This implements [#3868](https://github.com/HKUDS/LightRAG/issues/3868); it does not add `C(name=...)`, context-aware callbacks, identity enforcement, multiple active chunkers, or a transform hook for F/R/V/P.
+
+## Publish an import-cheap registration
+
+In your package's `pyproject.toml`:
+
+```toml
+[project.entry-points."lightrag.chunkers"]
+acme = "acme_chunker.plugin:register"
+```
+
+Keep both the package `__init__.py` and registration module free of implementation imports:
+
+```python
+# acme_chunker/plugin.py
+from lightrag.chunker.registry import ChunkerSpec, register_chunker
+
+def register():
+    register_chunker(ChunkerSpec(
+        name="acme",
+        impl="acme_chunker.implementation:chunk",
+        version="1",
+        description="Organization-specific document splitting",
+        executor_safe=False,
+    ))
+```
+
+The zero-argument function may register multiple specs. LightRAG stores their metadata without importing implementations; only the selected `impl` is resolved. Plugin registration is trusted installed Python code, not a sandbox: authors must not eagerly import implementations, perform network work, or initialize process/thread resources there.
+
+Names must match `[a-z0-9][a-z0-9_-]{0,63}`. Reserved names are `fixed_token`, `recursive_character`, `semantic_vector`, `paragraph_semantic`, and `f/r/v/p/c`. `version` is an opaque string for diagnostics, not compatibility enforcement. A one-line description is required. Optional spec fields can be extended without changing the entry-point contract.
+
+Discovery is once per process; Gunicorn preload resolves before forking, and workers inherit the same registration/selection snapshot. Keep implementation imports preload-safe too: allocate loop-bound/network resources inside the invocation, not at import. Restart the deployment after installing/updating packages or changing selection. Registration order is deterministic by distribution and entry-point origin. A duplicate logs both origins at ERROR; a selected duplicate fails startup, while an unselected duplicate retains the last registration. A failing provider is skipped with its origin logged, and its partial registrations are discarded; selection of a name it failed to provide then fails as unknown.
+
+## Implement the existing callback contract
+
+```python
+def chunk(tokenizer, content, split_by_character, split_by_character_only,
+          chunk_overlap_token_size, chunk_token_size):
+    # Return your algorithm's ordered list of dictionaries, each containing
+    # tokens (int), content (str), and chunk_order_index (int).
+    ...
+```
+
+Both synchronous and async callbacks are supported, and receive exactly these six positional arguments (no private `_emit_source_span` keyword). Default invocation is on the event loop, including synchronous factories returning awaitables. Exceptions fail the document rather than selecting a different algorithm. Existing downstream chunk validation and embedding-size handling still apply; custom text is not eligible for source-span sidecar backfill.
+
+For CPU-bound, synchronous, thread-safe code, set `executor_safe=True` to use LightRAG's existing bounded chunking executor. Such code must not need the running event loop or return awaitables. An async function/async callable object with that flag is rejected at startup. Leave it false for loop-dependent implementations, or offload explicitly inside an async callback. The declaration is an author promise, not a sandbox or a proof of thread safety.
+
+## Select in the Server
+
+Install the package into the same environment as LightRAG, then set:
+
+```dotenv
+CUSTOM_CHUNKER=acme
+```
+
+Or use `lightrag-server --custom-chunker acme` / `lightrag-gunicorn --custom-chunker acme` (CLI wins over `.env`). The value is a bare registered name. Python import paths, file paths and code are not configuration values; HTTP payloads cannot select an implementation either.
+
+Startup fails for an unknown/ambiguous selection, import or attribute errors, a non-callable implementation, or an introspectable callable that cannot accept six positional arguments. Native callables without an inspectable signature remain allowed; their output/runtime contract still applies.
+
+The selected callback is injected as `LightRAG(chunking_func=...)`, so it serves **both explicit C and no-selector inserts** instance-wide. F/R/V/P continue to select built-ins and retain the existing bypass diagnostic. Use `chunking.strategy="custom"` in text APIs or `C` in filename/routing hints for explicit selection. Unset means no constructor override: caller-present C remains 422, and persisted/background C still warns and uses exact fixed-token fallback. Merely installing a plugin does not select it.
+
+## SDK embedding
+
+```python
+from lightrag import LightRAG
+from lightrag.chunker.plugins import load_and_resolve_chunker
+
+callback = load_and_resolve_chunker("acme")
+rag = LightRAG(chunking_func=callback)  # Add your normal storage/LLM config.
+# await rag.initialize_storages() before inserting; finalize when finished.
+```
+
+SDK users may also call `register_chunker(spec, origin="my-application")` directly. An unset resolution returns `None`: omit the constructor argument in that case, rather than passing `chunking_func=None`.
+
+For discovery without selection, call `load_third_party_chunkers()`, then use `registered_chunker_names()` or `resolve_chunker(name)` from the registry. This discovery-only API logs failures without claiming that a selection has been validated.
+
+## Diagnostics and reprocessing
+
+One startup INFO line lists registered names, versions, descriptions, origins and the selection, explicitly noting the no-selector impact. Discovery failures are ERRORs and do not break an unrelated valid selection. Each Server failure line includes the outcome after selection validation: the named selected chunker remains available for C/no-selector inserts, startup aborted because selection failed, or the unset configuration preserves existing C admission/fallback behavior. A successful startup validation does not guarantee a plugin's later runtime/output correctness.
+
+`doc_status.metadata.custom_chunker` stores the most recent attempted identity as `{"name": "acme", "version": "1", "authoritative": false}` separately from `chunk_opts`. The existing `chunk_method` strings are unchanged. An attempt without a registered callback records null name/version when replacing a previous observation.
+
+This observation survives reset only for comparison. A persisted C document whose recorded name/version differs from the current configuration emits one drift WARNING per processing attempt, then runs with the **current** callback (or normal warned fallback if it was removed). The fallback warning is separate and keeps its existing per-document/per-attempt cadence. No identity/version string gates processing or chooses a callback. Unchanged identity strings cannot establish unchanged implementation; manage package versions and deployment reproducibility separately. Changing configuration does not automatically reprocess already-processed documents.

--- a/env.example
+++ b/env.example
@@ -775,6 +775,14 @@ DOCLING_DO_FORMULA_ENRICHMENT=false
 # CHUNK_SIZE=1200
 # CHUNK_OVERLAP_SIZE=100
 
+### Optional installed third-party chunker (lightrag.chunkers entry points).
+### Bare registered name only, not module:func or a file path. CLI: --custom-chunker.
+### Unset preserves the built-in callback. Selection serves C AND no-selector
+### inserts instance-wide; explicit F/R/V/P still use their built-in strategies.
+### Unknown/duplicate selected name or invalid implementation fails startup.
+### Authoring, diagnostics and executor opt-in: docs/ThirdPartyChunker.md
+# CUSTOM_CHUNKER=
+
 ### Overlap (in tokens) borrowed from the previous chunk's tail when the
 ### embedding hard fallback still has to token-window-split a chunk that
 ### remains over the embedding model's context limit after chunking.

--- a/lightrag/api/config.py
+++ b/lightrag/api/config.py
@@ -353,6 +353,12 @@ def parse_args() -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(description="LightRAG API Server")
 
+    parser.add_argument(
+        "--custom-chunker",
+        default=get_env_value("CUSTOM_CHUNKER", ""),
+        help="Registered third-party chunker name (CUSTOM_CHUNKER); not a Python import path",
+    )
+
     # Server configuration
     parser.add_argument(
         "--host",

--- a/lightrag/api/lightrag_server.py
+++ b/lightrag/api/lightrag_server.py
@@ -62,6 +62,8 @@ from lightrag.api.routers.document_routes import (
 )
 from lightrag.parser.docx.smart_heading.nlp import SmartHeadingNLPError
 from lightrag.parser.plugins import load_third_party_parsers
+from lightrag.chunker.plugins import load_and_resolve_chunker
+from lightrag.chunker.registry import log_chunker_selection
 from lightrag.parser.routing import (
     parser_rules_from_env,
     validate_parser_routing_config,
@@ -1506,6 +1508,8 @@ def create_app(args):
     # Discover third-party parser engines (``lightrag.parsers`` entry points)
     # BEFORE validating routing rules, so LIGHTRAG_PARSER may reference them.
     load_third_party_parsers()
+    selected_chunker = load_and_resolve_chunker(getattr(args, "custom_chunker", ""))
+    log_chunker_selection(selected_chunker)
     validate_parser_routing_config()
     # Fail fast when DOCX_SMART_HEADING / a LIGHTRAG_PARSER rule enables
     # smart_heading but the pinned spaCy models are missing — surfacing the
@@ -2457,6 +2461,7 @@ def create_app(args):
     # Initialize RAG with unified configuration
     try:
         rag = LightRAG(
+            **({"chunking_func": selected_chunker} if selected_chunker else {}),
             working_dir=args.working_dir,
             workspace=args.workspace,
             llm_model_func=create_llm_model_func(args.llm_binding),

--- a/lightrag/api/routers/document_routes.py
+++ b/lightrag/api/routers/document_routes.py
@@ -780,12 +780,16 @@ class TextChunkingConfig(BaseModel):
     ``custom`` explicitly invokes ``LightRAG.chunking_func`` and reuses the
     fixed-token parameter contract (split character, split-only flag, overlap,
     and size). It is rejected unless the application injected a non-default
-    callback.
+    callback (Server: ``CUSTOM_CHUNKER`` / ``--custom-chunker`` selects an
+    installed ``lightrag.chunkers`` registration, never an HTTP import path).
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    strategy: TextChunkingStrategy = "fixed_token"
+    strategy: TextChunkingStrategy = Field(
+        default="fixed_token",
+        description="custom invokes the constructor callback selected at Server startup by CUSTOM_CHUNKER; it accepts fixed-token parameters, never an implementation name or import path",
+    )
     params: Dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
@@ -2583,8 +2587,13 @@ def _validate_custom_chunking_available(process_options: str, rag: LightRAG) -> 
     from lightrag.chunker import chunking_by_token_size
 
     if getattr(rag, "chunking_func", chunking_by_token_size) is chunking_by_token_size:
+        from lightrag.chunker.registry import registered_chunker_names
+
         raise ValueError(
-            "custom chunking requires a non-default LightRAG.chunking_func"
+            "custom chunking requires a non-default LightRAG.chunking_func; "
+            "configure CUSTOM_CHUNKER / --custom-chunker with an installed "
+            "lightrag.chunkers registration. Registered names: "
+            + (", ".join(registered_chunker_names()) or "(none)")
         )
 
 

--- a/lightrag/chunker/__init__.py
+++ b/lightrag/chunker/__init__.py
@@ -55,15 +55,37 @@ how ``process_options`` and the new ``chunk_options`` snapshot drive
 chunker selection per document.
 """
 
-from lightrag.chunker.paragraph_semantic import chunking_by_paragraph_semantic
-from lightrag.chunker.recursive_character import (
-    chunking_by_recursive_character,
-)
-from lightrag.chunker.semantic_vector import chunking_by_semantic_vector
-from lightrag.chunker.token_size import (
-    chunking_by_fixed_token,
-    chunking_by_token_size,
-)
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lightrag.chunker.paragraph_semantic import chunking_by_paragraph_semantic
+    from lightrag.chunker.recursive_character import chunking_by_recursive_character
+    from lightrag.chunker.semantic_vector import chunking_by_semantic_vector
+    from lightrag.chunker.token_size import (
+        chunking_by_fixed_token,
+        chunking_by_token_size,
+    )
+
+# Importing chunker.registry/plugins must not eagerly load any implementation.
+# Preserve public exports and cache the original callable (identity matters to C).
+_EXPORT_MODULES = {
+    "chunking_by_fixed_token": "token_size",
+    "chunking_by_token_size": "token_size",
+    "chunking_by_paragraph_semantic": "paragraph_semantic",
+    "chunking_by_recursive_character": "recursive_character",
+    "chunking_by_semantic_vector": "semantic_vector",
+}
+
+
+def __getattr__(name: str) -> Any:
+    module = _EXPORT_MODULES.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(f"lightrag.chunker.{module}"), name)
+    globals()[name] = value
+    return value
+
 
 __all__ = [
     "chunking_by_fixed_token",

--- a/lightrag/chunker/plugins.py
+++ b/lightrag/chunker/plugins.py
@@ -1,0 +1,95 @@
+"""Discover import-cheap registration functions in ``lightrag.chunkers``.
+
+Mirrors the parser plugin seam. Each entry point resolves to a zero-argument
+function calling register_chunker(ChunkerSpec(...)), never the implementation
+itself. SDK users may call discovery before resolving a constructor callback.
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib.metadata import entry_points
+
+from lightrag.chunker.registry import (
+    ChunkerBinding,
+    _plugin_registration,
+    resolve_chunker,
+)
+
+ENTRY_POINT_GROUP = "lightrag.chunkers"
+logger = logging.getLogger("lightrag")
+_loaded = False
+_failures: list[tuple[str, str, str]] = []
+
+
+def _origin(ep) -> str:
+    dist = getattr(ep, "dist", None)
+    return f"{getattr(dist, 'name', 'unknown distribution')}@{getattr(dist, 'version', '?')} {ep.name}={ep.value}"
+
+
+def _discover() -> list[str]:
+    """Cache registrations and failure diagnostics, never implementations."""
+    global _loaded
+    if _loaded:
+        return []
+    _loaded = True
+    loaded = []
+    for ep in sorted(entry_points(group=ENTRY_POINT_GROUP), key=_origin):
+        origin = _origin(ep)
+        try:
+            with _plugin_registration(origin):
+                register = ep.load()
+                register()
+        except Exception as exc:
+            _failures.append((ep.name, origin, str(exc)))
+            continue
+        loaded.append(ep.name)
+    return loaded
+
+
+def _report_failures(outcome: str) -> None:
+    for name, origin, error in _failures:
+        logger.error(
+            "[chunker-plugins] skipped failed plugin %r (%s): %s; %s",
+            name,
+            origin,
+            error,
+            outcome,
+        )
+
+
+def load_third_party_chunkers() -> list[str]:
+    """Discover once for SDK registration without selecting a callback.
+
+    Failed providers are logged and skipped, including partial registrations.
+    Use load_and_resolve_chunker for selection-aware failure diagnostics.
+    No implementation is imported unless the plugin violates the authoring
+    contract by eagerly importing it inside its own registration module.
+    """
+    if _loaded:
+        return []
+    loaded = _discover()
+    _report_failures("discovery only; no chunker selection has been validated")
+    return loaded
+
+
+def load_and_resolve_chunker(name: str | None) -> ChunkerBinding | None:
+    """Validate before reporting whether a broken provider affects C startup.
+
+    Gunicorn preload workers inherit the same registration/selection snapshot.
+    Log outcomes, not guesses based on a failed entry point's unrelated name.
+    """
+    _discover()
+    try:
+        selected = resolve_chunker(name)
+    except ValueError:
+        _report_failures(
+            f"CUSTOM_CHUNKER={name!r} could not be activated; startup aborted"
+        )
+        raise
+    _report_failures(
+        f"selected chunker {selected.spec.name!r} validated; C and no-selector chunking remain available"
+        if selected
+        else "CUSTOM_CHUNKER is unset; built-in callback and existing C admission/fallback are unchanged"
+    )
+    return selected

--- a/lightrag/chunker/registry.py
+++ b/lightrag/chunker/registry.py
@@ -1,0 +1,243 @@
+"""Import-cheap third-party chunker specifications and startup resolution.
+
+Only installed plugins supply implementation references. Operator selection is
+a closed-set name, never an import string. Identity is diagnostic, not a fence.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import logging
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Iterator
+
+if TYPE_CHECKING:
+    from lightrag.utils import Tokenizer
+
+logger = logging.getLogger("lightrag")
+_NAME = re.compile(r"[a-z0-9][a-z0-9_-]{0,63}")
+_RESERVED = frozenset(
+    {
+        "fixed_token",
+        "recursive_character",
+        "semantic_vector",
+        "paragraph_semantic",
+        "f",
+        "r",
+        "v",
+        "p",
+        "c",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ChunkerSpec:
+    """Metadata only; ``impl`` is a lazy ``module:attribute`` reference.
+
+    ``version`` is an opaque author-supplied observation. ``executor_safe``
+    opts a synchronous, thread-safe implementation into the bounded chunking
+    executor; the default preserves the legacy on-event-loop contract.
+    Future optional fields can extend this spec without changing entry points.
+    """
+
+    name: str
+    impl: str
+    version: str
+    description: str
+    executor_safe: bool = False
+
+
+@dataclass(frozen=True)
+class _Registration:
+    spec: ChunkerSpec
+    origin: str
+
+
+_REGISTRY: dict[str, _Registration] = {}
+_DUPLICATES: set[str] = set()
+_registration_origin: str | None = None
+
+
+@contextmanager
+def _plugin_registration(origin: str) -> Iterator[None]:
+    """Attribute registrations to their provider; discard partial failures."""
+    global _registration_origin
+    previous_origin = _registration_origin
+    previous = _REGISTRY.copy()
+    previous_duplicates = _DUPLICATES.copy()
+    _registration_origin = origin
+    try:
+        yield
+    except Exception:
+        _REGISTRY.clear()
+        _REGISTRY.update(previous)
+        _DUPLICATES.clear()
+        _DUPLICATES.update(previous_duplicates)
+        raise
+    finally:
+        _registration_origin = previous_origin
+
+
+def register_chunker(spec: ChunkerSpec, *, origin: str | None = None) -> None:
+    """Register without importing an implementation; report every collision."""
+    if not isinstance(spec.name, str) or not _NAME.fullmatch(spec.name):
+        raise ValueError("chunker name must match [a-z0-9][a-z0-9_-]{0,63}")
+    if spec.name in _RESERVED:
+        raise ValueError(f"reserved chunker name: {spec.name!r}")
+    if not isinstance(spec.impl, str) or not spec.impl.strip():
+        raise ValueError(
+            f"chunker {spec.name!r} requires a lazy implementation reference"
+        )
+    if not isinstance(spec.version, str):
+        raise ValueError(f"chunker {spec.name!r} version must be a string")
+    if (
+        not isinstance(spec.description, str)
+        or not spec.description.strip()
+        or any(c in spec.description for c in "\r\n")
+    ):
+        raise ValueError(f"chunker {spec.name!r} requires a one-line description")
+    if not isinstance(spec.executor_safe, bool):
+        raise ValueError(f"chunker {spec.name!r} executor_safe must be a bool")
+    resolved_origin = _registration_origin or origin or spec.impl
+    previous = _REGISTRY.get(spec.name)
+    if previous is not None:
+        _DUPLICATES.add(spec.name)
+        logger.error(
+            "[chunker-plugins] duplicate chunker %r: %s -> %s",
+            spec.name,
+            previous.origin,
+            resolved_origin,
+        )
+    _REGISTRY[spec.name] = _Registration(spec, resolved_origin)
+
+
+def registered_chunker_names() -> tuple[str, ...]:
+    """Return names without importing any implementation."""
+    return tuple(sorted(_REGISTRY))
+
+
+class ChunkerBinding:
+    """Callable injected at construction, with non-authoritative provenance.
+
+    Not a dataclass: LightRAG's ``asdict`` snapshots must retain a callable,
+    rather than recursively turning the callback into a metadata dictionary.
+    """
+
+    def __init__(self, spec: ChunkerSpec, implementation: Callable[..., Any]):
+        self.spec = spec
+        self.implementation = implementation
+
+    def __call__(
+        self,
+        tokenizer: Tokenizer,
+        content: str,
+        split_by_character: str | None,
+        split_by_character_only: bool,
+        chunk_overlap_token_size: int,
+        chunk_token_size: int,
+    ) -> Any:
+        args = (
+            tokenizer,
+            content,
+            split_by_character,
+            split_by_character_only,
+            chunk_overlap_token_size,
+            chunk_token_size,
+        )
+        if self.spec.executor_safe:
+            from lightrag.utils import run_in_chunking_executor
+
+            return run_in_chunking_executor(self.implementation, *args)
+        return self.implementation(*args)
+
+
+def resolve_chunker(name: str | None) -> ChunkerBinding | None:
+    """Fail startup on invalid selection/import/arity; unset returns no override."""
+    if name is None or name == "":
+        return None
+    if not isinstance(name, str):
+        raise ValueError("CUSTOM_CHUNKER must be a registered chunker name")
+    if any(c in name for c in ":/\\."):
+        raise ValueError(
+            "CUSTOM_CHUNKER: import paths are not supported; install a plugin using lightrag.chunkers entry points and select its registered name"
+        )
+    if not _NAME.fullmatch(name):
+        raise ValueError("CUSTOM_CHUNKER must match [a-z0-9][a-z0-9_-]{0,63}")
+    if name in _DUPLICATES:
+        raise ValueError(
+            f"CUSTOM_CHUNKER selects duplicate name {name!r}; remove the conflicting registration (see both origins in the error log)"
+        )
+    registration = _REGISTRY.get(name)
+    if registration is None:
+        raise ValueError(
+            f"CUSTOM_CHUNKER: unknown chunker {name!r}; registered names: {', '.join(registered_chunker_names()) or '(none)'}. Check plugin discovery errors for a failed provider."
+        )
+    spec = registration.spec
+    try:
+        module, separator, attribute = spec.impl.partition(":")
+        if not module or not separator or not attribute:
+            raise ValueError("expected module:attribute")
+        implementation = importlib.import_module(module)
+        for part in attribute.split("."):
+            implementation = getattr(implementation, part)
+    except Exception as exc:
+        raise ValueError(
+            f"cannot load selected chunker {name!r} ({spec.impl}, {registration.origin}): {exc}"
+        ) from exc
+    if not callable(implementation):
+        raise ValueError(f"selected chunker {name!r} ({spec.impl}) is not callable")
+    try:
+        signature = inspect.signature(implementation)
+    except (ValueError, TypeError):
+        pass  # Some native callables expose no signature; do not invent a fence.
+    else:
+        try:
+            signature.bind(*([None] * 6))
+        except TypeError as exc:
+            raise ValueError(
+                f"selected chunker {name!r} must accept six positional arguments: {exc}"
+            ) from exc
+    if spec.executor_safe and (
+        inspect.iscoroutinefunction(implementation)
+        or inspect.iscoroutinefunction(getattr(implementation, "__call__", None))
+    ):
+        raise ValueError(
+            f"selected async chunker {name!r} cannot request executor offload"
+        )
+    return ChunkerBinding(spec, implementation)
+
+
+def chunker_identity(callback: Callable[..., Any]) -> dict[str, Any] | None:
+    """Describe the bound callback, never use persisted identity for selection."""
+    if isinstance(callback, ChunkerBinding):
+        return {
+            "name": callback.spec.name,
+            "version": callback.spec.version,
+            "authoritative": False,
+        }
+    return None
+
+
+def log_chunker_selection(selected: ChunkerBinding | None) -> None:
+    """One startup summary, including instance-wide legacy-path implications."""
+    registered = [
+        {
+            "name": r.spec.name,
+            "version": r.spec.version,
+            "origin": r.origin,
+            "description": r.spec.description,
+        }
+        for _, r in sorted(_REGISTRY.items())
+    ]
+    logger.info(
+        "[chunker-plugins] registered=%s; selected=%s%s",
+        registered,
+        selected.spec.name if selected else "(none)",
+        "; serves C and no-selector inserts"
+        if selected
+        else "; built-in callback unchanged",
+    )

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -556,6 +556,13 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     """
     Legacy chunking-function customization point. Synchronous or async.
 
+    Server deployments can select an installed ``lightrag.chunkers`` entry-point
+    registration with ``CUSTOM_CHUNKER`` / ``--custom-chunker``. Startup resolves
+    and validates it before injection here. This is instance-wide: both ``C``
+    and no-selector inserts invoke it; explicit F/R/V/P still use built-ins.
+    See ``docs/ThirdPartyChunker.md``. Recorded plugin name/version is only a
+    diagnostic observation and never controls dispatch or blocks reprocessing.
+
     **Where it runs.** A custom ``chunking_func`` is called on the event loop,
     exactly as before. The built-in default is dispatched to a worker thread
     instead, because chunking is CPU-bound and holding the loop for its duration
@@ -565,7 +572,9 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
     — a synchronous factory returning a Task, say — is supported and would fail
     outright in a worker thread, while an ``async def`` would gain nothing from
     the hop since its body runs on the loop regardless. A CPU-bound custom
-    chunker should therefore do its own ``asyncio.to_thread``.
+    chunker should therefore do its own offload, or an installed synchronous
+    plugin may declare ``ChunkerSpec.executor_safe=True`` to use LightRAG's
+    bounded chunking executor. Async plugins cannot request executor offload.
 
     **When this function is actually invoked.** The chunker dispatch in
     ``_PipelineMixin.process_single_document`` is driven by the

--- a/lightrag/pipeline.py
+++ b/lightrag/pipeline.py
@@ -76,6 +76,7 @@ from lightrag.kg.shared_storage import (
     with_reservation_lock,
 )
 from lightrag import pipeline_metrics
+from lightrag.chunker.registry import chunker_identity
 from lightrag.kg.pipeline_ingress import PipelineIngressMessage
 from lightrag.operate import merge_nodes_and_edges
 from lightrag.parser.base import ParseContext
@@ -4935,6 +4936,46 @@ class _PipelineMixin:
                 from lightrag.chunker import chunking_by_token_size
 
                 is_builtin_chunker = self.chunking_func is chunking_by_token_size
+                # Diagnostic only: never resolve, reject or select a callback
+                # using a previous document's author-supplied identity.
+                uses_custom_callback = (
+                    not doc_process_opts.chunking_explicit
+                    or doc_process_opts.chunking == "C"
+                )
+                current_identity = (
+                    chunker_identity(self.chunking_func)
+                    if uses_custom_callback
+                    else None
+                )
+                previous_identity = (
+                    status_doc.metadata.get("custom_chunker")
+                    if isinstance(status_doc.metadata, dict)
+                    else None
+                )
+                observation = current_identity or {
+                    "name": None,
+                    "version": None,
+                    "authoritative": False,
+                }
+                if doc_process_opts.chunking == "C" and isinstance(
+                    previous_identity, dict
+                ):
+                    if any(
+                        previous_identity.get(key) != observation[key]
+                        for key in ("name", "version")
+                    ):
+                        logger.warning(
+                            "Custom chunker identity changed for doc_id %s: %r@%r -> %r@%r; proceeding under current configuration (identity is non-authoritative)",
+                            doc_id,
+                            previous_identity.get("name"),
+                            previous_identity.get("version"),
+                            observation["name"],
+                            observation["version"],
+                        )
+                if current_identity is not None or previous_identity is not None:
+                    # Set before invocation so a failed callback still names
+                    # the attempted configuration in the FAILED record.
+                    extraction_meta["custom_chunker"] = observation
                 if (
                     doc_process_opts.chunking_explicit
                     and doc_process_opts.chunking != "C"
@@ -5266,24 +5307,26 @@ class _PipelineMixin:
                     if isinstance(content_data, dict)
                     else None
                 )
-                extraction_meta = {
-                    "parse_format": persisted_format,
-                    # Shared resolver with the parse stage (_parse_worker), so a
-                    # field already stamped at PARSING re-writes to the same
-                    # value here — no value jump across the transition.
-                    "parse_engine": resolve_doc_status_parse_engine(
-                        persisted_format, persisted_engine
-                    ),
-                    # Set by the actual branch taken, not merely the persisted
-                    # selector. This distinguishes C custom success from its
-                    # fixed-token fallback after callback removal.
-                    "chunk_method": chunk_method,
-                    # Mirrors the chunking start log line (params portion only,
-                    # without the strategy prefix or file path) so admins can
-                    # see the actual chunker params used.  Carried across
-                    # transitions via ``_DOC_STATUS_METADATA_CARRY_OVER_KEYS``.
-                    "chunk_opts": chunk_opts_str,
-                }
+                extraction_meta.update(
+                    {
+                        "parse_format": persisted_format,
+                        # Shared resolver with the parse stage (_parse_worker), so a
+                        # field already stamped at PARSING re-writes to the same
+                        # value here — no value jump across the transition.
+                        "parse_engine": resolve_doc_status_parse_engine(
+                            persisted_format, persisted_engine
+                        ),
+                        # Set by the actual branch taken, not merely the persisted
+                        # selector. This distinguishes C custom success from its
+                        # fixed-token fallback after callback removal.
+                        "chunk_method": chunk_method,
+                        # Mirrors the chunking start log line (params portion only,
+                        # without the strategy prefix or file path) so admins can
+                        # see the actual chunker params used.  Carried across
+                        # transitions via ``_DOC_STATUS_METADATA_CARRY_OVER_KEYS``.
+                        "chunk_opts": chunk_opts_str,
+                    }
+                )
 
                 blocks_path = str(parsed_data.get("blocks_path") or "").strip()
                 if blocks_path:

--- a/lightrag/utils_pipeline.py
+++ b/lightrag/utils_pipeline.py
@@ -376,6 +376,9 @@ _DOC_STATUS_METADATA_CARRY_OVER_KEYS: tuple[str, ...] = (
     "source_file",
     "parse_warnings",
     "chunk_opts",
+    # Last attempted registry identity, explicitly non-authoritative. Retained
+    # for drift diagnostics, never for admission or dispatch decisions.
+    "custom_chunker",
     "parse_start_time",
     "parse_end_time",
     "parse_stage_skipped",
@@ -681,6 +684,10 @@ def doc_status_reset_metadata(status_doc: Any) -> dict[str, Any]:
             value = raw_metadata.get(key)
         if value not in (None, ""):
             payload[key] = value
+    # Unlike timing/result fields this observation must survive retry/restart
+    # so the next attempt can report a changed deployment. It is NOT a directive.
+    if isinstance(raw_metadata.get("custom_chunker"), dict):
+        payload["custom_chunker"] = dict(raw_metadata["custom_chunker"])
     return payload
 
 

--- a/tests/api/config/test_api_config_custom_chunker.py
+++ b/tests/api/config/test_api_config_custom_chunker.py
@@ -1,0 +1,24 @@
+"""Operator selection is a name, with CLI taking precedence over .env."""
+
+import sys
+
+import pytest
+
+from lightrag.api.config import parse_args
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.mark.parametrize("value", ["", "company-chunker"])
+def test_custom_chunker_env(monkeypatch, value):
+    monkeypatch.setattr(sys, "argv", ["lightrag-server"])
+    monkeypatch.setenv("CUSTOM_CHUNKER", value)
+    assert parse_args().custom_chunker == value
+
+
+def test_custom_chunker_cli_overrides_env(monkeypatch):
+    monkeypatch.setenv("CUSTOM_CHUNKER", "env-chunker")
+    monkeypatch.setattr(
+        sys, "argv", ["lightrag-server", "--custom-chunker", "cli-chunker"]
+    )
+    assert parse_args().custom_chunker == "cli-chunker"

--- a/tests/api/test_custom_chunker_startup.py
+++ b/tests/api/test_custom_chunker_startup.py
@@ -1,0 +1,203 @@
+"""Exercise the shared uvicorn/Gunicorn app factory, not just a helper."""
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from lightrag.api import config
+from lightrag.chunker import plugins, registry
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.fixture
+def startup(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "_global_args", None)
+    monkeypatch.setattr(config, "_initialized", False)
+    monkeypatch.setattr(registry, "_REGISTRY", {})
+    monkeypatch.setattr(registry, "_DUPLICATES", set())
+    monkeypatch.setattr(plugins, "_loaded", False)
+    monkeypatch.setattr(plugins, "_failures", [])
+    monkeypatch.setattr(logging.getLogger("lightrag"), "propagate", True)
+    monkeypatch.setenv("CUSTOM_CHUNKER", "")
+    monkeypatch.setenv("LLM_BINDING", "openai")
+    monkeypatch.setenv("EMBEDDING_BINDING", "openai")
+    monkeypatch.setenv("RERANK_BINDING", "null")
+    monkeypatch.setenv("UI_TEMPLATES_DIR", "")
+    monkeypatch.setenv("AUTH_ACCOUNTS", "")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "lightrag-server",
+            "--working-dir",
+            str(tmp_path / "rag"),
+            "--input-dir",
+            str(tmp_path / "inputs"),
+        ],
+    )
+    args = config.initialize_config(force=True)
+    from lightrag.api import lightrag_server as server
+
+    captured = []
+
+    class Constructed(Exception):
+        pass
+
+    def construct(**kwargs):
+        captured.append(kwargs)
+        raise Constructed
+
+    monkeypatch.setattr(server, "LightRAG", construct)
+    monkeypatch.setattr(server, "check_frontend_build", lambda: (False, False))
+    monkeypatch.setattr(server, "check_workspace_frontend_build", lambda: False)
+    return server, args, captured, Constructed
+
+
+@pytest.mark.parametrize("factory", ["create_app", "get_application"])
+def test_discovered_chunker_injected_before_constructor(startup, monkeypatch, factory):
+    server, args, captured, constructed = startup
+
+    def callback(*args):
+        return args
+
+    monkeypatch.setitem(
+        sys.modules, "startup_chunker_impl", SimpleNamespace(chunk=callback)
+    )
+
+    def register():
+        registry.register_chunker(
+            registry.ChunkerSpec("acme", "startup_chunker_impl:chunk", "1", "Acme")
+        )
+
+    ep = SimpleNamespace(name="acme", value="provider:register", load=lambda: register)
+    monkeypatch.setattr(plugins, "entry_points", lambda **kwargs: [ep])
+
+    def validate():
+        assert registry.registered_chunker_names() == ("acme",)
+
+    monkeypatch.setattr(server, "validate_parser_routing_config", validate)
+    args.custom_chunker = "acme"
+    with pytest.raises(constructed):
+        getattr(server, factory)(args)
+    assert captured[0]["chunking_func"](*range(6)) == tuple(range(6))
+
+
+def test_unset_does_not_override_constructor_default(startup, monkeypatch):
+    server, args, captured, constructed = startup
+    monkeypatch.setattr(plugins, "entry_points", lambda **kwargs: [])
+    with pytest.raises(constructed):
+        server.create_app(args)
+    assert "chunking_func" not in captured[0]
+
+
+@pytest.mark.parametrize(
+    "selected,outcome",
+    [
+        (
+            "acme",
+            "selected chunker 'acme' validated; C and no-selector chunking remain available",
+        ),
+        ("partial", "CUSTOM_CHUNKER='partial' could not be activated; startup aborted"),
+        (
+            "",
+            "CUSTOM_CHUNKER is unset; built-in callback and existing C admission/fallback are unchanged",
+        ),
+    ],
+)
+def test_failed_provider_log_alone_describes_selected_chunker_outcome(
+    startup, monkeypatch, caplog, selected, outcome
+):
+    server, args, captured, constructed = startup
+    monkeypatch.setitem(
+        sys.modules, "startup_chunker_impl", SimpleNamespace(chunk=lambda *args: args)
+    )
+
+    def good():
+        registry.register_chunker(
+            registry.ChunkerSpec("acme", "startup_chunker_impl:chunk", "1", "Acme")
+        )
+
+    def broken():
+        registry.register_chunker(
+            registry.ChunkerSpec("partial", "absent:chunk", "1", "Partial")
+        )
+        raise RuntimeError("provider failed")
+
+    entries = [
+        SimpleNamespace(name=name, value=f"{name}:register", load=lambda fn=fn: fn)
+        for name, fn in [("good", good), ("broken", broken)]
+    ]
+    monkeypatch.setattr(plugins, "entry_points", lambda **kwargs: entries)
+    args.custom_chunker = selected
+    with pytest.raises(ValueError if selected == "partial" else constructed):
+        server.create_app(args)
+    errors = [
+        r.getMessage()
+        for r in caplog.records
+        if "skipped failed plugin" in r.getMessage()
+    ]
+    assert len(errors) == 1
+    assert "broken:register" in errors[0] and "provider failed" in errors[0]
+    assert outcome in errors[0]
+    if selected == "partial":
+        assert not captured
+    elif selected:
+        assert captured[0]["chunking_func"](*range(6)) == tuple(range(6))
+
+
+@pytest.mark.parametrize(
+    "name,match", [("missing", "unknown chunker"), ("pkg:func", "import paths")]
+)
+def test_invalid_selection_fails_before_constructor(startup, monkeypatch, name, match):
+    server, args, captured, _ = startup
+    monkeypatch.setattr(plugins, "entry_points", lambda **kwargs: [])
+    args.custom_chunker = name
+    with pytest.raises(ValueError, match=match):
+        server.create_app(args)
+    assert captured == []
+
+
+def test_ingress_error_names_config_and_registered_choices(monkeypatch):
+    from lightrag.api.routers.document_routes import _validate_custom_chunking_available
+    from lightrag.chunker import chunking_by_token_size
+
+    monkeypatch.setattr(registry, "_REGISTRY", {})
+    registry.register_chunker(registry.ChunkerSpec("acme", "absent:chunk", "1", "Acme"))
+    with pytest.raises(ValueError, match="CUSTOM_CHUNKER.*acme"):
+        _validate_custom_chunking_available(
+            "C", SimpleNamespace(chunking_func=chunking_by_token_size)
+        )
+
+
+@pytest.mark.parametrize(
+    "name,match",
+    [
+        ("missing-chunker", "unknown chunker"),
+        ("pkg:func", "import paths are not supported"),
+    ],
+)
+def test_invalid_cli_selection_exits_nonzero(monkeypatch, name, match):
+    monkeypatch.setenv("AUTH_ACCOUNTS", "")
+    monkeypatch.setenv("LLM_BINDING", "openai")
+    monkeypatch.setenv("EMBEDDING_BINDING", "openai")
+    monkeypatch.setenv("UI_TEMPLATES_DIR", "")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from lightrag.api.config import parse_args; from lightrag.api.lightrag_server import create_app; create_app(parse_args())",
+            "--custom-chunker",
+            name,
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert match in result.stderr

--- a/tests/chunker/test_registry.py
+++ b/tests/chunker/test_registry.py
@@ -1,0 +1,406 @@
+"""Closed-set selection, lazy imports and isolated plugin discovery."""
+
+import asyncio
+import logging
+import sys
+import subprocess
+from pathlib import Path
+from dataclasses import asdict, dataclass, replace
+from importlib import metadata
+from types import SimpleNamespace
+
+import pytest
+
+from lightrag.chunker import plugins, registry
+
+pytestmark = pytest.mark.offline
+
+
+def test_registry_import_does_not_load_builtin_or_plugin_implementations():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from lightrag.chunker.registry import ChunkerSpec, register_chunker; register_chunker(ChunkerSpec('demo', 'absent:chunk', '1', 'Demo')); assert not any(name in sys.modules for name in ('lightrag.chunker.token_size', 'lightrag.chunker.recursive_character', 'lightrag.chunker.semantic_vector', 'lightrag.chunker.paragraph_semantic', 'absent'))",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry(monkeypatch):
+    monkeypatch.setattr(registry, "_REGISTRY", {})
+    monkeypatch.setattr(registry, "_DUPLICATES", set())
+    monkeypatch.setattr(plugins, "_loaded", False)
+    monkeypatch.setattr(plugins, "_failures", [])
+    monkeypatch.setattr(plugins, "entry_points", lambda **kwargs: [])
+    monkeypatch.setattr(logging.getLogger("lightrag"), "propagate", True)
+
+
+def spec(name="acme", **kwargs):
+    return registry.ChunkerSpec(
+        name=name,
+        impl="test_chunker_impl:chunk",
+        version="1",
+        description="Example chunker",
+        **kwargs,
+    )
+
+
+def install_impl(monkeypatch, callback):
+    monkeypatch.setitem(
+        sys.modules, "test_chunker_impl", SimpleNamespace(chunk=callback)
+    )
+
+
+def ep(name, register):
+    return SimpleNamespace(
+        name=name,
+        value=f"{name}:register",
+        dist=SimpleNamespace(name=f"dist-{name}", version="1"),
+        load=lambda: register,
+    )
+
+
+def test_registration_imports_no_implementation(monkeypatch):
+    def unexpected(*args, **kwargs):
+        pytest.fail("registration imported an implementation")
+
+    monkeypatch.setattr(registry.importlib, "import_module", unexpected)
+    registry.register_chunker(spec(), origin="package-a")
+    registry.register_chunker(spec("another"), origin="package-b")
+    assert registry.registered_chunker_names() == ("acme", "another")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        "Upper",
+        "a.b",
+        "a:b",
+        "-a",
+        "_a",
+        "a b",
+        "a,b",
+        "a=b",
+        "a(b)",
+        "a" * 65,
+        "f",
+        "r",
+        "v",
+        "p",
+        "c",
+        "fixed_token",
+        "recursive_character",
+        "semantic_vector",
+        "paragraph_semantic",
+    ],
+)
+def test_reject_invalid_or_reserved_names(name):
+    with pytest.raises(ValueError):
+        registry.register_chunker(spec(name))
+
+
+@pytest.mark.parametrize("name", ["0", "a_b-c", "a" * 64])
+def test_valid_names(name):
+    registry.register_chunker(spec(name))
+    assert name in registry.registered_chunker_names()
+
+
+@pytest.mark.parametrize("value", ["pkg:func", "pkg.func", "/tmp/plugin", "pkg\\func"])
+def test_operator_import_paths_have_actionable_error(value):
+    with pytest.raises(ValueError, match="[Ii]mport paths.*entry.point"):
+        registry.resolve_chunker(value)
+
+
+def test_unknown_name_lists_available_names():
+    registry.register_chunker(spec())
+    with pytest.raises(ValueError, match="unknown.*missing.*acme"):
+        registry.resolve_chunker("missing")
+
+
+def test_unset_leaves_callback_default_untouched():
+    assert registry.resolve_chunker("") is None
+    assert registry.resolve_chunker(None) is None
+    assert registry.chunker_identity(lambda *args: []) is None
+
+
+def test_resolves_only_selected_implementation(monkeypatch):
+    def callback(*args):
+        return args
+
+    install_impl(monkeypatch, callback)
+    registry.register_chunker(spec())
+    registry.register_chunker(
+        registry.ChunkerSpec("broken", "does_not_exist:chunk", "1", "Broken")
+    )
+    bound = registry.resolve_chunker("acme")
+    assert bound(1, 2, 3, 4, 5, 6) == (1, 2, 3, 4, 5, 6)
+    assert registry.chunker_identity(bound) == {
+        "name": "acme",
+        "version": "1",
+        "authoritative": False,
+    }
+    with pytest.raises(ValueError, match="broken.*does_not_exist"):
+        registry.resolve_chunker("broken")
+
+
+@pytest.mark.parametrize(
+    "callback",
+    [
+        42,
+        lambda a: [],
+        lambda a, b, c, d, e, f, g: [],
+        lambda a, b, c, d, e, f, *, required: [],
+    ],
+)
+def test_selected_noncallable_or_wrong_arity_fails(monkeypatch, callback):
+    install_impl(monkeypatch, callback)
+    registry.register_chunker(spec())
+    with pytest.raises(ValueError, match="acme"):
+        registry.resolve_chunker("acme")
+
+
+def test_non_introspectable_callable_is_allowed(monkeypatch):
+    class Callback:
+        __signature__ = "unavailable"
+
+        def __call__(self, *args):
+            return args
+
+    install_impl(monkeypatch, Callback())
+    registry.register_chunker(spec())
+    assert registry.resolve_chunker("acme")(*range(6)) == tuple(range(6))
+
+
+def test_duplicate_selected_fails_but_unselected_does_not(monkeypatch, caplog):
+    install_impl(monkeypatch, lambda *args: [])
+    registry.register_chunker(spec(), origin="first")
+    registry.register_chunker(spec(), origin="second")
+    assert "first" in caplog.text and "second" in caplog.text
+    assert registry.resolve_chunker(None) is None
+    registry.register_chunker(spec("other"))
+    assert registry.resolve_chunker("other") is not None
+    with pytest.raises(ValueError, match="duplicate.*acme"):
+        registry.resolve_chunker("acme")
+
+
+def test_discovery_once_and_failed_provider_rolls_back(monkeypatch, caplog):
+    calls = []
+
+    def good():
+        calls.append("good")
+        registry.register_chunker(spec())
+        registry.register_chunker(spec("second"))
+
+    def broken():
+        registry.register_chunker(spec("partial"))
+        registry.register_chunker(spec())
+        raise RuntimeError("provider failed")
+
+    monkeypatch.setattr(
+        plugins,
+        "entry_points",
+        lambda **kwargs: [ep("a-good", good), ep("z-broken", broken)],
+    )
+    assert plugins.load_third_party_chunkers() == ["a-good"]
+    assert plugins.load_third_party_chunkers() == []
+    assert calls == ["good"]
+    assert registry.registered_chunker_names() == ("acme", "second")
+    assert not registry._DUPLICATES
+    assert "z-broken" in caplog.text and "dist-z-broken" in caplog.text
+    with pytest.raises(ValueError, match="unknown.*partial"):
+        registry.resolve_chunker("partial")
+
+
+def test_repeated_startup_reuses_discovery_but_retains_failure_diagnostics(
+    monkeypatch, caplog
+):
+    calls = []
+    install_impl(monkeypatch, lambda *args: args)
+
+    def good():
+        calls.append("registered")
+        registry.register_chunker(spec())
+
+    def broken():
+        raise RuntimeError("unrelated provider failed")
+
+    def discover(**kwargs):
+        calls.append("discovered")
+        return [ep("good", good), ep("broken", broken)]
+
+    monkeypatch.setattr(plugins, "entry_points", discover)
+    for _ in range(2):
+        caplog.clear()
+        assert plugins.load_and_resolve_chunker("acme")(*range(6)) == tuple(range(6))
+        assert len(caplog.records) == 1
+        assert "selected chunker 'acme' validated" in caplog.text
+    assert calls == ["discovered", "registered"]
+
+
+def test_startup_logs_one_line_and_no_selector_impact(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="lightrag")
+    registry.log_chunker_selection(None)
+    assert len(caplog.records) == 1
+    caplog.clear()
+    install_impl(monkeypatch, lambda *args: [])
+    registry.register_chunker(spec(), origin="origin-package")
+    registry.log_chunker_selection(registry.resolve_chunker("acme"))
+    assert len(caplog.records) == 1
+    assert all(
+        s in caplog.text
+        for s in ["acme", "origin-package", "no-selector", "Example chunker"]
+    )
+
+
+def test_async_callback_stays_on_loop_and_cannot_opt_into_executor(monkeypatch):
+    async def callback(*args):
+        return asyncio.get_running_loop()
+
+    install_impl(monkeypatch, callback)
+    registry.register_chunker(spec())
+
+    async def run():
+        assert (
+            await registry.resolve_chunker("acme")(*range(6))
+            is asyncio.get_running_loop()
+        )
+
+    asyncio.run(run())
+    registry.register_chunker(spec("offload", executor_safe=True))
+    with pytest.raises(ValueError, match="async.*executor"):
+        registry.resolve_chunker("offload")
+
+
+def test_executor_safe_uses_existing_bounded_pool(monkeypatch):
+    import lightrag.utils as utils
+
+    calls = []
+
+    def callback(*args):
+        return args
+
+    install_impl(monkeypatch, callback)
+
+    async def offload(fn, *args):
+        calls.append(fn)
+        return fn(*args)
+
+    monkeypatch.setattr(utils, "run_in_chunking_executor", offload)
+    registry.register_chunker(spec(executor_safe=True))
+    assert asyncio.run(registry.resolve_chunker("acme")(*range(6))) == tuple(range(6))
+    assert calls == [callback]
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"name": None},
+        {"impl": ""},
+        {"impl": None},
+        {"version": 1},
+        {"description": ""},
+        {"description": None},
+        {"description": "two\nlines"},
+        {"executor_safe": "true"},
+    ],
+)
+def test_invalid_spec_metadata_is_rejected(changes):
+    with pytest.raises(ValueError):
+        registry.register_chunker(replace(spec(), **changes))
+
+
+@pytest.mark.parametrize("value", [42, "UPPER", " name", "a,b", "x" * 65])
+def test_invalid_selection_is_rejected(value):
+    with pytest.raises(ValueError, match="CUSTOM_CHUNKER"):
+        registry.resolve_chunker(value)
+
+
+@pytest.mark.parametrize(
+    "reference",
+    ["no-colon", ":missing_module", "test_chunker_impl:", "test_chunker_impl:missing"],
+)
+def test_malformed_reference_or_missing_attribute_fails_at_resolution(
+    monkeypatch, reference
+):
+    install_impl(monkeypatch, lambda *args: [])
+    registry.register_chunker(replace(spec(), impl=reference))
+    with pytest.raises(ValueError, match="cannot load selected chunker"):
+        registry.resolve_chunker("acme")
+
+
+def test_async_callable_object_cannot_offload(monkeypatch):
+    class Callback:
+        async def __call__(self, *args):
+            return args
+
+    install_impl(monkeypatch, Callback())
+    registry.register_chunker(spec(executor_safe=True))
+    with pytest.raises(ValueError, match="async.*executor"):
+        registry.resolve_chunker("acme")
+
+
+def test_binding_remains_callable_in_dataclass_snapshots(monkeypatch):
+    @dataclass
+    class Config:
+        chunking_func: object
+
+    install_impl(monkeypatch, lambda *args: args)
+    registry.register_chunker(spec())
+    snapshot = asdict(Config(registry.resolve_chunker("acme")))
+    assert snapshot["chunking_func"](*range(6)) == tuple(range(6))
+
+
+def test_real_distribution_entry_point_imports_only_selected_impl(
+    tmp_path, monkeypatch
+):
+    package = tmp_path / "registry_test_plugin"
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "plugin.py").write_text(
+        "from lightrag.chunker.registry import ChunkerSpec, register_chunker\n"
+        "def register():\n"
+        "    for name in ('first', 'second'):\n"
+        "        register_chunker(ChunkerSpec(name, f'registry_test_plugin.{name}:chunk', '1', name))\n",
+        encoding="utf-8",
+    )
+    for name in ("first", "second"):
+        (package / f"{name}.py").write_text(
+            "def chunk(*args):\n    return args\n", encoding="utf-8"
+        )
+    info = tmp_path / "registry_test_plugin-1.dist-info"
+    info.mkdir()
+    (info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: registry-test-plugin\nVersion: 1\n",
+        encoding="utf-8",
+    )
+    (info / "entry_points.txt").write_text(
+        "[lightrag.chunkers]\nregistry-test = registry_test_plugin.plugin:register\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    entries = metadata.Distribution.at(info).entry_points
+    monkeypatch.setattr(
+        plugins, "entry_points", lambda *, group: entries.select(group=group)
+    )
+    try:
+        assert plugins.load_third_party_chunkers() == ["registry-test"]
+        assert "registry_test_plugin.first" not in sys.modules
+        assert "registry_test_plugin.second" not in sys.modules
+        assert registry.resolve_chunker("first")(*range(6)) == tuple(range(6))
+        assert "registry_test_plugin.first" in sys.modules
+        assert "registry_test_plugin.second" not in sys.modules
+    finally:
+        for name in (
+            "registry_test_plugin.first",
+            "registry_test_plugin.second",
+            "registry_test_plugin.plugin",
+            "registry_test_plugin",
+        ):
+            sys.modules.pop(name, None)

--- a/tests/pipeline/test_custom_chunking_selector.py
+++ b/tests/pipeline/test_custom_chunking_selector.py
@@ -7,7 +7,10 @@ making custom success and fixed-token fallback observable.
 
 import asyncio
 import logging
+import sys
+import threading
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -16,6 +19,216 @@ from lightrag import LightRAG, ROLES, RoleLLMConfig
 from lightrag.base import DocStatus
 from lightrag.chunker import chunking_by_token_size
 from lightrag.utils import EmbeddingFunc, Tokenizer
+
+
+def _registered_callback(monkeypatch, callback, name="acme", version="1", **kwargs):
+    from lightrag.chunker import registry
+
+    # Model a freshly installed deployment without leaking registrations.
+    monkeypatch.setattr(registry, "_REGISTRY", {})
+    monkeypatch.setattr(registry, "_DUPLICATES", set())
+    monkeypatch.setitem(
+        sys.modules, "custom_chunker_test_impl", SimpleNamespace(chunk=callback)
+    )
+    registry.register_chunker(
+        registry.ChunkerSpec(
+            name, "custom_chunker_test_impl:chunk", version, "Test chunker", **kwargs
+        )
+    )
+    return registry.resolve_chunker(name)
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize("options", ["C!", "!"])
+@pytest.mark.parametrize("executor_safe", [False, True])
+def test_registered_chunker_records_identity_and_preserves_six_args(
+    tmp_path, monkeypatch, options, executor_safe
+):
+    calls = []
+    threads = []
+
+    def callback(*args):
+        calls.append(args)
+        threads.append(threading.get_ident())
+        return [{"tokens": len(args[1]), "content": args[1], "chunk_order_index": 0}]
+
+    async def run():
+        bound = _registered_callback(monkeypatch, callback, executor_safe=executor_safe)
+        rag = _new_rag(tmp_path, chunking_func=bound)
+        await rag.initialize_storages()
+        try:
+            row = await _ingest(rag, doc_id="registered", process_options=options)
+        finally:
+            await rag.finalize_storages()
+        assert DocStatus(row["status"]) is DocStatus.PROCESSED
+        assert len(calls) == 1 and len(calls[0]) == 6
+        assert (threads[0] != threading.get_ident()) is executor_safe
+        assert _metadata(row)["custom_chunker"] == {
+            "name": "acme",
+            "version": "1",
+            "authoritative": False,
+        }
+        assert _metadata(row)["chunk_method"] == (
+            "custom_chunking_func" if options == "C!" else "legacy_chunking_func"
+        )
+
+    asyncio.run(run())
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize(
+    "selector,method",
+    [
+        ("F", "chunking_by_fixed_token"),
+        ("R", "chunking_by_recursive_character"),
+        ("V", "chunking_by_semantic_vector"),
+        ("P", "chunking_by_paragraph_semantic"),
+    ],
+)
+def test_registered_callback_does_not_intercept_builtins(
+    tmp_path, monkeypatch, selector, method
+):
+    import lightrag.chunker as chunker_pkg
+
+    builtins = []
+
+    def custom(*args):
+        pytest.fail("explicit built-in dispatched to a registered custom callback")
+
+    def builtin(tokenizer, content, *args, **kwargs):
+        builtins.append(selector)
+        return [{"tokens": len(content), "content": content, "chunk_order_index": 0}]
+
+    async def async_builtin(*args, **kwargs):
+        return builtin(*args, **kwargs)
+
+    monkeypatch.setattr(
+        chunker_pkg, method, async_builtin if selector == "V" else builtin
+    )
+
+    async def run():
+        rag = _new_rag(
+            tmp_path, chunking_func=_registered_callback(monkeypatch, custom)
+        )
+        await rag.initialize_storages()
+        try:
+            row = await _ingest(rag, doc_id="builtin", process_options=f"{selector}!")
+            assert DocStatus(row["status"]) is DocStatus.PROCESSED
+            assert "custom_chunker" not in _metadata(row)
+            assert builtins == [selector]
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(run())
+
+
+@pytest.mark.offline
+def test_registered_sync_factory_can_return_a_task(tmp_path, monkeypatch):
+    def callback(tokenizer, content, *args):
+        async def result():
+            return [
+                {"tokens": len(content), "content": content, "chunk_order_index": 0}
+            ]
+
+        return asyncio.get_running_loop().create_task(result())
+
+    async def run():
+        rag = _new_rag(
+            tmp_path, chunking_func=_registered_callback(monkeypatch, callback)
+        )
+        await rag.initialize_storages()
+        try:
+            row = await _ingest(rag, doc_id="task-factory", process_options="C!")
+            assert DocStatus(row["status"]) is DocStatus.PROCESSED
+            assert _metadata(row)["custom_chunker"]["name"] == "acme"
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(run())
+
+
+@pytest.mark.offline
+@pytest.mark.parametrize(
+    "next_name,next_version",
+    [("next", "1"), ("acme", "2"), (None, None), ("acme", "1")],
+)
+def test_registered_identity_survives_reset_and_warns_once_on_drift(
+    tmp_path, monkeypatch, next_name, next_version
+):
+    from lightrag.utils_pipeline import doc_status_reset_metadata
+
+    def callback(tokenizer, content, *args):
+        return [{"tokens": len(content), "content": content, "chunk_order_index": 0}]
+
+    async def run():
+        rag = _new_rag(
+            tmp_path, chunking_func=_registered_callback(monkeypatch, callback)
+        )
+        await rag.initialize_storages()
+        handler = _ListHandler()
+        logger = logging.getLogger("lightrag")
+        try:
+            first = await _ingest(rag, doc_id="drift", process_options="C!")
+            prior = _metadata(first)["custom_chunker"]
+            pending = dict(
+                first,
+                status=DocStatus.PENDING.value,
+                metadata=doc_status_reset_metadata(first),
+            )
+            assert pending["metadata"]["custom_chunker"] == prior
+            await rag.doc_status.upsert({"drift": pending})
+            rag.chunking_func = (
+                _registered_callback(monkeypatch, callback, next_name, next_version)
+                if next_name
+                else chunking_by_token_size
+            )
+            logger.addHandler(handler)
+            await rag.apipeline_process_enqueue_documents()
+            second = await rag.doc_status.get_by_id("drift")
+            warnings = [
+                r.getMessage()
+                for r in handler.records
+                if "Custom chunker identity changed" in r.getMessage()
+            ]
+            assert len(warnings) == (
+                0 if (next_name, next_version) == ("acme", "1") else 1
+            )
+            if warnings:
+                assert "acme" in warnings[0] and "current configuration" in warnings[0]
+            assert DocStatus(second["status"]) is DocStatus.PROCESSED
+            assert _metadata(second)["custom_chunker"] == {
+                "name": next_name,
+                "version": next_version,
+                "authoritative": False,
+            }
+        finally:
+            logger.removeHandler(handler)
+            await rag.finalize_storages()
+
+    asyncio.run(run())
+
+
+@pytest.mark.offline
+def test_registered_async_failure_records_attempt_without_fallback(
+    tmp_path, monkeypatch
+):
+    async def callback(*args):
+        raise RuntimeError("registered chunker failed")
+
+    async def run():
+        rag = _new_rag(
+            tmp_path, chunking_func=_registered_callback(monkeypatch, callback)
+        )
+        await rag.initialize_storages()
+        try:
+            row = await _ingest(rag, doc_id="failed-registered", process_options="C!")
+            assert DocStatus(row["status"]) is DocStatus.FAILED
+            assert "registered chunker failed" in row["error_msg"]
+            assert _metadata(row)["custom_chunker"]["name"] == "acme"
+        finally:
+            await rag.finalize_storages()
+
+    asyncio.run(run())
 
 
 class _SimpleTokenizerImpl:

--- a/tests/pipeline/test_pipeline_release_closure.py
+++ b/tests/pipeline/test_pipeline_release_closure.py
@@ -389,6 +389,8 @@ def test_carry_over_keys_grouped_by_stage():
         "source_file",
         "parse_warnings",
         "chunk_opts",
+        # Non-authoritative registry observation, grouped with chunk options.
+        "custom_chunker",
         "parse_start_time",
         "parse_end_time",
         "parse_stage_skipped",


### PR DESCRIPTION
## Description

Implements the startup-discovery slice assigned in #3868. Server construction currently leaves `chunking_func` at its built-in default, so installing an external chunker does not make it usable by Server operators. This adds the missing discovery, validation and constructor-injection seam without changing the six-argument callback contract or the C admission/fallback rules from #3665.

## Related Issues

Closes #3868. Scope confirmed in https://github.com/HKUDS/LightRAG/issues/3868#issuecomment-5574247557.

## Changes Made

- Mirror the parser entry-point pattern with `lightrag.chunkers`, lightweight `ChunkerSpec` registrations and selected-only implementation imports. Preserve the existing chunker package exports lazily so importing the registry itself does not load built-in implementations.
- Select one bare registered name with `CUSTOM_CHUNKER` / `--custom-chunker`. Validate names, reserved names, duplicates, imports, callability and introspectable six-argument signatures before the shared uvicorn/Gunicorn app factory constructs LightRAG. Operator/HTTP input never provides an import reference.
- Isolate failed providers, including partial registrations. In response to the FR-4.3 clarification, each Server failed-provider ERROR reports the validated selection outcome: selected chunker available for C/no-selector inserts, startup aborted, or unset/default behavior unchanged. SDK discovery without selection remains available and does not claim validated selection.
- Keep C, no-selector and explicit F/R/V/P dispatch behavior intact. The one startup INFO and both authoring guides explain the instance-wide injection. Keep `executor_safe=False` by default; optional synchronous offload reuses the existing bounded executor, with async offload rejected at startup. I retained FR-5.4 because it needs no new executor/lifecycle machinery and allows CPU-bound plugins to use the existing bound instead of creating an unbounded offload path. It remains an author declaration, not a thread-safety guarantee.
- Record `{name, version, authoritative: false}` separately in `doc_status.metadata.custom_chunker`. Retain it across reset only to diagnose drift once per C attempt; current configuration always determines execution. Existing `chunk_method` values, callback-failure behavior and fallback/backfill invariants remain unchanged.
- Add English/Chinese authoring and pipeline documentation, env guidance, callback/API descriptions and mirrored regression tests.

## Validation

Python 3.13.13; final upstream base `0ac2c5b0`. No dependency or lockfile changes.

```bash
python -m pytest tests/chunker/test_registry.py tests/pipeline/test_custom_chunking_selector.py tests/api/test_custom_chunker_startup.py tests/api/config/test_api_config_custom_chunker.py -q
# 97 passed

python -m pytest tests/chunker tests/pipeline tests/api -q
# 2392 passed, 15 skipped, 8 failed — baseline comparison below
```

- New configuration, persisted-identity, lazy-import and selection-aware failure-log cases were observed failing before the respective implementation changes.
- Coverage across the two new registry/plugin modules: 160 statements and 46 branches, 100% exercised by 74 registry/startup tests. This is not project-wide coverage.
- Pinned pre-commit checks passed for all 19 changed/new files; compileall and `git diff --check` passed.
- Tests include a temporary installed-distribution metadata/entry-point fixture, both shared app-factory entry points, actual executor thread identity, Task-returning callbacks, offline document processing/reset, explicit built-in bypass and existing C fallback/backfill cases.

### Baseline failures and limits

The wider suite is **not all green** in this local environment. All eight failing cases also reproduce on the untouched `25ed861e` base tree: running `tests/api/config/test_embedding_dimension_guard.py tests/api/test_path_prefixes.py` there gives 47 passed / 8 failed. The later base update only changes Zhipu implementation/tests.

- Four existing Bedrock/Voyage dimension-guard expectations (missing exception/default dimension).
- Two existing mount/root-path redirect expectations (307 vs 200), and two prefix-auth expectations (403 vs 401).

I have not changed or diagnosed those unrelated behaviors here. The local run used the locked optional `ollama` dependency and Cairo library path; some optional tests were skipped. No live LLM service, real multi-worker deployment or published external plugin has been exercised. Startup validation cannot establish later third-party runtime/output correctness.

## Checklist

- [x] Changes tested locally (scope and failures above)
- [ ] Code reviewed
- [x] Documentation updated
- [x] Unit tests added

## Additional Notes

AI-assisted implementation and local diff inspection; no independent human review is claimed. Commits include DCO sign-off. This does not implement named C selectors, context-aware callbacks, identity enforcement, multiple active custom chunkers or the transform hook remaining in #3664.
