### PR TITLE
fix(nvidia): enable asymmetric embedding support

### DIFF
--- a/lightrag/llm/nvidia_openai.py
+++ b/lightrag/llm/nvidia_openai.py
@@ -48,10 +48,23 @@ async def nvidia_openai_embed(
     # refer to https://build.nvidia.com/nim?filters=usecase%3Ausecase_text_to_embedding
     base_url: str = "https://integrate.api.nvidia.com/v1",
     api_key: str = None,
-    input_type: str = "passage",  # query for retrieval, passage for embedding
+    input_type: str | None = None,  # "query" or "passage"; None defers to context
     trunc: str = "NONE",  # NONE or START or END
     encode: str = "float",  # float or base64
+    context: str | None = None,
 ) -> np.ndarray:
+    """Generate embeddings with an NVIDIA NIM embedding model.
+
+    NVIDIA's embedqa models are asymmetric: a search query and an indexed
+    document embed into different regions of the vector space, distinguished
+    by `input_type`. Without an explicit `input_type`, this maps LightRAG's
+    own `context` ("query" / "document") onto NVIDIA's "query" / "passage"
+    values, so a query embedded via a LightRAG query path actually uses
+    NVIDIA's query mode instead of always defaulting to "passage".
+    """
+    if input_type is None:
+        input_type = "query" if context == "query" else "passage"
+
     client_kwargs = {}
     if base_url is not None:
         client_kwargs["base_url"] = base_url

--- a/tests/llm/nvidia_impl/test_nvidia_input_type_context.py
+++ b/tests/llm/nvidia_impl/test_nvidia_input_type_context.py
@@ -1,0 +1,113 @@
+"""nvidia_openai_embed(): NVIDIA's embedqa models are asymmetric -- a search
+query and an indexed document embed into different regions of the vector
+space, distinguished by the API's `input_type` field ("query" / "passage").
+
+Before this fix, `input_type` defaulted to a hardcoded "passage" with no way
+for LightRAG's own query/document distinction to reach it: the function had
+no `context` parameter, so `wrap_embedding_func_with_attrs`'s auto-detection
+left `supports_asymmetric=False`, and `EmbeddingFunc.__call__` never forwards
+`context` when that flag is off. Every query embedded through this provider
+silently used the wrong (document-tuned) region of the vector space,
+degrading retrieval without raising any error.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from lightrag.llm.nvidia_openai import nvidia_openai_embed
+
+
+class _FakeAsyncOpenAI:
+    def __init__(self, *, create):
+        self.embeddings = SimpleNamespace(create=create)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _make_response(dim=2048):
+    return SimpleNamespace(data=[SimpleNamespace(embedding=[0.1] * dim)])
+
+
+@pytest.mark.offline
+def test_context_makes_this_provider_asymmetric():
+    """wrap_embedding_func_with_attrs auto-detects supports_asymmetric from
+    the presence of a `context` parameter -- this is what actually gates
+    whether EmbeddingFunc.__call__ ever forwards context at all."""
+    assert nvidia_openai_embed.supports_asymmetric is True
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_query_context_uses_nvidias_query_input_type():
+    captured = {}
+
+    async def create(**kwargs):
+        captured.update(kwargs)
+        return _make_response()
+
+    fake = _FakeAsyncOpenAI(create=create)
+    with patch("lightrag.llm.nvidia_openai.AsyncOpenAI", return_value=fake):
+        await nvidia_openai_embed(["what is retrieval augmented generation?"], context="query")
+
+    assert captured["extra_body"]["input_type"] == "query"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_document_context_uses_nvidias_passage_input_type():
+    captured = {}
+
+    async def create(**kwargs):
+        captured.update(kwargs)
+        return _make_response()
+
+    fake = _FakeAsyncOpenAI(create=create)
+    with patch("lightrag.llm.nvidia_openai.AsyncOpenAI", return_value=fake):
+        await nvidia_openai_embed(["some chunk of document content"], context="document")
+
+    assert captured["extra_body"]["input_type"] == "passage"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_no_context_keeps_the_old_passage_default():
+    """Backward compatibility: a caller that never passes context (or an
+    older LightRAG version that doesn't supply one) must keep behaving
+    exactly like before this fix."""
+    captured = {}
+
+    async def create(**kwargs):
+        captured.update(kwargs)
+        return _make_response()
+
+    fake = _FakeAsyncOpenAI(create=create)
+    with patch("lightrag.llm.nvidia_openai.AsyncOpenAI", return_value=fake):
+        await nvidia_openai_embed(["no context supplied"])
+
+    assert captured["extra_body"]["input_type"] == "passage"
+
+
+@pytest.mark.offline
+@pytest.mark.asyncio
+async def test_explicit_input_type_overrides_context():
+    """An explicit input_type is a deliberate caller override and must win
+    over context-based inference, matching the voyageai_embed precedent."""
+    captured = {}
+
+    async def create(**kwargs):
+        captured.update(kwargs)
+        return _make_response()
+
+    fake = _FakeAsyncOpenAI(create=create)
+    with patch("lightrag.llm.nvidia_openai.AsyncOpenAI", return_value=fake):
+        await nvidia_openai_embed(
+            ["hello"], context="query", input_type="passage"
+        )
+
+    assert captured["extra_body"]["input_type"] == "passage"

--- a/tests/llm/nvidia_impl/test_nvidia_input_type_context.py
+++ b/tests/llm/nvidia_impl/test_nvidia_input_type_context.py
@@ -53,7 +53,9 @@ async def test_query_context_uses_nvidias_query_input_type():
 
     fake = _FakeAsyncOpenAI(create=create)
     with patch("lightrag.llm.nvidia_openai.AsyncOpenAI", return_value=fake):
-        await nvidia_openai_embed(["what is retrieval augmented generation?"], context="query")
+        await nvidia_openai_embed(
+            ["what is retrieval augmented generation?"], context="query"
+        )
 
     assert captured["extra_body"]["input_type"] == "query"
 
@@ -69,7 +71,9 @@ async def test_document_context_uses_nvidias_passage_input_type():
 
     fake = _FakeAsyncOpenAI(create=create)
     with patch("lightrag.llm.nvidia_openai.AsyncOpenAI", return_value=fake):
-        await nvidia_openai_embed(["some chunk of document content"], context="document")
+        await nvidia_openai_embed(
+            ["some chunk of document content"], context="document"
+        )
 
     assert captured["extra_body"]["input_type"] == "passage"
 
@@ -106,8 +110,6 @@ async def test_explicit_input_type_overrides_context():
 
     fake = _FakeAsyncOpenAI(create=create)
     with patch("lightrag.llm.nvidia_openai.AsyncOpenAI", return_value=fake):
-        await nvidia_openai_embed(
-            ["hello"], context="query", input_type="passage"
-        )
+        await nvidia_openai_embed(["hello"], context="query", input_type="passage")
 
     assert captured["extra_body"]["input_type"] == "passage"


### PR DESCRIPTION
## Problem

nvidia_openai_embed() had no context parameter, so every embedding used the hardcoded input_type="passage", even for search queries.

## Change

Added a context parameter that maps to NVIDIA's query/passage input_type, matching the asymmetric pattern used by voyageai_embed and jina_embed.

## Tests

tests/llm/nvidia_impl: 8 passed

## Related Issue

No related issue.