### PR TITLE
fix(setup): use direct Neo4j connections for single-node Compose deployments

### DIFF
--- a/docs/DockerDeployment.md
+++ b/docs/DockerDeployment.md
@@ -91,6 +91,13 @@ On reruns, unchanged wizard-managed service blocks in `docker-compose.final.yml`
 default. To repair or fully regenerate those managed blocks from the bundled templates, rerun the
 matching setup target with `make env-base-rewrite` or `make env-storage-rewrite`.
 
+For a Neo4j instance managed by the setup wizard, the generated Compose file uses
+`bolt://neo4j:7687`. This is a direct connection to the bundled single-node service and avoids
+the routing-table address advertised by `neo4j://`. Keep `neo4j://` for Aura or clustered Neo4j
+deployments that provide reachable routing addresses. When Neo4j runs outside the Compose stack,
+use a host-reachable address from the container; `localhost` refers to the LightRAG container,
+not the WSL2 or Windows host.
+
 If the generated stack includes local Milvus, compose resolves `MINIO_ACCESS_KEY_ID` and
 `MINIO_SECRET_ACCESS_KEY` at startup from the repo `.env` or exported shell environment. The
 generated compose file does not snapshot those values, and `docker compose` exits immediately if

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -282,6 +282,25 @@ normalize_loopback_uri_for_compose() {
   printf '%s' "$uri"
 }
 
