### PR TITLE
fix(storage): retry os.replace in atomic_write on Windows NTFS lock c…

### DIFF
--- a/lightrag/file_atomic.py
+++ b/lightrag/file_atomic.py
@@ -44,6 +44,18 @@ logger = logging.getLogger("lightrag")
 # running (multi-million-node graphml writes finish in minutes, not hours).
 TMP_REAP_AGE_SECONDS = 3600
 
+# Windows-only retry budget for ``os.replace`` (see ``_replace_file``). The
+# backoff sleeps run on the process-wide SINGLE-worker storage-io executor
+# (``lightrag.utils.get_storage_io_executor``), so the total is the worst-case
+# stall imposed on *every* file backend's flush, not just the one retrying.
+# Keep it around a second: a handle held by an indexer or antivirus clears in
+# tens to a few hundred milliseconds, and a longer hold is better surfaced as a
+# failure than paid for by every other namespace queued behind that one worker.
+# 7 sleeps of 0.05, 0.075, 0.1125, 0.169, 0.2, 0.2, 0.2 sum to ~1.0s.
+WINDOWS_REPLACE_MAX_ATTEMPTS = 8
+WINDOWS_REPLACE_INITIAL_DELAY = 0.05
+WINDOWS_REPLACE_MAX_DELAY = 0.2
+
 
 def tmp_path_for(file_name: str) -> str:
     """Return a per-writer tmp sibling for ``file_name``.
@@ -115,24 +127,38 @@ def reap_orphan_tmp_files(
 def _replace_file(src: str, dst: str, workspace: str = "_") -> None:
     """Replace src into dst, with exponential backoff retry on Windows NTFS.
 
-    On Windows, os.replace (MoveFileEx) raises PermissionError ([WinError 5]) if
-    another thread, coroutine, or system service (e.g. search indexer, antivirus)
-    momentarily holds an open handle to dst. We retry with gentle backoff.
+    On Windows, os.replace (MoveFileEx) raises PermissionError ([WinError 5]
+    ACCESS_DENIED or [WinError 32] SHARING_VIOLATION) if another thread,
+    coroutine, or system service (e.g. search indexer, antivirus) momentarily
+    holds an open handle to dst. We retry with gentle backoff. ``src`` stays in
+    place when the rename fails, so every attempt is idempotent.
+
+    Other platforms take a straight ``os.replace``: the retry loop would add a
+    branch and a misleading "after 1 attempts" log line to a path that never
+    retries.
     """
-    max_attempts = 10 if sys.platform == "win32" else 1
-    delay = 0.05
-    for attempt in range(max_attempts):
+    if sys.platform != "win32":
+        os.replace(src, dst)
+        return
+
+    delay = WINDOWS_REPLACE_INITIAL_DELAY
+    for attempt in range(WINDOWS_REPLACE_MAX_ATTEMPTS):
         try:
             os.replace(src, dst)
             return
         except PermissionError as exc:
-            if attempt == max_attempts - 1:
+            if attempt == WINDOWS_REPLACE_MAX_ATTEMPTS - 1:
                 logger.warning(
-                    f"[{workspace}] Failed to atomically replace {dst} after {max_attempts} attempts: {exc}"
+                    f"[{workspace}] Failed to atomically replace {dst} after "
+                    f"{WINDOWS_REPLACE_MAX_ATTEMPTS} attempts: {exc}"
                 )
                 raise
+            logger.debug(
+                f"[{workspace}] Retrying atomic replace of {dst} in {delay:.2f}s "
+                f"(attempt {attempt + 1}/{WINDOWS_REPLACE_MAX_ATTEMPTS}): {exc}"
+            )
             time.sleep(delay)
-            delay = min(delay * 1.5, 0.5)
+            delay = min(delay * 1.5, WINDOWS_REPLACE_MAX_DELAY)
 
 
 def atomic_write(
@@ -141,6 +167,7 @@ def atomic_write(
     workspace: str = "_",
 ) -> None:
     """Run ``write_fn(tmp_path)`` then atomically replace ``file_name`` with it.
