### PR TITLE
Fix commit ordering for entity/relation creation to prevent data loss

### DIFF
--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1580,6 +1580,22 @@ holds for any mix of backends, including a deferred graph with an immediate-writ
 tracking store, which is why the staging is by *durability* rather than by call
 order.
 
+That one-directional rule — **a graph object must never be durable while the
+tracking row carrying its attribution is not** — governs the other admin paths
+too, and it makes their commit order the mirror of the deletion order. On a
+create or an edit the row is the half that starts out absent, so
+`_persist_graph_updates` commits the tracking rows first and the graph and
+vector stores second. A failure in the first phase skips the second entirely: a
+tracking commit that did not land is never followed by publishing the object it
+describes. Both directions therefore converge on the same tolerated residue, a
+row whose object is not (or no longer) in the graph.
+
+Callers writing directly against `lightrag.utils_graph` inherit that contract.
+A helper that *removes* a tracking row must commit the graph itself first via
+`_commit_graph_or_raise` and only then flush the tracking stores; passing a
+graph store and a tracking store to `_persist_graph_updates` together is
+correct only in the add/update direction.
+
 Removing the object and cleaning up its rows is additionally one region a
 cancellation cannot cut in half. It has to begin at the graph mutation: a cancel
 before the commit leaves the removal in the in-memory graph with the backend