+normalize_neo4j_uri_for_compose() {
+  local uri="$1"
+
+  if [[ "$uri" == *,* ]]; then
+    printf '%s' "$uri"
+    return 0
+  fi
+
+  if [[ "$uri" =~ ^neo4j://([^/?#]+@)?(localhost|127\.0\.0\.1|0\.0\.0\.0|host\.docker\.internal)(:[0-9]+)?([/?#].*)?$ ]]; then
+    printf 'bolt://%shost.docker.internal%s%s' \
+      "${BASH_REMATCH[1]}" \
+      "${BASH_REMATCH[3]}" \
+      "${BASH_REMATCH[4]}"
+    return 0
+  fi
+
+  normalize_loopback_uri_for_compose "$uri"
+}
+
 ensure_mongodb_direct_connection_suffix() {
   local suffix="${1:-}"
   local path query fragment filtered_query=""
@@ -359,8 +378,7 @@ normalize_neo4j_uri_for_local_service() {
   local uri="$1"
 
   if [[ "$uri" =~ ^([a-zA-Z][a-zA-Z0-9+.-]*://)([^/?#]+@)?(neo4j|localhost|127\.0\.0\.1|0\.0\.0\.0)(:[0-9]+)?([/?#].*)?$ ]]; then
-    printf '%s%slocalhost:7687%s' \
-      "${BASH_REMATCH[1]}" \
+    printf 'bolt://%slocalhost:7687%s' \
       "${BASH_REMATCH[2]}" \
       "${BASH_REMATCH[5]}"
     return 0
@@ -566,7 +584,7 @@ set_managed_service_compose_overrides() {
       ;;
     neo4j)
       if [[ -z "${COMPOSE_ENV_OVERRIDES[NEO4J_URI]+set}" ]]; then
-        set_compose_override "NEO4J_URI" "neo4j://neo4j:7687"
+        set_compose_override "NEO4J_URI" "bolt://neo4j:7687"
       fi
       ;;
     mongodb)
@@ -655,7 +673,11 @@ prepare_compose_runtime_overrides() {
       continue
     fi
     if [[ -n "${ENV_VALUES[$key]:-}" ]]; then
-      normalized_value="$(normalize_loopback_uri_for_compose "${ENV_VALUES[$key]}")"
+      if [[ "$key" == "NEO4J_URI" ]]; then
+        normalized_value="$(normalize_neo4j_uri_for_compose "${ENV_VALUES[$key]}")"
+      else
+        normalized_value="$(normalize_loopback_uri_for_compose "${ENV_VALUES[$key]}")"
+      fi
       if [[ "$normalized_value" != "${ENV_VALUES[$key]}" ]]; then
         set_compose_override "$key" "$normalized_value"
       fi
@@ -1433,7 +1455,7 @@ collect_neo4j_config() {
   ENV_VALUES["NEO4J_PASSWORD"]="$password"
   ENV_VALUES["NEO4J_DATABASE"]="$database"
   if [[ "$use_docker" == "yes" ]]; then
-    set_compose_override "NEO4J_URI" "neo4j://neo4j:7687"
+    set_compose_override "NEO4J_URI" "bolt://neo4j:7687"
   else
     set_compose_override "NEO4J_URI" ""
   fi

--- a/tests/setup/test_collect.py
+++ b/tests/setup/test_collect.py
@@ -272,7 +272,7 @@ printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")\"
             ['ENV_VALUES[NEO4J_URI]="neo4j+s://graph.example.com"'],
             "collect_neo4j_config yes",
             "NEO4J_URI",
-            "neo4j://localhost:7687",
+            "bolt://localhost:7687",
         ),
         (
             ['ENV_VALUES[MONGO_URI]="mongodb://mongo.example.com:27018/"'],
@@ -308,7 +308,7 @@ printf 'PROMPT_LOG=%s\\n' "$(paste -sd '|' "$PROMPT_LOG_FILE")\"
             ['ENV_VALUES[NEO4J_URI]="neo4j://localhost:7777"'],
             "collect_neo4j_config yes",
             "NEO4J_URI",
-            "neo4j://localhost:7687",
+            "bolt://localhost:7687",
         ),
         (
             ['ENV_VALUES[MILVUS_URI]="http://localhost:29530"'],
@@ -1487,6 +1487,28 @@ printf 'DATABASE_PROMPTS=%s\\n' "$(grep -c '^Neo4j database$' "$prompt_log_file"
         in generated_compose
     )
     assert 'NEO4J_dbms_default__database: "custom-db-2"' in generated_compose
+
+
+def test_collect_neo4j_config_bundled_service_uses_direct_connection_scheme() -> None:
+    """Bundled single-node Neo4j should use a direct, non-routing URI."""
+    output = run_bash(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+reset_state
+
+confirm_default_yes() {{ return 0; }}
+prompt_until_valid() {{ printf '%s' "$2"; }}
+prompt_with_default() {{ printf '%s' "$2"; }}
+prompt_secret_until_valid_with_default() {{ printf '%s' "$2"; }}
+
+collect_neo4j_config yes
+
+printf 'NEO4J_URI=%s\\n' "${{ENV_VALUES[NEO4J_URI]}}"
+printf 'COMPOSE_NEO4J_URI=%s\\n' "${{COMPOSE_ENV_OVERRIDES[NEO4J_URI]}}"
+""")
+    values = parse_lines(output)
+    assert values["NEO4J_URI"] == "bolt://localhost:7687"
+    assert values["COMPOSE_NEO4J_URI"] == "bolt://neo4j:7687"
 
 
 def test_collect_neo4j_config_bundled_service_defaults_database_when_unset() -> None:

--- a/tests/setup/test_misc.py
+++ b/tests/setup/test_misc.py
@@ -475,7 +475,7 @@ validate_sensitive_env_literals() {{ return 0; }}
 finalize_base_setup
 """)
     result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
-    assert 'NEO4J_URI: "neo4j://neo4j:7687"' in result
+    assert 'NEO4J_URI: "bolt://neo4j:7687"' in result
     assert 'MILVUS_URI: "http://milvus:19530"' in result
     assert 'NEO4J_URI: "neo4j://host.docker.internal:7687"' not in result
     assert 'MILVUS_URI: "http://host.docker.internal:19530"' not in result
@@ -942,7 +942,7 @@ env_storage_flow
             "mongodb://root:root@localhost:27017/",
             "mongodb://root:root@host.docker.internal:27017/",
         ),
-        ("NEO4J_URI", "neo4j://localhost:7687", "neo4j://host.docker.internal:7687"),
+        ("NEO4J_URI", "neo4j://localhost:7687", "bolt://host.docker.internal:7687"),
         ("MILVUS_URI", "http://localhost:19530", "http://host.docker.internal:19530"),
         ("QDRANT_URL", "http://127.0.0.1:6333", "http://host.docker.internal:6333"),
         ("MEMGRAPH_URI", "bolt://localhost:7687", "bolt://host.docker.internal:7687"),
@@ -988,6 +988,44 @@ prepare_compose_runtime_overrides
 printf '{env_key}=%s\\n' "${{COMPOSE_ENV_OVERRIDES[{env_key}]}}\"
 """)
     assert values[env_key] == expected_value
+
+
+def test_normalize_neo4j_uri_for_compose_preserves_cluster_routing_uri() -> None:
+    """Non-local Neo4j endpoints should retain routing semantics."""
+    values = run_bash_lines(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+
+printf 'NEO4J_URI=%s\\n' "$(normalize_neo4j_uri_for_compose 'neo4j://graph.example:7687')"
+""")
+    assert values["NEO4J_URI"] == "neo4j://graph.example:7687"
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected"),
+    [
+        (
+            "neo4j://host.docker.internal:7687",
+            "bolt://host.docker.internal:7687",
+        ),
+        (
+            "neo4j://localhost:7687,localhost:7688",
+            "neo4j://localhost:7687,localhost:7688",
+        ),
+    ],
+    ids=["host-single-node", "multiple-routing-seeds"],
+)
+def test_normalize_neo4j_uri_for_compose_handles_single_node_only(
+    uri: str, expected: str
+) -> None:
+    """Only a single host endpoint may switch from routing to direct Bolt."""
+    values = run_bash_lines(f"""
+set -euo pipefail
+source "{REPO_ROOT}/scripts/setup/setup.sh"
+
+printf 'NEO4J_URI=%s\\n' "$(normalize_neo4j_uri_for_compose '{uri}')"
+""")
+    assert values["NEO4J_URI"] == expected
 
 
 @pytest.mark.parametrize(
@@ -1119,7 +1157,7 @@ validate_security_config() {{ return 0; }}
 finalize_server_setup
 """)
     result = (tmp_path / "docker-compose.final.yml").read_text(encoding="utf-8")
-    assert 'NEO4J_URI: "neo4j://neo4j:7687"' in result
+    assert 'NEO4J_URI: "bolt://neo4j:7687"' in result
     assert 'NEO4J_URI: "neo4j://host.docker.internal:7687"' not in result
 
 


### PR DESCRIPTION
## Summary

LightRAG's setup wizard used routed Neo4j URIs for single-node Compose and host-local endpoints, which can expose unreachable advertised addresses; this changes those paths to direct Bolt while preserving routing for non-local and multi-seed deployments.

Fixes #3297