+
     ``write_fn`` is responsible for actually producing the file contents at
     the path it receives. It must not assume the tmp path equals ``file_name``
     — Faiss/Nano callers rely on the tmp path being a real sibling.

--- a/lightrag/file_atomic.py
+++ b/lightrag/file_atomic.py
@@ -32,6 +32,7 @@ import glob
 import logging
 import os
 import stat
+import sys
 import threading
 import time
 from typing import Callable
@@ -110,6 +111,28 @@ def reap_orphan_tmp_files(
                     f"[{workspace}] Failed to reap orphan tmp file {path}: {exc}"
                 )
 
+def _replace_file(src: str, dst: str, workspace: str = "_") -> None:
+    """Replace src into dst, with exponential backoff retry on Windows NTFS.
+
+    On Windows, os.replace (MoveFileEx) raises PermissionError ([WinError 5]) if
+    another thread, coroutine, or system service (e.g. search indexer, antivirus)
+    momentarily holds an open handle to dst. We retry with gentle backoff.
+    """
+    max_attempts = 10 if sys.platform == "win32" else 1
+    delay = 0.05
+    for attempt in range(max_attempts):
+        try:
+            os.replace(src, dst)
+            return
+        except PermissionError as exc:
+            if attempt == max_attempts - 1:
+                logger.warning(
+                    f"[{workspace}] Failed to atomically replace {dst} after {max_attempts} attempts: {exc}"
+                )
+                raise
+            time.sleep(delay)
+            delay = min(delay * 1.5, 0.5)
+
 
 def atomic_write(
     file_name: str,
@@ -117,11 +140,9 @@ def atomic_write(
     workspace: str = "_",
 ) -> None:
     """Run ``write_fn(tmp_path)`` then atomically replace ``file_name`` with it.
-
     ``write_fn`` is responsible for actually producing the file contents at
     the path it receives. It must not assume the tmp path equals ``file_name``
     — Faiss/Nano callers rely on the tmp path being a real sibling.
-
     On any exception from ``write_fn`` or from the rename, the tmp is removed
     best-effort and the exception propagates. The destination file is not
     touched in that case.
@@ -130,7 +151,7 @@ def atomic_write(
     try:
         write_fn(tmp)
         _preserve_mode(tmp, file_name, workspace)
-        os.replace(tmp, file_name)
+        _replace_file(tmp, file_name, workspace)
     except BaseException:
         try:
             if os.path.exists(tmp):

--- a/lightrag/file_atomic.py
+++ b/lightrag/file_atomic.py
@@ -111,6 +111,7 @@ def reap_orphan_tmp_files(
                     f"[{workspace}] Failed to reap orphan tmp file {path}: {exc}"
                 )
 
+
 def _replace_file(src: str, dst: str, workspace: str = "_") -> None:
     """Replace src into dst, with exponential backoff retry on Windows NTFS.
 

--- a/tests/kg/test_file_atomic.py
+++ b/tests/kg/test_file_atomic.py
@@ -17,6 +17,7 @@ import pytest
 
 from lightrag.file_atomic import (
     TMP_REAP_AGE_SECONDS,
+    _replace_file,
     atomic_write,
     reap_orphan_tmp_files,
     tmp_path_for,
@@ -203,3 +204,90 @@ def test_reap_orphan_tmp_files_extra_patterns_clean_legacy_residue(tmp_path):
     # Explicit migration pattern clears it.
     reap_orphan_tmp_files(dst, extra_patterns=(glob.escape(dst) + ".tmp",))
     assert not os.path.exists(legacy_tmp)
+
+
+@pytest.mark.offline
+def test_replace_file_windows_transient_permission_error_retries_and_succeeds(tmp_path):
+    """On Windows, a transient PermissionError (e.g. WinError 5) should trigger
+    exponential backoff retries and succeed once the file lock is released."""
+    src = str(tmp_path / "src.txt")
+    dst = str(tmp_path / "dst.txt")
+    with open(src, "w") as f:
+        f.write("payload")
+
+    real_replace = os.replace
+    call_count = 0
+
+    def mock_replace(s, d):
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise PermissionError(13, "Permission denied (simulated WinError 5)")
+        real_replace(s, d)
+
+    with (
+        patch("lightrag.file_atomic.sys.platform", "win32"),
+        patch("lightrag.file_atomic.os.replace", side_effect=mock_replace),
+        patch("lightrag.file_atomic.time.sleep") as mock_sleep,
+    ):
+        _replace_file(src, dst)
+
+    assert call_count == 3
+    assert mock_sleep.call_count == 2
+    assert os.path.exists(dst)
+    assert open(dst).read() == "payload"
+
+
+@pytest.mark.offline
+def test_atomic_write_windows_retry_exhaustion_cleans_tmp_and_raises(tmp_path):
+    """When PermissionError persists on Windows up to max_attempts (10),
+    atomic_write raises the PermissionError and cleans up the in-flight tmp."""
+    dst = str(tmp_path / "out.txt")
+    with open(dst, "w") as f:
+        f.write("v1")
+
+    call_count = 0
+
+    def mock_replace(s, d):
+        nonlocal call_count
+        call_count += 1
+        raise PermissionError(13, "Permission denied (simulated WinError 5)")
+
+    with (
+        patch("lightrag.file_atomic.sys.platform", "win32"),
+        patch("lightrag.file_atomic.os.replace", side_effect=mock_replace),
+        patch("lightrag.file_atomic.time.sleep") as mock_sleep,
+    ):
+        with pytest.raises(PermissionError, match="Permission denied"):
+            atomic_write(dst, lambda tmp: open(tmp, "w").write("v2"))
+
+    assert call_count == 10
+    assert mock_sleep.call_count == 9
+    assert open(dst).read() == "v1"
+    leftovers = [p for p in os.listdir(tmp_path) if ".tmp." in p]
+    assert leftovers == [], f"exhausted retry must clean tmp, got {leftovers}"
+
+
+@pytest.mark.offline
+def test_atomic_write_non_windows_does_not_retry_permission_error(tmp_path):
+    """On non-Windows platforms (e.g. Linux), PermissionError is not retried."""
+    dst = str(tmp_path / "out.txt")
+    call_count = 0
+
+    def mock_replace(s, d):
+        nonlocal call_count
+        call_count += 1
+        raise PermissionError(13, "Permission denied")
+
+    with (
+        patch("lightrag.file_atomic.sys.platform", "linux"),
+        patch("lightrag.file_atomic.os.replace", side_effect=mock_replace),
+        patch("lightrag.file_atomic.time.sleep") as mock_sleep,
+    ):
+        with pytest.raises(PermissionError, match="Permission denied"):
+            atomic_write(dst, lambda tmp: open(tmp, "w").write("v1"))
+
+    assert call_count == 1
+    assert mock_sleep.call_count == 0
+    leftovers = [p for p in os.listdir(tmp_path) if ".tmp." in p]
+    assert leftovers == [], f"failure must clean tmp, got {leftovers}"

--- a/tests/kg/test_file_atomic.py
+++ b/tests/kg/test_file_atomic.py
@@ -6,6 +6,7 @@ individual storage backends that build on it lives in
 ``test_atomic_write_faiss.py``, and ``test_atomic_write_nano.py``.
 """
 
+import logging
 import os
 import stat
 import sys
@@ -17,6 +18,9 @@ import pytest
 
 from lightrag.file_atomic import (
     TMP_REAP_AGE_SECONDS,
+    WINDOWS_REPLACE_INITIAL_DELAY,
+    WINDOWS_REPLACE_MAX_ATTEMPTS,
+    WINDOWS_REPLACE_MAX_DELAY,
     _replace_file,
     atomic_write,
     reap_orphan_tmp_files,
@@ -240,8 +244,9 @@ def test_replace_file_windows_transient_permission_error_retries_and_succeeds(tm
 
 @pytest.mark.offline
 def test_atomic_write_windows_retry_exhaustion_cleans_tmp_and_raises(tmp_path):
-    """When PermissionError persists on Windows up to max_attempts (10),
-    atomic_write raises the PermissionError and cleans up the in-flight tmp."""
+    """When PermissionError persists on Windows up to
+    ``WINDOWS_REPLACE_MAX_ATTEMPTS``, atomic_write raises the PermissionError
+    and cleans up the in-flight tmp."""
     dst = str(tmp_path / "out.txt")
     with open(dst, "w") as f:
         f.write("v1")
@@ -261,8 +266,8 @@ def test_atomic_write_windows_retry_exhaustion_cleans_tmp_and_raises(tmp_path):
         with pytest.raises(PermissionError, match="Permission denied"):
             atomic_write(dst, lambda tmp: open(tmp, "w").write("v2"))
 
-    assert call_count == 10
-    assert mock_sleep.call_count == 9
+    assert call_count == WINDOWS_REPLACE_MAX_ATTEMPTS
+    assert mock_sleep.call_count == WINDOWS_REPLACE_MAX_ATTEMPTS - 1
     assert open(dst).read() == "v1"
     leftovers = [p for p in os.listdir(tmp_path) if ".tmp." in p]
     assert leftovers == [], f"exhausted retry must clean tmp, got {leftovers}"
@@ -291,3 +296,48 @@ def test_atomic_write_non_windows_does_not_retry_permission_error(tmp_path):
     assert mock_sleep.call_count == 0
     leftovers = [p for p in os.listdir(tmp_path) if ".tmp." in p]
     assert leftovers == [], f"failure must clean tmp, got {leftovers}"
+
+
+@pytest.mark.offline
+def test_replace_file_non_windows_permission_error_logs_nothing(tmp_path, caplog):
+    """A non-retrying platform must not log a misleading retry warning.
+
+    ``PermissionError`` on POSIX is a real permission problem, reported by the
+    caller (the pipeline turns it into a storage error). An extra
+    "after 1 attempts" warning here both implies a retry that never happened
+    and duplicates that report.
+    """
+    src = str(tmp_path / "src.txt")
+    dst = str(tmp_path / "dst.txt")
+
+    logger = logging.getLogger("lightrag")
+    previous_propagate = logger.propagate
+    logger.propagate = True  # lightrag's logger does not propagate by default
+    try:
+        with caplog.at_level(logging.DEBUG, logger="lightrag"):
+            with (
+                patch("lightrag.file_atomic.sys.platform", "linux"),
+                patch(
+                    "lightrag.file_atomic.os.replace",
+                    side_effect=PermissionError(13, "Permission denied"),
+                ),
+            ):
+                with pytest.raises(PermissionError, match="Permission denied"):
+                    _replace_file(src, dst)
+    finally:
+        logger.propagate = previous_propagate
+
+    assert caplog.records == []
+
+
+@pytest.mark.offline
+def test_windows_replace_backoff_budget_stays_within_one_second():
+    """The retry sleeps block the process-wide single-worker storage-io pool,
+    stalling every other file backend's flush. Cap the worst case near 1s."""
+    delay = WINDOWS_REPLACE_INITIAL_DELAY
+    total = 0.0
+    for _ in range(WINDOWS_REPLACE_MAX_ATTEMPTS - 1):
+        total += delay
+        delay = min(delay * 1.5, WINDOWS_REPLACE_MAX_DELAY)
+
+    assert total <= 1.05, f"worst-case storage-io stall grew to {total:.2f}s"

--- a/tests/kg/test_file_atomic.py
+++ b/tests/kg/test_file_atomic.py
@@ -18,9 +18,7 @@ import pytest
 
 from lightrag.file_atomic import (
     TMP_REAP_AGE_SECONDS,
-    WINDOWS_REPLACE_INITIAL_DELAY,
     WINDOWS_REPLACE_MAX_ATTEMPTS,
-    WINDOWS_REPLACE_MAX_DELAY,
     _replace_file,
     atomic_write,
     reap_orphan_tmp_files,
@@ -268,6 +266,11 @@ def test_atomic_write_windows_retry_exhaustion_cleans_tmp_and_raises(tmp_path):
 
     assert call_count == WINDOWS_REPLACE_MAX_ATTEMPTS
     assert mock_sleep.call_count == WINDOWS_REPLACE_MAX_ATTEMPTS - 1
+
+    # The sleeps run on the process-wide SINGLE-worker storage-io executor, so
+    # this total is the worst-case stall imposed on every file backend's flush.
+    stall = sum(call.args[0] for call in mock_sleep.call_args_list)
+    assert stall <= 1.05, f"worst-case storage-io stall grew to {stall:.2f}s"
     assert open(dst).read() == "v1"
     leftovers = [p for p in os.listdir(tmp_path) if ".tmp." in p]
     assert leftovers == [], f"exhausted retry must clean tmp, got {leftovers}"
@@ -328,16 +331,3 @@ def test_replace_file_non_windows_permission_error_logs_nothing(tmp_path, caplog
         logger.propagate = previous_propagate
 
     assert caplog.records == []
-
-
-@pytest.mark.offline
-def test_windows_replace_backoff_budget_stays_within_one_second():
-    """The retry sleeps block the process-wide single-worker storage-io pool,
-    stalling every other file backend's flush. Cap the worst case near 1s."""
-    delay = WINDOWS_REPLACE_INITIAL_DELAY
-    total = 0.0
-    for _ in range(WINDOWS_REPLACE_MAX_ATTEMPTS - 1):
-        total += delay
-        delay = min(delay * 1.5, WINDOWS_REPLACE_MAX_DELAY)
-
-    assert total <= 1.05, f"worst-case storage-io stall grew to {total:.2f}s"


### PR DESCRIPTION
## Description

Fixes transient `PermissionError: [WinError 5] Access is denied` during `atomic_write` on native Windows (NTFS) environments.

On Windows, `os.replace` (`MoveFileExW` with `MOVEFILE_REPLACE_EXISTING`) fails with `PermissionError` if the target file (such as `kv_store_doc_status.json`) is momentarily held open by another async worker, an IDE file watcher, or Windows Defender. Previously, `atomic_write` lacked a retry mechanism, causing a single millisecond-level lock collision during concurrent document ingestion to crash the entire process with `Pipeline halted on internal storage error`.

This PR introduces a lightweight exponential backoff retry specifically for `PermissionError` on `win32`, while preserving zero-overhead single-pass behavior on POSIX platforms.

## Related Issues

Fixed #3879

## Changes Made

- Added `_replace_file` helper in `lightrag/file_atomic.py` with exponential backoff retry (up to 10 attempts, starting at 50ms) on `PermissionError`.
- Scoped multi-attempt retry specifically to `sys.platform == "win32"` (`max_attempts = 10`), preserving single-attempt zero-overhead behavior on POSIX platforms (`max_attempts = 1`).
- Replaced direct `os.replace` call in `atomic_write` with `_replace_file`.
- Maintained pure standard library dependencies (`stdlib only`).

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

### Local Testing & Verification
- **Environment**: Native Windows (NTFS), Python 3.12, LightRAG.
- **Test Case**: Batch ingestion and graph building for a 143-chapter novel (500k+ words).
- **Result**: Prior to this change, the pipeline consistently halted around document 80~90 due to concurrent doc-status flush lock contention. With this retry logic applied, all 143 chapters completed smoothly with zero pipeline aborts.
