### PR TITLE
fix(storage): preserve create_time on KV replacement upserts

### DIFF
--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -438,7 +438,11 @@ def normalize_kv_create_time(value: Any) -> int:
         return 0
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError is not a ValueError: JSON ``1e309`` decodes to float
+        # infinity, and ``int(inf)`` raises it. Without it here a single
+        # hand-edited row would abort the whole upsert instead of taking this
+        # documented fallback.
         logger.warning(
             f"KV create_time is not a number ({value!r}); recording 0 (unknown)"
         )
@@ -533,11 +537,14 @@ class BaseKVStorage(StorageNameSpace, ABC):
             (``ON CONFLICT ... DO UPDATE`` that never assigns
             ``create_time``) are the reference implementations: the
             conditional write belongs on the server, not in a client-side
-            read-modify-write. A backend without such a primitive
+            read-modify-write: a client-side read-then-write cannot keep a
+            concurrent first insert or a concurrent delete from moving the
+            timestamp, and no later write repairs it, because every update
+            preserves what it finds. A backend without such a primitive
             reconstructs one -- ``OpenSearchKVStorage`` with a
-            ``scripted_upsert`` bulk action, ``RedisKVStorage`` with a
-            bounded prefix read -- rather than reading whole values back.
-            See issue #3870.
+            ``scripted_upsert`` bulk action, ``RedisKVStorage`` with a Lua
+            script that reads a bounded prefix and writes in the same step --
+            rather than reading whole values back. See issue #3870.
 
         Multi-worker note:
             Backends that buffer writes in process memory (e.g.

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -17,7 +17,7 @@ from typing import (
     List,
     AsyncIterator,
 )
-from .utils import EmbeddingFunc, get_env_value
+from .utils import EmbeddingFunc, get_env_value, logger
 from .types import KnowledgeGraph
 from .exceptions import (
     StorageCapabilityError,
@@ -414,6 +414,31 @@ class BaseVectorStorage(StorageNameSpace, ABC):
         pass
 
 
+def normalize_kv_create_time(value: Any) -> int:
+    """Coerce a stored ``create_time`` into the int the KV contract promises.
+
+    Stored rows are not always written by the current release: an older
+    LightRAG could store ``time.time()`` unrounded (a float), a hand-edited
+    ``JsonKVStorage`` file can carry ``null``, and external tooling can leave
+    the field a string. Every backend that preserves ``create_time`` across a
+    replacement upsert funnels the stored value through here, so the backends
+    agree on malformed input instead of each writing its own shape back.
+
+    ``None`` -- the documented "unknown" marker -- maps to ``0`` silently.
+    Anything that will not coerce is data corruption rather than a legacy
+    shape, so it is logged before falling back to ``0``.
+    """
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"KV create_time is not a number ({value!r}); recording 0 (unknown)"
+        )
+        return 0
+
+
 @dataclass
 class BaseKVStorage(StorageNameSpace, ABC):
     embedding_func: EmbeddingFunc
@@ -475,6 +500,34 @@ class BaseKVStorage(StorageNameSpace, ABC):
         Important notes for in-memory storage:
         1. Changes will be persisted to disk during the next index_done_callback
         2. update flags to notify other processes that data persistence is needed
+
+        Storage-managed timestamps (binding on every backend):
+            1. A key that does not exist yet is stamped with both
+               ``create_time`` and ``update_time``.
+            2. A key that already exists keeps its stored ``create_time`` and
+               only advances ``update_time`` -- including when ``data``
+               replaces the whole value with business fields only, which is
+               what the chunk-tracking writers send.
+            3. A stored row carrying no ``create_time`` (written before the
+               field existed) records ``0`` = unknown. Never invent an
+               original timestamp for it: ``0`` is what every read path
+               already substitutes, so the row keeps the meaning it had.
+            4. A caller-supplied ``create_time`` is ignored on the update
+               path. The timestamp is storage-managed, so preserving it must
+               not depend on callers round-tripping metadata fields.
+            5. Stored values reach ``int`` through
+               :func:`normalize_kv_create_time` so the backends agree on
+               legacy and malformed shapes.
+
+            ``MongoKVStorage`` (``$setOnInsert``) and ``PGKVStorage``
+            (``ON CONFLICT ... DO UPDATE`` that never assigns
+            ``create_time``) are the reference implementations: the
+            conditional write belongs on the server, not in a client-side
+            read-modify-write. A backend without such a primitive
+            reconstructs one -- ``OpenSearchKVStorage`` with a
+            ``scripted_upsert`` bulk action, ``RedisKVStorage`` with a
+            bounded prefix read -- rather than reading whole values back.
+            See issue #3870.
 
         Multi-worker note:
             Backends that buffer writes in process memory (e.g.

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -430,6 +430,12 @@ def normalize_kv_create_time(value: Any) -> int:
     """
     if value is None:
         return 0
+    if isinstance(value, bool):
+        # bool is an int subclass, so int(True) would record 1. A boolean
+        # timestamp is corruption, not a legacy shape -- and OpenSearch's
+        # server-side equivalent cannot coerce it either, so both answer 0.
+        logger.warning(f"KV create_time is a boolean ({value!r}); recording 0")
+        return 0
     try:
         return int(value)
     except (TypeError, ValueError):
@@ -503,7 +509,11 @@ class BaseKVStorage(StorageNameSpace, ABC):
 
         Storage-managed timestamps (binding on every backend):
             1. A key that does not exist yet is stamped with both
-               ``create_time`` and ``update_time``.
+               ``create_time`` and ``update_time``. Under concurrency the
+               FIRST creation defines ``create_time``: a backend whose insert
+               is not naturally atomic must make it so (Mongo's
+               ``$setOnInsert``, PG's ``ON CONFLICT``, Redis's ``SET ... NX``)
+               instead of letting the last writer's clock win.
             2. A key that already exists keeps its stored ``create_time`` and
                only advances ``update_time`` -- including when ``data``
                replaces the whole value with business fields only, which is

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -429,9 +429,17 @@ class JsonKVStorage(BaseKVStorage):
                     if "llm_cache_list" not in v:
                         v["llm_cache_list"] = []
 
-                # Add timestamps based on whether key exists
-                if k in self._data:  # Key exists, only update update_time
+                # Add timestamps based on whether key exists.
+                # On update, replace the business value but preserve the
+                # storage-managed create_time. Do not invent a timestamp for
+                # legacy rows that never had one (treat missing as 0).
+                if k in self._data:
                     v["update_time"] = current_time
+                    existing = self._data[k]
+                    if isinstance(existing, dict) and "create_time" in existing:
+                        v["create_time"] = existing["create_time"]
+                    else:
+                        v["create_time"] = 0
                 else:  # New key, set both create_time and update_time
                     v["create_time"] = current_time
                     v["update_time"] = current_time

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, ClassVar, final
 
 from lightrag.base import (
+    normalize_kv_create_time,
     BaseKVStorage,
 )
 from lightrag.file_atomic import reap_orphan_tmp_files
@@ -386,7 +387,14 @@ class JsonKVStorage(BaseKVStorage):
 
         Two side effects under ``_storage_lock``:
             1. Stamp ``create_time`` / ``update_time`` / ``_id`` on each
-               value, then ``self._data.update(data)``. Because
+               value, then ``self._data.update(data)``. Timestamping
+               follows the ``BaseKVStorage.upsert`` contract: a new key
+               gets both stamps, an existing key keeps its stored
+               ``create_time`` (``0`` when the row never had one) and only
+               advances ``update_time``, and a caller-supplied
+               ``create_time`` is ignored. No I/O is needed for that --
+               unlike the remote backends, the previous value is already in
+               shared memory. Because
                ``self._data`` is the shared ``Manager.dict()`` proxy, the
                update is visible to all processes immediately — no
                reload needed.
@@ -429,17 +437,24 @@ class JsonKVStorage(BaseKVStorage):
                     if "llm_cache_list" not in v:
                         v["llm_cache_list"] = []
 
-                # Add timestamps based on whether key exists.
-                # On update, replace the business value but preserve the
-                # storage-managed create_time. Do not invent a timestamp for
-                # legacy rows that never had one (treat missing as 0).
-                if k in self._data:
+                # Timestamps per the BaseKVStorage.upsert contract. A single
+                # ``get`` -- not ``__contains__`` + ``__getitem__`` -- because
+                # on a multi-worker deployment ``self._data`` is a
+                # ``Manager().dict()`` proxy and each subscript is a separate
+                # RPC; ``get`` is what this file's read paths already use.
+                # Values are always dicts, so ``None`` means absent.
+                existing = self._data.get(k)
+                if existing is not None:
+                    # Update: the business value is replaced wholesale, but the
+                    # storage-managed create_time survives it. A legacy row
+                    # without the field records 0 (unknown) -- never a
+                    # fabricated original timestamp.
                     v["update_time"] = current_time
-                    existing = self._data[k]
-                    if isinstance(existing, dict) and "create_time" in existing:
-                        v["create_time"] = existing["create_time"]
-                    else:
-                        v["create_time"] = 0
+                    v["create_time"] = normalize_kv_create_time(
+                        existing.get("create_time")
+                        if isinstance(existing, dict)
+                        else None
+                    )
                 else:  # New key, set both create_time and update_time
                     v["create_time"] = current_time
                     v["update_time"] = current_time

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -1311,12 +1311,77 @@ class OpenSearchKVStorage(BaseKVStorage):
         )
         current_time = int(time.time())
 
-        # Construct sources outside the lock (no IO; just dict shuffling)
-        # so we hold the lock only for the buffer-swap step.
+        # Resolve existing create_time for updates from the local buffer first,
+        # then from OpenSearch for keys not already buffered. Pending deletes
+        # count as "missing" so a delete-then-upsert stamps a fresh create_time.
+        existing_create_times: dict[str, int] = {}
+        async with self._flush_lock:
+            pending_deletes = set(self._pending_kv_deletes)
+            for doc_id in data:
+                if doc_id in pending_deletes:
+                    continue
+                pending = self._pending_upserts.get(doc_id)
+                if pending is not None:
+                    ct = pending.get("create_time", 0)
+                    existing_create_times[doc_id] = 0 if ct is None else int(ct)
+
+        to_fetch = [
+            doc_id
+            for doc_id in data
+            if doc_id not in existing_create_times and doc_id not in pending_deletes
+        ]
+        if to_fetch and self._index_ready:
+            try:
+                response = await self.client.mget(
+                    index=self._index_name,
+                    body={"ids": to_fetch},
+                    _source_includes=["create_time"],
+                )
+                docs = response.get("docs")
+                if not isinstance(docs, list) or len(docs) != len(to_fetch):
+                    raise RuntimeError(
+                        f"[{self.workspace}] OpenSearch mget returned "
+                        f"{len(docs) if isinstance(docs, list) else 'no'} items "
+                        f"for {len(to_fetch)} requested ids during upsert"
+                    )
+                for requested_id, item in zip(to_fetch, docs):
+                    interpreted = _interpret_mget_item(
+                        item, requested_id, require_source=False
+                    )
+                    if interpreted is None:
+                        continue
+                    source = interpreted.get("_source") or {}
+                    if isinstance(source, dict) and "create_time" in source:
+                        ct = source["create_time"]
+                        existing_create_times[requested_id] = (
+                            0 if ct is None else int(ct)
+                        )
+                    else:
+                        # Legacy persisted row without create_time: keep 0.
+                        existing_create_times[requested_id] = 0
+            except OpenSearchException as e:
+                if _is_missing_index_error(e):
+                    self._mark_index_missing()
+                else:
+                    logger.error(
+                        f"[{self.workspace}] Error resolving create_time "
+                        f"during upsert: {e}"
+                    )
+                    raise
+
+        # Construct sources outside the lock (dict shuffling + resolved
+        # timestamps) so we hold the lock only for the buffer-swap step.
         prepared: list[tuple[str, dict[str, Any]]] = []
         for i, (doc_id, doc_data) in enumerate(data.items(), start=1):
             doc_data["update_time"] = current_time
-            doc_data.setdefault("create_time", current_time)
+            if doc_id in existing_create_times:
+                # Update path: preserve storage-managed create_time; ignore
+                # any caller-supplied value so replacement payloads without
+                # timestamps cannot reset it.
+                doc_data["create_time"] = existing_create_times[doc_id]
+            else:
+                # Insert (or delete-then-upsert): stamp a fresh create_time.
+                doc_data["create_time"] = current_time
             source = {k: v for k, v in doc_data.items() if k != "_id"}
             source["__mirrored_id"] = doc_id
             prepared.append((doc_id, source))

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -1314,6 +1314,12 @@ class OpenSearchKVStorage(BaseKVStorage):
         # Resolve existing create_time for updates from the local buffer first,
         # then from OpenSearch for keys not already buffered. Pending deletes
         # count as "missing" so a delete-then-upsert stamps a fresh create_time.
+        #
+        # The create_time mget runs under `_flush_lock` so a concurrent
+        # delete()/flush cannot race the lookup and leave a replacement with
+        # the deleted incarnation's create_time. Dict shuffling stays outside
+        # the lock; the final buffer swap revalidates against any delete or
+        # buffered upsert that landed while we prepared.
         existing_create_times: dict[str, int] = {}
         async with self._flush_lock:
             pending_deletes = set(self._pending_kv_deletes)
@@ -1325,52 +1331,52 @@ class OpenSearchKVStorage(BaseKVStorage):
                     ct = pending.get("create_time", 0)
                     existing_create_times[doc_id] = 0 if ct is None else int(ct)
 
-        to_fetch = [
-            doc_id
-            for doc_id in data
-            if doc_id not in existing_create_times and doc_id not in pending_deletes
-        ]
-        if to_fetch and self._index_ready:
-            try:
-                response = await self.client.mget(
-                    index=self._index_name,
-                    body={"ids": to_fetch},
-                    _source_includes=["create_time"],
-                )
-                docs = response.get("docs")
-                if not isinstance(docs, list) or len(docs) != len(to_fetch):
-                    raise RuntimeError(
-                        f"[{self.workspace}] OpenSearch mget returned "
-                        f"{len(docs) if isinstance(docs, list) else 'no'} items "
-                        f"for {len(to_fetch)} requested ids during upsert"
+            to_fetch = [
+                doc_id
+                for doc_id in data
+                if doc_id not in existing_create_times and doc_id not in pending_deletes
+            ]
+            if to_fetch and self._index_ready:
+                try:
+                    response = await self.client.mget(
+                        index=self._index_name,
+                        body={"ids": to_fetch},
+                        _source_includes=["create_time"],
                     )
-                for requested_id, item in zip(to_fetch, docs):
-                    interpreted = _interpret_mget_item(
-                        item, requested_id, require_source=False
-                    )
-                    if interpreted is None:
-                        continue
-                    source = interpreted.get("_source") or {}
-                    if isinstance(source, dict) and "create_time" in source:
-                        ct = source["create_time"]
-                        existing_create_times[requested_id] = (
-                            0 if ct is None else int(ct)
+                    docs = response.get("docs")
+                    if not isinstance(docs, list) or len(docs) != len(to_fetch):
+                        raise RuntimeError(
+                            f"[{self.workspace}] OpenSearch mget returned "
+                            f"{len(docs) if isinstance(docs, list) else 'no'} items "
+                            f"for {len(to_fetch)} requested ids during upsert"
                         )
+                    for requested_id, item in zip(to_fetch, docs):
+                        interpreted = _interpret_mget_item(
+                            item, requested_id, require_source=False
+                        )
+                        if interpreted is None:
+                            continue
+                        source = interpreted.get("_source") or {}
+                        if isinstance(source, dict) and "create_time" in source:
+                            ct = source["create_time"]
+                            existing_create_times[requested_id] = (
+                                0 if ct is None else int(ct)
+                            )
+                        else:
+                            # Legacy persisted row without create_time: keep 0.
+                            existing_create_times[requested_id] = 0
+                except OpenSearchException as e:
+                    if _is_missing_index_error(e):
+                        self._mark_index_missing()
                     else:
-                        # Legacy persisted row without create_time: keep 0.
-                        existing_create_times[requested_id] = 0
-            except OpenSearchException as e:
-                if _is_missing_index_error(e):
-                    self._mark_index_missing()
-                else:
-                    logger.error(
-                        f"[{self.workspace}] Error resolving create_time "
-                        f"during upsert: {e}"
-                    )
-                    raise
+                        logger.error(
+                            f"[{self.workspace}] Error resolving create_time "
+                            f"during upsert: {e}"
+                        )
+                        raise
 
         # Construct sources outside the lock (dict shuffling + resolved
-        # timestamps) so we hold the lock only for the buffer-swap step.
+        # timestamps); the buffer-swap step revalidates create_time.
         prepared: list[tuple[str, dict[str, Any]]] = []
         for i, (doc_id, doc_data) in enumerate(data.items(), start=1):
             doc_data["update_time"] = current_time
@@ -1388,8 +1394,18 @@ class OpenSearchKVStorage(BaseKVStorage):
             await _cooperative_yield(i)
 
         # Buffer: an upsert cancels any pending delete on the same id.
+        # Revalidate create_time against concurrent buffer mutations that may
+        # have landed after the locked lookup above.
         async with self._flush_lock:
             for doc_id, source in prepared:
+                if doc_id in self._pending_kv_deletes:
+                    # delete-then-upsert: always stamp a fresh create_time.
+                    source["create_time"] = current_time
+                else:
+                    pending = self._pending_upserts.get(doc_id)
+                    if pending is not None:
+                        ct = pending.get("create_time", 0)
+                        source["create_time"] = 0 if ct is None else int(ct)
                 self._pending_kv_deletes.discard(doc_id)
                 self._pending_upserts[doc_id] = source
 

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -331,13 +331,30 @@ async def _run_chunked_async_bulk(
 #     field. A caller-supplied value can never win.
 # The sentinel decides "new", not ``ctx.op``, so the branch does not depend on
 # how the server happens to label a scripted upsert.
+# The restored value is also NORMALIZED to a long, mirroring
+# ``normalize_kv_create_time``: a row stored by an older release can carry a
+# float or a numeric string, and preserving that shape verbatim would leave
+# ``create_time`` mixed-typed across rows -- enough to make the LLM-cache
+# ordering in ``operate.py`` raise ``TypeError: '<' not supported between
+# instances of 'str' and 'int'``. Repairing it on the row's next write is the
+# same "fix the shape while you are here" rule the other backends follow.
+# ``tests/kg/opensearch_impl/test_opensearch_kv_create_time_integration.py``
+# pins the two normalizations to the same answers.
 _KV_CREATE_TIME_SENTINEL = "__lightrag_kv_new"
 _KV_UPSERT_SCRIPT_SOURCE = (
     "def prev = ctx._source.create_time;"
     f" boolean isNew = ctx._source.{_KV_CREATE_TIME_SENTINEL} == true;"
     " ctx._source.clear();"
     " ctx._source.putAll(params.doc);"
-    " if (!isNew) { ctx._source.create_time = prev == null ? 0 : prev; }"
+    " if (!isNew) {"
+    "   long ct = 0;"
+    "   if (prev instanceof Number) { ct = ((Number) prev).longValue(); }"
+    "   else if (prev instanceof String) {"
+    "     try { ct = Long.parseLong(((String) prev).trim()); }"
+    "     catch (Exception e) { ct = 0; }"
+    "   }"
+    "   ctx._source.create_time = ct;"
+    " }"
 )
 _KV_UPSERT_ACTION_UPSERT = {_KV_CREATE_TIME_SENTINEL: True}
 # Concurrent updates of the same id are resolved by the server instead of

--- a/lightrag/kg/opensearch_impl.py
+++ b/lightrag/kg/opensearch_impl.py
@@ -317,6 +317,35 @@ async def _run_chunked_async_bulk(
     )
 
 
+# Painless script behind every KV upsert. It reproduces MongoDB's
+# ``$setOnInsert`` semantics for ``create_time`` ON THE SERVER, so a
+# replacement upsert never has to read the stored row back first (issue
+# #3870 -- a client-side read-modify-write cost one extra HTTP round trip per
+# ``upsert()`` call, and this backend is deliberately called with many small
+# batches):
+#   * document missing -> ``_KV_UPSERT_ACTION_UPSERT`` becomes the starting
+#     ``_source``, the sentinel is therefore present, and the ``create_time``
+#     carried in ``params.doc`` (the moment the write was buffered) stands;
+#   * document present  -> the business value is replaced wholesale and the
+#     STORED ``create_time`` is put back, or ``0`` when the row predates the
+#     field. A caller-supplied value can never win.
+# The sentinel decides "new", not ``ctx.op``, so the branch does not depend on
+# how the server happens to label a scripted upsert.
+_KV_CREATE_TIME_SENTINEL = "__lightrag_kv_new"
+_KV_UPSERT_SCRIPT_SOURCE = (
+    "def prev = ctx._source.create_time;"
+    f" boolean isNew = ctx._source.{_KV_CREATE_TIME_SENTINEL} == true;"
+    " ctx._source.clear();"
+    " ctx._source.putAll(params.doc);"
+    " if (!isNew) { ctx._source.create_time = prev == null ? 0 : prev; }"
+)
+_KV_UPSERT_ACTION_UPSERT = {_KV_CREATE_TIME_SENTINEL: True}
+# Concurrent updates of the same id are resolved by the server instead of
+# failing the bulk item with a 409 (which _extract_bulk_failed_ids would
+# classify as permanent).
+_KV_UPSERT_RETRY_ON_CONFLICT = 3
+
+
 # Index _meta flag marking that an edges index has been migrated to canonical
 # (sorted-pair) document ids. Guards the one-time reindex in
 # PGGraphStorage-style startup so it runs at most once per index.
@@ -1300,6 +1329,12 @@ class OpenSearchKVStorage(BaseKVStorage):
         call is deferred to ``_flush_pending_kv_ops()`` invoked from
         ``index_done_callback`` / ``finalize``.
 
+        No IO happens here. ``create_time`` preservation (the
+        ``BaseKVStorage.upsert`` contract) is delegated to the flush's
+        ``scripted_upsert`` action, so this method never reads the stored row
+        back; the ``create_time`` it buffers is an optimistic estimate that
+        the server overwrites for an already-existing row.
+
         Multi-worker note: the buffer is process-local. Other workers will
         not see these writes until ``index_done_callback()`` flushes them.
         """
@@ -1311,101 +1346,33 @@ class OpenSearchKVStorage(BaseKVStorage):
         )
         current_time = int(time.time())
 
-        # Resolve existing create_time for updates from the local buffer first,
-        # then from OpenSearch for keys not already buffered. Pending deletes
-        # count as "missing" so a delete-then-upsert stamps a fresh create_time.
-        #
-        # The create_time mget runs under `_flush_lock` so a concurrent
-        # delete()/flush cannot race the lookup and leave a replacement with
-        # the deleted incarnation's create_time. Dict shuffling stays outside
-        # the lock; the final buffer swap revalidates against any delete or
-        # buffered upsert that landed while we prepared.
-        existing_create_times: dict[str, int] = {}
-        async with self._flush_lock:
-            pending_deletes = set(self._pending_kv_deletes)
-            for doc_id in data:
-                if doc_id in pending_deletes:
-                    continue
-                pending = self._pending_upserts.get(doc_id)
-                if pending is not None:
-                    ct = pending.get("create_time", 0)
-                    existing_create_times[doc_id] = 0 if ct is None else int(ct)
-
-            to_fetch = [
-                doc_id
-                for doc_id in data
-                if doc_id not in existing_create_times and doc_id not in pending_deletes
-            ]
-            if to_fetch and self._index_ready:
-                try:
-                    response = await self.client.mget(
-                        index=self._index_name,
-                        body={"ids": to_fetch},
-                        _source_includes=["create_time"],
-                    )
-                    docs = response.get("docs")
-                    if not isinstance(docs, list) or len(docs) != len(to_fetch):
-                        raise RuntimeError(
-                            f"[{self.workspace}] OpenSearch mget returned "
-                            f"{len(docs) if isinstance(docs, list) else 'no'} items "
-                            f"for {len(to_fetch)} requested ids during upsert"
-                        )
-                    for requested_id, item in zip(to_fetch, docs):
-                        interpreted = _interpret_mget_item(
-                            item, requested_id, require_source=False
-                        )
-                        if interpreted is None:
-                            continue
-                        source = interpreted.get("_source") or {}
-                        if isinstance(source, dict) and "create_time" in source:
-                            ct = source["create_time"]
-                            existing_create_times[requested_id] = (
-                                0 if ct is None else int(ct)
-                            )
-                        else:
-                            # Legacy persisted row without create_time: keep 0.
-                            existing_create_times[requested_id] = 0
-                except OpenSearchException as e:
-                    if _is_missing_index_error(e):
-                        self._mark_index_missing()
-                    else:
-                        logger.error(
-                            f"[{self.workspace}] Error resolving create_time "
-                            f"during upsert: {e}"
-                        )
-                        raise
-
-        # Construct sources outside the lock (dict shuffling + resolved
-        # timestamps); the buffer-swap step revalidates create_time.
+        # Construct sources outside the lock (no IO; just dict shuffling)
+        # so we hold the lock only for the buffer-swap step.
         prepared: list[tuple[str, dict[str, Any]]] = []
         for i, (doc_id, doc_data) in enumerate(data.items(), start=1):
             doc_data["update_time"] = current_time
-            if doc_id in existing_create_times:
-                # Update path: preserve storage-managed create_time; ignore
-                # any caller-supplied value so replacement payloads without
-                # timestamps cannot reset it.
-                doc_data["create_time"] = existing_create_times[doc_id]
-            else:
-                # Insert (or delete-then-upsert): stamp a fresh create_time.
-                doc_data["create_time"] = current_time
+            # An OPTIMISTIC create_time: right for an insert, and overwritten
+            # by the flush script with the stored value when the row already
+            # exists (see _KV_UPSERT_SCRIPT_SOURCE). Resolving it here would
+            # cost a read per upsert() call, so the buffered value is an
+            # estimate and the persisted one is authoritative. A caller-
+            # supplied create_time is overwritten either way, as the
+            # BaseKVStorage.upsert contract requires.
+            #
+            # Residue: a read served from the buffer (get_by_id / get_by_ids)
+            # reports this estimate, so an update of a row that already exists
+            # on the server shows the write time until the next flush, when the
+            # stored value wins. Same shape as before issue #3870's fix; it
+            # heals at flush and never reaches storage.
+            doc_data["create_time"] = current_time
             source = {k: v for k, v in doc_data.items() if k != "_id"}
             source["__mirrored_id"] = doc_id
             prepared.append((doc_id, source))
             await _cooperative_yield(i)
 
         # Buffer: an upsert cancels any pending delete on the same id.
-        # Revalidate create_time against concurrent buffer mutations that may
-        # have landed after the locked lookup above.
         async with self._flush_lock:
             for doc_id, source in prepared:
-                if doc_id in self._pending_kv_deletes:
-                    # delete-then-upsert: always stamp a fresh create_time.
-                    source["create_time"] = current_time
-                else:
-                    pending = self._pending_upserts.get(doc_id)
-                    if pending is not None:
-                        ct = pending.get("create_time", 0)
-                        source["create_time"] = 0 if ct is None else int(ct)
                 self._pending_kv_deletes.discard(doc_id)
                 self._pending_upserts[doc_id] = source
 
@@ -1435,6 +1402,13 @@ class OpenSearchKVStorage(BaseKVStorage):
 
     async def _flush_pending_kv_ops(self) -> None:
         """Flush buffered upserts + deletes via a single async_bulk call.
+
+        Upserts are ``scripted_upsert`` update actions, not index actions: the
+        script preserves the stored ``create_time`` while replacing the
+        business value, which is how this backend meets the
+        ``BaseKVStorage.upsert`` contract without reading rows back
+        client-side (issue #3870). ``retry_on_conflict`` lets the server
+        resolve concurrent updates of one id instead of failing the item.
 
         Concurrency contract: the entire flush runs under ``_flush_lock``;
         ``upsert`` / ``delete`` / reads / ``drop`` all acquire the same lock
@@ -1474,12 +1448,22 @@ class OpenSearchKVStorage(BaseKVStorage):
                 }
                 for doc_id in pending_deletes
             ]
+            # A scripted upsert rather than a plain index: the script keeps the
+            # stored create_time while replacing the business value, which is
+            # what lets upsert() stay read-free. See _KV_UPSERT_SCRIPT_SOURCE.
             index_actions: list[dict[str, Any]] = [
                 {
-                    "_op_type": "index",
+                    "_op_type": "update",
                     "_index": self._index_name,
                     "_id": doc_id,
-                    "_source": source,
+                    "retry_on_conflict": _KV_UPSERT_RETRY_ON_CONFLICT,
+                    "scripted_upsert": True,
+                    "upsert": dict(_KV_UPSERT_ACTION_UPSERT),
+                    "script": {
+                        "lang": "painless",
+                        "source": _KV_UPSERT_SCRIPT_SOURCE,
+                        "params": {"doc": source},
+                    },
                 }
                 for doc_id, source in pending_upserts.items()
             ]

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -96,7 +96,12 @@ _CREATE_TIME_PREFIX_LUA_PATTERN = '^{%s*"create_time"%s*:%s*(%-?%d+)%s*[,}]'
 #
 #   * key absent            -> stamp ARGV[3] (the write's own clock). Two
 #     writers racing a first insert therefore cannot disagree: the second one
-#     to run finds the row and keeps the first one's timestamp.
+#     to run finds the row and keeps the first one's timestamp. ``GETRANGE``
+#     answers ``''`` for a missing key AND for a key holding an empty string,
+#     so an ``EXISTS`` disambiguates them -- only on that branch, so the
+#     steady state still reads once. An empty row is a stored row with no
+#     usable timestamp, and the contract says such a row records ``0``; it
+#     must never be mistaken for a first creation and given this clock.
 #   * prefix carries an int -> keep it. This is the steady state, and it needs
 #     nothing from the caller: one round trip, no read amplification.
 #   * prefix does not match -> a row written before this layout existed, or by
@@ -114,7 +119,7 @@ _CREATE_TIME_UPSERT_LUA = f"""
 local prefix = redis.call('GETRANGE', KEYS[1], 0, tonumber(ARGV[4]) - 1)
 local outcome
 local create_time
-if prefix == '' then
+if prefix == '' and redis.call('EXISTS', KEYS[1]) == 0 then
     create_time = ARGV[3]
     outcome = 'created'
 else
@@ -624,10 +629,10 @@ class RedisKVStorage(BaseKVStorage):
         come back to find it. The upsert rewrites them ``create_time``-first,
         which makes this a one-time cost per row.
 
-        A key absent from the result is either genuinely gone or holds
-        something that is not a JSON object; the caller passes its own clock
-        for those, and a decodable object with no ``create_time`` yields the
-        documented ``0``.
+        A key absent from the result is genuinely gone -- only ``None``
+        counts, because a key holding an empty string is a stored row and
+        must record the documented ``0`` rather than borrow the caller's
+        clock. A decodable object with no ``create_time`` yields ``0`` too.
         """
         resolved: dict[str, int] = {}
         if not keys:
@@ -644,8 +649,10 @@ class RedisKVStorage(BaseKVStorage):
         values = await pipe.execute()
 
         for k, raw in zip(keys, values):
-            if not raw:
-                # Deleted between the script's read and this one.
+            if raw is None:
+                # Deleted between the script's read and this one. An empty
+                # string is NOT this case -- it falls through to the decode
+                # below, which records 0 like any other unusable value.
                 continue
             try:
                 stored = json.loads(raw)

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import asyncio
+import re
 import time
 import hashlib
 from typing import Any, ClassVar, final, Sequence, Union
@@ -30,6 +31,7 @@ from lightrag.utils import (
 )
 
 from lightrag.base import (
+    normalize_kv_create_time,
     CURSOR_END,
     CURSOR_START,
     CursorAfter,
@@ -65,6 +67,42 @@ from tenacity import (
     retry_if_exception_type,
     before_sleep_log,
 )
+
+# Storage-managed ``create_time`` is serialized as the FIRST key of every KV
+# value so an update can recover the previous timestamp with a bounded prefix
+# read instead of pulling the whole row back over the wire -- a ``full_docs``
+# row is an entire document, and Redis has no way to read one JSON field.
+# 64 bytes covers ``{"create_time":`` plus a 19-digit integer and its comma.
+#
+# The separator is matched loosely on purpose: ``json.dumps`` writes
+# ``{"create_time": 1700000000,`` (a space after the colon) while a compact
+# dump or a hand-edited row writes it without one. A prefix that does not
+# match is not a failure -- it falls back to a full read -- but a needlessly
+# strict pattern would silently send EVERY update down that fallback and
+# quietly undo the optimization.
+_CREATE_TIME_PREFIX_BYTES = 64
+_CREATE_TIME_PREFIX_RE = re.compile(r'^\{\s*"create_time"\s*:\s*(-?\d+)\s*[,}]')
+
+
+def _dumps_create_time_first(value: dict[str, Any]) -> str:
+    """Serialize a KV row with ``create_time`` as its first key.
+
+    ``RedisKVStorage.upsert`` recovers the stored ``create_time`` with a
+    ``GETRANGE`` prefix read, which only works while the field leads the
+    serialized object. Python dicts preserve insertion order and
+    ``json.dumps`` follows it, so the ordering is established here -- the one
+    place a KV row is serialized. Seeding the key first and then ``update``-ing
+    keeps that position, because ``dict.update`` replaces an existing key's
+    value without moving it.
+
+    The ordering is an optimization, not a correctness fence: a row that does
+    not match the prefix (written by an older release, or by hand) falls back
+    to a full read in ``upsert`` and is rewritten in this layout afterwards.
+    """
+    ordered: dict[str, Any] = {"create_time": value.get("create_time", 0)}
+    ordered.update(value)
+    return json.dumps(ordered)
+
 
 config = configparser.ConfigParser()
 config.read("config.ini", "utf-8")
@@ -536,13 +574,74 @@ class RedisKVStorage(BaseKVStorage):
 
         async with self._get_redis_connection() as redis:
             try:
-                # Fetch existing values so updates can preserve create_time
-                # without merging stale business fields from storage.
+                # Resolve the stored create_time with a BOUNDED prefix read.
+                # An update must not reset the field (issue #3870), and Redis
+                # cannot read one JSON field, but it can read a byte range:
+                # _dumps_create_time_first() puts create_time first, so 64
+                # bytes per key is enough. An empty answer means the key does
+                # not exist -- an existing row is never written empty by this
+                # class, and it would be replaced wholesale here anyway.
                 pipe = redis.pipeline()
                 for i, k in enumerate(data.keys(), start=1):
-                    pipe.get(f"{self.final_namespace}:{k}")
+                    pipe.getrange(
+                        f"{self.final_namespace}:{k}",
+                        0,
+                        _CREATE_TIME_PREFIX_BYTES - 1,
+                    )
                     await _cooperative_yield(i)
-                existing_values = await pipe.execute()
+                prefixes = await pipe.execute()
+
+                stored_create_times: dict[str, int] = {}
+                needs_full_read: list[str] = []
+                for i, k in enumerate(data.keys()):
+                    prefix = prefixes[i]
+                    if not prefix:
+                        continue  # absent -> insert
+                    match = _CREATE_TIME_PREFIX_RE.match(prefix)
+                    if match is not None:
+                        stored_create_times[k] = int(match.group(1))
+                    else:
+                        # Row written before this layout existed (or by hand):
+                        # the field may be anywhere in the value, or missing.
+                        needs_full_read.append(k)
+                    await _cooperative_yield(i + 1)
+
+                if needs_full_read:
+                    # Rare and self-healing: the rewrite below stores these
+                    # rows create_time-first, so they take the prefix path
+                    # from now on.
+                    logger.debug(
+                        f"[{self.workspace}] {self.namespace}: full read for "
+                        f"{len(needs_full_read)} row(s) whose create_time is "
+                        f"not in the value prefix"
+                    )
+                    pipe = redis.pipeline()
+                    for i, k in enumerate(needs_full_read, start=1):
+                        pipe.get(f"{self.final_namespace}:{k}")
+                        await _cooperative_yield(i)
+                    legacy_values = await pipe.execute()
+                    for k, raw in zip(needs_full_read, legacy_values):
+                        if not raw:
+                            # Deleted between the two reads: it is an insert
+                            # again, so leave it out of stored_create_times.
+                            continue
+                        try:
+                            stored = json.loads(raw)
+                        except (json.JSONDecodeError, TypeError):
+                            # Not a legacy shape but corruption: say so
+                            # instead of silently recording an unknown.
+                            logger.warning(
+                                f"[{self.workspace}] {self.namespace}: row "
+                                f"'{k}' is not decodable JSON; recording "
+                                f"create_time=0 (unknown)"
+                            )
+                            stored_create_times[k] = 0
+                            continue
+                        stored_create_times[k] = normalize_kv_create_time(
+                            stored.get("create_time")
+                            if isinstance(stored, dict)
+                            else None
+                        )
 
                 # Add timestamps to data
                 for i, (k, v) in enumerate(data.items(), start=1):
@@ -551,20 +650,14 @@ class RedisKVStorage(BaseKVStorage):
                         if "llm_cache_list" not in v:
                             v["llm_cache_list"] = []
 
-                    # On update, replace the business value but preserve the
-                    # storage-managed create_time. Legacy rows missing the
-                    # field keep the 0/unknown convention.
-                    existing_raw = existing_values[i - 1]
-                    if existing_raw:
+                    # Update: the business value is replaced wholesale, but the
+                    # storage-managed create_time survives it; a legacy row
+                    # without the field records 0 (unknown). A caller-supplied
+                    # create_time is ignored on this path -- see the
+                    # BaseKVStorage.upsert contract.
+                    if k in stored_create_times:
                         v["update_time"] = current_time
-                        try:
-                            existing = json.loads(existing_raw)
-                        except (json.JSONDecodeError, TypeError):
-                            existing = None
-                        if isinstance(existing, dict) and "create_time" in existing:
-                            v["create_time"] = existing["create_time"]
-                        else:
-                            v["create_time"] = 0
+                        v["create_time"] = stored_create_times[k]
                     else:  # New key, set both create_time and update_time
                         v["create_time"] = current_time
                         v["update_time"] = current_time
@@ -575,7 +668,10 @@ class RedisKVStorage(BaseKVStorage):
                 # Store the data
                 pipe = redis.pipeline()
                 for i, (k, v) in enumerate(data.items(), start=1):
-                    pipe.set(f"{self.final_namespace}:{k}", json.dumps(v))
+                    pipe.set(
+                        f"{self.final_namespace}:{k}",
+                        _dumps_create_time_first(v),
+                    )
                     await _cooperative_yield(i)
                 await pipe.execute()
 

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -536,12 +536,13 @@ class RedisKVStorage(BaseKVStorage):
 
         async with self._get_redis_connection() as redis:
             try:
-                # Check which keys already exist to determine create vs update
+                # Fetch existing values so updates can preserve create_time
+                # without merging stale business fields from storage.
                 pipe = redis.pipeline()
                 for i, k in enumerate(data.keys(), start=1):
-                    pipe.exists(f"{self.final_namespace}:{k}")
+                    pipe.get(f"{self.final_namespace}:{k}")
                     await _cooperative_yield(i)
-                exists_results = await pipe.execute()
+                existing_values = await pipe.execute()
 
                 # Add timestamps to data
                 for i, (k, v) in enumerate(data.items(), start=1):
@@ -550,9 +551,20 @@ class RedisKVStorage(BaseKVStorage):
                         if "llm_cache_list" not in v:
                             v["llm_cache_list"] = []
 
-                    # Add timestamps based on whether key exists
-                    if exists_results[i - 1]:  # Key exists, only update update_time
+                    # On update, replace the business value but preserve the
+                    # storage-managed create_time. Legacy rows missing the
+                    # field keep the 0/unknown convention.
+                    existing_raw = existing_values[i - 1]
+                    if existing_raw:
                         v["update_time"] = current_time
+                        try:
+                            existing = json.loads(existing_raw)
+                        except (json.JSONDecodeError, TypeError):
+                            existing = None
+                        if isinstance(existing, dict) and "create_time" in existing:
+                            v["create_time"] = existing["create_time"]
+                        else:
+                            v["create_time"] = 0
                     else:  # New key, set both create_time and update_time
                         v["create_time"] = current_time
                         v["update_time"] = current_time

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -69,10 +69,10 @@ from tenacity import (
 )
 
 # Storage-managed ``create_time`` is serialized as the FIRST key of every KV
-# value so an update can recover the previous timestamp with a bounded prefix
-# read instead of pulling the whole row back over the wire -- a ``full_docs``
-# row is an entire document, and Redis has no way to read one JSON field.
-# 64 bytes covers ``{"create_time":`` plus a 19-digit integer and its comma.
+# value so it can be recovered with a bounded prefix read instead of pulling
+# the whole row back over the wire -- a ``full_docs`` row is an entire
+# document, and Redis has no way to read one JSON field. 64 bytes covers
+# ``{"create_time":`` plus a 19-digit integer and its comma.
 #
 # The separator is matched loosely on purpose: ``json.dumps`` writes
 # ``{"create_time": 1700000000,`` (a space after the colon) while a compact
@@ -83,25 +83,76 @@ from tenacity import (
 _CREATE_TIME_PREFIX_BYTES = 64
 _CREATE_TIME_PREFIX_RE = re.compile(r'^\{\s*"create_time"\s*:\s*(-?\d+)\s*[,}]')
 
+# Lua counterpart of _CREATE_TIME_PREFIX_RE. Keep the two in step; the
+# integration suite pins them to the same verdict on the same prefixes.
+_CREATE_TIME_PREFIX_LUA_PATTERN = '^{%s*"create_time"%s*:%s*(%-?%d+)%s*[,}]'
 
-def _dumps_create_time_first(value: dict[str, Any]) -> str:
-    """Serialize a KV row with ``create_time`` as its first key.
+# The script that writes a KV row. Reading the previous ``create_time`` and
+# writing the new value must be ONE atomic step, or a concurrent ``delete()``
+# landing between them lets the row come back carrying the deleted
+# incarnation's timestamp -- and nothing would ever correct it, because every
+# later update preserves what it finds. Redis runs a script atomically, so the
+# decision happens next to the data:
+#
+#   * key absent            -> stamp ARGV[3] (the write's own clock). Two
+#     writers racing a first insert therefore cannot disagree: the second one
+#     to run finds the row and keeps the first one's timestamp.
+#   * prefix carries an int -> keep it. This is the steady state, and it needs
+#     nothing from the caller: one round trip, no read amplification.
+#   * prefix does not match -> a row written before this layout existed, or by
+#     hand. The timestamp may sit anywhere in the value or be malformed, and
+#     normalizing it belongs to ``normalize_kv_create_time`` and not to a
+#     second implementation in Lua -- so the script WRITES NOTHING and answers
+#     ``needs_hint``. The caller reads the value, normalizes it, and calls
+#     again with ARGV[2] set; a non-empty hint always writes, so the exchange
+#     cannot loop.
+#
+# No ``cjson`` and no arithmetic: the timestamp travels as a string and the
+# value is spliced in front of the caller's payload, so a large row is never
+# decoded server-side and Lua's number formatting never enters the picture.
+_CREATE_TIME_UPSERT_LUA = f"""
+local prefix = redis.call('GETRANGE', KEYS[1], 0, tonumber(ARGV[4]) - 1)
+local outcome
+local create_time
+if prefix == '' then
+    create_time = ARGV[3]
+    outcome = 'created'
+else
+    local matched = string.match(prefix, '{_CREATE_TIME_PREFIX_LUA_PATTERN}')
+    if matched then
+        create_time = matched
+        outcome = 'kept'
+    elseif ARGV[2] == '' then
+        return {{'needs_hint', ''}}
+    else
+        create_time = ARGV[2]
+        outcome = 'hinted'
+    end
+end
+local rest = string.sub(ARGV[1], 2)
+if rest == '}}' or rest == '' then
+    redis.call('SET', KEYS[1], '{{"create_time":' .. create_time .. '}}')
+else
+    redis.call('SET', KEYS[1], '{{"create_time":' .. create_time .. ',' .. rest)
+end
+return {{outcome, create_time}}
+"""
 
-    ``RedisKVStorage.upsert`` recovers the stored ``create_time`` with a
-    ``GETRANGE`` prefix read, which only works while the field leads the
-    serialized object. Python dicts preserve insertion order and
-    ``json.dumps`` follows it, so the ordering is established here -- the one
-    place a KV row is serialized. Seeding the key first and then ``update``-ing
-    keeps that position, because ``dict.update`` replaces an existing key's
-    value without moving it.
 
-    The ordering is an optimization, not a correctness fence: a row that does
-    not match the prefix (written by an older release, or by hand) falls back
-    to a full read in ``upsert`` and is rewritten in this layout afterwards.
+def _dumps_kv_payload(value: dict[str, Any]) -> str:
+    """Serialize a KV row WITHOUT ``create_time``, for the upsert script.
+
+    The script prepends the timestamp it decided on, which is what puts the
+    field first (see ``_CREATE_TIME_PREFIX_BYTES``) and what keeps the
+    decision atomic. Dropping the key here also means a caller-supplied
+    ``create_time`` cannot reach storage, as the ``BaseKVStorage.upsert``
+    contract requires.
+
+    The result always starts with ``{`` and normally carries at least
+    ``_id`` and ``update_time``; the script handles the empty-object case
+    anyway so the splice cannot produce invalid JSON.
     """
-    ordered: dict[str, Any] = {"create_time": value.get("create_time", 0)}
-    ordered.update(value)
-    return json.dumps(ordered)
+    return json.dumps({k: v for k, v in value.items() if k != "create_time"})
 
 
 config = configparser.ConfigParser()
@@ -565,62 +616,36 @@ class RedisKVStorage(BaseKVStorage):
             existing_ids = {keys_list[i] for i, exists in enumerate(results) if exists}
             return set(keys) - existing_ids
 
-    async def _resolve_stored_create_times(
-        self, redis, keys: list[str]
-    ) -> dict[str, int]:
-        """Return the stored ``create_time`` of ``keys`` that already exist.
+    async def _read_legacy_create_times(self, redis, keys: list[str]) -> dict[str, int]:
+        """Full-read the ``create_time`` of rows the upsert script could not.
 
-        Redis cannot read a single JSON field, but it can read a byte range,
-        and ``_dumps_create_time_first`` puts the field first — so 64 bytes
-        per key is enough and a ``full_docs`` row does not have to travel the
-        wire to yield one integer.
+        Only rows whose stored prefix does not carry the field reach this --
+        an older layout or a hand-edited value -- so the whole value has to
+        come back to find it. The upsert rewrites them ``create_time``-first,
+        which makes this a one-time cost per row.
 
-        A key missing from the returned mapping is CONFIRMED absent (empty
-        ``GETRANGE``); an existing row is never written empty by this class.
-        A row whose prefix does not match (older layout, hand-edited) costs
-        one full read here and is rewritten in the prefix layout by the
-        caller, so the fallback is a one-time cost per row.
+        A key absent from the result is either genuinely gone or holds
+        something that is not a JSON object; the caller passes its own clock
+        for those, and a decodable object with no ``create_time`` yields the
+        documented ``0``.
         """
         resolved: dict[str, int] = {}
         if not keys:
             return resolved
 
-        pipe = redis.pipeline()
-        for i, k in enumerate(keys, start=1):
-            pipe.getrange(
-                f"{self.final_namespace}:{k}", 0, _CREATE_TIME_PREFIX_BYTES - 1
-            )
-            await _cooperative_yield(i)
-        prefixes = await pipe.execute()
-
-        needs_full_read: list[str] = []
-        for i, k in enumerate(keys):
-            prefix = prefixes[i]
-            if not prefix:
-                continue  # absent
-            match = _CREATE_TIME_PREFIX_RE.match(prefix)
-            if match is not None:
-                resolved[k] = int(match.group(1))
-            else:
-                needs_full_read.append(k)
-            await _cooperative_yield(i + 1)
-
-        if not needs_full_read:
-            return resolved
-
         logger.debug(
-            f"[{self.workspace}] {self.namespace}: full read for "
-            f"{len(needs_full_read)} row(s) whose create_time is not in the "
-            f"value prefix"
+            f"[{self.workspace}] {self.namespace}: full read for {len(keys)} "
+            f"row(s) whose create_time is not in the value prefix"
         )
         pipe = redis.pipeline()
-        for i, k in enumerate(needs_full_read, start=1):
+        for i, k in enumerate(keys, start=1):
             pipe.get(f"{self.final_namespace}:{k}")
             await _cooperative_yield(i)
-        legacy_values = await pipe.execute()
-        for k, raw in zip(needs_full_read, legacy_values):
+        values = await pipe.execute()
+
+        for k, raw in zip(keys, values):
             if not raw:
-                # Deleted between the two reads: confirmed absent again.
+                # Deleted between the script's read and this one.
                 continue
             try:
                 stored = json.loads(raw)
@@ -642,26 +667,29 @@ class RedisKVStorage(BaseKVStorage):
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         """Write KV rows, preserving each row's original ``create_time``.
 
-        Concurrency (issue #3870): resolving the stored timestamp and writing
-        the new value are two round trips, so they cannot be one atomic step.
-        They do not need to be, because only ONE of the two outcomes is
-        contended:
+        ``create_time`` is the moment the row was FIRST created; only
+        ``update_time`` may move afterwards (issue #3870). Redis cannot read
+        one JSON field, so the value is written ``create_time``-first and the
+        previous timestamp is recovered from a bounded prefix.
 
-        * **Update** — every writer derives the same ``create_time`` from the
-          same stored row (a preserved value, ``0`` for a legacy row, and the
-          normalization in between is deterministic), so read-modify-write is
-          idempotent. Concurrent updates cannot disagree.
-        * **Insert** — writers that all see the key absent would each stamp
-          their own clock, and the last ``SET`` would win, moving
-          ``create_time`` forward off the real first creation. That one is
-          made atomic by ``SET ... NX``: the first creation wins, and a
-          writer whose ``NX`` is refused re-reads the winner's timestamp and
-          rewrites the row with it.
+        The decision is made INSIDE ``_CREATE_TIME_UPSERT_LUA``, atomically
+        with the write. A client-side read-then-write would leave two holes
+        that no later write repairs, because every update preserves the
+        timestamp it finds:
 
-        Accepted residue: an upsert racing a ``delete`` + re-create of the
-        same key can rewrite the row with the pre-delete timestamp. An upsert
-        concurrent with a delete has no defined winner to begin with, and the
-        next write of that row settles it.
+        * two writers that both saw the key absent would each stamp their own
+          clock, and the last ``SET`` would report a creation that never
+          happened;
+        * a ``delete()`` completing between one writer's read and its ``SET``
+          would let the row come back carrying the deleted incarnation's
+          timestamp.
+
+        The steady state is therefore ONE round trip. A second one happens
+        only for rows written before this layout existed: the script answers
+        ``needs_hint`` without writing, and this method reads those values,
+        normalizes them through ``normalize_kv_create_time`` (the single
+        authority for malformed shapes) and calls the script again. Their
+        rewrite puts the field first, so they take the fast path afterwards.
         """
         if not data:
             return
@@ -671,77 +699,72 @@ class RedisKVStorage(BaseKVStorage):
         async with self._get_redis_connection() as redis:
             try:
                 keys = list(data.keys())
-                stored_create_times = await self._resolve_stored_create_times(
-                    redis, keys
-                )
-
-                # Add timestamps to data
                 for i, (k, v) in enumerate(data.items(), start=1):
                     # For text_chunks namespace, ensure llm_cache_list field exists
                     if self.namespace.endswith("text_chunks"):
                         if "llm_cache_list" not in v:
                             v["llm_cache_list"] = []
 
-                    # Update: the business value is replaced wholesale, but the
-                    # storage-managed create_time survives it; a legacy row
-                    # without the field records 0 (unknown). A caller-supplied
-                    # create_time is ignored on this path -- see the
-                    # BaseKVStorage.upsert contract.
-                    if k in stored_create_times:
-                        v["update_time"] = current_time
-                        v["create_time"] = stored_create_times[k]
-                    else:  # New key, set both create_time and update_time
-                        v["create_time"] = current_time
-                        v["update_time"] = current_time
-
+                    v["update_time"] = current_time
+                    # Optimistic: right for an insert, and replaced below by
+                    # whatever the script decided. A caller-supplied value
+                    # never reaches storage -- _dumps_kv_payload drops the key
+                    # and the script writes its own.
+                    v["create_time"] = current_time
                     v["_id"] = k
                     await _cooperative_yield(i)
 
-                # Store the data. Rows we believe to be new go out as SET NX
-                # so a concurrent first creation cannot be overwritten; rows
-                # that already exist are a plain SET (see the docstring: every
-                # writer computes the same create_time for them).
-                pipe = redis.pipeline()
-                for i, k in enumerate(keys, start=1):
-                    pipe.set(
-                        f"{self.final_namespace}:{k}",
-                        _dumps_create_time_first(data[k]),
-                        nx=k not in stored_create_times,
-                    )
-                    await _cooperative_yield(i)
-                results = await pipe.execute()
+                # register_script only hashes the source locally; the pipeline
+                # loads it server-side before executing (redis-py tracks it
+                # via ``pipe.scripts``) and retries on NOSCRIPT.
+                script = redis.register_script(_CREATE_TIME_UPSERT_LUA)
 
-                # SET NX refused: somebody else created the key first, so
-                # THEIR create_time is the row's real one. One bounded repair
-                # round, then a plain SET -- by now the timestamp is settled,
-                # so this cannot loop.
-                # A falsy pipeline result belongs to a key sent with NX (an
-                # existing row's plain SET always answers True).
-                refused = [
-                    k
-                    for k, result in zip(keys, results)
-                    if k not in stored_create_times and not result
-                ]
-                if not refused:
+                async def write_rows(
+                    row_keys: list[str], hints: dict[str, int]
+                ) -> list[Any]:
+                    pipe = redis.pipeline()
+                    for i, key in enumerate(row_keys, start=1):
+                        hint = hints.get(key)
+                        await script(
+                            keys=[f"{self.final_namespace}:{key}"],
+                            args=[
+                                _dumps_kv_payload(data[key]),
+                                "" if hint is None else hint,
+                                current_time,
+                                _CREATE_TIME_PREFIX_BYTES,
+                            ],
+                            client=pipe,
+                        )
+                        await _cooperative_yield(i)
+                    return await pipe.execute()
+
+                def adopt(row_keys: list[str], results: list[Any]) -> list[str]:
+                    """Record what the server decided; return the unwritten ids."""
+                    deferred: list[str] = []
+                    for key, result in zip(row_keys, results):
+                        outcome, value = result[0], result[1]
+                        if outcome == "needs_hint":
+                            deferred.append(key)
+                            continue
+                        data[key]["create_time"] = int(value)
+                    return deferred
+
+                needs_hint = adopt(keys, await write_rows(keys, {}))
+                if not needs_hint:
                     return
-                logger.debug(
-                    f"[{self.workspace}] {self.namespace}: {len(refused)} "
-                    f"row(s) lost the create_time insert race; adopting the "
-                    f"stored timestamp"
-                )
-                winner_create_times = await self._resolve_stored_create_times(
-                    redis, refused
-                )
-                pipe = redis.pipeline()
-                for i, k in enumerate(refused, start=1):
-                    if k in winner_create_times:
-                        data[k]["create_time"] = winner_create_times[k]
-                    pipe.set(
-                        f"{self.final_namespace}:{k}",
-                        _dumps_create_time_first(data[k]),
+
+                # A non-empty hint always writes, so this cannot loop. Rows the
+                # read could not resolve (gone, or not a JSON object) fall back
+                # to this write's own clock.
+                legacy = await self._read_legacy_create_times(redis, needs_hint)
+                hints = {k: legacy.get(k, current_time) for k in needs_hint}
+                still_deferred = adopt(needs_hint, await write_rows(needs_hint, hints))
+                if still_deferred:
+                    raise RuntimeError(
+                        f"[{self.workspace}] {self.namespace}: upsert script "
+                        f"asked twice for a create_time hint on "
+                        f"{len(still_deferred)} row(s); refusing to loop"
                     )
-                    await _cooperative_yield(i)
-                await pipe.execute()
 
             except json.JSONDecodeError as e:
                 logger.error(f"[{self.workspace}] JSON decode error during upsert: {e}")

--- a/lightrag/kg/redis_impl.py
+++ b/lightrag/kg/redis_impl.py
@@ -565,8 +565,104 @@ class RedisKVStorage(BaseKVStorage):
             existing_ids = {keys_list[i] for i, exists in enumerate(results) if exists}
             return set(keys) - existing_ids
 
+    async def _resolve_stored_create_times(
+        self, redis, keys: list[str]
+    ) -> dict[str, int]:
+        """Return the stored ``create_time`` of ``keys`` that already exist.
+
+        Redis cannot read a single JSON field, but it can read a byte range,
+        and ``_dumps_create_time_first`` puts the field first — so 64 bytes
+        per key is enough and a ``full_docs`` row does not have to travel the
+        wire to yield one integer.
+
+        A key missing from the returned mapping is CONFIRMED absent (empty
+        ``GETRANGE``); an existing row is never written empty by this class.
+        A row whose prefix does not match (older layout, hand-edited) costs
+        one full read here and is rewritten in the prefix layout by the
+        caller, so the fallback is a one-time cost per row.
+        """
+        resolved: dict[str, int] = {}
+        if not keys:
+            return resolved
+
+        pipe = redis.pipeline()
+        for i, k in enumerate(keys, start=1):
+            pipe.getrange(
+                f"{self.final_namespace}:{k}", 0, _CREATE_TIME_PREFIX_BYTES - 1
+            )
+            await _cooperative_yield(i)
+        prefixes = await pipe.execute()
+
+        needs_full_read: list[str] = []
+        for i, k in enumerate(keys):
+            prefix = prefixes[i]
+            if not prefix:
+                continue  # absent
+            match = _CREATE_TIME_PREFIX_RE.match(prefix)
+            if match is not None:
+                resolved[k] = int(match.group(1))
+            else:
+                needs_full_read.append(k)
+            await _cooperative_yield(i + 1)
+
+        if not needs_full_read:
+            return resolved
+
+        logger.debug(
+            f"[{self.workspace}] {self.namespace}: full read for "
+            f"{len(needs_full_read)} row(s) whose create_time is not in the "
+            f"value prefix"
+        )
+        pipe = redis.pipeline()
+        for i, k in enumerate(needs_full_read, start=1):
+            pipe.get(f"{self.final_namespace}:{k}")
+            await _cooperative_yield(i)
+        legacy_values = await pipe.execute()
+        for k, raw in zip(needs_full_read, legacy_values):
+            if not raw:
+                # Deleted between the two reads: confirmed absent again.
+                continue
+            try:
+                stored = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                # Not a legacy shape but corruption: say so instead of
+                # silently recording an unknown.
+                logger.warning(
+                    f"[{self.workspace}] {self.namespace}: row '{k}' is not "
+                    f"decodable JSON; recording create_time=0 (unknown)"
+                )
+                resolved[k] = 0
+                continue
+            resolved[k] = normalize_kv_create_time(
+                stored.get("create_time") if isinstance(stored, dict) else None
+            )
+        return resolved
+
     @redis_retry
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
+        """Write KV rows, preserving each row's original ``create_time``.
+
+        Concurrency (issue #3870): resolving the stored timestamp and writing
+        the new value are two round trips, so they cannot be one atomic step.
+        They do not need to be, because only ONE of the two outcomes is
+        contended:
+
+        * **Update** — every writer derives the same ``create_time`` from the
+          same stored row (a preserved value, ``0`` for a legacy row, and the
+          normalization in between is deterministic), so read-modify-write is
+          idempotent. Concurrent updates cannot disagree.
+        * **Insert** — writers that all see the key absent would each stamp
+          their own clock, and the last ``SET`` would win, moving
+          ``create_time`` forward off the real first creation. That one is
+          made atomic by ``SET ... NX``: the first creation wins, and a
+          writer whose ``NX`` is refused re-reads the winner's timestamp and
+          rewrites the row with it.
+
+        Accepted residue: an upsert racing a ``delete`` + re-create of the
+        same key can rewrite the row with the pre-delete timestamp. An upsert
+        concurrent with a delete has no defined winner to begin with, and the
+        next write of that row settles it.
+        """
         if not data:
             return
 
@@ -574,74 +670,10 @@ class RedisKVStorage(BaseKVStorage):
 
         async with self._get_redis_connection() as redis:
             try:
-                # Resolve the stored create_time with a BOUNDED prefix read.
-                # An update must not reset the field (issue #3870), and Redis
-                # cannot read one JSON field, but it can read a byte range:
-                # _dumps_create_time_first() puts create_time first, so 64
-                # bytes per key is enough. An empty answer means the key does
-                # not exist -- an existing row is never written empty by this
-                # class, and it would be replaced wholesale here anyway.
-                pipe = redis.pipeline()
-                for i, k in enumerate(data.keys(), start=1):
-                    pipe.getrange(
-                        f"{self.final_namespace}:{k}",
-                        0,
-                        _CREATE_TIME_PREFIX_BYTES - 1,
-                    )
-                    await _cooperative_yield(i)
-                prefixes = await pipe.execute()
-
-                stored_create_times: dict[str, int] = {}
-                needs_full_read: list[str] = []
-                for i, k in enumerate(data.keys()):
-                    prefix = prefixes[i]
-                    if not prefix:
-                        continue  # absent -> insert
-                    match = _CREATE_TIME_PREFIX_RE.match(prefix)
-                    if match is not None:
-                        stored_create_times[k] = int(match.group(1))
-                    else:
-                        # Row written before this layout existed (or by hand):
-                        # the field may be anywhere in the value, or missing.
-                        needs_full_read.append(k)
-                    await _cooperative_yield(i + 1)
-
-                if needs_full_read:
-                    # Rare and self-healing: the rewrite below stores these
-                    # rows create_time-first, so they take the prefix path
-                    # from now on.
-                    logger.debug(
-                        f"[{self.workspace}] {self.namespace}: full read for "
-                        f"{len(needs_full_read)} row(s) whose create_time is "
-                        f"not in the value prefix"
-                    )
-                    pipe = redis.pipeline()
-                    for i, k in enumerate(needs_full_read, start=1):
-                        pipe.get(f"{self.final_namespace}:{k}")
-                        await _cooperative_yield(i)
-                    legacy_values = await pipe.execute()
-                    for k, raw in zip(needs_full_read, legacy_values):
-                        if not raw:
-                            # Deleted between the two reads: it is an insert
-                            # again, so leave it out of stored_create_times.
-                            continue
-                        try:
-                            stored = json.loads(raw)
-                        except (json.JSONDecodeError, TypeError):
-                            # Not a legacy shape but corruption: say so
-                            # instead of silently recording an unknown.
-                            logger.warning(
-                                f"[{self.workspace}] {self.namespace}: row "
-                                f"'{k}' is not decodable JSON; recording "
-                                f"create_time=0 (unknown)"
-                            )
-                            stored_create_times[k] = 0
-                            continue
-                        stored_create_times[k] = normalize_kv_create_time(
-                            stored.get("create_time")
-                            if isinstance(stored, dict)
-                            else None
-                        )
+                keys = list(data.keys())
+                stored_create_times = await self._resolve_stored_create_times(
+                    redis, keys
+                )
 
                 # Add timestamps to data
                 for i, (k, v) in enumerate(data.items(), start=1):
@@ -665,12 +697,48 @@ class RedisKVStorage(BaseKVStorage):
                     v["_id"] = k
                     await _cooperative_yield(i)
 
-                # Store the data
+                # Store the data. Rows we believe to be new go out as SET NX
+                # so a concurrent first creation cannot be overwritten; rows
+                # that already exist are a plain SET (see the docstring: every
+                # writer computes the same create_time for them).
                 pipe = redis.pipeline()
-                for i, (k, v) in enumerate(data.items(), start=1):
+                for i, k in enumerate(keys, start=1):
                     pipe.set(
                         f"{self.final_namespace}:{k}",
-                        _dumps_create_time_first(v),
+                        _dumps_create_time_first(data[k]),
+                        nx=k not in stored_create_times,
+                    )
+                    await _cooperative_yield(i)
+                results = await pipe.execute()
+
+                # SET NX refused: somebody else created the key first, so
+                # THEIR create_time is the row's real one. One bounded repair
+                # round, then a plain SET -- by now the timestamp is settled,
+                # so this cannot loop.
+                # A falsy pipeline result belongs to a key sent with NX (an
+                # existing row's plain SET always answers True).
+                refused = [
+                    k
+                    for k, result in zip(keys, results)
+                    if k not in stored_create_times and not result
+                ]
+                if not refused:
+                    return
+                logger.debug(
+                    f"[{self.workspace}] {self.namespace}: {len(refused)} "
+                    f"row(s) lost the create_time insert race; adopting the "
+                    f"stored timestamp"
+                )
+                winner_create_times = await self._resolve_stored_create_times(
+                    redis, refused
+                )
+                pipe = redis.pipeline()
+                for i, k in enumerate(refused, start=1):
+                    if k in winner_create_times:
+                        data[k]["create_time"] = winner_create_times[k]
+                    pipe.set(
+                        f"{self.final_namespace}:{k}",
+                        _dumps_create_time_first(data[k]),
                     )
                     await _cooperative_yield(i)
                 await pipe.execute()

--- a/tests/kg/json_impl/test_json_kv_upsert_create_time.py
+++ b/tests/kg/json_impl/test_json_kv_upsert_create_time.py
@@ -1,0 +1,113 @@
+"""Regression tests: JsonKVStorage replacement upserts preserve create_time.
+
+Fixes https://github.com/HKUDS/LightRAG/issues/3870 — callers that replace a
+KV value with business fields only must not discard the storage-managed
+create_time. update_time advances; legacy rows missing create_time keep the
+0/unknown convention rather than inventing an original timestamp.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from lightrag.kg.json_kv_impl import JsonKVStorage
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+from lightrag.namespace import NameSpace
+
+pytestmark = pytest.mark.offline
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
+
+
+@pytest.fixture(autouse=True)
+def setup_shared_data():
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+def _make_storage(tmp_path, workspace="ct-ws"):
+    return JsonKVStorage(
+        namespace=NameSpace.KV_STORE_ENTITY_CHUNKS,
+        global_config={"working_dir": str(tmp_path)},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace=workspace,
+    )
+
+
+@pytest.mark.asyncio
+async def test_replacement_upsert_preserves_create_time(tmp_path):
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+
+    with patch("time.time", return_value=1_700_000_000):
+        await storage.upsert({"E": {"chunk_ids": ["c1"], "count": 1}})
+
+    created = await storage.get_by_id("E")
+    assert created is not None
+    assert created["create_time"] == 1_700_000_000
+    assert created["update_time"] == 1_700_000_000
+    assert created["chunk_ids"] == ["c1"]
+    assert created["count"] == 1
+
+    with patch("time.time", return_value=1_700_000_100):
+        await storage.upsert({"E": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+    updated = await storage.get_by_id("E")
+    assert updated is not None
+    assert updated["create_time"] == 1_700_000_000
+    assert updated["update_time"] == 1_700_000_100
+    assert updated["chunk_ids"] == ["c1", "c2"]
+    assert updated["count"] == 2
+    # Business fields are replaced, not merged with the previous value.
+    assert "llm_cache_list" not in updated
+
+    await storage.index_done_callback()
+    persisted = storage._data["E"]
+    assert persisted["create_time"] == 1_700_000_000
+    assert persisted["update_time"] == 1_700_000_100
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_missing_create_time_keeps_zero(tmp_path):
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+
+    # Simulate a legacy row written before create_time existed.
+    storage._data["legacy"] = {
+        "chunk_ids": ["c1"],
+        "count": 1,
+        "update_time": 1_600_000_000,
+        "_id": "legacy",
+    }
+
+    with patch("time.time", return_value=1_700_000_200):
+        await storage.upsert({"legacy": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+    row = await storage.get_by_id("legacy")
+    assert row is not None
+    assert row["create_time"] == 0
+    assert row["update_time"] == 1_700_000_200
+    assert storage._data["legacy"]["create_time"] == 0
+
+
+@pytest.mark.asyncio
+async def test_insert_stamps_both_timestamps(tmp_path):
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+
+    with patch("time.time", return_value=1_700_000_300):
+        await storage.upsert({"new": {"chunk_ids": ["c9"], "count": 1}})
+
+    row = await storage.get_by_id("new")
+    assert row is not None
+    assert row["create_time"] == 1_700_000_300
+    assert row["update_time"] == 1_700_000_300

--- a/tests/kg/json_impl/test_json_kv_upsert_create_time.py
+++ b/tests/kg/json_impl/test_json_kv_upsert_create_time.py
@@ -3,7 +3,13 @@
 Fixes https://github.com/HKUDS/LightRAG/issues/3870 — callers that replace a
 KV value with business fields only must not discard the storage-managed
 create_time. update_time advances; legacy rows missing create_time keep the
-0/unknown convention rather than inventing an original timestamp.
+0/unknown convention rather than inventing an original timestamp. See
+``BaseKVStorage.upsert`` for the contract these tests pin.
+
+Unlike the remote backends this one needs no I/O to preserve the field -- the
+previous value is already in shared memory -- but on a multi-worker
+deployment that memory is a ``Manager().dict()`` proxy, so the number of
+subscripts is the cost that matters and is asserted here too.
 """
 
 from __future__ import annotations
@@ -111,3 +117,91 @@ async def test_insert_stamps_both_timestamps(tmp_path):
     assert row is not None
     assert row["create_time"] == 1_700_000_300
     assert row["update_time"] == 1_700_000_300
+
+
+class _CountingDict(dict):
+    """Stand-in for the multiprocess ``Manager().dict()`` proxy.
+
+    Every subscript on the real proxy is a separate IPC round trip, and
+    ``__getitem__`` ships the whole value back. Counting them is the only way
+    to pin "one lookup per key" -- the timestamps are identical either way.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.calls = {"get": 0, "getitem": 0, "contains": 0}
+
+    def get(self, key, default=None):
+        self.calls["get"] += 1
+        return super().get(key, default)
+
+    def __getitem__(self, key):
+        self.calls["getitem"] += 1
+        return super().__getitem__(key)
+
+    def __contains__(self, key):
+        self.calls["contains"] += 1
+        return super().__contains__(key)
+
+
+@pytest.mark.asyncio
+async def test_update_uses_one_lookup_per_key(tmp_path):
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+
+    counting = _CountingDict()
+    storage._data = counting
+
+    with patch("time.time", return_value=1_700_000_000):
+        await storage.upsert({"A": {"x": 1}, "B": {"x": 1}})
+    with patch("time.time", return_value=1_700_000_100):
+        counting.calls.update({"get": 0, "getitem": 0, "contains": 0})
+        await storage.upsert({"A": {"x": 2}, "B": {"x": 2}})
+
+    assert counting.calls["get"] == 2
+    assert counting.calls["getitem"] == 0
+    assert counting.calls["contains"] == 0
+    assert counting["A"]["create_time"] == 1_700_000_000
+    assert counting["A"]["update_time"] == 1_700_000_100
+
+
+@pytest.mark.asyncio
+async def test_null_create_time_normalized_to_zero(tmp_path):
+    """A hand-edited JSON file can carry an explicit null."""
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+
+    storage._data["legacy"] = {"x": 1, "create_time": None}
+    with patch("time.time", return_value=1_700_000_200):
+        await storage.upsert({"legacy": {"x": 2}})
+
+    assert storage._data["legacy"]["create_time"] == 0
+    assert storage._data["legacy"]["update_time"] == 1_700_000_200
+
+
+@pytest.mark.asyncio
+async def test_legacy_float_create_time_is_normalized(tmp_path):
+    """An older release could store time.time() unrounded."""
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+
+    storage._data["f"] = {"x": 1, "create_time": 1_650_000_000.75}
+    with patch("time.time", return_value=1_700_000_200):
+        await storage.upsert({"f": {"x": 2}})
+
+    stored = storage._data["f"]
+    assert stored["create_time"] == 1_650_000_000
+    assert isinstance(stored["create_time"], int)
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_create_time_ignored_on_update(tmp_path):
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+
+    with patch("time.time", return_value=1_700_000_000):
+        await storage.upsert({"E": {"x": 1}})
+    with patch("time.time", return_value=1_700_000_100):
+        await storage.upsert({"E": {"x": 2, "create_time": 1}})
+
+    assert storage._data["E"]["create_time"] == 1_700_000_000

--- a/tests/kg/json_impl/test_json_kv_upsert_create_time.py
+++ b/tests/kg/json_impl/test_json_kv_upsert_create_time.py
@@ -14,6 +14,7 @@ subscripts is the cost that matters and is asserted here too.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -205,3 +206,21 @@ async def test_caller_supplied_create_time_ignored_on_update(tmp_path):
         await storage.upsert({"E": {"x": 2, "create_time": 1}})
 
     assert storage._data["E"]["create_time"] == 1_700_000_000
+
+
+@pytest.mark.asyncio
+async def test_infinite_create_time_does_not_abort_the_upsert(tmp_path):
+    """JSON ``1e309`` decodes to float infinity, and ``int(inf)`` overflows.
+
+    The helper's documented fallback is 0; before OverflowError was handled
+    one hand-edited row aborted the whole upsert instead.
+    """
+    storage = _make_storage(tmp_path)
+    await storage.initialize()
+
+    storage._data["inf"] = {"x": 1, "create_time": json.loads("1e309")}
+    with patch("time.time", return_value=1_700_000_600):
+        await storage.upsert({"inf": {"x": 2}})
+
+    assert storage._data["inf"]["create_time"] == 0
+    assert storage._data["inf"]["update_time"] == 1_700_000_600

--- a/tests/kg/opensearch_impl/test_opensearch_kv_create_time_integration.py
+++ b/tests/kg/opensearch_impl/test_opensearch_kv_create_time_integration.py
@@ -22,11 +22,13 @@ Validated on OpenSearch 3.6.0.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 
 import pytest
 
+from lightrag.base import normalize_kv_create_time
 from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
 
 pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
@@ -204,3 +206,106 @@ async def test_many_small_upserts_share_one_flush(storage):
     rows = await storage.get_by_ids(ids)
     assert [row["create_time"] for row in rows] == [created] * len(ids)
     assert all(row["update_time"] > created for row in rows)
+
+
+# Shapes a LightRAG release (or external tooling) could have left in a stored
+# row. ``True`` is deliberately absent: a document with a boolean
+# ``create_time`` makes dynamic mapping type the field BOOLEAN, and the mapper
+# then refuses the long the repair writes -- loudly, as a failed bulk item. No
+# release ever wrote a boolean there, so the equivalence claim is scoped to
+# shapes that can actually occur.
+_NORMALIZATION_CASES = [
+    1650000000,
+    1650000000.75,
+    -1.5,
+    "1650000000",
+    " 1650000000 ",
+    "1.5",
+    "broken",
+    None,
+    [],
+    0,
+]
+
+
+@pytest.mark.parametrize("stored_value", _NORMALIZATION_CASES, ids=repr)
+@pytest.mark.asyncio
+async def test_script_normalization_matches_the_python_helper(storage, stored_value):
+    """The painless script must answer exactly ``normalize_kv_create_time``.
+
+    Two implementations of one rule drift unless something pins them
+    together; a row whose ``create_time`` stays a float or a string is enough
+    to make the LLM-cache ordering in ``operate.py`` compare ``str`` with
+    ``int`` and raise. Each case gets a virgin index (the fixture drops and
+    recreates it) because dynamic mapping types the field from the first
+    document it sees and would otherwise reject the later shapes.
+    """
+    await storage.client.index(
+        index=storage._index_name,
+        id="N",
+        body={"x": 1, "create_time": stored_value, "__mirrored_id": "N"},
+        refresh=True,
+    )
+
+    await _write(storage, {"N": {"x": 2}})
+
+    row = await storage.get_by_id("N")
+    assert row["create_time"] == normalize_kv_create_time(stored_value)
+    assert isinstance(row["create_time"], int)
+
+
+@pytest.mark.asyncio
+async def test_legacy_float_row_is_repaired_to_an_int(storage):
+    """The shape is fixed on the row's next write, not only on read."""
+    await storage.client.index(
+        index=storage._index_name,
+        id="F",
+        body={"x": 1, "create_time": 1_650_000_000.75, "__mirrored_id": "F"},
+        refresh=True,
+    )
+
+    await _write(storage, {"F": {"x": 2}})
+
+    persisted = await storage.client.get(index=storage._index_name, id="F")
+    assert persisted["_source"]["create_time"] == 1_650_000_000
+    assert isinstance(persisted["_source"]["create_time"], int)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_insert_keeps_the_earliest_create_time(storage):
+    """The first creation wins even when two writers flush the same new id.
+
+    The script needs no extra coordination for this: the server applies the
+    two update actions one after another, and the second one finds the
+    document already there (no sentinel) and restores the timestamp the first
+    one wrote.
+    """
+    from lightrag.kg.opensearch_impl import OpenSearchKVStorage
+
+    other = OpenSearchKVStorage(
+        namespace="entity_chunks",
+        global_config={
+            "embedding_batch_num": 1,
+            "max_graph_nodes": 10,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace=_WORKSPACE,
+    )
+    await other.initialize()
+    try:
+        await storage.upsert({"R": {"writer": "a"}})
+        time.sleep(1.1)  # the second writer's estimate is strictly later
+        await other.upsert({"R": {"writer": "b"}})
+
+        await asyncio.gather(storage.index_done_callback(), other.index_done_callback())
+        settled = (await storage.get_by_id("R"))["create_time"]
+
+        # Whoever landed first owns the timestamp, and it must not move.
+        time.sleep(1.1)
+        await _write(storage, {"R": {"writer": "a", "round": 2}})
+        row = await storage.get_by_id("R")
+        assert row["create_time"] == settled
+        assert row["update_time"] > settled
+    finally:
+        await other.finalize()

--- a/tests/kg/opensearch_impl/test_opensearch_kv_create_time_integration.py
+++ b/tests/kg/opensearch_impl/test_opensearch_kv_create_time_integration.py
@@ -1,0 +1,206 @@
+"""Integration tests: create_time preservation against a REAL OpenSearch.
+
+The unit tests can only pin the bulk action shape; the semantics of the
+``scripted_upsert`` painless script (issue #3870) are a server behavior, so
+they are verified here against a live cluster.
+
+Opt-in — these tests CREATE and DROP an index, so they never run against the
+hosts configured for a real deployment. They read
+``LIGHTRAG_TEST_OPENSEARCH_HOSTS`` and are skipped when it is unset::
+
+    docker run -d --name lr-os-test -p 19200:9200 \\
+        -e "discovery.type=single-node" -e "DISABLE_SECURITY_PLUGIN=true" \\
+        -e "DISABLE_INSTALL_DEMO_CONFIG=true" \\
+        opensearchproject/opensearch:3
+
+    LIGHTRAG_TEST_OPENSEARCH_HOSTS=localhost:19200 \\
+        ./scripts/test.sh tests/kg/opensearch_impl/test_opensearch_kv_create_time_integration.py \\
+        --run-integration
+
+Validated on OpenSearch 3.6.0.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
+
+_WORKSPACE = "ittest_create_time"
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
+
+
+@pytest.fixture
+async def storage():
+    hosts = os.getenv("LIGHTRAG_TEST_OPENSEARCH_HOSTS")
+    if not hosts:
+        pytest.skip(
+            "OpenSearch not configured for tests "
+            "(LIGHTRAG_TEST_OPENSEARCH_HOSTS not set)"
+        )
+
+    previous = {
+        key: os.environ.get(key)
+        for key in ("OPENSEARCH_HOSTS", "OPENSEARCH_USE_SSL", "OPENSEARCH_USER")
+    }
+    os.environ["OPENSEARCH_HOSTS"] = hosts
+    os.environ["OPENSEARCH_USE_SSL"] = os.getenv(
+        "LIGHTRAG_TEST_OPENSEARCH_USE_SSL", "false"
+    )
+    os.environ["OPENSEARCH_USER"] = os.getenv("LIGHTRAG_TEST_OPENSEARCH_USER", "")
+
+    from lightrag.kg.opensearch_impl import OpenSearchKVStorage
+
+    initialize_share_data()
+    kv = OpenSearchKVStorage(
+        namespace="entity_chunks",
+        global_config={
+            "embedding_batch_num": 1,
+            "max_graph_nodes": 10,
+            "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+        },
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace=_WORKSPACE,
+    )
+    await kv.initialize()
+    await kv.drop()
+    await kv.initialize()
+    try:
+        yield kv
+    finally:
+        await kv.drop()
+        await kv.finalize()
+        finalize_share_data()
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+async def _write(storage, payload):
+    await storage.upsert(payload)
+    await storage.index_done_callback()
+
+
+@pytest.mark.asyncio
+async def test_insert_stamps_both_timestamps(storage):
+    before = int(time.time())
+    await _write(storage, {"E": {"chunk_ids": ["c1"], "count": 1}})
+
+    row = await storage.get_by_id("E")
+    assert row["create_time"] >= before
+    assert row["update_time"] >= before
+
+
+@pytest.mark.asyncio
+async def test_replacement_upsert_preserves_create_time(storage):
+    await _write(storage, {"E": {"chunk_ids": ["c1"], "count": 1}})
+    created = (await storage.get_by_id("E"))["create_time"]
+
+    time.sleep(1.1)  # update_time must be observably later
+    await _write(storage, {"E": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+    row = await storage.get_by_id("E")
+    assert row["create_time"] == created
+    assert row["update_time"] > created
+    # The business value is replaced, not merged.
+    assert row["chunk_ids"] == ["c1", "c2"]
+    assert row["count"] == 2
+    # The scripted-upsert sentinel is an implementation detail of the write.
+    assert "__lightrag_kv_new" not in row
+
+
+@pytest.mark.asyncio
+async def test_replacement_drops_fields_the_payload_omits(storage):
+    """A scripted upsert must replace the source, not partially merge it."""
+    await _write(storage, {"E": {"chunk_ids": ["c1"], "count": 1, "extra": "x"}})
+    await _write(storage, {"E": {"chunk_ids": ["c1"], "count": 1}})
+
+    assert "extra" not in await storage.get_by_id("E")
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_create_time_is_ignored_on_update(storage):
+    await _write(storage, {"E": {"chunk_ids": ["c1"], "count": 1}})
+    created = (await storage.get_by_id("E"))["create_time"]
+
+    await _write(storage, {"E": {"chunk_ids": ["c2"], "count": 1, "create_time": 1}})
+
+    assert (await storage.get_by_id("E"))["create_time"] == created
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_without_create_time_records_zero(storage):
+    """A row written before the field existed keeps the 0/unknown meaning."""
+    await storage.client.index(
+        index=storage._index_name,
+        id="L",
+        body={"chunk_ids": ["c1"], "count": 1, "__mirrored_id": "L"},
+        refresh=True,
+    )
+
+    await _write(storage, {"L": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+    assert (await storage.get_by_id("L"))["create_time"] == 0
+
+
+@pytest.mark.asyncio
+async def test_null_create_time_records_zero(storage):
+    await storage.client.index(
+        index=storage._index_name,
+        id="N",
+        body={"chunk_ids": ["c1"], "create_time": None, "__mirrored_id": "N"},
+        refresh=True,
+    )
+
+    await _write(storage, {"N": {"chunk_ids": ["c2"]}})
+
+    assert (await storage.get_by_id("N"))["create_time"] == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_then_upsert_stamps_a_fresh_create_time(storage):
+    await _write(storage, {"E": {"chunk_ids": ["c1"], "count": 1}})
+    created = (await storage.get_by_id("E"))["create_time"]
+
+    time.sleep(1.1)
+    await storage.delete(["E"])
+    await storage.index_done_callback()
+    await _write(storage, {"E": {"chunk_ids": ["new"], "count": 1}})
+
+    assert (await storage.get_by_id("E"))["create_time"] > created
+
+
+@pytest.mark.asyncio
+async def test_many_small_upserts_share_one_flush(storage):
+    """The buffering pattern this backend exists for (issue #2785)."""
+    ids = [f"B{i}" for i in range(5)]
+    for doc_id in ids:
+        await storage.upsert({doc_id: {"chunk_ids": ["c"], "count": 1}})
+    await storage.index_done_callback()
+
+    rows = await storage.get_by_ids(ids)
+    assert all(row is not None for row in rows)
+    created = rows[0]["create_time"]
+
+    time.sleep(1.1)
+    for doc_id in ids:
+        await storage.upsert({doc_id: {"chunk_ids": ["c", "d"], "count": 2}})
+    await storage.index_done_callback()
+
+    rows = await storage.get_by_ids(ids)
+    assert [row["create_time"] for row in rows] == [created] * len(ids)
+    assert all(row["update_time"] > created for row in rows)

--- a/tests/kg/opensearch_impl/test_opensearch_kv_upsert_create_time.py
+++ b/tests/kg/opensearch_impl/test_opensearch_kv_upsert_create_time.py
@@ -1,27 +1,43 @@
-"""Regression tests: OpenSearchKVStorage must not reset create_time on update.
+"""Regression tests: OpenSearchKVStorage preserves create_time server-side.
 
-Issue #3870 — setdefault(create_time, current_time) on every upsert reset the
-field whenever the caller omitted it. Updates must preserve the existing
-storage-managed create_time (buffer or index); legacy rows missing the field
-keep 0.
+Issue #3870: ``upsert`` used ``setdefault("create_time", now)``, so an update
+whose payload carried business fields only RESET the field to the update time.
+
+The fix does not read the stored row back — that would cost an HTTP round trip
+per ``upsert()`` call, and this backend is deliberately called with many small
+batches. Instead the flush emits a ``scripted_upsert`` bulk action whose
+painless script restores the stored ``create_time`` after replacing the
+business value, reproducing Mongo's ``$setOnInsert`` semantics on the server.
+
+These tests pin the two halves that are observable without a cluster: that
+``upsert`` reads nothing, and that the flush emits the scripted action. The
+script's own semantics are verified against a real OpenSearch in
+``test_opensearch_kv_create_time_integration.py``.
 """
 
 from __future__ import annotations
 
-import asyncio
 from contextlib import asynccontextmanager
-from unittest.mock import AsyncMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-pytest.importorskip(
-    "opensearchpy",
-    reason="opensearchpy is required for OpenSearch storage tests",
+from lightrag.kg.opensearch_impl import (
+    _KV_CREATE_TIME_SENTINEL,
+    ClientManager,
+    OpenSearchKVStorage,
 )
 
-from lightrag.kg.opensearch_impl import ClientManager, OpenSearchKVStorage
-
 pytestmark = pytest.mark.offline
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
 
 
 @asynccontextmanager
@@ -29,213 +45,179 @@ async def _mock_lock():
     yield
 
 
-def _mock_lock_factory():
-    return _mock_lock()
-
-
-@pytest.fixture(autouse=True)
-def patch_data_init_lock():
-    with patch(
-        "lightrag.kg.opensearch_impl.get_data_init_lock", side_effect=_mock_lock_factory
-    ):
-        yield
-
-
-@pytest.fixture(autouse=True)
-def patch_namespace_lock():
-    cache: dict[tuple[str, str | None], asyncio.Lock] = {}
-
-    def factory(namespace, workspace=None, enable_logging=False):
-        key = (namespace, workspace or "")
-        lock = cache.get(key)
-        if lock is None:
-            lock = asyncio.Lock()
-            cache[key] = lock
-        return lock
-
-    with patch("lightrag.kg.opensearch_impl.get_namespace_lock", side_effect=factory):
-        yield
-
-
 @pytest.fixture
-def embed_func():
-    class _Embed:
-        embedding_dim = 1
-        max_token_size = 1
-
-        async def __call__(self, texts, **kwargs):
-            return [[0.0] for _ in texts]
-
-    return _Embed()
-
-
-@pytest.fixture
-def global_config(tmp_path):
+def global_config() -> dict[str, Any]:
     return {
-        "working_dir": str(tmp_path),
-        "embedding_batch_num": 1,
+        "embedding_batch_num": 10,
+        "max_graph_nodes": 1000,
         "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
     }
 
 
-async def _mget_not_found(index=None, body=None, **kwargs):
-    ids = (body or {}).get("ids") or []
-    return {"docs": [{"_id": doc_id, "found": False} for doc_id in ids]}
-
-
 @pytest.fixture
-def mock_client():
+def mock_client() -> AsyncMock:
     client = AsyncMock()
-    client.indices.exists = AsyncMock(return_value=False)
-    client.indices.create = AsyncMock(return_value={"acknowledged": True})
+    client.indices = AsyncMock()
+    client.indices.exists = AsyncMock(return_value=True)
     client.indices.get_mapping = AsyncMock(
         return_value={
-            "test_text_chunks": {
+            "ct_text_chunks": {
                 "mappings": {
-                    "properties": {
-                        "content": {"type": "text"},
-                        "__mirrored_id": {"type": "keyword"},
-                    }
+                    "_meta": {
+                        "lightrag_workspace": "ct",
+                        "lightrag_final_namespace": "ct_text_chunks",
+                    },
+                    "properties": {"__mirrored_id": {"type": "keyword"}},
                 }
             }
         }
     )
-    client.mget = AsyncMock(side_effect=_mget_not_found)
+    client.indices.refresh = AsyncMock(return_value={})
     return client
 
 
-def _make(global_config, embed_func, workspace="test"):
-    return OpenSearchKVStorage(
-        namespace="text_chunks",
-        global_config=global_config,
-        embedding_func=embed_func,
-        workspace=workspace,
-    )
+@pytest.fixture
+def storage(global_config, mock_client):
+    """A KV storage wired to the mock client, locks stubbed out."""
+    with (
+        patch.object(ClientManager, "get_client", return_value=mock_client),
+        patch("lightrag.kg.opensearch_impl.get_data_init_lock", _mock_lock),
+        patch(
+            "lightrag.kg.opensearch_impl.get_namespace_lock",
+            MagicMock(return_value=_mock_lock()),
+        ),
+    ):
+        s = OpenSearchKVStorage(
+            namespace="text_chunks",
+            global_config=global_config,
+            embedding_func=_DummyEmbeddingFunc(),
+            workspace="ct",
+        )
+        s.client = mock_client
+        s._index_ready = True
+        s._flush_lock = _MockLock()
+        yield s
+
+
+class _MockLock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _upsert_actions(mock_bulk: AsyncMock) -> list[dict[str, Any]]:
+    """The index (non-delete) actions of the last flush."""
+    actions: list[dict[str, Any]] = []
+    for call in mock_bulk.await_args_list:
+        for action in call.args[1]:
+            if action.get("_op_type") != "delete":
+                actions.append(action)
+    return actions
 
 
 @pytest.mark.asyncio
-async def test_replacement_upsert_preserves_create_time_from_buffer(
-    global_config, embed_func, mock_client
-):
-    with patch.object(ClientManager, "get_client", return_value=mock_client):
-        s = _make(global_config, embed_func)
-        await s.initialize()
+async def test_upsert_reads_nothing(storage, mock_client):
+    """The whole point of the scripted upsert: no read on the write path.
 
-        with patch("time.time", return_value=1_700_000_000):
-            await s.upsert({"E": {"chunk_ids": ["c1"], "count": 1}})
+    A per-upsert lookup would also have to be held under ``_flush_lock`` (the
+    cross-process namespace lock), turning every one of the many small
+    ``upsert()`` calls into a network round trip inside that lock.
+    """
+    with patch("time.time", return_value=1_700_000_000):
+        await storage.upsert({"k1": {"content": "a"}})
+        await storage.upsert({"k1": {"content": "b"}, "k2": {"content": "c"}})
 
-        first = s._pending_upserts["E"]
-        assert first["create_time"] == 1_700_000_000
-        assert first["update_time"] == 1_700_000_000
-
-        # Second upsert in the same buffer window must keep create_time.
-        with patch("time.time", return_value=1_700_000_100):
-            await s.upsert({"E": {"chunk_ids": ["c1", "c2"], "count": 2}})
-
-        second = s._pending_upserts["E"]
-        assert second["create_time"] == 1_700_000_000
-        assert second["update_time"] == 1_700_000_100
-        assert second["chunk_ids"] == ["c1", "c2"]
-        assert second["count"] == 2
-        # First insert resolves absence via mget; the replacement must not.
-        assert mock_client.mget.await_count == 1
+    mock_client.mget.assert_not_awaited()
+    mock_client.get.assert_not_awaited()
+    mock_client.search.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_replacement_upsert_preserves_create_time_from_index(
-    global_config, embed_func, mock_client
-):
-    mock_client.indices.exists = AsyncMock(return_value=True)
-    mock_client.mget = AsyncMock(
-        return_value={
-            "docs": [
-                {
-                    "_id": "E",
-                    "found": True,
-                    "_source": {"create_time": 1_650_000_000},
-                }
-            ]
-        }
-    )
+async def test_flush_emits_scripted_upsert_action(storage):
+    with patch("time.time", return_value=1_700_000_000):
+        await storage.upsert({"k1": {"content": "a", "tokens": 3}})
 
-    with patch.object(ClientManager, "get_client", return_value=mock_client):
-        s = _make(global_config, embed_func)
-        await s.initialize()
+    with patch(
+        "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+    ) as mock_bulk:
+        mock_bulk.return_value = (1, [])
+        await storage._flush_pending_kv_ops()
 
-        with patch("time.time", return_value=1_700_000_100):
-            await s.upsert({"E": {"chunk_ids": ["c1", "c2"], "count": 2}})
-
-        pending = s._pending_upserts["E"]
-        assert pending["create_time"] == 1_650_000_000
-        assert pending["update_time"] == 1_700_000_100
-        mock_client.mget.assert_awaited()
-
-
-@pytest.mark.asyncio
-async def test_legacy_index_row_missing_create_time_keeps_zero(
-    global_config, embed_func, mock_client
-):
-    mock_client.indices.exists = AsyncMock(return_value=True)
-    mock_client.mget = AsyncMock(
-        return_value={
-            "docs": [
-                {
-                    "_id": "legacy",
-                    "found": True,
-                    "_source": {"chunk_ids": ["c1"], "count": 1},
-                }
-            ]
-        }
-    )
-
-    with patch.object(ClientManager, "get_client", return_value=mock_client):
-        s = _make(global_config, embed_func)
-        await s.initialize()
-
-        with patch("time.time", return_value=1_700_000_200):
-            await s.upsert({"legacy": {"chunk_ids": ["c1", "c2"], "count": 2}})
-
-        pending = s._pending_upserts["legacy"]
-        assert pending["create_time"] == 0
-        assert pending["update_time"] == 1_700_000_200
+    actions = _upsert_actions(mock_bulk)
+    assert len(actions) == 1
+    action = actions[0]
+    assert action["_op_type"] == "update"
+    assert action["_id"] == "k1"
+    assert action["scripted_upsert"] is True
+    assert action["upsert"] == {_KV_CREATE_TIME_SENTINEL: True}
+    assert action["retry_on_conflict"] >= 1
+    # The replacement value travels as script params, not as _source.
+    assert "_source" not in action
+    doc = action["script"]["params"]["doc"]
+    assert doc["content"] == "a"
+    assert doc["tokens"] == 3
+    assert doc["__mirrored_id"] == "k1"
+    assert doc["update_time"] == 1_700_000_000
+    # ...and the script is what restores the stored timestamp.
+    source = action["script"]["source"]
+    assert "create_time" in source
+    assert _KV_CREATE_TIME_SENTINEL in source
 
 
 @pytest.mark.asyncio
-async def test_insert_stamps_create_time_when_key_absent(
-    global_config, embed_func, mock_client
-):
-    mock_client.indices.exists = AsyncMock(return_value=True)
-    mock_client.mget = AsyncMock(
-        return_value={"docs": [{"_id": "new", "found": False}]}
-    )
+async def test_buffered_create_time_is_the_write_time(storage):
+    """Documented residue: a buffered read reports the optimistic estimate.
 
-    with patch.object(ClientManager, "get_client", return_value=mock_client):
-        s = _make(global_config, embed_func)
-        await s.initialize()
+    ``create_time`` is authoritative only once the flush script has run, so a
+    read served from the buffer shows the write time — right for an insert,
+    and superseded at flush for a row that already exists on the server.
+    """
+    with patch("time.time", return_value=1_700_000_000):
+        await storage.upsert({"k1": {"content": "a"}})
 
-        with patch("time.time", return_value=1_700_000_300):
-            await s.upsert({"new": {"content": "v1"}})
-
-        pending = s._pending_upserts["new"]
-        assert pending["create_time"] == 1_700_000_300
-        assert pending["update_time"] == 1_700_000_300
+    buffered = await storage.get_by_id("k1")
+    assert buffered["create_time"] == 1_700_000_000
+    assert buffered["update_time"] == 1_700_000_000
 
 
 @pytest.mark.asyncio
-async def test_delete_then_upsert_stamps_fresh_create_time(
-    global_config, embed_func, mock_client
-):
-    with patch.object(ClientManager, "get_client", return_value=mock_client):
-        s = _make(global_config, embed_func)
-        await s.initialize()
+async def test_caller_supplied_create_time_is_overwritten(storage):
+    """A caller cannot smuggle a create_time past the storage."""
+    with patch("time.time", return_value=1_700_000_000):
+        await storage.upsert({"k1": {"content": "a", "create_time": 1}})
 
-        with patch("time.time", return_value=1_700_000_000):
-            await s.upsert({"E": {"content": "old"}})
-        await s.delete(["E"])
+    with patch(
+        "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+    ) as mock_bulk:
+        mock_bulk.return_value = (1, [])
+        await storage._flush_pending_kv_ops()
 
-        with patch("time.time", return_value=1_700_000_400):
-            await s.upsert({"E": {"content": "new"}})
+    doc = _upsert_actions(mock_bulk)[0]["script"]["params"]["doc"]
+    assert doc["create_time"] == 1_700_000_000
 
-        pending = s._pending_upserts["E"]
-        assert pending["create_time"] == 1_700_000_400
-        assert pending["update_time"] == 1_700_000_400
+
+@pytest.mark.asyncio
+async def test_upsert_after_delete_flushes_only_the_upsert(storage):
+    """delete-then-upsert still cancels the tombstone, as before the fix."""
+    await storage.delete(["k1"])
+    with patch("time.time", return_value=1_700_000_400):
+        await storage.upsert({"k1": {"content": "fresh"}})
+
+    with patch(
+        "lightrag.kg.opensearch_impl.helpers.async_bulk", new_callable=AsyncMock
+    ) as mock_bulk:
+        mock_bulk.return_value = (1, [])
+        await storage._flush_pending_kv_ops()
+
+    deletes = [
+        action
+        for call in mock_bulk.await_args_list
+        for action in call.args[1]
+        if action.get("_op_type") == "delete"
+    ]
+    assert deletes == []
+    actions = _upsert_actions(mock_bulk)
+    assert len(actions) == 1
+    assert actions[0]["script"]["params"]["doc"]["create_time"] == 1_700_000_400

--- a/tests/kg/opensearch_impl/test_opensearch_kv_upsert_create_time.py
+++ b/tests/kg/opensearch_impl/test_opensearch_kv_upsert_create_time.py
@@ -1,0 +1,241 @@
+"""Regression tests: OpenSearchKVStorage must not reset create_time on update.
+
+Issue #3870 — setdefault(create_time, current_time) on every upsert reset the
+field whenever the caller omitted it. Updates must preserve the existing
+storage-managed create_time (buffer or index); legacy rows missing the field
+keep 0.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip(
+    "opensearchpy",
+    reason="opensearchpy is required for OpenSearch storage tests",
+)
+
+from lightrag.kg.opensearch_impl import ClientManager, OpenSearchKVStorage
+
+pytestmark = pytest.mark.offline
+
+
+@asynccontextmanager
+async def _mock_lock():
+    yield
+
+
+def _mock_lock_factory():
+    return _mock_lock()
+
+
+@pytest.fixture(autouse=True)
+def patch_data_init_lock():
+    with patch(
+        "lightrag.kg.opensearch_impl.get_data_init_lock", side_effect=_mock_lock_factory
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_namespace_lock():
+    cache: dict[tuple[str, str | None], asyncio.Lock] = {}
+
+    def factory(namespace, workspace=None, enable_logging=False):
+        key = (namespace, workspace or "")
+        lock = cache.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            cache[key] = lock
+        return lock
+
+    with patch("lightrag.kg.opensearch_impl.get_namespace_lock", side_effect=factory):
+        yield
+
+
+@pytest.fixture
+def embed_func():
+    class _Embed:
+        embedding_dim = 1
+        max_token_size = 1
+
+        async def __call__(self, texts, **kwargs):
+            return [[0.0] for _ in texts]
+
+    return _Embed()
+
+
+@pytest.fixture
+def global_config(tmp_path):
+    return {
+        "working_dir": str(tmp_path),
+        "embedding_batch_num": 1,
+        "vector_db_storage_cls_kwargs": {"cosine_better_than_threshold": 0.2},
+    }
+
+
+async def _mget_not_found(index=None, body=None, **kwargs):
+    ids = (body or {}).get("ids") or []
+    return {"docs": [{"_id": doc_id, "found": False} for doc_id in ids]}
+
+
+@pytest.fixture
+def mock_client():
+    client = AsyncMock()
+    client.indices.exists = AsyncMock(return_value=False)
+    client.indices.create = AsyncMock(return_value={"acknowledged": True})
+    client.indices.get_mapping = AsyncMock(
+        return_value={
+            "test_text_chunks": {
+                "mappings": {
+                    "properties": {
+                        "content": {"type": "text"},
+                        "__mirrored_id": {"type": "keyword"},
+                    }
+                }
+            }
+        }
+    )
+    client.mget = AsyncMock(side_effect=_mget_not_found)
+    return client
+
+
+def _make(global_config, embed_func, workspace="test"):
+    return OpenSearchKVStorage(
+        namespace="text_chunks",
+        global_config=global_config,
+        embedding_func=embed_func,
+        workspace=workspace,
+    )
+
+
+@pytest.mark.asyncio
+async def test_replacement_upsert_preserves_create_time_from_buffer(
+    global_config, embed_func, mock_client
+):
+    with patch.object(ClientManager, "get_client", return_value=mock_client):
+        s = _make(global_config, embed_func)
+        await s.initialize()
+
+        with patch("time.time", return_value=1_700_000_000):
+            await s.upsert({"E": {"chunk_ids": ["c1"], "count": 1}})
+
+        first = s._pending_upserts["E"]
+        assert first["create_time"] == 1_700_000_000
+        assert first["update_time"] == 1_700_000_000
+
+        # Second upsert in the same buffer window must keep create_time.
+        with patch("time.time", return_value=1_700_000_100):
+            await s.upsert({"E": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+        second = s._pending_upserts["E"]
+        assert second["create_time"] == 1_700_000_000
+        assert second["update_time"] == 1_700_000_100
+        assert second["chunk_ids"] == ["c1", "c2"]
+        assert second["count"] == 2
+        # First insert resolves absence via mget; the replacement must not.
+        assert mock_client.mget.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_replacement_upsert_preserves_create_time_from_index(
+    global_config, embed_func, mock_client
+):
+    mock_client.indices.exists = AsyncMock(return_value=True)
+    mock_client.mget = AsyncMock(
+        return_value={
+            "docs": [
+                {
+                    "_id": "E",
+                    "found": True,
+                    "_source": {"create_time": 1_650_000_000},
+                }
+            ]
+        }
+    )
+
+    with patch.object(ClientManager, "get_client", return_value=mock_client):
+        s = _make(global_config, embed_func)
+        await s.initialize()
+
+        with patch("time.time", return_value=1_700_000_100):
+            await s.upsert({"E": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+        pending = s._pending_upserts["E"]
+        assert pending["create_time"] == 1_650_000_000
+        assert pending["update_time"] == 1_700_000_100
+        mock_client.mget.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_legacy_index_row_missing_create_time_keeps_zero(
+    global_config, embed_func, mock_client
+):
+    mock_client.indices.exists = AsyncMock(return_value=True)
+    mock_client.mget = AsyncMock(
+        return_value={
+            "docs": [
+                {
+                    "_id": "legacy",
+                    "found": True,
+                    "_source": {"chunk_ids": ["c1"], "count": 1},
+                }
+            ]
+        }
+    )
+
+    with patch.object(ClientManager, "get_client", return_value=mock_client):
+        s = _make(global_config, embed_func)
+        await s.initialize()
+
+        with patch("time.time", return_value=1_700_000_200):
+            await s.upsert({"legacy": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+        pending = s._pending_upserts["legacy"]
+        assert pending["create_time"] == 0
+        assert pending["update_time"] == 1_700_000_200
+
+
+@pytest.mark.asyncio
+async def test_insert_stamps_create_time_when_key_absent(
+    global_config, embed_func, mock_client
+):
+    mock_client.indices.exists = AsyncMock(return_value=True)
+    mock_client.mget = AsyncMock(
+        return_value={"docs": [{"_id": "new", "found": False}]}
+    )
+
+    with patch.object(ClientManager, "get_client", return_value=mock_client):
+        s = _make(global_config, embed_func)
+        await s.initialize()
+
+        with patch("time.time", return_value=1_700_000_300):
+            await s.upsert({"new": {"content": "v1"}})
+
+        pending = s._pending_upserts["new"]
+        assert pending["create_time"] == 1_700_000_300
+        assert pending["update_time"] == 1_700_000_300
+
+
+@pytest.mark.asyncio
+async def test_delete_then_upsert_stamps_fresh_create_time(
+    global_config, embed_func, mock_client
+):
+    with patch.object(ClientManager, "get_client", return_value=mock_client):
+        s = _make(global_config, embed_func)
+        await s.initialize()
+
+        with patch("time.time", return_value=1_700_000_000):
+            await s.upsert({"E": {"content": "old"}})
+        await s.delete(["E"])
+
+        with patch("time.time", return_value=1_700_000_400):
+            await s.upsert({"E": {"content": "new"}})
+
+        pending = s._pending_upserts["E"]
+        assert pending["create_time"] == 1_700_000_400
+        assert pending["update_time"] == 1_700_000_400

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -215,14 +215,15 @@ def _make_client():
             "_source": {"content": "hello", "create_time": 0, "update_time": 0},
         }
     )
-    client.mget = AsyncMock(
-        return_value={
-            "docs": [
-                {"_id": "id1", "found": True, "_source": {"content": "c1"}},
-                {"_id": "id2", "found": True, "_source": {"content": "c2"}},
-            ]
-        }
-    )
+
+    async def _default_mget(index=None, body=None, **kwargs):
+        # Echo one entry per requested id. Upsert resolves create_time via mget
+        # and rejects length mismatches; a canned multi-doc return_value breaks
+        # single-id upserts under the strict contract.
+        ids = (body or {}).get("ids") or []
+        return {"docs": [{"_id": doc_id, "found": False} for doc_id in ids]}
+
+    client.mget = AsyncMock(side_effect=_default_mget)
     client.count = AsyncMock(return_value={"count": 5})
     client.search = AsyncMock(
         return_value={
@@ -605,6 +606,20 @@ class TestKVStorage:
     async def test_get_by_ids_preserves_order(
         self, global_config, embed_func, mock_client
     ):
+        async def mget_side_effect(index=None, body=None, **kwargs):
+            sources = {"id1": {"content": "c1"}, "id2": {"content": "c2"}}
+            return {
+                "docs": [
+                    {
+                        "_id": doc_id,
+                        "found": True,
+                        "_source": dict(sources[doc_id]),
+                    }
+                    for doc_id in body["ids"]
+                ]
+            }
+
+        mock_client.mget = AsyncMock(side_effect=mget_side_effect)
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -215,15 +215,14 @@ def _make_client():
             "_source": {"content": "hello", "create_time": 0, "update_time": 0},
         }
     )
-
-    async def _default_mget(index=None, body=None, **kwargs):
-        # Echo one entry per requested id. Upsert resolves create_time via mget
-        # and rejects length mismatches; a canned multi-doc return_value breaks
-        # single-id upserts under the strict contract.
-        ids = (body or {}).get("ids") or []
-        return {"docs": [{"_id": doc_id, "found": False} for doc_id in ids]}
-
-    client.mget = AsyncMock(side_effect=_default_mget)
+    client.mget = AsyncMock(
+        return_value={
+            "docs": [
+                {"_id": "id1", "found": True, "_source": {"content": "c1"}},
+                {"_id": "id2", "found": True, "_source": {"content": "c2"}},
+            ]
+        }
+    )
     client.count = AsyncMock(return_value={"count": 5})
     client.search = AsyncMock(
         return_value={
@@ -606,20 +605,6 @@ class TestKVStorage:
     async def test_get_by_ids_preserves_order(
         self, global_config, embed_func, mock_client
     ):
-        async def mget_side_effect(index=None, body=None, **kwargs):
-            sources = {"id1": {"content": "c1"}, "id2": {"content": "c2"}}
-            return {
-                "docs": [
-                    {
-                        "_id": doc_id,
-                        "found": True,
-                        "_source": dict(sources[doc_id]),
-                    }
-                    for doc_id in body["ids"]
-                ]
-            }
-
-        mock_client.mget = AsyncMock(side_effect=mget_side_effect)
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
@@ -682,9 +667,11 @@ class TestKVStorage:
                 assert "update_time" in s._pending_upserts["k1"]
                 await s.index_done_callback()
                 actions = mock_bulk.call_args[0][1]
-                src = actions[0]["_source"]
-                assert "create_time" in src
-                assert "update_time" in src
+                # The replacement value travels as scripted-upsert params so
+                # the flush can restore a stored create_time server-side.
+                doc = actions[0]["script"]["params"]["doc"]
+                assert "create_time" in doc
+                assert "update_time" in doc
 
     @pytest.mark.asyncio
     async def test_is_empty(self, global_config, embed_func, mock_client):
@@ -920,7 +907,7 @@ class TestKVStorageBatching:
                 await s.index_done_callback()
                 actions = mock_bulk.call_args[0][1]
                 assert len(actions) == 1
-                assert actions[0]["_source"]["content"] == "second"
+                assert actions[0]["script"]["params"]["doc"]["content"] == "second"
 
     @pytest.mark.asyncio
     async def test_kv_delete_cancels_pending_upsert(
@@ -966,7 +953,8 @@ class TestKVStorageBatching:
                 await s.index_done_callback()
                 actions = mock_bulk.call_args[0][1]
                 assert len(actions) == 1
-                assert actions[0]["_op_type"] == "index"
+                # KV upserts flush as scripted updates (see issue #3870).
+                assert actions[0]["_op_type"] == "update"
 
     @pytest.mark.asyncio
     async def test_kv_delete_works_when_index_not_ready(
@@ -999,8 +987,6 @@ class TestKVStorageBatching:
             s = self._make(global_config, embed_func)
             await s.initialize()
             await s.upsert({"k1": {"content": "buffered"}})
-            # Upsert may mget for create_time; the read path must not.
-            mock_client.mget.reset_mock()
             doc = await s.get_by_id("k1")
             assert doc is not None
             assert doc["_id"] == "k1"
@@ -1042,30 +1028,21 @@ class TestKVStorageBatching:
         self, global_config, embed_func, mock_client
     ):
         """get_by_ids returns buffered docs and falls back to mget for the rest."""
-
-        async def mget_side_effect(index=None, body=None, **kwargs):
-            # Echo one entry per requested id so upsert create_time lookup and
-            # get_by_ids share a strict-length-safe mock.
-            docs = []
-            for doc_id in (body or {}).get("ids") or []:
-                if doc_id == "k2":
-                    docs.append(
-                        {
-                            "_id": "k2",
-                            "found": True,
-                            "_source": {"content": "from_index"},
-                        }
-                    )
-                else:
-                    docs.append({"_id": doc_id, "found": False})
-            return {"docs": docs}
-
-        mock_client.mget = AsyncMock(side_effect=mget_side_effect)
+        mock_client.mget = AsyncMock(
+            return_value={
+                "docs": [
+                    {
+                        "_id": "k2",
+                        "found": True,
+                        "_source": {"content": "from_index"},
+                    },
+                ]
+            }
+        )
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
             await s.upsert({"k1": {"content": "buffered"}})
-            mock_client.mget.reset_mock()
             docs = await s.get_by_ids(["k1", "k2"])
             assert docs[0]["content"] == "buffered"
             assert "__mirrored_id" not in docs[0]
@@ -1080,19 +1057,13 @@ class TestKVStorageBatching:
     ):
         """Buffered upserts shadow OpenSearch: filter_keys treats them as
         existing and never queries them via mget."""
-
-        async def mget_side_effect(index=None, body=None, **kwargs):
-            docs = []
-            for doc_id in (body or {}).get("ids") or []:
-                docs.append({"_id": doc_id, "found": False})
-            return {"docs": docs}
-
-        mock_client.mget = AsyncMock(side_effect=mget_side_effect)
+        mock_client.mget = AsyncMock(
+            return_value={"docs": [{"_id": "k2", "found": False}]}
+        )
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
             await s.upsert({"k1": {"content": "x"}})
-            mock_client.mget.reset_mock()
             missing = await s.filter_keys({"k1", "k2"})
             assert missing == {"k2"}
             # Only the unbuffered id is queried server-side.
@@ -1414,7 +1385,7 @@ class TestKVStorageBatching:
                 for call in mock_bulk.call_args_list:
                     actions = call.args[1]
                     by_op[actions[0]["_op_type"]] = call.kwargs["chunk_size"]
-                assert by_op == {"delete": 22, "index": 11}
+                assert by_op == {"delete": 22, "update": 11}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/kg/opensearch_impl/test_opensearch_storage.py
+++ b/tests/kg/opensearch_impl/test_opensearch_storage.py
@@ -999,6 +999,8 @@ class TestKVStorageBatching:
             s = self._make(global_config, embed_func)
             await s.initialize()
             await s.upsert({"k1": {"content": "buffered"}})
+            # Upsert may mget for create_time; the read path must not.
+            mock_client.mget.reset_mock()
             doc = await s.get_by_id("k1")
             assert doc is not None
             assert doc["_id"] == "k1"
@@ -1040,21 +1042,30 @@ class TestKVStorageBatching:
         self, global_config, embed_func, mock_client
     ):
         """get_by_ids returns buffered docs and falls back to mget for the rest."""
-        mock_client.mget = AsyncMock(
-            return_value={
-                "docs": [
-                    {
-                        "_id": "k2",
-                        "found": True,
-                        "_source": {"content": "from_index"},
-                    },
-                ]
-            }
-        )
+
+        async def mget_side_effect(index=None, body=None, **kwargs):
+            # Echo one entry per requested id so upsert create_time lookup and
+            # get_by_ids share a strict-length-safe mock.
+            docs = []
+            for doc_id in (body or {}).get("ids") or []:
+                if doc_id == "k2":
+                    docs.append(
+                        {
+                            "_id": "k2",
+                            "found": True,
+                            "_source": {"content": "from_index"},
+                        }
+                    )
+                else:
+                    docs.append({"_id": doc_id, "found": False})
+            return {"docs": docs}
+
+        mock_client.mget = AsyncMock(side_effect=mget_side_effect)
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
             await s.upsert({"k1": {"content": "buffered"}})
+            mock_client.mget.reset_mock()
             docs = await s.get_by_ids(["k1", "k2"])
             assert docs[0]["content"] == "buffered"
             assert "__mirrored_id" not in docs[0]
@@ -1069,13 +1080,19 @@ class TestKVStorageBatching:
     ):
         """Buffered upserts shadow OpenSearch: filter_keys treats them as
         existing and never queries them via mget."""
-        mock_client.mget = AsyncMock(
-            return_value={"docs": [{"_id": "k2", "found": False}]}
-        )
+
+        async def mget_side_effect(index=None, body=None, **kwargs):
+            docs = []
+            for doc_id in (body or {}).get("ids") or []:
+                docs.append({"_id": doc_id, "found": False})
+            return {"docs": docs}
+
+        mock_client.mget = AsyncMock(side_effect=mget_side_effect)
         with patch.object(ClientManager, "get_client", return_value=mock_client):
             s = self._make(global_config, embed_func)
             await s.initialize()
             await s.upsert({"k1": {"content": "x"}})
+            mock_client.mget.reset_mock()
             missing = await s.filter_keys({"k1", "k2"})
             assert missing == {"k2"}
             # Only the unbuffered id is queried server-side.

--- a/tests/kg/opensearch_impl/test_os_scheduling_pages.py
+++ b/tests/kg/opensearch_impl/test_os_scheduling_pages.py
@@ -148,6 +148,14 @@ def _make_client() -> AsyncMock:
     # query_params wraps the client methods in a SYNC wrapper, so spec'd
     # children default to MagicMock — async ones must be set explicitly.
     client.update_by_query = AsyncMock(return_value={"updated": 0, "failures": []})
+
+    async def _default_mget(index=None, body=None, **kwargs):
+        # Echo one entry per requested id. KV upsert resolves create_time via
+        # mget and rejects length mismatches / bare MagicMock responses.
+        ids = (body or {}).get("ids") or []
+        return {"docs": [{"_id": doc_id, "found": False} for doc_id in ids]}
+
+    client.mget = AsyncMock(side_effect=_default_mget)
     return client
 
 
@@ -1067,9 +1075,10 @@ async def test_repair_index_not_ready_raises(global_config):
 async def test_kv_strict_pending_delete_is_confirmed_absent(global_config):
     client = _make_client()
     storage = await _make_kv(global_config, client)
-    client.mget = AsyncMock()
     await storage.upsert({"doc-1": {"content": "x"}})
     await storage.delete(["doc-1"])
+    # Upsert may mget for create_time; the strict read must not.
+    client.mget.reset_mock()
     assert await storage.get_by_id_strict("doc-1") is None
     client.mget.assert_not_awaited()
 
@@ -1077,8 +1086,9 @@ async def test_kv_strict_pending_delete_is_confirmed_absent(global_config):
 async def test_kv_strict_pending_upsert_is_present(global_config):
     client = _make_client()
     storage = await _make_kv(global_config, client)
-    client.mget = AsyncMock()
     await storage.upsert({"doc-1": {"content": "x"}})
+    # Upsert may mget for create_time; the strict read must not.
+    client.mget.reset_mock()
     doc = await storage.get_by_id_strict("doc-1")
     assert doc["content"] == "x"
     assert doc["_id"] == "doc-1"

--- a/tests/kg/opensearch_impl/test_os_scheduling_pages.py
+++ b/tests/kg/opensearch_impl/test_os_scheduling_pages.py
@@ -148,14 +148,6 @@ def _make_client() -> AsyncMock:
     # query_params wraps the client methods in a SYNC wrapper, so spec'd
     # children default to MagicMock — async ones must be set explicitly.
     client.update_by_query = AsyncMock(return_value={"updated": 0, "failures": []})
-
-    async def _default_mget(index=None, body=None, **kwargs):
-        # Echo one entry per requested id. KV upsert resolves create_time via
-        # mget and rejects length mismatches / bare MagicMock responses.
-        ids = (body or {}).get("ids") or []
-        return {"docs": [{"_id": doc_id, "found": False} for doc_id in ids]}
-
-    client.mget = AsyncMock(side_effect=_default_mget)
     return client
 
 
@@ -1075,10 +1067,9 @@ async def test_repair_index_not_ready_raises(global_config):
 async def test_kv_strict_pending_delete_is_confirmed_absent(global_config):
     client = _make_client()
     storage = await _make_kv(global_config, client)
+    client.mget = AsyncMock()
     await storage.upsert({"doc-1": {"content": "x"}})
     await storage.delete(["doc-1"])
-    # Upsert may mget for create_time; the strict read must not.
-    client.mget.reset_mock()
     assert await storage.get_by_id_strict("doc-1") is None
     client.mget.assert_not_awaited()
 
@@ -1086,9 +1077,8 @@ async def test_kv_strict_pending_delete_is_confirmed_absent(global_config):
 async def test_kv_strict_pending_upsert_is_present(global_config):
     client = _make_client()
     storage = await _make_kv(global_config, client)
+    client.mget = AsyncMock()
     await storage.upsert({"doc-1": {"content": "x"}})
-    # Upsert may mget for create_time; the strict read must not.
-    client.mget.reset_mock()
     doc = await storage.get_by_id_strict("doc-1")
     assert doc["content"] == "x"
     assert doc["_id"] == "doc-1"

--- a/tests/kg/redis_impl/fake_redis.py
+++ b/tests/kg/redis_impl/fake_redis.py
@@ -12,7 +12,7 @@ storage class calls; unknown commands fail loudly.
 
 from __future__ import annotations
 
-from collections import defaultdict
+from collections import Counter, defaultdict
 from typing import Any
 
 from redis.exceptions import ResponseError, WatchError
@@ -27,6 +27,10 @@ class FakeRedis:
         self.versions: dict[str, int] = defaultdict(int)
         # Test hook: raise this exception on the next matching command.
         self.fail_next: dict[str, Exception] = {}
+        # Per-command call counts, so a test can assert WHICH command a code
+        # path used (e.g. RedisKVStorage.upsert must read create_time with
+        # GETRANGE and never pull whole values back with GET).
+        self.command_counts: Counter[str] = Counter()
         # CONFIG GET response; the default is an eviction-safe server.
         self.config_values: dict[str, str] = {
             "maxmemory": "0",
@@ -58,7 +62,23 @@ class FakeRedis:
 
     async def get(self, key: str):
         self._maybe_fail("get")
+        self.command_counts["get"] += 1
         return self.store.get(key)
+
+    async def getrange(self, key: str, start: int, end: int) -> str:
+        """Real GETRANGE semantics: inclusive range, empty string when absent.
+
+        Redis returns an empty string (not nil) for a missing key, which is
+        what RedisKVStorage.upsert reads as "this is an insert".
+        """
+        self._maybe_fail("getrange")
+        self.command_counts["getrange"] += 1
+        value = self.store.get(key)
+        if value is None:
+            return ""
+        if end < 0:
+            end = len(value) + end
+        return value[start : end + 1]
 
     async def set(self, key: str, value: str, nx: bool = False, ex: int | None = None):
         self._maybe_fail("set")
@@ -206,8 +226,17 @@ class FakeRedis:
 
     def _apply(self, op: tuple) -> Any:
         kind = op[0]
+        self.command_counts[kind] += 1
         if kind == "get":
             return self.store.get(op[1])
+        if kind == "getrange":
+            key, start, end = op[1], op[2], op[3]
+            value = self.store.get(key)
+            if value is None:
+                return ""
+            if end < 0:
+                end = len(value) + end
+            return value[start : end + 1]
         if kind == "set":
             self.store[op[1]] = op[2]
             self._bump(op[1])
@@ -349,6 +378,9 @@ class FakePipeline:
             return _run()
         self._ops.append(op)
         return self
+
+    def getrange(self, key: str, start: int, end: int):
+        return self._command(("getrange", key, start, end))
 
     def get(self, key: str):
         if self._immediate:

--- a/tests/kg/redis_impl/fake_redis.py
+++ b/tests/kg/redis_impl/fake_redis.py
@@ -245,12 +245,16 @@ class FakeRedis:
                 str(args[2]),
                 int(args[3]),
             )
-            stored = self.store.get(key)
             # The script's own GETRANGE, counted so a test can assert that the
             # fast path reads a prefix and never a whole value.
             self.command_counts["getrange"] += 1
-            prefix = "" if stored is None else stored[:prefix_bytes]
+            exists = key in self.store
+            prefix = self.store[key][:prefix_bytes] if exists else ""
             if prefix == "":
+                # GETRANGE cannot tell a missing key from an empty value, so
+                # the script disambiguates with EXISTS on this branch only.
+                self.command_counts["exists"] += 1
+            if prefix == "" and not exists:
                 create_time, outcome = now, "created"
             else:
                 match = _CREATE_TIME_PREFIX_RE.match(prefix)
@@ -383,7 +387,9 @@ class FakeScript:
     ``kept`` when the stored prefix carries the timestamp, ``needs_hint``
     (writing nothing) when it does not and no hint was supplied, ``hinted``
     when one was -- and the atomic read-decide-write step that makes the
-    decision safe against a concurrent delete.
+    decision safe against a concurrent delete. A key holding an empty string
+    is a stored row, not an absent one, exactly as the script's ``EXISTS``
+    check decides.
 
     It reuses the production prefix regex, so a divergence between that regex
     and the Lua pattern is invisible here by construction; the integration

--- a/tests/kg/redis_impl/fake_redis.py
+++ b/tests/kg/redis_impl/fake_redis.py
@@ -238,6 +238,12 @@ class FakeRedis:
                 end = len(value) + end
             return value[start : end + 1]
         if kind == "set":
+            # NX mirrors real Redis: refuse (and answer nil) when the key
+            # already exists. RedisKVStorage.upsert relies on that to make a
+            # first creation atomic.
+            nx = op[3] if len(op) > 3 else False
+            if nx and op[1] in self.store:
+                return None
             self.store[op[1]] = op[2]
             self._bump(op[1])
             return True
@@ -406,8 +412,8 @@ class FakePipeline:
             )
         return self._fake.scan(cursor, match=match, count=count)
 
-    def set(self, key: str, value: str):
-        return self._command(("set", key, value))
+    def set(self, key: str, value: str, nx: bool = False):
+        return self._command(("set", key, value, nx))
 
     def delete(self, key: str):
         return self._command(("delete", key))

--- a/tests/kg/redis_impl/fake_redis.py
+++ b/tests/kg/redis_impl/fake_redis.py
@@ -8,6 +8,12 @@ atomic rebuild switch, and hashes.
 Shared by the doc-status lookup tests and the scheduling-page tests so the
 fake's semantics stay consistent. Deliberately implements only the subset the
 storage class calls; unknown commands fail loudly.
+
+One deliberate limitation: ``register_script`` cannot run Lua, so the KV
+upsert script is REIMPLEMENTED here in Python (see ``FakeScript``). Unit tests
+therefore pin the storage's use of the script, not the script itself -- the
+real thing runs in
+``tests/kg/redis_impl/test_redis_kv_create_time_integration.py``.
 """
 
 from __future__ import annotations
@@ -229,6 +235,38 @@ class FakeRedis:
         self.command_counts[kind] += 1
         if kind == "get":
             return self.store.get(op[1])
+        if kind == "script":
+            from lightrag.kg.redis_impl import _CREATE_TIME_PREFIX_RE
+
+            key, args = op[1], op[2]
+            payload, hint, now, prefix_bytes = (
+                args[0],
+                str(args[1]),
+                str(args[2]),
+                int(args[3]),
+            )
+            stored = self.store.get(key)
+            # The script's own GETRANGE, counted so a test can assert that the
+            # fast path reads a prefix and never a whole value.
+            self.command_counts["getrange"] += 1
+            prefix = "" if stored is None else stored[:prefix_bytes]
+            if prefix == "":
+                create_time, outcome = now, "created"
+            else:
+                match = _CREATE_TIME_PREFIX_RE.match(prefix)
+                if match is not None:
+                    create_time, outcome = match.group(1), "kept"
+                elif hint == "":
+                    return ["needs_hint", ""]
+                else:
+                    create_time, outcome = hint, "hinted"
+            rest = payload[1:]
+            if rest in ("}", ""):
+                self.store[key] = '{"create_time":' + create_time + "}"
+            else:
+                self.store[key] = '{"create_time":' + create_time + "," + rest
+            self._bump(key)
+            return [outcome, create_time]
         if kind == "getrange":
             key, start, end = op[1], op[2], op[3]
             value = self.store.get(key)
@@ -331,8 +369,36 @@ class FakeRedis:
             return dict(self.hashes.get(op[1], {}))
         raise ValueError(f"FakeRedis: unsupported op {kind}")  # pragma: no cover
 
+    def register_script(self, script: str):
+        return FakeScript(self, script)
+
     def pipeline(self, transaction: bool = True):
         return FakePipeline(self)
+
+
+class FakeScript:
+    """Python model of ``_CREATE_TIME_UPSERT_LUA``.
+
+    Mirrors the script's four outcomes -- ``created`` for an absent key,
+    ``kept`` when the stored prefix carries the timestamp, ``needs_hint``
+    (writing nothing) when it does not and no hint was supplied, ``hinted``
+    when one was -- and the atomic read-decide-write step that makes the
+    decision safe against a concurrent delete.
+
+    It reuses the production prefix regex, so a divergence between that regex
+    and the Lua pattern is invisible here by construction; the integration
+    suite pins the Lua side.
+    """
+
+    def __init__(self, fake: FakeRedis, script: str):
+        self._fake = fake
+        self.script = script
+
+    async def __call__(self, keys=None, args=None, client=None):
+        op = ("script", (keys or [None])[0], list(args or []))
+        if client is None or client is self._fake:
+            return self._fake._apply(op)
+        return client._command(op)
 
 
 class FakePipeline:

--- a/tests/kg/redis_impl/test_redis_kv_create_time_integration.py
+++ b/tests/kg/redis_impl/test_redis_kv_create_time_integration.py
@@ -250,35 +250,41 @@ async def test_set_nx_refuses_an_existing_key(storage):
 
 
 @pytest.mark.asyncio
-async def test_stale_absent_read_cannot_move_create_time(storage):
-    """Forced interleaving: the second writer adopts the first creation.
+async def test_upsert_racing_a_delete_never_resurrects_the_old_timestamp(storage):
+    """The delete race, which only server-side atomicity can close.
 
-    The classification read is stubbed absent ONCE -- what a writer would
-    have read a moment before the other one's SET landed. Everything after
-    that, including the refused ``SET NX`` and the repair read, is the real
-    server.
+    If the row exists afterwards, the upsert's write was the last one on that
+    key, so the row is a new incarnation and must carry the upsert's own
+    clock. A client-side read-then-write leaves a window where the read sees
+    the pre-delete row, the delete lands, and the write puts the removed
+    incarnation's timestamp back -- and nothing ever repairs it, because every
+    later update preserves what it finds.
+
+    Measured against the read-then-write predecessor of this code, the window
+    was hit in roughly a quarter of the rounds below; the script closes it
+    because its read and write are one step.
     """
-    with patch("time.time", return_value=1_700_000_100):
-        await storage.upsert({"K": {"x": 1}})
+    rounds = 40
+    resurrected = []
+    for index in range(rounds):
+        key = f"race-{index}"
+        with patch("time.time", return_value=1_700_000_000):
+            await storage.upsert({key: {"round": 1}})
+        first = (await storage.get_by_id(key))["create_time"]
 
-    real_resolve = storage._resolve_stored_create_times
-    calls = {"n": 0}
+        with patch("time.time", return_value=1_700_000_500):
+            await asyncio.gather(
+                storage.upsert({key: {"round": 2}}), storage.delete([key])
+            )
 
-    async def stale_once(redis, keys):
-        calls["n"] += 1
-        if calls["n"] == 1:
-            return {}
-        return await real_resolve(redis, keys)
+        row = await storage.get_by_id(key)
+        if row is not None and row["create_time"] == first:
+            resurrected.append(key)
 
-    storage._resolve_stored_create_times = stale_once
-    with patch("time.time", return_value=1_700_000_200):
-        await storage.upsert({"K": {"x": 2}})
-
-    assert calls["n"] == 2, "the refused NX must trigger exactly one repair read"
-    row = await storage.get_by_id("K")
-    assert row["create_time"] == 1_700_000_100
-    assert row["update_time"] == 1_700_000_200
-    assert row["x"] == 2
+    assert not resurrected, (
+        f"{len(resurrected)}/{rounds} rows came back carrying the deleted "
+        f"incarnation's create_time"
+    )
 
 
 @pytest.mark.asyncio
@@ -322,3 +328,53 @@ async def test_concurrent_inserts_converge_on_one_create_time(storage):
     finally:
         for other in others:
             await other.finalize()
+
+
+# Raw stored values, chosen so each side of the prefix pattern is exercised:
+# compact and spaced separators, zero, a negative value, and four shapes the
+# pattern must REFUSE (tail position, float, null, quoted) plus non-JSON.
+_PREFIX_SAMPLES = [
+    '{"create_time":1650000000,"x":1}',
+    '{"create_time": 1650000000, "x": 1}',
+    '{"create_time":0}',
+    '{"create_time": -5, "x": 1}',
+    '{"x":1,"create_time":1650000000}',
+    '{"create_time": 1.5, "x": 1}',
+    '{"create_time": null}',
+    '{"create_time": "1650000000"}',
+    "not json at all",
+]
+
+
+@pytest.mark.parametrize("raw", _PREFIX_SAMPLES, ids=range(len(_PREFIX_SAMPLES)))
+@pytest.mark.asyncio
+async def test_lua_prefix_pattern_agrees_with_the_python_regex(storage, raw):
+    """The two patterns are one rule written twice; keep them in step.
+
+    A Lua pattern that refused a prefix the Python regex accepts would send
+    every update down the legacy read; one that accepted more would take a
+    timestamp the caller never normalized.
+    """
+    from lightrag.kg.redis_impl import (
+        _CREATE_TIME_PREFIX_BYTES,
+        _CREATE_TIME_PREFIX_RE,
+        _CREATE_TIME_UPSERT_LUA,
+    )
+
+    key = f"{storage.final_namespace}:pattern"
+    expected = _CREATE_TIME_PREFIX_RE.match(raw[:_CREATE_TIME_PREFIX_BYTES])
+
+    async with storage._get_redis_connection() as redis:
+        await redis.set(key, raw)
+        script = redis.register_script(_CREATE_TIME_UPSERT_LUA)
+        outcome, value = await script(
+            keys=[key],
+            args=['{"x":2}', "", 1_700_000_000, _CREATE_TIME_PREFIX_BYTES],
+        )
+
+    if expected is None:
+        assert outcome == "needs_hint"
+        assert value == ""
+    else:
+        assert outcome == "kept"
+        assert value == expected.group(1)

--- a/tests/kg/redis_impl/test_redis_kv_create_time_integration.py
+++ b/tests/kg/redis_impl/test_redis_kv_create_time_integration.py
@@ -23,11 +23,13 @@ are skipped when it is unset::
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import time
 
 import pytest
+from unittest.mock import patch
 
 from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
 from lightrag.namespace import NameSpace
@@ -230,3 +232,93 @@ async def test_batch_update_preserves_every_create_time(storage):
     rows = await storage.get_by_ids(ids)
     assert [row["create_time"] for row in rows] == [created] * len(ids)
     assert all(row["update_time"] > created for row in rows)
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: the insert race
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_nx_refuses_an_existing_key(storage):
+    """The server primitive the insert race relies on."""
+    async with storage._get_redis_connection() as redis:
+        key = f"{storage.final_namespace}:nx"
+        assert await redis.set(key, "first", nx=True) is True
+        assert await redis.set(key, "second", nx=True) is None
+        assert await redis.get(key) == "first"
+
+
+@pytest.mark.asyncio
+async def test_stale_absent_read_cannot_move_create_time(storage):
+    """Forced interleaving: the second writer adopts the first creation.
+
+    The classification read is stubbed absent ONCE -- what a writer would
+    have read a moment before the other one's SET landed. Everything after
+    that, including the refused ``SET NX`` and the repair read, is the real
+    server.
+    """
+    with patch("time.time", return_value=1_700_000_100):
+        await storage.upsert({"K": {"x": 1}})
+
+    real_resolve = storage._resolve_stored_create_times
+    calls = {"n": 0}
+
+    async def stale_once(redis, keys):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return {}
+        return await real_resolve(redis, keys)
+
+    storage._resolve_stored_create_times = stale_once
+    with patch("time.time", return_value=1_700_000_200):
+        await storage.upsert({"K": {"x": 2}})
+
+    assert calls["n"] == 2, "the refused NX must trigger exactly one repair read"
+    row = await storage.get_by_id("K")
+    assert row["create_time"] == 1_700_000_100
+    assert row["update_time"] == 1_700_000_200
+    assert row["x"] == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_inserts_converge_on_one_create_time(storage):
+    """Unforced concurrency: many writers, one first-creation timestamp."""
+    from lightrag.kg.redis_impl import RedisKVStorage
+
+    others = [
+        RedisKVStorage(
+            namespace=NameSpace.KV_STORE_ENTITY_CHUNKS,
+            global_config={},
+            embedding_func=_DummyEmbeddingFunc(),
+            workspace=_WORKSPACE,
+        )
+        for _ in range(4)
+    ]
+    for other in others:
+        await other.initialize()
+    workers = [storage, *others]
+
+    try:
+        await asyncio.gather(
+            *(
+                worker.upsert({"R": {"writer": index}})
+                for index, worker in enumerate(workers)
+            )
+        )
+        settled = (await storage.get_by_id("R"))["create_time"]
+
+        # Whatever won, it must not move afterwards.
+        time.sleep(1.1)
+        await asyncio.gather(
+            *(
+                worker.upsert({"R": {"writer": index, "round": 2}})
+                for index, worker in enumerate(workers)
+            )
+        )
+        row = await storage.get_by_id("R")
+        assert row["create_time"] == settled
+        assert row["update_time"] > settled
+    finally:
+        for other in others:
+            await other.finalize()

--- a/tests/kg/redis_impl/test_redis_kv_create_time_integration.py
+++ b/tests/kg/redis_impl/test_redis_kv_create_time_integration.py
@@ -1,0 +1,232 @@
+"""Integration tests: create_time preservation against a REAL Redis.
+
+The unit tests run on the FakeRedis stand-in, which can only prove the fake's
+own semantics. Two things here need the real server (issue #3870):
+
+* ``GETRANGE`` returns an empty string — not nil — for a missing key, which is
+  how ``upsert`` recognizes an insert;
+* the prefix actually MATCHES what ``json.dumps`` writes. A pattern that is
+  too strict still produces correct timestamps (the full-read fallback covers
+  it) while silently sending every update down that fallback, so the
+  optimization is asserted through ``INFO commandstats``.
+
+Opt-in — these tests write and DELETE keys, so they never run against the URI
+configured for a real deployment. They read ``LIGHTRAG_TEST_REDIS_URI`` and
+are skipped when it is unset::
+
+    docker run -d --name lr-redis-test -p 16379:6379 redis:latest
+
+    LIGHTRAG_TEST_REDIS_URI=redis://localhost:16379 \\
+        ./scripts/test.sh tests/kg/redis_impl/test_redis_kv_create_time_integration.py \\
+        --run-integration
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import pytest
+
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+from lightrag.namespace import NameSpace
+
+pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
+
+_WORKSPACE = "ittest_create_time"
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
+
+
+@pytest.fixture
+async def storage():
+    uri = os.getenv("LIGHTRAG_TEST_REDIS_URI")
+    if not uri:
+        pytest.skip("Redis not configured for tests (LIGHTRAG_TEST_REDIS_URI not set)")
+
+    previous = os.environ.get("REDIS_URI")
+    os.environ["REDIS_URI"] = uri
+
+    from lightrag.kg import redis_impl
+    from lightrag.kg.redis_impl import RedisKVStorage
+
+    cache = getattr(redis_impl, "_eviction_checked", None)
+    if cache is not None:
+        cache.clear()
+
+    initialize_share_data()
+    kv = RedisKVStorage(
+        namespace=NameSpace.KV_STORE_ENTITY_CHUNKS,
+        global_config={},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace=_WORKSPACE,
+    )
+    await kv.initialize()
+    await kv.drop()
+    try:
+        yield kv
+    finally:
+        await kv.drop()
+        await kv.finalize()
+        finalize_share_data()
+        if previous is None:
+            os.environ.pop("REDIS_URI", None)
+        else:
+            os.environ["REDIS_URI"] = previous
+
+
+async def _raw(storage, key: str) -> str:
+    async with storage._get_redis_connection() as redis:
+        return await redis.get(f"{storage.final_namespace}:{key}")
+
+
+@pytest.mark.asyncio
+async def test_value_is_stored_create_time_first(storage):
+    await storage.upsert({"E": {"chunk_ids": ["c1"], "count": 1}})
+
+    raw = await _raw(storage, "E")
+    assert raw.startswith('{"create_time"')
+    assert next(iter(json.loads(raw))) == "create_time"
+
+
+@pytest.mark.asyncio
+async def test_prefix_read_matches_what_the_writer_produced(storage):
+    """The regex must match real json.dumps output, spacing included."""
+    from lightrag.kg.redis_impl import (
+        _CREATE_TIME_PREFIX_BYTES,
+        _CREATE_TIME_PREFIX_RE,
+    )
+
+    await storage.upsert({"E": {"chunk_ids": ["c1"], "count": 1}})
+    created = json.loads(await _raw(storage, "E"))["create_time"]
+
+    async with storage._get_redis_connection() as redis:
+        prefix = await redis.getrange(
+            f"{storage.final_namespace}:E", 0, _CREATE_TIME_PREFIX_BYTES - 1
+        )
+    match = _CREATE_TIME_PREFIX_RE.match(prefix)
+    assert match is not None, f"prefix did not match: {prefix!r}"
+    assert int(match.group(1)) == created
+
+
+@pytest.mark.asyncio
+async def test_getrange_on_a_missing_key_is_empty(storage):
+    """Redis answers a missing key with "", which upsert reads as an insert."""
+    async with storage._get_redis_connection() as redis:
+        assert (
+            await redis.getrange(f"{storage.final_namespace}:__absent__", 0, 63) == ""
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_never_pulls_the_whole_value_back(storage):
+    await storage.upsert({"E": {"chunk_ids": ["c1"], "count": 1}})
+
+    async with storage._get_redis_connection() as redis:
+        await redis.config_resetstat()
+        await storage.upsert({"E": {"chunk_ids": ["c1", "c2"], "count": 2}})
+        stats = await redis.info("commandstats")
+
+    assert stats.get("cmdstat_getrange", {}).get("calls", 0) >= 1
+    assert stats.get("cmdstat_get", {}).get("calls", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_replacement_upsert_preserves_create_time(storage):
+    await storage.upsert({"E": {"chunk_ids": ["c1"], "count": 1}})
+    created = (await storage.get_by_id("E"))["create_time"]
+
+    time.sleep(1.1)  # update_time must be observably later
+    await storage.upsert({"E": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+    row = await storage.get_by_id("E")
+    assert row["create_time"] == created
+    assert row["update_time"] > created
+    assert row["chunk_ids"] == ["c1", "c2"]
+    assert row["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_create_time_is_ignored_on_update(storage):
+    await storage.upsert({"E": {"chunk_ids": ["c1"]}})
+    created = (await storage.get_by_id("E"))["create_time"]
+
+    await storage.upsert({"E": {"chunk_ids": ["c2"], "create_time": 1}})
+
+    assert (await storage.get_by_id("E"))["create_time"] == created
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_with_trailing_create_time_is_recovered_and_repaired(storage):
+    async with storage._get_redis_connection() as redis:
+        await redis.set(
+            f"{storage.final_namespace}:L",
+            json.dumps({"chunk_ids": ["c1"], "count": 1, "create_time": 1_650_000_000}),
+        )
+
+    await storage.upsert({"L": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+    assert (await storage.get_by_id("L"))["create_time"] == 1_650_000_000
+    # Rewritten in the prefix layout, so the next update takes the fast path.
+    assert (await _raw(storage, "L")).startswith('{"create_time"')
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_missing_create_time_records_zero(storage):
+    async with storage._get_redis_connection() as redis:
+        await redis.set(
+            f"{storage.final_namespace}:M", json.dumps({"chunk_ids": ["c1"]})
+        )
+
+    await storage.upsert({"M": {"chunk_ids": ["c2"]}})
+
+    assert (await storage.get_by_id("M"))["create_time"] == 0
+
+
+@pytest.mark.asyncio
+async def test_legacy_float_create_time_is_normalized(storage):
+    async with storage._get_redis_connection() as redis:
+        await redis.set(
+            f"{storage.final_namespace}:F",
+            json.dumps({"x": 1, "create_time": 1_650_000_000.75}),
+        )
+
+    await storage.upsert({"F": {"x": 2}})
+
+    stored = json.loads(await _raw(storage, "F"))
+    assert stored["create_time"] == 1_650_000_000
+    assert isinstance(stored["create_time"], int)
+
+
+@pytest.mark.asyncio
+async def test_corrupt_row_records_zero(storage):
+    async with storage._get_redis_connection() as redis:
+        await redis.set(f"{storage.final_namespace}:C", "}} not json {{")
+
+    await storage.upsert({"C": {"chunk_ids": ["c1"]}})
+
+    assert (await storage.get_by_id("C"))["create_time"] == 0
+
+
+@pytest.mark.asyncio
+async def test_batch_update_preserves_every_create_time(storage):
+    ids = [f"B{i}" for i in range(50)]
+    await storage.upsert({doc_id: {"chunk_ids": ["c"], "count": 1} for doc_id in ids})
+    rows = await storage.get_by_ids(ids)
+    created = rows[0]["create_time"]
+
+    time.sleep(1.1)
+    await storage.upsert(
+        {doc_id: {"chunk_ids": ["c", "d"], "count": 2} for doc_id in ids}
+    )
+
+    rows = await storage.get_by_ids(ids)
+    assert [row["create_time"] for row in rows] == [created] * len(ids)
+    assert all(row["update_time"] > created for row in rows)

--- a/tests/kg/redis_impl/test_redis_kv_create_time_integration.py
+++ b/tests/kg/redis_impl/test_redis_kv_create_time_integration.py
@@ -208,6 +208,27 @@ async def test_legacy_float_create_time_is_normalized(storage):
 
 
 @pytest.mark.asyncio
+async def test_empty_value_row_records_zero(storage):
+    """Redis answers GETRANGE with "" for a missing key AND an empty value.
+
+    Only a server-side EXISTS separates them, so this pins that an existing
+    empty row is treated as a stored row with an unknown timestamp instead of
+    a first creation.
+    """
+    async with storage._get_redis_connection() as redis:
+        await redis.set(f"{storage.final_namespace}:empty", "")
+        assert await redis.exists(f"{storage.final_namespace}:empty") == 1
+        assert await redis.getrange(f"{storage.final_namespace}:empty", 0, 63) == ""
+
+    with patch("time.time", return_value=1_700_000_700):
+        await storage.upsert({"empty": {"x": 1}})
+
+    row = await storage.get_by_id("empty")
+    assert row["create_time"] == 0
+    assert row["update_time"] == 1_700_000_700
+
+
+@pytest.mark.asyncio
 async def test_corrupt_row_records_zero(storage):
     async with storage._get_redis_connection() as redis:
         await redis.set(f"{storage.final_namespace}:C", "}} not json {{")

--- a/tests/kg/redis_impl/test_redis_kv_upsert_create_time.py
+++ b/tests/kg/redis_impl/test_redis_kv_upsert_create_time.py
@@ -246,6 +246,38 @@ async def test_legacy_float_create_time_is_normalized(fake):
 
 
 @pytest.mark.asyncio
+async def test_empty_value_row_records_zero_not_a_new_timestamp(fake, caplog):
+    """An empty value is a stored row with no usable timestamp, not an insert.
+
+    ``GETRANGE`` answers ``''`` for a missing key and for a key holding an
+    empty string alike, so classifying on the prefix alone would fabricate a
+    ``create_time`` for a row that already existed -- the very direction issue
+    #3870 is about, and inconsistent with the corrupt-value row next door.
+    """
+    storage = _kv_storage()
+    await storage.initialize()
+
+    fake.store[f"{storage.final_namespace}:empty"] = ""
+
+    logger = logging.getLogger("lightrag")
+    previous = logger.propagate
+    logger.propagate = True  # lightrag's logger does not propagate by default
+    try:
+        with caplog.at_level(logging.WARNING, logger="lightrag"):
+            with patch("time.time", return_value=1_700_000_700):
+                await storage.upsert({"empty": {"x": 1}})
+    finally:
+        logger.propagate = previous
+
+    stored = _stored(fake, storage, "empty")
+    assert stored["create_time"] == 0
+    assert stored["update_time"] == 1_700_000_700
+    assert any("not decodable JSON" in record.message for record in caplog.records)
+    # It took the hint round, like every other unusable value.
+    assert fake.command_counts["get"] == 1
+
+
+@pytest.mark.asyncio
 async def test_corrupt_row_records_zero_and_warns(fake, caplog):
     """Undecodable storage is corruption, not a legacy shape: say so."""
     storage = _kv_storage()

--- a/tests/kg/redis_impl/test_redis_kv_upsert_create_time.py
+++ b/tests/kg/redis_impl/test_redis_kv_upsert_create_time.py
@@ -1,0 +1,138 @@
+"""Regression tests: RedisKVStorage replacement upserts preserve create_time.
+
+Mirrors the JsonKVStorage invariant from issue #3870 against the in-memory
+FakeRedis stand-in (no live Redis required).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
+from lightrag.namespace import NameSpace
+
+from .fake_redis import FakeRedis
+
+pytestmark = pytest.mark.offline
+
+
+class _DummyEmbeddingFunc:
+    embedding_dim = 1
+    max_token_size = 1
+
+    async def __call__(self, texts, **kwargs):
+        return [[0.0] for _ in texts]
+
+
+@pytest.fixture(autouse=True)
+def _shared():
+    initialize_share_data()
+    yield
+    finalize_share_data()
+
+
+@pytest.fixture(autouse=True)
+def _reset_eviction_cache():
+    from lightrag.kg import redis_impl
+
+    cache = getattr(redis_impl, "_eviction_checked", None)
+    if cache is not None:
+        cache.clear()
+    yield
+    if cache is not None:
+        cache.clear()
+
+
+@pytest.fixture
+def fake(monkeypatch):
+    instance = FakeRedis()
+    monkeypatch.setattr(
+        "lightrag.kg.redis_impl.RedisConnectionManager.get_pool",
+        lambda redis_url: MagicMock(name="fake_pool"),
+    )
+    monkeypatch.setattr(
+        "lightrag.kg.redis_impl.Redis", lambda connection_pool=None, **_: instance
+    )
+    return instance
+
+
+def _kv_storage(workspace: str = "ct-ws"):
+    from lightrag.kg.redis_impl import RedisKVStorage
+
+    return RedisKVStorage(
+        namespace=NameSpace.KV_STORE_ENTITY_CHUNKS,
+        global_config={},
+        embedding_func=_DummyEmbeddingFunc(),
+        workspace=workspace,
+    )
+
+
+@pytest.mark.asyncio
+async def test_replacement_upsert_preserves_create_time(fake):
+    storage = _kv_storage()
+    await storage.initialize()
+
+    with patch("time.time", return_value=1_700_000_000):
+        await storage.upsert({"E": {"chunk_ids": ["c1"], "count": 1}})
+
+    created = await storage.get_by_id("E")
+    assert created is not None
+    assert created["create_time"] == 1_700_000_000
+    assert created["update_time"] == 1_700_000_000
+
+    with patch("time.time", return_value=1_700_000_100):
+        await storage.upsert({"E": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+    updated = await storage.get_by_id("E")
+    assert updated is not None
+    assert updated["create_time"] == 1_700_000_000
+    assert updated["update_time"] == 1_700_000_100
+    assert updated["chunk_ids"] == ["c1", "c2"]
+    assert updated["count"] == 2
+
+    raw = fake.store[f"{storage.final_namespace}:E"]
+    persisted = json.loads(raw)
+    assert persisted["create_time"] == 1_700_000_000
+    assert persisted["update_time"] == 1_700_000_100
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_missing_create_time_keeps_zero(fake):
+    storage = _kv_storage()
+    await storage.initialize()
+
+    key = f"{storage.final_namespace}:legacy"
+    fake.store[key] = json.dumps(
+        {
+            "chunk_ids": ["c1"],
+            "count": 1,
+            "update_time": 1_600_000_000,
+            "_id": "legacy",
+        }
+    )
+
+    with patch("time.time", return_value=1_700_000_200):
+        await storage.upsert({"legacy": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+    row = await storage.get_by_id("legacy")
+    assert row is not None
+    assert row["create_time"] == 0
+    assert row["update_time"] == 1_700_000_200
+    assert json.loads(fake.store[key])["create_time"] == 0
+
+
+@pytest.mark.asyncio
+async def test_insert_stamps_both_timestamps(fake):
+    storage = _kv_storage()
+    await storage.initialize()
+
+    with patch("time.time", return_value=1_700_000_300):
+        await storage.upsert({"new": {"chunk_ids": ["c9"], "count": 1}})
+
+    row = await storage.get_by_id("new")
+    assert row is not None
+    assert row["create_time"] == 1_700_000_300
+    assert row["update_time"] == 1_700_000_300

--- a/tests/kg/redis_impl/test_redis_kv_upsert_create_time.py
+++ b/tests/kg/redis_impl/test_redis_kv_upsert_create_time.py
@@ -2,14 +2,15 @@
 
 Issue #3870: an update whose payload carries business fields only used to drop
 the storage-managed ``create_time``. Redis cannot read one JSON field, so the
-value is serialized ``create_time``-first and the previous timestamp is
-recovered with a bounded ``GETRANGE`` prefix read -- see
-``BaseKVStorage.upsert`` for the contract these tests pin, and
-``_dumps_create_time_first`` for why the ordering is only an optimization.
+value is written ``create_time``-first and ``_CREATE_TIME_UPSERT_LUA`` recovers
+the previous timestamp from a bounded ``GETRANGE`` prefix -- in the same atomic
+step as the write, which is what keeps a concurrent insert or delete from
+moving it. See ``BaseKVStorage.upsert`` for the contract these tests pin.
 
-Runs against the in-memory FakeRedis stand-in (no live Redis required);
-``tests/kg/redis_impl/test_redis_kv_create_time_integration.py`` re-checks the
-same invariants against a real server.
+Runs against the in-memory FakeRedis stand-in (no live Redis required). The
+fake models the script in Python rather than running Lua, so the script's own
+semantics and the two races are checked against a real server in
+``tests/kg/redis_impl/test_redis_kv_create_time_integration.py``.
 """
 
 from __future__ import annotations
@@ -126,12 +127,12 @@ async def test_value_is_serialized_create_time_first(fake):
 
 
 @pytest.mark.asyncio
-async def test_update_reads_prefix_and_never_pulls_whole_value(fake):
-    """The optimization itself: GETRANGE only, no full GET.
+async def test_update_is_one_script_call_and_never_pulls_the_whole_value(fake):
+    """The optimization itself: one round trip, a prefix read, no full GET.
 
-    Without this the fix still behaves correctly -- the fallback full read
-    produces the same timestamps -- so only a command-level assertion can tell
-    the fast path apart from a silently dead one.
+    Without this the fix still behaves correctly -- the legacy full-read
+    fallback produces the same timestamps -- so only a command-level
+    assertion can tell the fast path apart from a silently dead one.
     """
     storage = _kv_storage()
     await storage.initialize()
@@ -143,13 +144,14 @@ async def test_update_reads_prefix_and_never_pulls_whole_value(fake):
     with patch("time.time", return_value=1_700_000_100):
         await storage.upsert({"E": {"chunk_ids": ["c1", "c2"], "count": 2}})
 
-    assert fake.command_counts["getrange"] == 1
+    assert fake.command_counts["script"] == 1
+    assert fake.command_counts["getrange"] == 1  # inside the script
     assert fake.command_counts["get"] == 0
 
 
 @pytest.mark.asyncio
-async def test_insert_reads_prefix_only(fake):
-    """A brand-new key must not trigger the legacy full-read fallback."""
+async def test_insert_is_one_script_call(fake):
+    """A brand-new key must not trigger the legacy hint round."""
     storage = _kv_storage()
     await storage.initialize()
 
@@ -157,7 +159,7 @@ async def test_insert_reads_prefix_only(fake):
     with patch("time.time", return_value=1_700_000_300):
         await storage.upsert({"new": {"chunk_ids": ["c9"], "count": 1}})
 
-    assert fake.command_counts["getrange"] == 1
+    assert fake.command_counts["script"] == 1
     assert fake.command_counts["get"] == 0
     row = await storage.get_by_id("new")
     assert row["create_time"] == 1_700_000_300
@@ -184,7 +186,9 @@ async def test_legacy_row_with_trailing_create_time_falls_back_to_full_read(fake
     with patch("time.time", return_value=1_700_000_200):
         await storage.upsert({"legacy": {"chunk_ids": ["c1", "c2"], "count": 2}})
 
-    assert fake.command_counts["get"] == 1  # the fallback ran
+    # needs_hint, then a full read, then the write.
+    assert fake.command_counts["get"] == 1
+    assert fake.command_counts["script"] == 2
     row = await storage.get_by_id("legacy")
     assert row["create_time"] == 1_650_000_000
     assert row["update_time"] == 1_700_000_200
@@ -195,6 +199,7 @@ async def test_legacy_row_with_trailing_create_time_falls_back_to_full_read(fake
     with patch("time.time", return_value=1_700_000_400):
         await storage.upsert({"legacy": {"chunk_ids": ["c3"], "count": 1}})
     assert fake.command_counts["get"] == 0
+    assert fake.command_counts["script"] == 1
     assert _stored(fake, storage, "legacy")["create_time"] == 1_650_000_000
 
 
@@ -276,24 +281,29 @@ async def test_caller_supplied_create_time_ignored_on_update(fake):
 
 
 @pytest.mark.asyncio
-async def test_row_deleted_between_the_two_reads_is_an_insert(fake, monkeypatch):
-    """The fallback's second read can find the key already gone."""
+async def test_legacy_row_deleted_before_the_hint_read_stamps_this_write(fake):
+    """The only two-step branch left, and its absent case.
+
+    A legacy-shaped row answers ``needs_hint``; if it is gone by the time the
+    hint read runs, there is no earlier creation to preserve, so the write's
+    own clock stands.
+    """
     storage = _kv_storage()
     await storage.initialize()
 
     key = f"{storage.final_namespace}:gone"
-    # Trailing create_time forces the two-phase path.
+    # Trailing create_time forces the hint round.
     fake.store[key] = json.dumps({"x": 1, "create_time": 1_650_000_000})
 
-    original_apply = fake._apply
+    real_apply = fake._apply
 
     def apply_and_vanish(op):
-        result = original_apply(op)
-        if op[0] == "getrange" and op[1] == key:
+        result = real_apply(op)
+        if op[0] == "script" and op[1] == key and result[0] == "needs_hint":
             fake.store.pop(key, None)
         return result
 
-    monkeypatch.setattr(fake, "_apply", apply_and_vanish)
+    fake._apply = apply_and_vanish
 
     with patch("time.time", return_value=1_700_000_500):
         await storage.upsert({"gone": {"x": 2}})
@@ -304,44 +314,23 @@ async def test_row_deleted_between_the_two_reads_is_an_insert(fake, monkeypatch)
 
 
 # ---------------------------------------------------------------------------
-# Concurrency: the insert race (issue #3870 follow-up)
+# Concurrency
 # ---------------------------------------------------------------------------
 #
-# Resolving the stored timestamp and writing the value are two round trips, so
-# a second writer can slip in between them. Only the INSERT outcome is
-# contended -- two writers that both see the key absent would each stamp their
-# own clock -- which is why a presumed-insert goes out as ``SET NX``.
-#
-# The interleaving is forced by giving the second storage a stale "absent"
-# resolution, which is exactly what it would have read a moment before the
-# first writer's SET landed.
-
-
-def _hide_key_from_the_next_prefix_read(fake: FakeRedis, full_key: str):
-    """Model the interleaving at the SERVER, not through storage internals.
-
-    The classification read lands before the other writer's ``SET`` (so it
-    reports "absent") and the repair read lands after it (so it sees the
-    winner). Driving that through the fake keeps the test independent of how
-    the storage happens to structure its reads.
-    """
-    real_apply = fake._apply
-    state = {"hidden": False}
-
-    def apply(op):
-        if not state["hidden"] and op[0] == "getrange" and op[1] == full_key:
-            state["hidden"] = True
-            fake.command_counts["getrange"] += 1  # it did reach the server
-            return ""
-        return real_apply(op)
-
-    fake._apply = apply
-    return state
+# The timestamp decision and the write are ONE atomic step inside
+# _CREATE_TIME_UPSERT_LUA, which is what closes both races: two writers
+# racing a first insert, and a delete() landing between a writer's read and
+# its write. Neither window can be reproduced here -- FakeRedis cannot run
+# Lua, and its model of the script is a single indivisible step, exactly like
+# the real one. What these tests pin is the storage's side of the protocol:
+# that it lets the server decide and then adopts that decision. The races
+# themselves are measured against a real server in
+# test_redis_kv_create_time_integration.py.
 
 
 @pytest.mark.asyncio
-async def test_concurrent_first_insert_keeps_the_earliest_create_time(fake):
-    """A later writer must not move create_time off the real first creation."""
+async def test_second_writer_of_a_new_key_keeps_the_first_timestamp(fake):
+    """Whoever creates the row owns create_time; later writers adopt it."""
     worker_a = _kv_storage()
     worker_b = _kv_storage()
     await worker_a.initialize()
@@ -350,12 +339,15 @@ async def test_concurrent_first_insert_keeps_the_earliest_create_time(fake):
     with patch("time.time", return_value=100):
         await worker_a.upsert({"K": {"chunk_ids": ["c1"], "count": 1}})
 
-    # Worker B's classification read lands before A's SET became visible.
-    _hide_key_from_the_next_prefix_read(fake, f"{worker_b.final_namespace}:K")
+    fake.command_counts.clear()
     with patch("time.time", return_value=200):
         await worker_b.upsert({"K": {"chunk_ids": ["c2"], "count": 2}})
 
-    row = _stored(fake, worker_a, "K")
+    # The server answered "kept", so no hint round was needed.
+    assert fake.command_counts["script"] == 1
+    assert fake.command_counts["get"] == 0
+
+    row = _stored(fake, worker_b, "K")
     assert row["create_time"] == 100, "the first creation must win"
     assert row["update_time"] == 200
     # B's business value still lands -- only the timestamp is adopted.
@@ -364,50 +356,33 @@ async def test_concurrent_first_insert_keeps_the_earliest_create_time(fake):
 
 
 @pytest.mark.asyncio
-async def test_insert_race_repair_stays_bounded(fake):
-    """Losing the NX race costs one prefix read and one SET, never a full GET."""
-    worker_a = _kv_storage()
-    worker_b = _kv_storage()
-    await worker_a.initialize()
-    await worker_b.initialize()
+async def test_the_callers_payload_ends_up_matching_storage(fake):
+    """The dict the caller passed in carries what the SERVER decided.
 
-    with patch("time.time", return_value=100):
-        await worker_a.upsert({"K": {"x": 1}})
-
-    _hide_key_from_the_next_prefix_read(fake, f"{worker_b.final_namespace}:K")
-    fake.command_counts.clear()
-    with patch("time.time", return_value=200):
-        await worker_b.upsert({"K": {"x": 2}})
-
-    assert fake.command_counts["getrange"] == 2  # classify + repair
-    assert fake.command_counts["get"] == 0
-    assert fake.command_counts["set"] == 2  # refused NX + repairing SET
-    assert _stored(fake, worker_b, "K")["create_time"] == 100
-
-
-@pytest.mark.asyncio
-async def test_uncontended_insert_does_no_repair_round(fake):
-    """The race handling must not cost anything when there is no race."""
+    The optimistic value the loop stamps would otherwise be wrong for every
+    update, which callers that reuse the dict (or log it) would see.
+    """
     storage = _kv_storage()
     await storage.initialize()
 
-    fake.command_counts.clear()
-    with patch("time.time", return_value=300):
-        await storage.upsert({"fresh": {"x": 1}})
+    with patch("time.time", return_value=100):
+        await storage.upsert({"K": {"x": 1}})
 
-    assert fake.command_counts["getrange"] == 1
-    assert fake.command_counts["set"] == 1
-    row = _stored(fake, storage, "fresh")
-    assert row["create_time"] == 300
-    assert row["update_time"] == 300
+    payload = {"x": 2}
+    with patch("time.time", return_value=200):
+        await storage.upsert({"K": payload})
+
+    assert payload["create_time"] == 100
+    assert payload["update_time"] == 200
+    assert payload["create_time"] == _stored(fake, storage, "K")["create_time"]
 
 
 @pytest.mark.asyncio
 async def test_concurrent_updates_agree_without_coordination(fake):
-    """An existing row needs no NX: every writer derives the same timestamp.
+    """Two writers updating an existing row cannot disagree.
 
-    This is why only the insert is made atomic -- pinning it keeps a future
-    change from "fixing" the update path with coordination it does not need.
+    Every writer derives the timestamp from the same stored row, so the
+    outcome does not depend on who writes last.
     """
     worker_a = _kv_storage()
     worker_b = _kv_storage()
@@ -417,7 +392,6 @@ async def test_concurrent_updates_agree_without_coordination(fake):
     with patch("time.time", return_value=100):
         await worker_a.upsert({"K": {"x": 1}})
 
-    # Both workers resolve the same stored row, then write in either order.
     with patch("time.time", return_value=200):
         await worker_a.upsert({"K": {"x": 2}})
         await worker_b.upsert({"K": {"x": 3}})
@@ -425,3 +399,19 @@ async def test_concurrent_updates_agree_without_coordination(fake):
     row = _stored(fake, worker_b, "K")
     assert row["create_time"] == 100
     assert row["x"] == 3
+
+
+@pytest.mark.asyncio
+async def test_infinite_create_time_does_not_abort_the_upsert(fake):
+    """A stored ``1e309`` must take the 0 fallback, not raise OverflowError."""
+    storage = _kv_storage()
+    await storage.initialize()
+
+    fake.store[f"{storage.final_namespace}:inf"] = json.dumps(
+        {"x": 1, "create_time": json.loads("1e309")}
+    )
+
+    with patch("time.time", return_value=1_700_000_600):
+        await storage.upsert({"inf": {"x": 2}})
+
+    assert _stored(fake, storage, "inf")["create_time"] == 0

--- a/tests/kg/redis_impl/test_redis_kv_upsert_create_time.py
+++ b/tests/kg/redis_impl/test_redis_kv_upsert_create_time.py
@@ -301,3 +301,127 @@ async def test_row_deleted_between_the_two_reads_is_an_insert(fake, monkeypatch)
     stored = _stored(fake, storage, "gone")
     assert stored["create_time"] == 1_700_000_500
     assert stored["update_time"] == 1_700_000_500
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: the insert race (issue #3870 follow-up)
+# ---------------------------------------------------------------------------
+#
+# Resolving the stored timestamp and writing the value are two round trips, so
+# a second writer can slip in between them. Only the INSERT outcome is
+# contended -- two writers that both see the key absent would each stamp their
+# own clock -- which is why a presumed-insert goes out as ``SET NX``.
+#
+# The interleaving is forced by giving the second storage a stale "absent"
+# resolution, which is exactly what it would have read a moment before the
+# first writer's SET landed.
+
+
+def _hide_key_from_the_next_prefix_read(fake: FakeRedis, full_key: str):
+    """Model the interleaving at the SERVER, not through storage internals.
+
+    The classification read lands before the other writer's ``SET`` (so it
+    reports "absent") and the repair read lands after it (so it sees the
+    winner). Driving that through the fake keeps the test independent of how
+    the storage happens to structure its reads.
+    """
+    real_apply = fake._apply
+    state = {"hidden": False}
+
+    def apply(op):
+        if not state["hidden"] and op[0] == "getrange" and op[1] == full_key:
+            state["hidden"] = True
+            fake.command_counts["getrange"] += 1  # it did reach the server
+            return ""
+        return real_apply(op)
+
+    fake._apply = apply
+    return state
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_insert_keeps_the_earliest_create_time(fake):
+    """A later writer must not move create_time off the real first creation."""
+    worker_a = _kv_storage()
+    worker_b = _kv_storage()
+    await worker_a.initialize()
+    await worker_b.initialize()
+
+    with patch("time.time", return_value=100):
+        await worker_a.upsert({"K": {"chunk_ids": ["c1"], "count": 1}})
+
+    # Worker B's classification read lands before A's SET became visible.
+    _hide_key_from_the_next_prefix_read(fake, f"{worker_b.final_namespace}:K")
+    with patch("time.time", return_value=200):
+        await worker_b.upsert({"K": {"chunk_ids": ["c2"], "count": 2}})
+
+    row = _stored(fake, worker_a, "K")
+    assert row["create_time"] == 100, "the first creation must win"
+    assert row["update_time"] == 200
+    # B's business value still lands -- only the timestamp is adopted.
+    assert row["chunk_ids"] == ["c2"]
+    assert row["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_insert_race_repair_stays_bounded(fake):
+    """Losing the NX race costs one prefix read and one SET, never a full GET."""
+    worker_a = _kv_storage()
+    worker_b = _kv_storage()
+    await worker_a.initialize()
+    await worker_b.initialize()
+
+    with patch("time.time", return_value=100):
+        await worker_a.upsert({"K": {"x": 1}})
+
+    _hide_key_from_the_next_prefix_read(fake, f"{worker_b.final_namespace}:K")
+    fake.command_counts.clear()
+    with patch("time.time", return_value=200):
+        await worker_b.upsert({"K": {"x": 2}})
+
+    assert fake.command_counts["getrange"] == 2  # classify + repair
+    assert fake.command_counts["get"] == 0
+    assert fake.command_counts["set"] == 2  # refused NX + repairing SET
+    assert _stored(fake, worker_b, "K")["create_time"] == 100
+
+
+@pytest.mark.asyncio
+async def test_uncontended_insert_does_no_repair_round(fake):
+    """The race handling must not cost anything when there is no race."""
+    storage = _kv_storage()
+    await storage.initialize()
+
+    fake.command_counts.clear()
+    with patch("time.time", return_value=300):
+        await storage.upsert({"fresh": {"x": 1}})
+
+    assert fake.command_counts["getrange"] == 1
+    assert fake.command_counts["set"] == 1
+    row = _stored(fake, storage, "fresh")
+    assert row["create_time"] == 300
+    assert row["update_time"] == 300
+
+
+@pytest.mark.asyncio
+async def test_concurrent_updates_agree_without_coordination(fake):
+    """An existing row needs no NX: every writer derives the same timestamp.
+
+    This is why only the insert is made atomic -- pinning it keeps a future
+    change from "fixing" the update path with coordination it does not need.
+    """
+    worker_a = _kv_storage()
+    worker_b = _kv_storage()
+    await worker_a.initialize()
+    await worker_b.initialize()
+
+    with patch("time.time", return_value=100):
+        await worker_a.upsert({"K": {"x": 1}})
+
+    # Both workers resolve the same stored row, then write in either order.
+    with patch("time.time", return_value=200):
+        await worker_a.upsert({"K": {"x": 2}})
+        await worker_b.upsert({"K": {"x": 3}})
+
+    row = _stored(fake, worker_b, "K")
+    assert row["create_time"] == 100
+    assert row["x"] == 3

--- a/tests/kg/redis_impl/test_redis_kv_upsert_create_time.py
+++ b/tests/kg/redis_impl/test_redis_kv_upsert_create_time.py
@@ -1,12 +1,21 @@
 """Regression tests: RedisKVStorage replacement upserts preserve create_time.
 
-Mirrors the JsonKVStorage invariant from issue #3870 against the in-memory
-FakeRedis stand-in (no live Redis required).
+Issue #3870: an update whose payload carries business fields only used to drop
+the storage-managed ``create_time``. Redis cannot read one JSON field, so the
+value is serialized ``create_time``-first and the previous timestamp is
+recovered with a bounded ``GETRANGE`` prefix read -- see
+``BaseKVStorage.upsert`` for the contract these tests pin, and
+``_dumps_create_time_first`` for why the ordering is only an optimization.
+
+Runs against the in-memory FakeRedis stand-in (no live Redis required);
+``tests/kg/redis_impl/test_redis_kv_create_time_integration.py`` re-checks the
+same invariants against a real server.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -70,6 +79,10 @@ def _kv_storage(workspace: str = "ct-ws"):
     )
 
 
+def _stored(fake: FakeRedis, storage, key: str) -> dict:
+    return json.loads(fake.store[f"{storage.final_namespace}:{key}"])
+
+
 @pytest.mark.asyncio
 async def test_replacement_upsert_preserves_create_time(fake):
     storage = _kv_storage()
@@ -93,10 +106,96 @@ async def test_replacement_upsert_preserves_create_time(fake):
     assert updated["chunk_ids"] == ["c1", "c2"]
     assert updated["count"] == 2
 
-    raw = fake.store[f"{storage.final_namespace}:E"]
-    persisted = json.loads(raw)
+    persisted = _stored(fake, storage, "E")
     assert persisted["create_time"] == 1_700_000_000
     assert persisted["update_time"] == 1_700_000_100
+
+
+@pytest.mark.asyncio
+async def test_value_is_serialized_create_time_first(fake):
+    """The prefix read only works while create_time leads the value."""
+    storage = _kv_storage()
+    await storage.initialize()
+
+    with patch("time.time", return_value=1_700_000_000):
+        await storage.upsert({"E": {"chunk_ids": ["c1"], "count": 1}})
+
+    raw = fake.store[f"{storage.final_namespace}:E"]
+    assert next(iter(json.loads(raw))) == "create_time"
+    assert raw.startswith('{"create_time"')
+
+
+@pytest.mark.asyncio
+async def test_update_reads_prefix_and_never_pulls_whole_value(fake):
+    """The optimization itself: GETRANGE only, no full GET.
+
+    Without this the fix still behaves correctly -- the fallback full read
+    produces the same timestamps -- so only a command-level assertion can tell
+    the fast path apart from a silently dead one.
+    """
+    storage = _kv_storage()
+    await storage.initialize()
+
+    with patch("time.time", return_value=1_700_000_000):
+        await storage.upsert({"E": {"chunk_ids": ["c1"], "count": 1}})
+
+    fake.command_counts.clear()
+    with patch("time.time", return_value=1_700_000_100):
+        await storage.upsert({"E": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+    assert fake.command_counts["getrange"] == 1
+    assert fake.command_counts["get"] == 0
+
+
+@pytest.mark.asyncio
+async def test_insert_reads_prefix_only(fake):
+    """A brand-new key must not trigger the legacy full-read fallback."""
+    storage = _kv_storage()
+    await storage.initialize()
+
+    fake.command_counts.clear()
+    with patch("time.time", return_value=1_700_000_300):
+        await storage.upsert({"new": {"chunk_ids": ["c9"], "count": 1}})
+
+    assert fake.command_counts["getrange"] == 1
+    assert fake.command_counts["get"] == 0
+    row = await storage.get_by_id("new")
+    assert row["create_time"] == 1_700_000_300
+    assert row["update_time"] == 1_700_000_300
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_with_trailing_create_time_falls_back_to_full_read(fake):
+    """A row written before the ordering existed keeps its real create_time."""
+    storage = _kv_storage()
+    await storage.initialize()
+
+    key = f"{storage.final_namespace}:legacy"
+    fake.store[key] = json.dumps(
+        {
+            "chunk_ids": ["c1"],
+            "count": 1,
+            "create_time": 1_650_000_000,
+            "update_time": 1_650_000_000,
+        }
+    )
+
+    fake.command_counts.clear()
+    with patch("time.time", return_value=1_700_000_200):
+        await storage.upsert({"legacy": {"chunk_ids": ["c1", "c2"], "count": 2}})
+
+    assert fake.command_counts["get"] == 1  # the fallback ran
+    row = await storage.get_by_id("legacy")
+    assert row["create_time"] == 1_650_000_000
+    assert row["update_time"] == 1_700_000_200
+
+    # ...and the row is rewritten in the prefix layout, so the next update
+    # takes the fast path.
+    fake.command_counts.clear()
+    with patch("time.time", return_value=1_700_000_400):
+        await storage.upsert({"legacy": {"chunk_ids": ["c3"], "count": 1}})
+    assert fake.command_counts["get"] == 0
+    assert _stored(fake, storage, "legacy")["create_time"] == 1_650_000_000
 
 
 @pytest.mark.asyncio
@@ -121,18 +220,84 @@ async def test_legacy_row_missing_create_time_keeps_zero(fake):
     assert row is not None
     assert row["create_time"] == 0
     assert row["update_time"] == 1_700_000_200
-    assert json.loads(fake.store[key])["create_time"] == 0
+    assert _stored(fake, storage, "legacy")["create_time"] == 0
 
 
 @pytest.mark.asyncio
-async def test_insert_stamps_both_timestamps(fake):
+async def test_legacy_float_create_time_is_normalized(fake):
+    """An older release could store time.time() unrounded."""
     storage = _kv_storage()
     await storage.initialize()
 
-    with patch("time.time", return_value=1_700_000_300):
-        await storage.upsert({"new": {"chunk_ids": ["c9"], "count": 1}})
+    key = f"{storage.final_namespace}:f"
+    fake.store[key] = json.dumps({"chunk_ids": ["c1"], "create_time": 1_650_000_000.75})
 
-    row = await storage.get_by_id("new")
-    assert row is not None
-    assert row["create_time"] == 1_700_000_300
-    assert row["update_time"] == 1_700_000_300
+    with patch("time.time", return_value=1_700_000_200):
+        await storage.upsert({"f": {"chunk_ids": ["c2"]}})
+
+    stored = _stored(fake, storage, "f")
+    assert stored["create_time"] == 1_650_000_000
+    assert isinstance(stored["create_time"], int)
+
+
+@pytest.mark.asyncio
+async def test_corrupt_row_records_zero_and_warns(fake, caplog):
+    """Undecodable storage is corruption, not a legacy shape: say so."""
+    storage = _kv_storage()
+    await storage.initialize()
+
+    fake.store[f"{storage.final_namespace}:c"] = "}} not json {{"
+
+    logger = logging.getLogger("lightrag")
+    previous = logger.propagate
+    logger.propagate = True  # lightrag's logger does not propagate by default
+    try:
+        with caplog.at_level(logging.WARNING, logger="lightrag"):
+            with patch("time.time", return_value=1_700_000_200):
+                await storage.upsert({"c": {"chunk_ids": ["c1"]}})
+    finally:
+        logger.propagate = previous
+
+    assert _stored(fake, storage, "c")["create_time"] == 0
+    assert any("not decodable JSON" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_create_time_ignored_on_update(fake):
+    storage = _kv_storage()
+    await storage.initialize()
+
+    with patch("time.time", return_value=1_700_000_000):
+        await storage.upsert({"E": {"chunk_ids": ["c1"]}})
+    with patch("time.time", return_value=1_700_000_100):
+        await storage.upsert({"E": {"chunk_ids": ["c2"], "create_time": 1}})
+
+    assert _stored(fake, storage, "E")["create_time"] == 1_700_000_000
+
+
+@pytest.mark.asyncio
+async def test_row_deleted_between_the_two_reads_is_an_insert(fake, monkeypatch):
+    """The fallback's second read can find the key already gone."""
+    storage = _kv_storage()
+    await storage.initialize()
+
+    key = f"{storage.final_namespace}:gone"
+    # Trailing create_time forces the two-phase path.
+    fake.store[key] = json.dumps({"x": 1, "create_time": 1_650_000_000})
+
+    original_apply = fake._apply
+
+    def apply_and_vanish(op):
+        result = original_apply(op)
+        if op[0] == "getrange" and op[1] == key:
+            fake.store.pop(key, None)
+        return result
+
+    monkeypatch.setattr(fake, "_apply", apply_and_vanish)
+
+    with patch("time.time", return_value=1_700_000_500):
+        await storage.upsert({"gone": {"x": 2}})
+
+    stored = _stored(fake, storage, "gone")
+    assert stored["create_time"] == 1_700_000_500
+    assert stored["update_time"] == 1_700_000_500


### PR DESCRIPTION
## What Problem
Replacement KV upserts were losing or resetting storage-managed `create_time` when callers sent business fields only (common for entity/relation chunk tracking). JsonKV and RedisKV dropped the field on full value replace; OpenSearch reset it via `setdefault(create_time, current_time)` on updates.

## Why
`create_time` should be assigned on first insert and stay stable. Mongo/Postgres already do this; Json/Redis/OpenSearch should match that invariant without merging stale business fields.

## How verified
- `pytest` create_time suites + TestKVStorage + json copy-on-read → 34 passed
- Covers insert then replacement without timestamps, create_time preserved, update_time advanced, legacy missing create_time → 0

Fixes #3870