### PR TITLE
fix(query): preserve minimum vector chunk quota

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -6203,6 +6203,12 @@ async def _find_most_related_edges_from_entities(
     return all_edges_data
 
 
+def _vector_chunk_quota(max_related_chunks: int, group_count: int) -> int:
+    if max_related_chunks <= 0 or group_count <= 0:
+        return 0
+    return max(1, int(max_related_chunks * group_count / 2))
+
+
 async def _find_related_text_unit_from_entities(
     node_datas: list[dict],
     query_param: QueryParam,
@@ -6287,7 +6293,9 @@ async def _find_related_text_unit_from_entities(
     #     The order of text chunks aligns with the naive retrieval's destination.
     #     When reranking is disabled, the text chunks delivered to the LLM tend to favor naive retrieval.
     if kg_chunk_pick_method == "VECTOR" and query and chunks_vdb:
-        num_of_chunks = int(max_related_chunks * len(entities_with_chunks) / 2)
+        num_of_chunks = _vector_chunk_quota(
+            max_related_chunks, len(entities_with_chunks)
+        )
 
         # Get embedding function from global config
         actual_embedding_func = text_chunks_db.embedding_func
@@ -6579,7 +6587,9 @@ async def _find_related_text_unit_from_relations(
     selected_chunk_ids = []  # Initialize to avoid UnboundLocalError
 
     if kg_chunk_pick_method == "VECTOR" and query and chunks_vdb:
-        num_of_chunks = int(max_related_chunks * len(relations_with_chunks) / 2)
+        num_of_chunks = _vector_chunk_quota(
+            max_related_chunks, len(relations_with_chunks)
+        )
 
         # Get embedding function from global config
         actual_embedding_func = text_chunks_db.embedding_func

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -6204,6 +6204,17 @@ async def _find_most_related_edges_from_entities(
 
 
 def _vector_chunk_quota(max_related_chunks: int, group_count: int) -> int:
+    """How many chunks VECTOR-mode selection may draw, scaled by group count.
+
+    Floored at 1 (once max_related_chunks and group_count are both positive)
+    so a query with very few related entities/relations still gets at least
+    one chunk instead of being rounded down to zero by the /2 scaling below.
+
+    The group_count <= 0 branch is defensive only: both call sites already
+    guard on their group list being non-empty (entities_with_chunks /
+    relations_with_chunks) before reaching here, so group_count is always
+    >= 1 in practice.
+    """
     if max_related_chunks <= 0 or group_count <= 0:
         return 0
     return max(1, int(max_related_chunks * group_count / 2))

--- a/tests/llm/test_kg_vector_chunk_quota.py
+++ b/tests/llm/test_kg_vector_chunk_quota.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from lightrag.base import QueryParam
+from lightrag.operate import (
+    _find_related_text_unit_from_entities,
+    _find_related_text_unit_from_relations,
+)
+
+
+pytestmark = pytest.mark.offline
+
+
+def _text_chunks_db():
+    return SimpleNamespace(
+        global_config={
+            "kg_chunk_pick_method": "VECTOR",
+            "related_chunk_number": 1,
+        },
+        embedding_func=Mock(),
+        get_by_ids=AsyncMock(return_value=[{"content": "chunk"}]),
+    )
+
+
+async def _vector_picker(**kwargs):
+    if kwargs["num_of_chunks"] <= 0:
+        return []
+    return ["chunk-1"]
+
+
+@pytest.mark.asyncio
+async def test_single_entity_uses_vector_picker_with_one_chunk(monkeypatch):
+    vector_picker = AsyncMock(side_effect=_vector_picker)
+    weighted_picker = Mock(return_value=["weighted-chunk"])
+    monkeypatch.setattr("lightrag.operate.pick_by_vector_similarity", vector_picker)
+    monkeypatch.setattr("lightrag.operate.pick_by_weighted_polling", weighted_picker)
+
+    result = await _find_related_text_unit_from_entities(
+        [{"entity_name": "entity", "source_id": "chunk-1"}],
+        QueryParam(),
+        _text_chunks_db(),
+        SimpleNamespace(),
+        query="query",
+        chunks_vdb=SimpleNamespace(),
+        query_embedding=[1.0],
+    )
+
+    assert vector_picker.await_args.kwargs["num_of_chunks"] == 1
+    weighted_picker.assert_not_called()
+    assert [chunk["chunk_id"] for chunk in result] == ["chunk-1"]
+
+
+@pytest.mark.asyncio
+async def test_single_relation_uses_vector_picker_with_one_chunk(monkeypatch):
+    vector_picker = AsyncMock(side_effect=_vector_picker)
+    weighted_picker = Mock(return_value=["weighted-chunk"])
+    monkeypatch.setattr("lightrag.operate.pick_by_vector_similarity", vector_picker)
+    monkeypatch.setattr("lightrag.operate.pick_by_weighted_polling", weighted_picker)
+
+    result = await _find_related_text_unit_from_relations(
+        [{"src_id": "source", "tgt_id": "target", "source_id": "chunk-1"}],
+        QueryParam(),
+        _text_chunks_db(),
+        entity_chunks=[],
+        query="query",
+        chunks_vdb=SimpleNamespace(),
+        query_embedding=[1.0],
+    )
+
+    assert vector_picker.await_args.kwargs["num_of_chunks"] == 1
+    weighted_picker.assert_not_called()
+    assert [chunk["chunk_id"] for chunk in result] == ["chunk-1"]
+
+
+@pytest.mark.asyncio
+async def test_zero_related_chunk_limit_remains_disabled(monkeypatch):
+    vector_picker = AsyncMock(side_effect=_vector_picker)
+    weighted_picker = Mock(return_value=[])
+    monkeypatch.setattr("lightrag.operate.pick_by_vector_similarity", vector_picker)
+    monkeypatch.setattr("lightrag.operate.pick_by_weighted_polling", weighted_picker)
+    text_chunks_db = _text_chunks_db()
+    text_chunks_db.global_config["related_chunk_number"] = 0
+
+    result = await _find_related_text_unit_from_entities(
+        [{"entity_name": "entity", "source_id": "chunk-1"}],
+        QueryParam(),
+        text_chunks_db,
+        SimpleNamespace(),
+        query="query",
+        chunks_vdb=SimpleNamespace(),
+        query_embedding=[1.0],
+    )
+
+    assert vector_picker.await_args.kwargs["num_of_chunks"] == 0
+    assert result == []

--- a/tests/test_kg_vector_chunk_quota.py
+++ b/tests/test_kg_vector_chunk_quota.py
@@ -7,10 +7,26 @@ from lightrag.base import QueryParam
 from lightrag.operate import (
     _find_related_text_unit_from_entities,
     _find_related_text_unit_from_relations,
+    _vector_chunk_quota,
 )
 
 
 pytestmark = pytest.mark.offline
+
+
+@pytest.mark.parametrize(
+    ("max_related_chunks", "group_count", "expected"),
+    [
+        (0, 5, 0),  # related_chunk_number disabled entirely
+        (5, 0, 0),  # defensive branch: no call site reaches this in practice
+        (1, 1, 1),  # floor kicks in: 1 * 1 / 2 would round down to 0
+        (2, 1, 1),  # 2 * 1 / 2 == 1, floor is a no-op here
+        (4, 3, 6),  # normal scaling, no floor/rounding involved
+        (3, 1, 1),  # 3 * 1 / 2 == 1.5, int() truncates to 1
+    ],
+)
+def test_vector_chunk_quota(max_related_chunks, group_count, expected):
+    assert _vector_chunk_quota(max_related_chunks, group_count) == expected
 
 
 def _text_chunks_db():


### PR DESCRIPTION
## Summary

Preserve vector-based chunk selection when the configured quota is small.

## Problem

A positive `related_chunk_number` could produce a zero vector quota, causing selection to fall back to weight-based ranking.

## Changes

Ensure positive chunk limits allocate at least one vector-selected chunk.

## Testing

Relevant query tests: 28 passed. Ruff, pre-commit and `git diff --check` passed.

## Compatibility and Risk

Low risk. Non-positive limits and larger quotas remain unchanged.

## Related Issue

No related issue.