### PR TITLE
fix: clarify worker timeout guidance

### DIFF
--- a/lightrag/utils.py
+++ b/lightrag/utils.py
@@ -1151,7 +1151,11 @@ class WorkerTimeoutError(Exception):
     def __init__(self, timeout_value: float, timeout_type: str = "execution"):
         self.timeout_value = timeout_value
         self.timeout_type = timeout_type
-        super().__init__(f"Worker {timeout_type} timeout after {timeout_value}s")
+        super().__init__(
+            f"Worker {timeout_type} timeout after {timeout_value}s; increase the "
+            "configured LLM timeout or reduce provider work if the call is "
+            "expected to take longer"
+        )
 
 
 class HealthCheckTimeoutError(Exception):

--- a/tests/llm/test_llm_role_runtime.py
+++ b/tests/llm/test_llm_role_runtime.py
@@ -119,6 +119,26 @@ ROLE_MAX_ASYNC_ENV_KEYS = (
 
 
 @pytest.mark.asyncio
+async def test_worker_timeout_explains_how_to_adjust_provider_budget():
+    async def slow_func(**_kwargs):
+        await asyncio.sleep(0.05)
+
+    wrapped = priority_limit_async_func_call(
+        1,
+        max_execution_timeout=0.01,
+        queue_name="extract LLM func",
+    )(slow_func)
+
+    with pytest.raises(
+        TimeoutError,
+        match="increase the configured LLM timeout or reduce provider work",
+    ):
+        await wrapped()
+
+    await wrapped.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_priority_queue_stats_track_running_and_queued():
     started = asyncio.Event()
     release = asyncio.Event()


### PR DESCRIPTION
## Summary

Worker timeout errors previously reported only elapsed duration, making the failure difficult to diagnose. The message now explains how to increase the configured LLM timeout or reduce provider work, with a regression test covering the public error.

## Motivation

This gives operators a supported next step when provider work exceeds the configured budget.

Fixes #2415