### PR TITLE
fix(parser): preserve alphabetic numbering after z

### DIFF
--- a/lightrag/parser/docx/numbering_resolver.py
+++ b/lightrag/parser/docx/numbering_resolver.py
@@ -558,10 +558,19 @@ class NumberingResolver:
                 n -= value
         return result
 
+    #: Above this count, _to_letter degrades to the plain decimal string
+    #: instead of a repeated-letter label. Output length is n // 26, and n
+    #: comes from an attacker-controlled w:start (see _parse_numbering_xml,
+    #: parsed with no upper bound) -- without this cap a single crafted
+    #: numbering.xml value can force a multi-gigabyte allocation from a few
+    #: bytes of XML. Same order of magnitude as _to_roman's 4000 cutoff;
+    #: at the cap the output is still only ~385 characters.
+    _MAX_LETTER_COUNT = 10_000
+
     @staticmethod
     def _to_letter(n: int, *, upper: bool = False) -> str:
         """Convert an integer to the repeated-letter numbering used by Word."""
-        if n <= 0:
+        if n <= 0 or n > NumberingResolver._MAX_LETTER_COUNT:
             return str(n)
         base = ord("A" if upper else "a")
         letter = chr(base + (n - 1) % 26)

--- a/lightrag/parser/docx/numbering_resolver.py
+++ b/lightrag/parser/docx/numbering_resolver.py
@@ -35,8 +35,8 @@ class NumberingResolver:
     # (not chineseCounting), which is why both are mapped here.
     FORMAT_CONVERTERS = {
         "decimal": lambda n: str(n),
-        "lowerLetter": lambda n: chr(ord("a") + (n - 1) % 26),
-        "upperLetter": lambda n: chr(ord("A") + (n - 1) % 26),
+        "lowerLetter": lambda n: NumberingResolver._to_letter(n),
+        "upperLetter": lambda n: NumberingResolver._to_letter(n, upper=True),
         "lowerRoman": lambda n: NumberingResolver._to_roman(n).lower(),
         "upperRoman": lambda n: NumberingResolver._to_roman(n),
         "chineseCounting": lambda n: NumberingResolver._to_chinese(n),
@@ -557,6 +557,15 @@ class NumberingResolver:
                 result += numeral
                 n -= value
         return result
+
+    @staticmethod
+    def _to_letter(n: int, *, upper: bool = False) -> str:
+        """Convert an integer to the repeated-letter numbering used by Word."""
+        if n <= 0:
+            return str(n)
+        base = ord("A" if upper else "a")
+        letter = chr(base + (n - 1) % 26)
+        return letter * ((n - 1) // 26 + 1)
 
     @staticmethod
     def _to_chinese(n: int) -> str:

--- a/tests/parser/docx/test_numbering_resolver.py
+++ b/tests/parser/docx/test_numbering_resolver.py
@@ -193,6 +193,20 @@ def test_letter_formats_repeat_after_z(num_fmt, count, expected) -> None:
     assert _label(_fmt_resolver(num_fmt, "%1"), count) == expected
 
 
+def test_letter_format_degrades_to_decimal_above_the_cap() -> None:
+    """A crafted or corrupted w:start flows into this counter unbounded
+    (_parse_numbering_xml has no upper bound on the parsed int). Without a
+    cap, letter * ((n - 1) // 26 + 1) allocates output proportional to n --
+    a single huge w:start in a few bytes of XML would force a
+    multi-gigabyte string. Past the cap it must degrade to plain decimal,
+    same fallback _to_roman already uses above its own 4000 cutoff."""
+    r = _fmt_resolver("lowerLetter", "%1")
+    at_cap = NumberingResolver._MAX_LETTER_COUNT
+    assert _label(r, at_cap) == NumberingResolver._to_letter(at_cap)
+    assert _label(r, at_cap + 1) == str(at_cap + 1)
+    assert _label(r, 10_000_000_000) == "10000000000"
+
+
 # The counting families all render 一/二/十/十一/… — [MS-DOCX] gives
 # japaneseCounting as 一,二,三 and chineseCounting / taiwaneseCounting as
 # 一 (1) / 十 (10). Chinese-locale Word writes 一二三 auto-numbering as

--- a/tests/parser/docx/test_numbering_resolver.py
+++ b/tests/parser/docx/test_numbering_resolver.py
@@ -178,6 +178,21 @@ def _label(r: NumberingResolver, count: int) -> str:
     return r._format_label("100", 0, r.abstract_nums["10"])
 
 
+@pytest.mark.parametrize(
+    ("num_fmt", "count", "expected"),
+    [
+        ("lowerLetter", 1, "a"),
+        ("lowerLetter", 26, "z"),
+        ("lowerLetter", 27, "aa"),
+        ("lowerLetter", 52, "zz"),
+        ("lowerLetter", 53, "aaa"),
+        ("upperLetter", 27, "AA"),
+    ],
+)
+def test_letter_formats_repeat_after_z(num_fmt, count, expected) -> None:
+    assert _label(_fmt_resolver(num_fmt, "%1"), count) == expected
+
+
 # The counting families all render 一/二/十/十一/… — [MS-DOCX] gives
 # japaneseCounting as 一,二,三 and chineseCounting / taiwaneseCounting as
 # 一 (1) / 十 (10). Chinese-locale Word writes 一二三 auto-numbering as


### PR DESCRIPTION
## Summary

Preserve Word-style alphabetic numbering after `z`.

## Problem

DOCX list numbering wrapped from `z` back to `a` instead of continuing to `aa`.

## Changes

Generate repeated-letter numbering for lower- and upper-case alphabetic lists.

## Testing

DOCX parser tests: 846 passed, 44 skipped. Ruff, pre-commit and `git diff --check` passed.

## Compatibility and Risk

Low risk. Other numbering formats are unchanged.

## Related Issue

No related issue.