@@ -1606,6 +1622,42 @@ deletion is always the recovery step:
 | A failing tracking delete leaves incident relation rows of an entity deletion | Entity gone, relation rows stale | Not reachable automatically — the node is gone, so its edges are unknowable. Logged with the exact storage keys; delete the relation directly to sweep its row, or run the [chunk-tracking repair](#repairing-chunk-tracking) |
 | The cleanup never runs although the graph commit landed — process exit before a **deferred** tracking backend (JSON) flushes, or a direct cancellation of the deletion task mid-write | Entity gone, its rows and its relations' rows stale | The entity's own row is swept by a repeated deletion; its incident relation rows are not, and their keys are not logged because nothing failed — so there is nothing to delete directly *by*. The recovery is the [chunk-tracking repair](#repairing-chunk-tracking). Not closed by this staging: neither a hard process exit nor a cancellation carries evidence about what landed. A commit notification that raises *after* the write does, and no longer reaches this row — it arrives as `CommitBookkeepingError` and `_commit_graph_or_raise` continues with the cleanup |
 | Vector flush | Entity and rows gone, vector record stale | The rebuildable window this codebase accepts elsewhere; `lightrag-rebuild-vdb` restores it |
+
+#### Concurrent admin writes
+
+The graph mutation endpoints (`/graph/entity/*`, `/graph/relation/*`) refuse a
+request with HTTP 409 while the document pipeline is busy, so an admin write
+never overlaps ingestion except in the narrow window between that snapshot check
+and the underlying write. Holding the pipeline's `busy` flag across a UI edit
+would close that window and is deliberately not done — it would serialize every
+edit against ingestion.
+
+Two admin writes are **not** serialized against each other. Each takes only a
+per-entity or per-edge keyed lock, so two calls for different keys run
+concurrently. On a file-backed workspace this matters because a commit there
+publishes the whole namespace: one caller's flush makes another caller's
+unfinished in-memory state durable.
+
+What that can leave behind, and why it is tolerated:
+
+- Two admin writes overlapping *in time* on different workers are caught by the
+  reload fence: the losing writer declines its commit, the caller gets a 500,
+  and retrying re-applies the edit against the peer's snapshot. Loud, and
+  recoverable by the operator.
+- A hard process exit can leave a tracking row whose graph object never became
+  durable. That row is harmless to queries, cannot be inherited as evidence by a
+  later object (the explicit creation paths reset attribution), and is removed by
+  the [chunk-tracking repair](#repairing-chunk-tracking).
+- The forbidden mirror — an object durable without its row — is not produced by
+  a single-writer crash, because of the commit order above.
+
+A workspace-wide admin lock was specified and dropped: it would not have changed
+what a crash can leave behind, since the same residue is reachable with no
+concurrency at all. If you drive the public Python admin API yourself
+(`acreate_entity`, `aedit_entity`, `amerge_entities`, `adelete_by_entity` and
+their relation counterparts) **do not call them concurrently on a file-backed
+workspace** — one at a time, or use a server-backed graph and KV store.
+`ainsert_custom_kg` is subject to the same rule.
 
 #### Repairing chunk tracking
 

--- a/lightrag/kg/faiss_impl.py
+++ b/lightrag/kg/faiss_impl.py
@@ -305,9 +305,16 @@ class FaissVectorDBStorage(BaseVectorStorage):
         and must be guarded externally:
             * ``drop`` — gated by the API layer (``/documents/clear``
               takes the pipeline busy reservation before invoking it).
-            * ``delete_entity`` / ``delete_entity_relation`` — currently
-              not exposed in the WebUI. Any future caller must arrange
-              single-writer serialization the same way the pipeline does.
+            * ``delete_entity`` / ``delete_entity_relation`` — reached
+              from the ``utils_graph.py`` admin flows, which the WebUI does
+              exercise (the ``/graph/*`` endpoints). Admin-vs-pipeline is
+              guarded by ``check_pipeline_busy_or_raise``; admin-vs-admin is
+              not, and deliberately stays that way — see the *Non-pipeline
+              write paths* section of ``NetworkXStorage`` for the accepted
+              residue and issue #3838 for the reasoning.
+
+        As in ``NanoVectorDBStorage``, a flush publishes every pending
+        upsert buffered in this instance, not only the caller's.
     """
 
     def __post_init__(self):

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -99,6 +99,29 @@ class JsonKVStorage(BaseKVStorage):
               dict outside the lock (it only mutates the input, not the
               shared store).
 
+    Commit granularity — a commit publishes the whole namespace:
+        ``index_done_callback`` snapshots the entire ``_data`` dict and
+        rewrites the whole JSON file. There is no scoped or transactional
+        commit, and issue #3838 rejects adding one for the file-backed
+        storages. So **any writer's flush durably publishes every other
+        writer's pending in-memory mutation in this namespace.**
+
+        This matters most for the chunk-tracking namespaces
+        (``entity_chunks`` / ``relation_chunks``), whose rows are the
+        authoritative attribution carriers behind
+        ``_purge_kg_contributions``: a row and the graph object it describes
+        live in different stores with no transaction between them, and the
+        forbidden ordering is the object durable without the row.
+        ``utils_graph._persist_graph_updates`` commits the rows first for
+        exactly that reason; a co-tenant's flush can still publish a row
+        early, which lands in the benign direction. See the *Non-pipeline
+        write paths* section of ``NetworkXStorage`` for the full residue.
+
+        Scope decision (issue #3838): this backend is supported for
+        small-scale testing and validation only, so the cost of the
+        whole-file rewrite is not a consideration and no change here may be
+        justified by it.
+
     Who can write:
         Pipeline ``busy`` still serializes the document ingest / purge
         flows, but the *file-flush trigger* is symmetric: any process

--- a/lightrag/kg/nano_vector_db_impl.py
+++ b/lightrag/kg/nano_vector_db_impl.py
@@ -178,10 +178,22 @@ class NanoVectorDBStorage(BaseVectorStorage):
             * ``drop`` — currently gated by the API layer (the
               ``/documents/clear`` endpoint takes the pipeline busy
               reservation before invoking it).
-            * ``delete_entity`` / ``delete_entity_relation`` — currently
-              not exposed in the WebUI. If you wire them up to a new
-              caller, that caller must arrange single-writer
-              serialization the same way the pipeline does.
+            * ``delete_entity`` / ``delete_entity_relation`` — reached
+              from the ``utils_graph.py`` admin flows, which the WebUI does
+              exercise (``/graph/entity/edit`` and the other ``/graph/*``
+              endpoints). Admin-vs-pipeline is guarded by
+              ``check_pipeline_busy_or_raise``; admin-vs-admin is not, and
+              deliberately stays that way — see the *Non-pipeline write
+              paths* section of ``NetworkXStorage`` for the accepted residue
+              and issue #3838 for why a workspace-wide admin lock was
+              specified and then dropped.
+
+        A flush here publishes every pending upsert buffered in this
+        instance, not only the caller's, so a co-tenant's unfinished
+        sequence can become durable on someone else's commit. Unlike the
+        graph store this class loses nothing to it (a peer commit is
+        reloaded and the pending buffer and redo log replayed on top), but
+        the *timing* is still not the caller's to choose.
 
     Deferred-embedding protocol:
         ``upsert`` does **not** call the embedding model. It only buffers a

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -288,21 +288,79 @@ class NetworkXStorage(BaseGraphStorage):
         to add a value after the check and before ``add_node`` /
         ``add_edge`` consumes it.
 
+    Commit granularity — a commit publishes the whole namespace:
+        ``index_done_callback`` serializes ``self._graph`` in full and
+        renames the result over the GraphML file. There is no scoped or
+        transactional commit, and none is planned (issue #3838 rejects one
+        for the file-backed storages explicitly). Two consequences the
+        callers have to live with:
+
+        * **Any writer's flush durably publishes every other writer's
+          pending in-memory mutation in this namespace**, including partial
+          state its author had not finished. A caller that stages its own
+          writes to guarantee an ordering guarantees it only for its own
+          objects; a co-tenant's half-applied sequence rides along.
+        * The pipeline tolerates this, because ``doc_status`` plus
+          idempotent FAILED reprocessing rewrites whatever a restart finds
+          half-applied. The admin flows below have no equivalent, which is
+          what makes their residue worth stating rather than assuming away.
+
+    Scope decision (issue #3838):
+        This backend — like ``JsonKVStorage`` / ``JsonDocStatusStorage`` /
+        ``NanoVectorDBStorage`` / ``FaissVectorDBStorage`` — is supported for
+        **small-scale testing and validation only**. Production deployments
+        run a server-backed graph store. Write throughput of the whole-file
+        commit path is therefore not a consideration, and no change to this
+        file may be justified by — or blocked on — it.
+
     Non-pipeline write paths:
         The pipeline's ``busy`` gate serializes mutation calls reached
         through the document ingestion and purge flows. The following
-        entry points are **not** serialized by the pipeline gate and
-        must be guarded externally:
-            * ``drop`` — currently gated by the API layer (the
-              ``/documents/clear`` endpoint takes the pipeline busy
-              reservation before invoking it).
+        entry points are **not** serialized by the pipeline gate:
+            * ``drop`` — gated by the API layer (the ``/documents/clear``
+              endpoint takes the pipeline busy reservation before invoking
+              it).
             * ``delete_node`` / ``remove_nodes`` / ``remove_edges`` /
-              ``upsert_node`` / ``upsert_edge`` when invoked from
+              ``upsert_node`` / ``upsert_edge`` when invoked from the
               ``utils_graph.py`` admin flows (``adelete_by_entity`` /
-              ``adelete_by_relation`` / entity-edit flows). These flows
-              are currently not exposed in the WebUI; any future caller
-              must arrange single-writer serialization the same way the
-              pipeline does.
+              ``adelete_by_relation`` / the create, edit and merge paths).
+
+        For the admin flows, invariant 1 is **not** met and is not going to
+        be. Stating it accurately, because the previous wording ("must be
+        guarded externally", plus a claim that the flows are not exposed in
+        the WebUI) was false on both counts — the WebUI calls
+        ``/graph/entity/edit``:
+
+        * Admin-vs-pipeline **is** guarded: every graph mutation endpoint
+          calls ``check_pipeline_busy_or_raise`` and returns 409 while the
+          pipeline is busy. That check is a snapshot, so a narrow race with
+          the underlying write remains; closing it would mean holding
+          ``busy`` across every UI edit, which is deliberately rejected.
+        * Admin-vs-admin is **not** guarded. Two concurrent
+          ``/graph/*`` calls for different keys both pass the busy check and
+          proceed under different per-entity keyed locks. A workspace-wide
+          admin lock was specified (issue #3838 R3) and then dropped: with
+          the reload fence of issue #3854 in place the losing writer of an
+          overlapping pair *declines*, so the caller gets a loud 500 and
+          retries rather than losing the write silently; and the residue the
+          lock would have prevented is reachable with no concurrency at all,
+          so serializing admin writes would not have changed what a crash can
+          leave behind.
+
+        **Accepted residue.** A hard process exit, or an ill-timed co-tenant
+        flush, can leave a chunk-tracking row whose graph object never became
+        durable. It is harmless to queries; it cannot be inherited as
+        evidence by a later object, because the explicit creation paths reset
+        attribution (issue #3838 R1); and it is repairable offline with the
+        chunk-tracking rebuild tool (R4). The mirror state — a graph object
+        durable without its tracking row — is the forbidden one, and
+        ``utils_graph._persist_graph_updates`` is ordered so no single-writer
+        crash produces it.
+
+        **Requirement on new callers.** Any new caller of these mutators
+        must keep tracking rows ahead of the objects they describe, the way
+        ``_persist_graph_updates`` does, and must not be invoked
+        concurrently with another admin writer on a file-backed workspace.
     """
 
     def _node_context(self, node_id: str) -> str:

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -525,6 +525,13 @@ async def adelete_by_entity(
         entity_name: Name of the entity to delete
         entity_chunks_storage: Optional KV storage for tracking chunks that reference this entity
         relation_chunks_storage: Optional KV storage for tracking chunks that reference relations
+
+    Concurrency (issue #3838): admin writes are serialized against the document
+    pipeline (HTTP 409 while it is busy) but **not against each other**. On a
+    file-backed workspace a commit publishes the whole namespace, so two admin
+    calls running at once can publish each other's unfinished state. Call the
+    admin API one operation at a time there, or use a server-backed graph and KV
+    store. See ``docs/ProgramingWithCore.md`` for the accepted residue.
     """
     # Use keyed lock for entity to ensure atomic graph and vector db operations.
     # The doc-ingest pipeline locks edges under sorted([src, tgt]) in this same
@@ -710,6 +717,13 @@ async def adelete_by_relation(
         source_entity: Name of the source entity
         target_entity: Name of the target entity
         relation_chunks_storage: Optional KV storage for tracking chunks that reference this relation
+
+    Concurrency (issue #3838): admin writes are serialized against the document
+    pipeline (HTTP 409 while it is busy) but **not against each other**. On a
+    file-backed workspace a commit publishes the whole namespace, so two admin
+    calls running at once can publish each other's unfinished state. Call the
+    admin API one operation at a time there, or use a server-backed graph and KV
+    store. See ``docs/ProgramingWithCore.md`` for the accepted residue.
     """
     relation_str = f"{source_entity} -> {target_entity}"
     # Normalize entity order for undirected graph (ensures consistent key generation)
@@ -1297,6 +1311,13 @@ async def aedit_entity(
             - "success": Entity successfully merged into target
             - "failed": Merge operation failed
             - "not_attempted": No merge was attempted (normal update/rename)
+
+    Concurrency (issue #3838): admin writes are serialized against the document
+    pipeline (HTTP 409 while it is busy) but **not against each other**. On a
+    file-backed workspace a commit publishes the whole namespace, so two admin
+    calls running at once can publish each other's unfinished state. Call the
+    admin API one operation at a time there, or use a server-backed graph and KV
+    store. See ``docs/ProgramingWithCore.md`` for the accepted residue.
     """
     # Order matters: the empty-description check runs first so a `None`
     # description keeps reporting itself as empty (which is what it means to a
@@ -1557,6 +1578,13 @@ async def aedit_relation(
 
     Returns:
         Dictionary containing updated relation information
+
+    Concurrency (issue #3838): admin writes are serialized against the document
+    pipeline (HTTP 409 while it is busy) but **not against each other**. On a
+    file-backed workspace a commit publishes the whole namespace, so two admin
+    calls running at once can publish each other's unfinished state. Call the
+    admin API one operation at a time there, or use a server-backed graph and KV
+    store. See ``docs/ProgramingWithCore.md`` for the accepted residue.
     """
     # See `aedit_entity` for the ordering rationale.
     if "description" in updated_data:
@@ -1797,6 +1825,13 @@ async def acreate_entity(
 
     Returns:
         Dictionary containing created entity information
+
+    Concurrency (issue #3838): admin writes are serialized against the document
+    pipeline (HTTP 409 while it is busy) but **not against each other**. On a
+    file-backed workspace a commit publishes the whole namespace, so two admin
+    calls running at once can publish each other's unfinished state. Call the
+    admin API one operation at a time there, or use a server-backed graph and KV
+    store. See ``docs/ProgramingWithCore.md`` for the accepted residue.
     """
     _require_non_empty_description(
         entity_data.get("description"), operation="create", object_type="entity"
@@ -1971,6 +2006,13 @@ async def acreate_relation(
 
     Returns:
         Dictionary containing created relation information
+
+    Concurrency (issue #3838): admin writes are serialized against the document
+    pipeline (HTTP 409 while it is busy) but **not against each other**. On a
+    file-backed workspace a commit publishes the whole namespace, so two admin
+    calls running at once can publish each other's unfinished state. Call the
+    admin API one operation at a time there, or use a server-backed graph and KV
+    store. See ``docs/ProgramingWithCore.md`` for the accepted residue.
     """
     _require_non_empty_description(
         relation_data.get("description"), operation="create", object_type="relation"
@@ -2903,6 +2945,13 @@ async def amerge_entities(
 
     Returns:
         Dictionary containing the merged entity information
+
+    Concurrency (issue #3838): admin writes are serialized against the document
+    pipeline (HTTP 409 while it is busy) but **not against each other**. On a
+    file-backed workspace a commit publishes the whole namespace, so two admin
+    calls running at once can publish each other's unfinished state. Call the
+    admin API one operation at a time there, or use a server-backed graph and KV
+    store. See ``docs/ProgramingWithCore.md`` for the accepted residue.
     """
     if not source_entities:
         raise ValueError("At least one source entity is required for merge")

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -289,6 +289,41 @@ async def _persist_graph_updates(
     tracking rows the retry would then believe it still owed. Every other
     exception still propagates: those mean the flush did not happen.
 
+    Commit order (issue #3838) -- the tracking rows are committed BEFORE the
+    graph, in two phases:
+
+        1. ``entity_chunks_storage`` / ``relation_chunks_storage``
+        2. ``chunk_entity_relation_graph`` and the vector stores
+
+    The invariant behind the split is one-directional: **a graph object must
+    never be durable while the tracking row that carries its attribution is
+    not.** With the row absent, the union in ``_purge_kg_contributions``
+    degrades to the KEEP-truncated graph ``source_id``, from which a later
+    document purge can conclude "no remaining sources" and delete an entity
+    other documents still reference -- the one over-deletion direction this
+    module exists to prevent. Flushing every store in one ``asyncio.gather``
+    left that outcome to whichever write the interpreter finished first, so a
+    hard process exit inside a *single, uncontended* ``acreate_entity`` could
+    put it on disk; no concurrency and no co-tenant flush were required.
+
+    The residue the order accepts instead is the mirror one -- a tracking row
+    whose object never became durable. It is the same state ``adelete_by_entity``
+    already stages for and documents: harmless to queries, unable to be
+    inherited by a new object (issue #3838 R1 resets evidence on explicit
+    creation), and repairable with the offline chunk-tracking rebuild.
+
+    Phase 1 failing skips phase 2 entirely, which is the point: a tracking
+    commit that did not land must not be followed by publishing the object it
+    describes.
+
+    Contract for callers, because the order is only correct in one direction:
+    this helper is for callers that ADD or UPDATE a tracking row. A caller that
+    REMOVES one must commit the graph itself first -- ``_commit_graph_or_raise``
+    -- and only then call this helper with the tracking storages alone, so the
+    removal lands in the same benign direction. Every deletion path in this
+    module already does exactly that, which is why none of them passes
+    ``chunk_entity_relation_graph`` and a tracking storage together.
+
     Args:
         entities_vdb: Entity vector database storage (optional)
         relationships_vdb: Relationship vector database storage (optional)
@@ -296,19 +331,6 @@ async def _persist_graph_updates(
         entity_chunks_storage: Entity-chunk tracking storage (optional)
         relation_chunks_storage: Relation-chunk tracking storage (optional)
     """
-    storages = []
-
-    # Collect all non-None storage instances
-    if entities_vdb is not None:
-        storages.append(entities_vdb)
-    if relationships_vdb is not None:
-        storages.append(relationships_vdb)
-    if chunk_entity_relation_graph is not None:
-        storages.append(chunk_entity_relation_graph)
-    if entity_chunks_storage is not None:
-        storages.append(entity_chunks_storage)
-    if relation_chunks_storage is not None:
-        storages.append(relation_chunks_storage)
 
     async def _flush(storage_inst) -> None:
         try:
@@ -322,9 +344,28 @@ async def _persist_graph_updates(
                 "commit.",
             )
 
-    # Persist all storage instances in parallel
-    if storages:
-        await asyncio.gather(*[_flush(storage_inst) for storage_inst in storages])
+    # Phase 1: attribution carriers.
+    tracking_storages = [
+        storage_inst
+        for storage_inst in (entity_chunks_storage, relation_chunks_storage)
+        if storage_inst is not None
+    ]
+    # Phase 2: the objects those rows describe, plus their vector records.
+    object_storages = [
+        storage_inst
+        for storage_inst in (
+            entities_vdb,
+            relationships_vdb,
+            chunk_entity_relation_graph,
+        )
+        if storage_inst is not None
+    ]
+
+    # Within a phase the order is unconstrained, so they still flush in
+    # parallel; only the boundary between the two phases is ordered.
+    for phase in (tracking_storages, object_storages):
+        if phase:
+            await asyncio.gather(*[_flush(storage_inst) for storage_inst in phase])
 
 
 async def _finish_deferring_cancellation(coro, description: str) -> None:

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -111,6 +111,11 @@ class _VectorStorage:
     async def delete(self, ids):
         self._check()
 
+    async def upsert(self, data):
+        # Creation paths write through the vector store before the commit; the
+        # deletion cases never reach this, so it stays a bare success stub.
+        self._check()
+
     async def delete_entity(self, entity_name):
         self._check()
 
@@ -1048,3 +1053,213 @@ class TestPublishedCommitSurvivesABrokenSink:
 
         assert result.status == "success"
         assert ENTITY not in rag.entity_chunks.records
+
+
+NEW_ENTITY = "CASSIOPEIA"
+NEW_RELATION_KEY = make_relation_chunk_key(*sorted([NEW_ENTITY, OTHER]))
+
+
+@pytest.fixture
+async def creating(tmp_path):
+    """Real NetworkX graph plus deferred-commit tracking doubles, for creation.
+
+    Same shape as the ``deferred`` fixture, but the object under test does not
+    exist yet: creation is the only direction in which a tracking row goes from
+    absent to present, which is what makes its commit order load-bearing.
+    """
+    fixture = _Fixture(tmp_path)
+    fixture.commit_log: list[str] = []
+    fixture.entity_chunks = _DeferredKVStorage("entity_chunks", fixture.commit_log)
+    fixture.relation_chunks = _DeferredKVStorage("relation_chunks", fixture.commit_log)
+    await fixture.start()
+    await fixture.entity_chunks.index_done_callback()
+    await fixture.relation_chunks.index_done_callback()
+    fixture.commit_log.clear()
+    yield fixture
+    await fixture.graph.finalize()
+
+
+async def _create_entity(fixture, name=NEW_ENTITY):
+    return await utils_graph.acreate_entity(
+        fixture.graph,
+        fixture.entities_vdb,
+        fixture.relationships_vdb,
+        name,
+        {"description": "d", "entity_type": "thing", "source_id": "chunk-9"},
+        entity_chunks_storage=fixture.entity_chunks,
+        relation_chunks_storage=fixture.relation_chunks,
+    )
+
+
+async def _create_relation(fixture, source=NEW_ENTITY, target=OTHER):
+    return await utils_graph.acreate_relation(
+        fixture.graph,
+        fixture.entities_vdb,
+        fixture.relationships_vdb,
+        source,
+        target,
+        {"description": "d", "weight": 1.0, "source_id": "chunk-9"},
+        relation_chunks_storage=fixture.relation_chunks,
+    )
+
+
+class TestCreationCommitsTrackingBeforeTheObject:
+    """The mirror of `TestDurableCommitOrdering`, for the creation direction.
+
+    Deletion commits the graph first because that is the order which leaves the
+    benign residue (a row whose object is gone). Creation must commit the row
+    first for exactly the same reason: the forbidden state is an object durable
+    without the row that carries its attribution, and on creation the row is the
+    half that starts out absent.
+
+    The two order tests and the two "never starts" tests are fix proofs: they go
+    red on the previous single `asyncio.gather`, which started every commit at
+    once and so left it to the interpreter whether the node or its row reached
+    disk first. No concurrency and no co-tenant flush were needed to lose that
+    race -- one uncontended `acreate_entity` and a hard exit was enough.
+
+    `test_accepted_residue_is_the_row_without_the_object` is not a fix proof;
+    the unordered flush produced that residue too. It pins the state the chosen
+    order deliberately keeps, so a later reshuffle cannot quietly trade it for
+    its forbidden mirror.
+    """
+
+    @pytest.mark.asyncio
+    async def test_entity_creation_commits_the_row_first(self, creating, monkeypatch):
+        _log_graph_commit(creating, monkeypatch, fail=False)
+
+        await _create_entity(creating)
+
+        assert creating.commit_log[0] == "entity_chunks"
+        assert creating.commit_log.index("entity_chunks") < creating.commit_log.index(
+            "graph"
+        )
+        assert NEW_ENTITY in creating.entity_chunks.disk
+
+    @pytest.mark.asyncio
+    async def test_relation_creation_commits_the_row_first(self, creating, monkeypatch):
+        _log_graph_commit(creating, monkeypatch, fail=False)
+        await creating.graph.upsert_node(
+            NEW_ENTITY, {"entity_id": NEW_ENTITY, "description": "d", "source_id": "s"}
+        )
+
+        await _create_relation(creating)
+
+        assert creating.commit_log.index("relation_chunks") < creating.commit_log.index(
+            "graph"
+        )
+        assert NEW_RELATION_KEY in creating.relation_chunks.disk
+
+    @pytest.mark.asyncio
+    async def test_tracking_commit_failure_never_publishes_the_entity(
+        self, creating, monkeypatch
+    ):
+        # Asserting only "the node is not in GraphML" would pass on the pre-fix
+        # gather too, for the wrong reason: the tracking commit raises out of
+        # the gather before the graph task finishes its write. What actually
+        # separates the two is whether the object commit was ever ENTERED --
+        # in a real process it is offloaded, so once entered it lands.
+        _log_graph_commit(creating, monkeypatch, fail=False)
+        creating.entity_chunks.fail_commit_times = 1
+
+        with pytest.raises(_Boom):
+            await _create_entity(creating)
+
+        assert "graph" not in creating.commit_log
+        assert NEW_ENTITY not in creating.entity_chunks.disk
+        persisted = creating.persisted_graph()
+        assert persisted.has_node(NEW_ENTITY) is False
+
+    @pytest.mark.asyncio
+    async def test_tracking_commit_failure_never_publishes_the_relation(
+        self, creating, monkeypatch
+    ):
+        _log_graph_commit(creating, monkeypatch, fail=False)
+        await creating.graph.upsert_node(
+            NEW_ENTITY, {"entity_id": NEW_ENTITY, "description": "d", "source_id": "s"}
+        )
+        creating.relation_chunks.fail_commit_times = 1
+
+        with pytest.raises(_Boom):
+            await _create_relation(creating)
+
+        assert "graph" not in creating.commit_log
+        assert NEW_RELATION_KEY not in creating.relation_chunks.disk
+        persisted = creating.persisted_graph()
+        assert persisted.has_edge(NEW_ENTITY, OTHER) is False
+
+    @pytest.mark.asyncio
+    async def test_accepted_residue_is_the_row_without_the_object(
+        self, creating, monkeypatch
+    ):
+        # The mirror residue the order deliberately keeps: the row is durable
+        # while the object never became so. Harmless to queries, not inheritable
+        # (R1 resets evidence on explicit creation), repairable offline.
+        _log_graph_commit(creating, monkeypatch, fail=True)
+
+        with pytest.raises(_Boom):
+            await _create_entity(creating)
+
+        assert NEW_ENTITY in creating.entity_chunks.disk
+        persisted = creating.persisted_graph()
+        assert persisted.has_node(NEW_ENTITY) is False
+
+
+class TestDeletionOrderIsUnchanged:
+    """The deletion direction must keep committing the graph first.
+
+    `TestDurableCommitOrdering` already pins this, but the two-phase split is
+    only correct because every deletion path commits the graph itself and then
+    calls `_persist_graph_updates` with the tracking storages alone. This pins
+    that call-shape contract directly, so a future caller that hands the helper
+    a graph and a tracking store together in the removal direction is caught
+    here rather than in production.
+    """
+
+    @pytest.mark.asyncio
+    async def test_persist_helper_orders_tracking_before_graph(self):
+        log: list[str] = []
+
+        class _Store:
+            def __init__(self, name):
+                self.name = name
+                self.namespace = name
+
+            async def index_done_callback(self):
+                await asyncio.sleep(0)
+                log.append(self.name)
+
+        await utils_graph._persist_graph_updates(
+            entities_vdb=_Store("entities_vdb"),
+            chunk_entity_relation_graph=_Store("graph"),
+            entity_chunks_storage=_Store("entity_chunks"),
+            relation_chunks_storage=_Store("relation_chunks"),
+        )
+
+        assert set(log[:2]) == {"entity_chunks", "relation_chunks"}
+        assert set(log[2:]) == {"entities_vdb", "graph"}
+
+    @pytest.mark.asyncio
+    async def test_no_deletion_path_passes_graph_and_tracking_together(self, deferred):
+        # `adelete_by_entity` commits the graph through `_commit_graph_or_raise`
+        # and only then flushes tracking, so the helper never sees both.
+        seen: list[dict] = []
+        original = utils_graph._persist_graph_updates
+
+        async def _record(**kwargs):
+            seen.append({k: v is not None for k, v in kwargs.items()})
+            return await original(**kwargs)
+
+        utils_graph._persist_graph_updates = _record
+        try:
+            await deferred.delete_entity()
+        finally:
+            utils_graph._persist_graph_updates = original
+
+        assert seen
+        for call in seen:
+            graph_passed = call.get("chunk_entity_relation_graph", False)
+            tracking_passed = call.get("entity_chunks_storage", False) or call.get(
+                "relation_chunks_storage", False
+            )
+            assert not (graph_passed and tracking_passed)


### PR DESCRIPTION
## Description

This PR fixes a critical data loss bug in entity and relation creation by ensuring tracking rows are committed to durable storage before the graph objects they describe. The fix mirrors the existing deletion path ordering and prevents a forbidden state where a graph object is durable without its attribution tracking row.

## Related Issues

Issue #3838 - Commit ordering and residue handling for graph mutations

## Changes Made

### Core Fix: `lightrag/utils_graph.py`
- **Reordered `_persist_graph_updates` to commit in two phases:**
  1. **Phase 1 (tracking rows first):** `entity_chunks_storage` and `relation_chunks_storage`
  2. **Phase 2 (objects second):** `entities_vdb`, `relationships_vdb`, and `chunk_entity_relation_graph`
- Within each phase, stores still flush in parallel; only the boundary between phases is ordered
- Phase 1 failure now skips Phase 2 entirely, preventing object publication without tracking attribution
- Added comprehensive documentation explaining the invariant: "a graph object must never be durable while the tracking row that carries its attribution is not"
- Added concurrency warnings to `acreate_entity`, `acreate_relation`, `aedit_entity`, `aedit_relation`, `adelete_by_entity`, `adelete_by_relation`, and `amerge_entities` docstrings

### Documentation: `docs/ProgramingWithCore.md`
- Documented the one-directional commit ordering rule for all admin paths (create, edit, delete, merge)
- Explained the accepted residue: a tracking row whose object never became durable (harmless, non-inheritable, repairable)
- Clarified that admin-vs-pipeline writes are guarded by `check_pipeline_busy_or_raise`, but admin-vs-admin writes are not serialized
- Documented why a workspace-wide admin lock was rejected: it wouldn't prevent the residue reachable with no concurrency
- Added guidance for direct API users: don't call admin functions concurrently on file-backed workspaces

### Storage Backend Documentation
- **`lightrag/kg/networkx_impl.py`:** Documented commit granularity (whole-namespace publishes), scope decision (testing/validation only), and the accepted residue for concurrent admin writes
- **`lightrag/kg/json_kv_impl.py`:** Documented whole-file rewrite semantics and co-tenant flush implications
- **`lightrag/kg/nano_vector_db_impl.py`:** Clarified that admin flows do exercise these paths and documented the timing implications
- **`lightrag/kg/faiss_impl.py`:** Similar clarifications about admin flow exposure and flush semantics

### Tests: `tests/pipeline/test_graph_deletion_tracking_ordering.py`
- Added `upsert` stub method to `_DeferredKVStorage` test double
- Added `creating` fixture for testing creation paths with deferred-commit tracking
- Added `TestCreationCommitsTrackingBeforeTheObject` class with 5 tests:
  - `test_entity_creation_commits_the_row_first`: Verifies entity tracking row commits before graph
  - `test_relation_creation_commits_the_row_first`: Verifies relation tracking row commits before graph
  - `test_tracking_commit_failure_never_publishes_the_entity`: Ensures entity not published if tracking commit fails
  - `test_tracking_commit_failure_never_publishes_the_relation`: Ensures relation not published if tracking commit fails
  - `test_accepted_residue_is_the_row_without_the_object`: Pins the benign residue state
- Added `TestDeletionOrderIsUnchanged` class with 2 tests:
  - `test_persist_helper_orders_tracking_before_graph`: Verifies the two-phase ordering in the helper
  - `test_no_deletion_path_passes_graph_and_tracking_together`: Ensures deletion paths maintain the contract (graph committed separately, then tracking flushed)

## Checklist

- [x] Changes tested locally (comprehensive test suite added)
- [x] Code reviewed (fix addresses root cause of data

https://claude.ai/code/session_01JmhsNufu5jyLFj2xraMNKi