### PR TITLE
fix(milvus): handle concurrent database creation race on first boot

### DIFF
--- a/lightrag/kg/milvus_impl.py
+++ b/lightrag/kg/milvus_impl.py
@@ -615,7 +615,22 @@ class MilvusVectorDBStorage(BaseVectorStorage):
             logger.warning(
                 f"[{self.workspace}] Milvus database '{db_name}' not found, creating it"
             )
-            client.create_database(db_name)
+            try:
+                client.create_database(db_name)
+            except MilvusException as e:
+                # Two or more workers can both see the database missing and race to
+                # create it; the loser must treat "already exists" as
+                # success rather than failing startup. Matching on the
+                # message (not the error code, which isn't consistently
+                # assigned across server versions) avoids a second
+                # list_databases() call, which could itself observe stale
+                # cluster metadata and re-raise despite the create having
+                # actually succeeded.
+                if "already exist" not in str(e).lower():
+                    raise
+                logger.debug(
+                    f"[{self.workspace}] Milvus database '{db_name}' already exists — continuing"
+                )
 
         use_database = getattr(client, "use_database", None) or getattr(
             client, "using_database", None

--- a/tests/kg/milvus_impl/test_milvus_index_creation.py
+++ b/tests/kg/milvus_impl/test_milvus_index_creation.py
@@ -9,9 +9,9 @@ This test suite validates:
 import asyncio
 import pytest
 from unittest.mock import MagicMock, patch
-from pymilvus import MilvusException
 from lightrag.kg.milvus_impl import (
     MILVUS_MAX_VARCHAR_BYTES,
+    MilvusException,
     MilvusIndexConfig,
     MilvusVectorDBStorage,
 )

--- a/tests/kg/milvus_impl/test_milvus_index_creation.py
+++ b/tests/kg/milvus_impl/test_milvus_index_creation.py
@@ -9,6 +9,7 @@ This test suite validates:
 import asyncio
 import pytest
 from unittest.mock import MagicMock, patch
+from pymilvus import MilvusException
 from lightrag.kg.milvus_impl import (
     MILVUS_MAX_VARCHAR_BYTES,
     MilvusIndexConfig,
@@ -66,6 +67,7 @@ def _make_model_storage(namespace="entities", workspace="test_workspace", dim=12
         workspace=workspace,
         global_config={
             "embedding_batch_num": 100,
+            "working_dir": "/tmp/lightrag",
             "vector_db_storage_cls_kwargs": {
                 "cosine_better_than_threshold": 0.3,
             },
@@ -938,6 +940,79 @@ class TestMilvusIndexCreation:
         bootstrap_client.list_databases.assert_called_once_with()
         bootstrap_client.create_database.assert_not_called()
         bootstrap_client.use_database.assert_called_once_with("lightrag")
+
+    def test_create_database_race_already_exists_is_swallowed(self):
+        """Two workers can both see the database missing and race to create it;
+        the loser's create_database('already exist') must not fail startup."""
+        storage = _make_model_storage()
+        bootstrap_client = MagicMock()
+        bootstrap_client.list_databases.return_value = ["default"]
+        bootstrap_client.create_database.side_effect = MilvusException(
+            message="Database already exist[database=lightrag]"
+        )
+
+        with patch.dict("os.environ", {"MILVUS_DB_NAME": "lightrag"}, clear=False):
+            with patch(
+                "lightrag.kg.milvus_impl.MilvusClient",
+                return_value=bootstrap_client,
+            ):
+                client = storage._create_milvus_client()
+
+        bootstrap_client.create_database.assert_called_once_with("lightrag")
+        bootstrap_client.use_database.assert_called_once_with("lightrag")
+        assert client is bootstrap_client
+
+    def test_create_database_race_message_match_is_case_insensitive(self):
+        storage = _make_model_storage()
+        bootstrap_client = MagicMock()
+        bootstrap_client.list_databases.return_value = ["default"]
+        bootstrap_client.create_database.side_effect = MilvusException(
+            message="Database Already Exists"
+        )
+
+        with patch.dict("os.environ", {"MILVUS_DB_NAME": "lightrag"}, clear=False):
+            with patch(
+                "lightrag.kg.milvus_impl.MilvusClient",
+                return_value=bootstrap_client,
+            ):
+                storage._create_milvus_client()
+
+        bootstrap_client.use_database.assert_called_once_with("lightrag")
+
+    def test_create_database_unrelated_milvus_exception_is_reraised(self):
+        """A genuine failure (not a create race) must still abort startup."""
+        storage = _make_model_storage()
+        bootstrap_client = MagicMock()
+        bootstrap_client.list_databases.return_value = ["default"]
+        bootstrap_client.create_database.side_effect = MilvusException(
+            message="permission denied"
+        )
+
+        with patch.dict("os.environ", {"MILVUS_DB_NAME": "lightrag"}, clear=False):
+            with patch(
+                "lightrag.kg.milvus_impl.MilvusClient",
+                return_value=bootstrap_client,
+            ):
+                with pytest.raises(MilvusException, match="permission denied"):
+                    storage._create_milvus_client()
+
+        bootstrap_client.use_database.assert_not_called()
+
+    def test_create_database_non_milvus_exception_is_not_swallowed(self):
+        """Only MilvusException is inspected for the race message; anything
+        else propagates unmodified."""
+        storage = _make_model_storage()
+        bootstrap_client = MagicMock()
+        bootstrap_client.list_databases.return_value = ["default"]
+        bootstrap_client.create_database.side_effect = RuntimeError("connection reset")
+
+        with patch.dict("os.environ", {"MILVUS_DB_NAME": "lightrag"}, clear=False):
+            with patch(
+                "lightrag.kg.milvus_impl.MilvusClient",
+                return_value=bootstrap_client,
+            ):
+                with pytest.raises(RuntimeError, match="connection reset"):
+                    storage._create_milvus_client()
 
     def test_existing_collection_missing_vector_index_is_repaired(self):
         """Existing collections missing vector indexes should be repaired automatically."""


### PR DESCRIPTION
<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

Fixes a crash-on-first-boot (`MilvusException: database already exist`,
Milvus server error code `65535`) that any multi-process LightRAG deployment
(Kubernetes `replicas > 1`, or any second instance started concurrently
against the same fresh Milvus) can hit when
[`MilvusVectorDBStorage._create_milvus_client`](https://github.com/HKUDS/LightRAG/blob/ab2e08fb191179f28ae2ea4c207ee2fcd826f9cb/lightrag/kg/milvus_impl.py#L603-L630)
races on Milvus's non-atomic `list_databases()`-then-`create_database()`
check.

## Related Issues

Fixes [#3875](https://github.com/HKUDS/LightRAG/issues/3875)

## Changes Made

- `MilvusVectorDBStorage._create_milvus_client` now wraps
  `client.create_database(db_name)` in a `try/except MilvusException`,
  treating a case-insensitive `"already exist"` substring match against the
  exception's message as benign, and re-raising any other `MilvusException`
  unchanged. The match is on the message rather than `MilvusException.code`
  because the numeric code for this condition isn't consistently assigned
  across Milvus server versions, and re-verifying via a second
  `list_databases()` call risks observing stale cluster metadata and
  re-raising even though the create actually succeeded.
- Added four regression tests to `tests/kg/milvus_impl/test_milvus_index_creation.py`:
  - `test_create_database_race_already_exists_is_swallowed` — a
    `create_database` call raising an "already exist" `MilvusException`
    must not fail `_create_milvus_client()`.
  - `test_create_database_race_message_match_is_case_insensitive` — the
    match tolerates the server's varying capitalization of the message.
  - `test_create_database_unrelated_milvus_exception_is_reraised` — any
    *other* `MilvusException` (e.g. a permission error) from
    `create_database` must still propagate, so the fix narrowly targets the
    known race and doesn't swallow genuine errors.
  - `test_create_database_non_milvus_exception_is_not_swallowed` — a
    non-`MilvusException` error (e.g. a connection reset) is never
    inspected for the race message and always propagates unmodified.

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation updated (if necessary) — N/A, no behavior/API change on
      the non-race path
- [x] Unit tests added (if applicable)

## Additional Notes

**Root cause**: `list_databases()` then `create_database()` is not atomic on
the Milvus server. Any deployment starting more than one LightRAG process
against the same fresh Milvus database name can have two processes both
observe the database as absent and both call `create_database()`; the loser
receives error code `65535` ("database already exist"), which currently
propagates uncaught through `initialize_storages()` and kills that process.
On any later restart the database already exists, so the race window only
appears on a genuinely fresh volume.

**Verification**: reproduced independently using the official 
`ghcr.io/hkuds/lightrag:latest` image against a fresh, official Milvus standalone 
stack (two replicas started at once) — one replica crashed with the exact traceback 
this PR fixes, while the surviving replica (identical image/config) booted cleanly, 
ruling out a configuration issue. Re-verified against the patched code (`uv run
lightrag-server`, two processes, same fresh Milvus): one process hit the
identical `MilvusException` the "before" run crashed on, and both processes
now complete `Application startup complete.` and return `200` from
`/health`. `ruff check` / `ruff format --check` pass on both changed files,
and `tests/kg/milvus_impl/test_milvus_index_creation.py` passes in full (46
tests, including the 4 new ones). 