### PR TITLE
Close the three ordering holes left by the entity/relation create-edit rework

### DIFF
--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1659,10 +1659,14 @@ What that can leave behind, and why it is tolerated:
   a narrowed row landing ahead of the graph write is itself the over-deleting
   state. `aedit_relation` therefore stages such an edit as grow-then-shrink: the
   superset row, then the graph write, then the final row. If the last step
-  fails, the edit still succeeds and the row keeps naming a chunk the relation
-  no longer cites (under-deletion, logged with the storage key, repaired by the
-  chunk-tracking repair) — a retry cannot heal it, because the second edit sees
-  an unchanged `source_id` and skips the tracking update.
+  fails, the edit is already durable and the row keeps naming a chunk the
+  relation no longer cites — under-deletion, the accepted direction, repaired by
+  the [chunk-tracking repair](#repairing-chunk-tracking). The accepted *state*
+  does not make it a silent one: the failure raises
+  `VectorStorageConsistencyError` (a 500 naming the row and the repair tool),
+  because a retry cannot heal it — the second edit sees an unchanged `source_id`
+  and skips the tracking update — so the operator is the only recovery path, and
+  a 200 would guarantee they never learn to take it.
 - **Accepted residue, not yet closed: `aedit_entity`'s non-rename path.** It
   still commits the graph *before* flushing the tracking row, so a hard process
   exit in that window leaves a **growing** edit — one that adds evidence IDs —

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1648,13 +1648,13 @@ What that can leave behind, and why it is tolerated:
   durable. That row is harmless to queries, cannot be inherited as evidence by a
   later object (the explicit creation paths reset attribution), and is removed by
   the [chunk-tracking repair](#repairing-chunk-tracking).
-- The forbidden mirror — an object durable without its row — is not produced by
-  a single-writer crash, because on the creation paths the tracking row is
-  written *and committed before the graph mutation is issued at all*. Ordering
-  only the flushes would not have been enough: on Neo4j or PostgreSQL the
-  `upsert_node` is durable the moment it returns, and on NetworkX it is already
-  in the process-wide in-memory graph, where the next flush by any co-tenant
-  publishes it.
+- The forbidden mirror — an object durable without the row that carries its
+  attribution — is not produced by a single-writer crash **on the creation
+  paths**, because there the tracking row is written *and committed before the
+  graph mutation is issued at all*. Ordering only the flushes would not have
+  been enough: on Neo4j or PostgreSQL the `upsert_node` is durable the moment it
+  returns, and on NetworkX it is already in the process-wide in-memory graph,
+  where the next flush by any co-tenant publishes it.
 - An edit that *removes* evidence IDs from a row cannot use the creation order —
   a narrowed row landing ahead of the graph write is itself the over-deleting
   state. `aedit_relation` therefore stages such an edit as grow-then-shrink: the
@@ -1663,6 +1663,22 @@ What that can leave behind, and why it is tolerated:
   no longer cites (under-deletion, logged with the storage key, repaired by the
   chunk-tracking repair) — a retry cannot heal it, because the second edit sees
   an unchanged `source_id` and skips the tracking update.
+- **Accepted residue, not yet closed: `aedit_entity`'s non-rename path.** It
+  still commits the graph *before* flushing the tracking row, so a hard process
+  exit in that window leaves a **growing** edit — one that adds evidence IDs —
+  with the node on disk citing chunks its row does not yet name. That is the
+  `rows ⊂ graph` direction, the one this codebase does **not** accept: a later
+  purge of a document naming only the older chunks reads the row, concludes "no
+  remaining sources" and deletes an entity the added chunk still anchors. It is
+  reachable from `POST /graph/entity/edit`, whose `updated_data` accepts
+  `source_id`. It is a pre-existing gap rather than a new one — the rename
+  branch of the same function already stages its rows ahead of the commit (see
+  the [merge and rename failure model](design/PurgeRecoveryContract.md#merge-and-rename-failure-model))
+  — and closing it wants the same grow-then-shrink staging as `aedit_relation`,
+  applied without disturbing the rename branch's opposite, deliberate ordering
+  (issue #3609). Until then the recovery for an affected row is the
+  [chunk-tracking repair](#repairing-chunk-tracking), and a growing entity edit
+  should not be issued concurrently with, or shortly before, a document purge.
 - A graph backend that *declines* its commit (the NetworkX reload fence) raises
   out of the create, edit, merge and delete paths alike, so the caller sees a
   500 instead of a success for a write that was discarded.

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1649,7 +1649,23 @@ What that can leave behind, and why it is tolerated:
   later object (the explicit creation paths reset attribution), and is removed by
   the [chunk-tracking repair](#repairing-chunk-tracking).
 - The forbidden mirror — an object durable without its row — is not produced by
-  a single-writer crash, because of the commit order above.
+  a single-writer crash, because on the creation paths the tracking row is
+  written *and committed before the graph mutation is issued at all*. Ordering
+  only the flushes would not have been enough: on Neo4j or PostgreSQL the
+  `upsert_node` is durable the moment it returns, and on NetworkX it is already
+  in the process-wide in-memory graph, where the next flush by any co-tenant
+  publishes it.
+- An edit that *removes* evidence IDs from a row cannot use the creation order —
+  a narrowed row landing ahead of the graph write is itself the over-deleting
+  state. `aedit_relation` therefore stages such an edit as grow-then-shrink: the
+  superset row, then the graph write, then the final row. If the last step
+  fails, the edit still succeeds and the row keeps naming a chunk the relation
+  no longer cites (under-deletion, logged with the storage key, repaired by the
+  chunk-tracking repair) — a retry cannot heal it, because the second edit sees
+  an unchanged `source_id` and skips the tracking update.
+- A graph backend that *declines* its commit (the NetworkX reload fence) raises
+  out of the create, edit, merge and delete paths alike, so the caller sees a
+  500 instead of a success for a write that was discarded.
 
 A workspace-wide admin lock was specified and dropped: it would not have changed
 what a crash can leave behind, since the same residue is reachable with no

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -360,6 +360,17 @@ class NetworkXStorage(BaseGraphStorage):
         here: an uncommitted ``upsert_node`` still sits in the process-wide
         in-memory graph, where the next flush by any co-tenant publishes it.
 
+        **One path still reaches the forbidden state.**
+        ``utils_graph._edit_entity_impl``'s NON-rename branch commits the graph
+        before it flushes the tracking row, so a hard exit in that window
+        leaves a *growing* edit's node on disk citing chunks its row does not
+        name yet -- the state a later purge misreads as "no remaining
+        sources". Pre-existing (the rename branch of the same function already
+        stages its rows ahead of the commit); recovery is the chunk-tracking
+        rebuild tool; the fix is the grow-then-shrink staging
+        ``aedit_relation`` uses, applied without disturbing the rename
+        branch's opposite ordering (issue #3609).
+
         **Requirement on new callers.** Any new caller of these mutators must
         make the tracking row durable BEFORE the mutation call, not merely
         before the flush, and must not be invoked concurrently with another

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -353,14 +353,17 @@ class NetworkXStorage(BaseGraphStorage):
         evidence by a later object, because the explicit creation paths reset
         attribution (issue #3838 R1); and it is repairable offline with the
         chunk-tracking rebuild tool (R4). The mirror state — a graph object
-        durable without its tracking row — is the forbidden one, and
-        ``utils_graph._persist_graph_updates`` is ordered so no single-writer
-        crash produces it.
+        durable without its tracking row — is the forbidden one, and the
+        creation paths in ``utils_graph`` keep it out of reach by writing and
+        committing the tracking row **before** calling ``upsert_node`` /
+        ``upsert_edge`` at all. Ordering only the flushes would not be enough
+        here: an uncommitted ``upsert_node`` still sits in the process-wide
+        in-memory graph, where the next flush by any co-tenant publishes it.
 
-        **Requirement on new callers.** Any new caller of these mutators
-        must keep tracking rows ahead of the objects they describe, the way
-        ``_persist_graph_updates`` does, and must not be invoked
-        concurrently with another admin writer on a file-backed workspace.
+        **Requirement on new callers.** Any new caller of these mutators must
+        make the tracking row durable BEFORE the mutation call, not merely
+        before the flush, and must not be invoked concurrently with another
+        admin writer on a file-backed workspace.
     """
 
     def _node_context(self, node_id: str) -> str:

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -270,12 +270,26 @@ def _normalize_manual_entity_name(entity_name: Any) -> str:
     return normalize_entity_name(entity_name)
 
 
+def _declined_commit_error(context: str) -> RuntimeError:
+    """The single wording for a graph backend that refused to publish a write.
+
+    Raised from both commit sites (``_commit_graph_or_raise`` and the phase-2
+    flush of ``_persist_graph_updates``) so a declined commit reads the same way
+    whichever path reached it.
+    """
+    return RuntimeError(
+        f"{context}: the graph commit was skipped because another process "
+        "updated the graph, so the in-memory mutation was discarded"
+    )
+
+
 async def _persist_graph_updates(
     entities_vdb=None,
     relationships_vdb=None,
     chunk_entity_relation_graph=None,
     entity_chunks_storage=None,
     relation_chunks_storage=None,
+    context: str = "Graph update",
 ) -> None:
     """Unified callback to persist updates after graph operations.
 
@@ -312,17 +326,35 @@ async def _persist_graph_updates(
     inherited by a new object (issue #3838 R1 resets evidence on explicit
     creation), and repairable with the offline chunk-tracking rebuild.
 
-    Phase 1 failing skips phase 2 entirely, which is the point: a tracking
-    commit that did not land must not be followed by publishing the object it
-    describes.
+    **What this ordering does and does not buy.** It orders the *flushes issued
+    by this call*, nothing more. It does not order the mutations themselves: by
+    the time a caller reaches this helper, ``upsert_node`` / ``upsert_edge`` has
+    already run, which on an immediate-write backend (Neo4j, PostgreSQL) is
+    already durable, and on a deferred backend has already mutated the
+    process-wide in-memory graph, where the *next* flush by any co-tenant
+    publishes it. Phase 1 failing therefore only guarantees that *this call*
+    does not publish the object -- it cannot unwrite what the caller already
+    wrote. Keeping the forbidden state unreachable is consequently the caller's
+    job, and the creation paths do it by writing and flushing the tracking row
+    BEFORE the graph mutation; this helper's two phases are the second line of
+    defence for the flush that follows.
 
     Contract for callers, because the order is only correct in one direction:
-    this helper is for callers that ADD or UPDATE a tracking row. A caller that
-    REMOVES one must commit the graph itself first -- ``_commit_graph_or_raise``
-    -- and only then call this helper with the tracking storages alone, so the
-    removal lands in the same benign direction. Every deletion path in this
-    module already does exactly that, which is why none of them passes
+    this helper is for callers that ADD to a tracking row. A caller that REMOVES
+    from one must commit the graph itself first -- ``_commit_graph_or_raise`` --
+    and only then call this helper with the tracking storages alone, so the
+    removal lands in the same benign direction. A caller whose update does both
+    (``aedit_relation``) has to stage it as grow-then-shrink: the superset row
+    first, then the graph, then the final row. Every deletion path in this
+    module already commits the graph itself, which is why none of them passes
     ``chunk_entity_relation_graph`` and a tracking storage together.
+
+    A graph backend that DECLINES its commit -- ``NetworkXStorage`` reloading
+    from disk and discarding the in-memory mutation because a peer committed
+    first -- is raised as a ``RuntimeError``, exactly as in
+    ``_commit_graph_or_raise``. Returning normally there would report a mutation
+    that was thrown away as a success, and would leave the tracking row phase 1
+    just made durable describing an object that never reached disk.
 
     Args:
         entities_vdb: Entity vector database storage (optional)
@@ -330,11 +362,12 @@ async def _persist_graph_updates(
         chunk_entity_relation_graph: Graph storage instance (optional)
         entity_chunks_storage: Entity-chunk tracking storage (optional)
         relation_chunks_storage: Relation-chunk tracking storage (optional)
+        context: Operation prefix used in the declined-commit error message
     """
 
-    async def _flush(storage_inst) -> None:
+    async def _flush(storage_inst, *, require_commit: bool = False) -> None:
         try:
-            await cast(StorageNameSpace, storage_inst).index_done_callback()
+            committed = await cast(StorageNameSpace, storage_inst).index_done_callback()
         except CommitBookkeepingError as e:
             log_without_raising(
                 logger.error,
@@ -343,6 +376,11 @@ async def _persist_graph_updates(
                 "durable; cross-process visibility is deferred to the next "
                 "commit.",
             )
+            return
+        # Only an explicit False means "did not commit"; the base signature is
+        # ``-> None``, so backends that return nothing are unaffected.
+        if require_commit and committed is False:
+            raise _declined_commit_error(context)
 
     # Phase 1: attribution carriers.
     tracking_storages = [
@@ -350,9 +388,12 @@ async def _persist_graph_updates(
         for storage_inst in (entity_chunks_storage, relation_chunks_storage)
         if storage_inst is not None
     ]
-    # Phase 2: the objects those rows describe, plus their vector records.
+    # Phase 2: the objects those rows describe, plus their vector records. Only
+    # the graph is checked for a declined commit -- the vector stores have no
+    # such fence, and their staleness is the rebuildable window accepted
+    # elsewhere in this module.
     object_storages = [
-        storage_inst
+        (storage_inst, storage_inst is chunk_entity_relation_graph)
         for storage_inst in (
             entities_vdb,
             relationships_vdb,
@@ -363,9 +404,32 @@ async def _persist_graph_updates(
 
     # Within a phase the order is unconstrained, so they still flush in
     # parallel; only the boundary between the two phases is ordered.
-    for phase in (tracking_storages, object_storages):
-        if phase:
-            await asyncio.gather(*[_flush(storage_inst) for storage_inst in phase])
+    # ``return_exceptions=True`` keeps a raising flush from stranding its
+    # siblings as never-awaited tasks. A declined graph commit is re-raised
+    # ahead of any sibling failure: it is the one answer that says the caller's
+    # mutation was thrown away, and a stale vector store must not mask it.
+    phases = [
+        [(storage_inst, False) for storage_inst in tracking_storages],
+        object_storages,
+    ]
+    for phase in phases:
+        if not phase:
+            continue
+        results = await asyncio.gather(
+            *[
+                _flush(storage_inst, require_commit=require_commit)
+                for storage_inst, require_commit in phase
+            ],
+            return_exceptions=True,
+        )
+        errors = [
+            (require_commit, result)
+            for (_, require_commit), result in zip(phase, results)
+            if isinstance(result, BaseException)
+        ]
+        if errors:
+            errors.sort(key=lambda item: not item[0])
+            raise errors[0][1]
 
 
 async def _finish_deferring_cancellation(coro, description: str) -> None:
@@ -438,10 +502,7 @@ async def _commit_graph_or_raise(chunk_entity_relation_graph, context: str) -> N
         )
         return
     if committed is False:
-        raise RuntimeError(
-            f"{context}: the graph commit was skipped because another process "
-            "updated the graph, so the in-memory deletion was discarded"
-        )
+        raise _declined_commit_error(context)
 
 
 async def _sweep_orphan_tracking_row(
@@ -1670,29 +1731,22 @@ async def aedit_relation(
                 }
             }
 
-            # 3. Update relation information in the graph
-            await chunk_entity_relation_graph.upsert_edge(
-                source_entity, target_entity, new_edge_data
-            )
-
-            # Delete the old relation record from the vector database.
-            # Delete both permutations to handle relationships created
-            # before normalization.
-            rel_ids_to_delete = [
-                compute_mdhash_id(source_entity + target_entity, prefix="rel-"),
-                compute_mdhash_id(target_entity + source_entity, prefix="rel-"),
-            ]
-            await relationships_vdb.delete(rel_ids_to_delete)
-            logger.debug(
-                f"Relation Delete: delete vdb for `{source_entity}`~`{target_entity}`"
-            )
-
-            # Update vector database
-            await relationships_vdb.upsert(relation_data)
-
-            # 4. Synchronize relation chunk tracking after source edits, when
+            # 3. Synchronize relation chunk tracking after source edits, when
             #    tracking is missing, or when a legacy row still contains a
             #    historical no-evidence placeholder.
+            #
+            #    An edit can both ADD and REMOVE evidence IDs, and the two have
+            #    opposite safe orderings: an addition must be durable before the
+            #    graph write that relies on it, a removal only after it. A
+            #    single ordering cannot serve both -- it just moves which edit
+            #    direction leaves an over-deleting row on disk. So the update is
+            #    staged as grow-then-shrink around the graph write: the superset
+            #    row first, the graph write next, the shrunken row last. The row
+            #    is then never a strict subset of the durable graph evidence,
+            #    and the only residue is a row that still names IDs the edit
+            #    removed -- under-deletion, the direction this codebase accepts.
+            pending_tracking_shrink: list[str] | None = None
+            tracking_storage_key: str | None = None
             if relation_chunks_storage is not None:
                 from .utils import (
                     make_relation_chunk_key,
@@ -1755,29 +1809,99 @@ async def aedit_relation(
                         existing_full_chunk_ids, old_chunk_ids, new_chunk_ids
                     )
 
-                    # Update storage (Update even if updated_chunk_ids is empty)
+                    # Grow phase: everything the row already held, plus the
+                    # genuine additions. Identical to the final row whenever
+                    # this edit removes nothing, which is the common case.
+                    additions = [
+                        cid
+                        for cid in updated_chunk_ids
+                        if cid not in set(existing_full_chunk_ids)
+                    ]
+                    superset_chunk_ids = existing_full_chunk_ids + additions
+                    if set(superset_chunk_ids) != set(updated_chunk_ids):
+                        pending_tracking_shrink = updated_chunk_ids
+                        tracking_storage_key = storage_key
+
+                    # Update storage (Update even if the list is empty)
                     await relation_chunks_storage.upsert(
                         {
                             storage_key: {
-                                "chunk_ids": updated_chunk_ids,
-                                "count": len(updated_chunk_ids),
+                                "chunk_ids": superset_chunk_ids,
+                                "count": len(superset_chunk_ids),
                             }
                         }
                     )
+                    await _persist_graph_updates(
+                        relation_chunks_storage=relation_chunks_storage,
+                    )
 
                     logger.info(
-                        f"Relation Delete: update chunk tracking for `{source_entity}`~`{target_entity}`"
+                        f"Relation Edit: update chunk tracking for `{source_entity}`~`{target_entity}`"
                     )
+
+            # 4. Update relation information in the graph
+            await chunk_entity_relation_graph.upsert_edge(
+                source_entity, target_entity, new_edge_data
+            )
+
+            # Delete the old relation record from the vector database.
+            # Delete both permutations to handle relationships created
+            # before normalization.
+            rel_ids_to_delete = [
+                compute_mdhash_id(source_entity + target_entity, prefix="rel-"),
+                compute_mdhash_id(target_entity + source_entity, prefix="rel-"),
+            ]
+            await relationships_vdb.delete(rel_ids_to_delete)
+            logger.debug(
+                f"Relation Edit: delete vdb for `{source_entity}`~`{target_entity}`"
+            )
+
+            # Update vector database
+            await relationships_vdb.upsert(relation_data)
 
             # 5. Save changes
             await _persist_graph_updates(
                 relationships_vdb=relationships_vdb,
                 chunk_entity_relation_graph=chunk_entity_relation_graph,
-                relation_chunks_storage=relation_chunks_storage,
+                context=f"Relation Edit: `{source_entity}`~`{target_entity}`",
             )
 
+            # 6. Shrink phase: the graph write that justifies dropping these IDs
+            #    is durable now, so the row may finally lose them.
+            #
+            #    A failure here is logged, not raised: the edit itself landed,
+            #    so reporting it as failed would be a lie about the graph, and a
+            #    repeated edit cannot heal the row anyway -- the second run sees
+            #    an unchanged source_id and skips the tracking block entirely.
+            #    What survives is the accepted direction (a row naming IDs the
+            #    relation no longer cites), and the recovery is the offline
+            #    chunk-tracking repair.
+            if pending_tracking_shrink is not None:
+                try:
+                    await relation_chunks_storage.upsert(
+                        {
+                            tracking_storage_key: {
+                                "chunk_ids": pending_tracking_shrink,
+                                "count": len(pending_tracking_shrink),
+                            }
+                        }
+                    )
+                    await _persist_graph_updates(
+                        relation_chunks_storage=relation_chunks_storage,
+                    )
+                except Exception as e:
+                    log_without_raising(
+                        logger.error,
+                        f"Relation Edit: `{source_entity}`~`{target_entity}` is "
+                        f"durable, but pruning its chunk tracking row "
+                        f"`{tracking_storage_key}` down to "
+                        f"{pending_tracking_shrink} failed: {e}. The row still "
+                        "names chunk IDs this edit removed; run "
+                        "lightrag-repair-chunk-tracking to reconcile it.",
+                    )
+
             logger.info(
-                f"Relation Delete: `{source_entity}`~`{target_entity}`' successfully updated"
+                f"Relation Edit: `{source_entity}`~`{target_entity}` successfully updated"
             )
             return await get_relation_info(
                 chunk_entity_relation_graph,
@@ -1919,13 +2043,15 @@ async def acreate_entity(
             if before_create is not None:
                 await before_create()
 
-            # Add entity to knowledge graph
-            await chunk_entity_relation_graph.upsert_node(entity_name, node_data)
-
-            # Update vector database
-            await entities_vdb.upsert(entity_data_for_vdb)
-
-            # Update entity_chunks_storage to track chunk references
+            # Write and commit the attribution row BEFORE the graph mutation
+            # (issue #3838). Ordering only the flushes is not enough: an
+            # immediate-write backend makes `upsert_node` durable on the spot,
+            # and a deferred one leaves the node in the process-wide in-memory
+            # graph, where any co-tenant flush publishes it. Both reach the
+            # forbidden state -- an entity durable with no row carrying its
+            # attribution -- before this function's own flush is even reached.
+            # Writing the row first makes the only residue the benign mirror: a
+            # row whose node never became durable.
             if entity_chunks_storage is not None:
                 source_id = node_data.get("source_id", "")
                 chunk_ids = list(
@@ -1946,17 +2072,25 @@ async def acreate_entity(
                         }
                     }
                 )
+                await _persist_graph_updates(
+                    entity_chunks_storage=entity_chunks_storage,
+                )
                 logger.info(
                     f"Entity Create: tracked {len(chunk_ids)} chunks for `{entity_name}`"
                 )
+
+            # Add entity to knowledge graph
+            await chunk_entity_relation_graph.upsert_node(entity_name, node_data)
+
+            # Update vector database
+            await entities_vdb.upsert(entity_data_for_vdb)
 
             # Save changes
             await _persist_graph_updates(
                 entities_vdb=entities_vdb,
                 relationships_vdb=relationships_vdb,
                 chunk_entity_relation_graph=chunk_entity_relation_graph,
-                entity_chunks_storage=entity_chunks_storage,
-                relation_chunks_storage=relation_chunks_storage,
+                context=f"Entity Create: `{entity_name}`",
             )
 
             logger.info(f"Entity Create: '{entity_name}' successfully created")
@@ -2121,15 +2255,9 @@ async def acreate_relation(
             if before_create is not None:
                 await before_create()
 
-            # Add relation to knowledge graph
-            await chunk_entity_relation_graph.upsert_edge(
-                source_entity, target_entity, edge_data
-            )
-
-            # Update vector database
-            await relationships_vdb.upsert(relation_data_for_vdb)
-
-            # Update relation_chunks_storage to track chunk references
+            # Attribution row first, graph second -- see the same staging in
+            # `acreate_entity` for why ordering the flushes alone leaves the
+            # forbidden state reachable (issue #3838).
             if relation_chunks_storage is not None:
                 from .utils import make_relation_chunk_key
 
@@ -2148,15 +2276,26 @@ async def acreate_relation(
                         }
                     }
                 )
+                await _persist_graph_updates(
+                    relation_chunks_storage=relation_chunks_storage,
+                )
                 logger.info(
                     f"Relation Create: tracked {len(chunk_ids)} chunks for `{vdb_src}`~`{vdb_tgt}`"
                 )
+
+            # Add relation to knowledge graph
+            await chunk_entity_relation_graph.upsert_edge(
+                source_entity, target_entity, edge_data
+            )
+
+            # Update vector database
+            await relationships_vdb.upsert(relation_data_for_vdb)
 
             # Save changes
             await _persist_graph_updates(
                 relationships_vdb=relationships_vdb,
                 chunk_entity_relation_graph=chunk_entity_relation_graph,
-                relation_chunks_storage=relation_chunks_storage,
+                context=f"Relation Create: `{vdb_src}`~`{vdb_tgt}`",
             )
 
             logger.info(

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1882,13 +1882,23 @@ async def aedit_relation(
             # 6. Shrink phase: the graph write that justifies dropping these IDs
             #    is durable now, so the row may finally lose them.
             #
-            #    A failure here is logged, not raised: the edit itself landed,
-            #    so reporting it as failed would be a lie about the graph, and a
-            #    repeated edit cannot heal the row anyway -- the second run sees
-            #    an unchanged source_id and skips the tracking block entirely.
-            #    What survives is the accepted direction (a row naming IDs the
-            #    relation no longer cites), and the recovery is the offline
-            #    chunk-tracking repair.
+            #    A failure here raises `VectorStorageConsistencyError`, the type
+            #    this codebase already uses for "a step AFTER a durable graph
+            #    update failed" -- its docstring names a chunk-tracking
+            #    retirement as one of its two cases, and the rename branch of
+            #    `_edit_entity_impl` raises it for exactly this shape. The edit
+            #    IS durable, so the message says so; what must not happen is
+            #    answering 200 and letting the caller believe the row matches.
+            #    Logging alone would be a swallowed failure (AGENTS.md,
+            #    *Consistency without transactions*): the residue may heal at
+            #    leisure, the failure may not go unreported. It is also the one
+            #    residue in this function a retry CANNOT heal -- the second edit
+            #    sees an unchanged source_id and skips the tracking block
+            #    entirely -- so the operator is the only recovery path, and a
+            #    silent 200 guarantees they never learn to take it. The residue
+            #    itself stays the accepted direction (a row naming IDs the
+            #    relation no longer cites); reordering to avoid it would produce
+            #    the over-deleting mirror instead.
             if pending_tracking_shrink is not None:
                 try:
                     await relation_chunks_storage.upsert(
@@ -1903,15 +1913,24 @@ async def aedit_relation(
                         relation_chunks_storage=relation_chunks_storage,
                     )
                 except Exception as e:
-                    log_without_raising(
-                        logger.error,
+                    logger.error(
                         f"Relation Edit: `{source_entity}`~`{target_entity}` is "
                         f"durable, but pruning its chunk tracking row "
                         f"`{tracking_storage_key}` down to "
-                        f"{pending_tracking_shrink} failed: {e}. The row still "
-                        "names chunk IDs this edit removed; run "
-                        "lightrag-repair-chunk-tracking to reconcile it.",
+                        f"{pending_tracking_shrink} failed: {e}"
                     )
+                    raise VectorStorageConsistencyError(
+                        f"Pruning the chunk tracking row `{tracking_storage_key}` "
+                        f"failed after editing relation `{source_entity}`~"
+                        f"`{target_entity}`: {e}. The edit itself is durable -- the "
+                        "graph and vector records carry the new values -- but the "
+                        "row still names chunk IDs the edit removed, so it is wider "
+                        "than the relation's evidence. No data is lost (a purge "
+                        "reading the wider row is more conservative, not less), and "
+                        "re-issuing the edit cannot repair it: the second run sees "
+                        "an unchanged source_id and skips the tracking update. Run "
+                        "lightrag-repair-chunk-tracking to reconcile the row."
+                    ) from e
 
             logger.info(
                 f"Relation Edit: `{source_entity}`~`{target_entity}` successfully updated"

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1044,6 +1044,19 @@ async def _edit_entity_impl(
 
         entity_name = new_entity_name
     else:
+        # KNOWN GAP -- this mutation precedes the tracking row it needs, and the
+        # graph commit below (`_commit_rename_and_retire_tracking`) precedes the
+        # row's flush. A hard exit in between leaves a GROWING edit -- one whose
+        # `updated_data` adds evidence IDs, which `/graph/entity/edit` accepts --
+        # with the node durable citing chunks its row does not name yet: the
+        # `rows subset-of graph` direction a later purge misreads as "no
+        # remaining sources". Pre-existing, not introduced by the ordering work
+        # above; the rename branch already stages its rows ahead of the commit.
+        # The fix is the grow-then-shrink staging `aedit_relation` uses, which
+        # cannot simply be lifted here because this tracking block is shared
+        # with the rename branch, whose ordering is deliberately the opposite
+        # (issue #3609). Recovery meanwhile: lightrag-repair-chunk-tracking.
+        # Documented in docs/ProgramingWithCore.md -> Concurrent admin writes.
         await chunk_entity_relation_graph.upsert_node(entity_name, new_node_data)
 
     description = new_node_data.get("description", "")

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -40,6 +40,7 @@ from copy import deepcopy
 import pytest
 
 from lightrag import utils_graph
+from lightrag.constants import GRAPH_FIELD_SEP
 from lightrag.exceptions import CommitBookkeepingError
 from lightrag.kg.networkx_impl import NetworkXStorage
 from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
@@ -1169,6 +1170,12 @@ class TestCreationCommitsTrackingBeforeTheObject:
         assert NEW_ENTITY not in creating.entity_chunks.disk
         persisted = creating.persisted_graph()
         assert persisted.has_node(NEW_ENTITY) is False
+        # Skipping this call's own graph commit is not the guarantee: on a
+        # deferred backend the node would sit in the process-wide in-memory
+        # graph, and the next flush by ANY co-tenant would publish it. The node
+        # must never have entered the graph at all.
+        await creating.graph.index_done_callback()
+        assert creating.persisted_graph().has_node(NEW_ENTITY) is False
 
     @pytest.mark.asyncio
     async def test_tracking_commit_failure_never_publishes_the_relation(
@@ -1187,6 +1194,9 @@ class TestCreationCommitsTrackingBeforeTheObject:
         assert NEW_RELATION_KEY not in creating.relation_chunks.disk
         persisted = creating.persisted_graph()
         assert persisted.has_edge(NEW_ENTITY, OTHER) is False
+        # As above: a later co-tenant flush must find nothing to publish.
+        await creating.graph.index_done_callback()
+        assert creating.persisted_graph().has_edge(NEW_ENTITY, OTHER) is False
 
     @pytest.mark.asyncio
     async def test_accepted_residue_is_the_row_without_the_object(
@@ -1263,3 +1273,311 @@ class TestDeletionOrderIsUnchanged:
                 "relation_chunks_storage", False
             )
             assert not (graph_passed and tracking_passed)
+
+
+class _ImmediateGraphStorage:
+    """Immediate-write graph double: `upsert_*` is durable before the next await.
+
+    Models Neo4j / PostgreSQL, where the mutation itself is the durable write
+    and `index_done_callback` is bookkeeping. On such a backend, ordering the
+    *flushes* cannot keep a node out of the store -- only ordering the calls
+    can, which is what the creation paths do.
+    """
+
+    def __init__(self):
+        self.nodes: dict = {}
+        self.edges: dict = {}
+        self.flushes = 0
+
+    async def has_node(self, node_id):
+        await asyncio.sleep(0)
+        return node_id in self.nodes
+
+    async def get_node(self, node_id):
+        return deepcopy(self.nodes.get(node_id))
+
+    async def has_edge(self, source, target):
+        await asyncio.sleep(0)
+        return (source, target) in self.edges or (target, source) in self.edges
+
+    async def get_edge(self, source, target):
+        return deepcopy(
+            self.edges.get((source, target)) or self.edges.get((target, source))
+        )
+
+    async def upsert_node(self, node_id, node_data):
+        await asyncio.sleep(0)
+        self.nodes[node_id] = deepcopy(node_data)
+
+    async def upsert_edge(self, source, target, edge_data):
+        await asyncio.sleep(0)
+        self.edges[(source, target)] = deepcopy(edge_data)
+
+    async def index_done_callback(self):
+        await asyncio.sleep(0)
+        self.flushes += 1
+
+
+class TestCreationWritesTheRowBeforeTheGraphCall:
+    """Fix proof: the tracking row must precede the graph MUTATION, not only its flush.
+
+    Splitting the flush into two phases orders nothing on an immediate-write
+    graph backend -- `upsert_node` is already durable by the time
+    `_persist_graph_updates` is reached, so a tracking store that then fails
+    leaves exactly the forbidden state (object durable, no attribution row).
+    The same hole exists on a deferred backend for a different reason: the node
+    sits in the process-wide in-memory graph, and the next flush by any
+    co-tenant publishes it.
+
+    These go red on the pre-fix ordering because the node/edge is in the store
+    even though the tracking write never landed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_entity_is_not_written_when_its_row_cannot_be_stored(self, creating):
+        graph = _ImmediateGraphStorage()
+        creating.entity_chunks.fail_commit_times = 1
+
+        with pytest.raises(_Boom):
+            await utils_graph.acreate_entity(
+                graph,
+                creating.entities_vdb,
+                creating.relationships_vdb,
+                NEW_ENTITY,
+                {"description": "d", "entity_type": "thing", "source_id": "chunk-9"},
+                entity_chunks_storage=creating.entity_chunks,
+                relation_chunks_storage=creating.relation_chunks,
+            )
+
+        assert NEW_ENTITY not in graph.nodes
+        assert NEW_ENTITY not in creating.entity_chunks.disk
+
+    @pytest.mark.asyncio
+    async def test_relation_is_not_written_when_its_row_cannot_be_stored(
+        self, creating
+    ):
+        graph = _ImmediateGraphStorage()
+        for name in (NEW_ENTITY, OTHER):
+            await graph.upsert_node(name, {"entity_id": name, "source_id": "chunk-1"})
+        creating.relation_chunks.fail_commit_times = 1
+
+        with pytest.raises(_Boom):
+            await utils_graph.acreate_relation(
+                graph,
+                creating.entities_vdb,
+                creating.relationships_vdb,
+                NEW_ENTITY,
+                OTHER,
+                {"description": "d", "weight": 1.0, "source_id": "chunk-9"},
+                relation_chunks_storage=creating.relation_chunks,
+            )
+
+        assert (NEW_ENTITY, OTHER) not in graph.edges
+        assert NEW_RELATION_KEY not in creating.relation_chunks.disk
+
+
+class TestDeclinedCommitFailsTheCreateAndEditPaths:
+    """Fix proof: a declined graph commit must surface, not be swallowed.
+
+    `_persist_graph_updates` used to discard `index_done_callback`'s return
+    value, so `NetworkXStorage` reloading from disk and DISCARDING the caller's
+    mutation looked exactly like a successful commit. The create and edit paths
+    commit through that helper (the deletion paths use
+    `_commit_graph_or_raise`), so they returned HTTP 200 for a write that never
+    reached disk -- while the tracking row phase 1 had just made durable stayed
+    behind, describing an object that does not exist.
+    """
+
+    @staticmethod
+    def _decline_graph_commit(fixture, monkeypatch):
+        async def _declined():
+            return False
+
+        monkeypatch.setattr(fixture.graph, "index_done_callback", _declined)
+
+    @pytest.mark.asyncio
+    async def test_entity_creation_raises_when_the_graph_declines(
+        self, creating, monkeypatch
+    ):
+        self._decline_graph_commit(creating, monkeypatch)
+
+        with pytest.raises(RuntimeError, match="discarded"):
+            await _create_entity(creating)
+
+    @pytest.mark.asyncio
+    async def test_relation_creation_raises_when_the_graph_declines(
+        self, creating, monkeypatch
+    ):
+        await creating.graph.upsert_node(
+            NEW_ENTITY, {"entity_id": NEW_ENTITY, "description": "d", "source_id": "s"}
+        )
+        self._decline_graph_commit(creating, monkeypatch)
+
+        with pytest.raises(RuntimeError, match="discarded"):
+            await _create_relation(creating)
+
+    @pytest.mark.asyncio
+    async def test_relation_edit_raises_when_the_graph_declines(
+        self, deferred, monkeypatch
+    ):
+        self._decline_graph_commit(deferred, monkeypatch)
+
+        with pytest.raises(RuntimeError, match="discarded"):
+            await utils_graph.aedit_relation(
+                deferred.graph,
+                deferred.entities_vdb,
+                deferred.relationships_vdb,
+                ENTITY,
+                OTHER,
+                {"description": "edited"},
+                relation_chunks_storage=deferred.relation_chunks,
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_declined_commit_outranks_a_failing_vector_flush(
+        self, creating, monkeypatch
+    ):
+        # Both halves of phase 2 fail. The vector store being stale is the
+        # rebuildable window; the graph having discarded the write is not, so
+        # that is the answer the caller has to get.
+        creating.entities_vdb.fail_flush = True
+        self._decline_graph_commit(creating, monkeypatch)
+
+        with pytest.raises(RuntimeError, match="discarded"):
+            await _create_entity(creating)
+
+    @pytest.mark.asyncio
+    async def test_a_backend_returning_none_still_creates(self, creating, monkeypatch):
+        # The base signature is `-> None`; only an explicit False means refusal.
+        async def _committed_quietly():
+            return None
+
+        monkeypatch.setattr(creating.graph, "index_done_callback", _committed_quietly)
+
+        result = await _create_entity(creating)
+
+        assert result["entity_name"] == NEW_ENTITY
+
+
+class TestRelationEditGrowsBeforeItShrinks:
+    """Fix proof: an edit that DROPS evidence must not persist the drop first.
+
+    `aedit_relation`'s tracking update applies a delta in both directions. With
+    the row committed unconditionally before the graph, a shrinking edit puts
+    the narrowed row on disk while the edge still carries the wider
+    `source_id`: a later purge of the dropped chunk's document reads the row,
+    concludes "no remaining sources" and deletes a relation another document
+    still anchors. The staging is therefore grow-then-shrink -- superset row,
+    graph, final row -- so the durable row is never a strict subset of the
+    durable evidence.
+    """
+
+    SHRINKING_EDIT = {"source_id": "chunk-1"}
+
+    @staticmethod
+    async def _seed_two_chunk_relation(fixture):
+        await fixture.graph.upsert_edge(
+            ENTITY,
+            OTHER,
+            {
+                "description": "d",
+                "weight": 2.0,
+                "source_id": f"chunk-1{GRAPH_FIELD_SEP}chunk-2",
+            },
+        )
+        await fixture.graph.index_done_callback()
+        await fixture.relation_chunks.upsert(
+            {RELATION_KEY: {"chunk_ids": ["chunk-1", "chunk-2"], "count": 2}}
+        )
+        await fixture.relation_chunks.index_done_callback()
+        fixture.commit_log.clear()
+
+    async def _edit(self, fixture):
+        return await utils_graph.aedit_relation(
+            fixture.graph,
+            fixture.entities_vdb,
+            fixture.relationships_vdb,
+            ENTITY,
+            OTHER,
+            dict(self.SHRINKING_EDIT),
+            relation_chunks_storage=fixture.relation_chunks,
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_failed_graph_commit_leaves_the_wider_row_on_disk(
+        self, deferred, monkeypatch
+    ):
+        await self._seed_two_chunk_relation(deferred)
+        _log_graph_commit(deferred, monkeypatch, fail=True)
+
+        with pytest.raises(_Boom):
+            await self._edit(deferred)
+
+        # The edge on disk still cites both chunks, so the row must too.
+        assert deferred.relation_chunks.disk[RELATION_KEY]["chunk_ids"] == [
+            "chunk-1",
+            "chunk-2",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_successful_edit_ends_with_the_narrowed_row(self, deferred):
+        await self._seed_two_chunk_relation(deferred)
+
+        await self._edit(deferred)
+
+        assert deferred.relation_chunks.disk[RELATION_KEY]["chunk_ids"] == ["chunk-1"]
+        assert deferred.relation_chunks.disk[RELATION_KEY]["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_a_purely_growing_edit_commits_the_row_before_the_graph(
+        self, deferred, monkeypatch
+    ):
+        # Stability: the additive direction keeps the original ordering, so the
+        # new IDs are durable before the edge that cites them.
+        _log_graph_commit(deferred, monkeypatch, fail=False)
+
+        await utils_graph.aedit_relation(
+            deferred.graph,
+            deferred.entities_vdb,
+            deferred.relationships_vdb,
+            ENTITY,
+            OTHER,
+            {"source_id": f"chunk-1{GRAPH_FIELD_SEP}chunk-7", "weight": 2.0},
+            relation_chunks_storage=deferred.relation_chunks,
+        )
+
+        assert deferred.commit_log.index("relation_chunks") < deferred.commit_log.index(
+            "graph"
+        )
+        assert deferred.relation_chunks.disk[RELATION_KEY]["chunk_ids"] == [
+            "chunk-1",
+            "chunk-7",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_failed_shrink_keeps_the_edit_and_the_wider_row(
+        self, deferred, monkeypatch
+    ):
+        # The accepted residue of the staging: the edge is durable, the row
+        # still names a chunk it no longer cites. Under-deletion, repairable
+        # offline -- and deliberately NOT reported as a failed edit.
+        await self._seed_two_chunk_relation(deferred)
+        calls = {"n": 0}
+        original = deferred.relation_chunks.upsert
+
+        async def _upsert(data):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise _Boom("shrink write failed")
+            return await original(data)
+
+        monkeypatch.setattr(deferred.relation_chunks, "upsert", _upsert)
+
+        result = await self._edit(deferred)
+
+        assert result["graph_data"]["source_id"] == "chunk-1"
+        assert deferred.persisted_graph()[ENTITY][OTHER]["source_id"] == "chunk-1"
+        assert deferred.relation_chunks.disk[RELATION_KEY]["chunk_ids"] == [
+            "chunk-1",
+            "chunk-2",
+        ]

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -44,7 +44,7 @@ from lightrag.constants import GRAPH_FIELD_SEP
 from lightrag.exceptions import CommitBookkeepingError
 from lightrag.kg.networkx_impl import NetworkXStorage
 from lightrag.kg.shared_storage import finalize_share_data, initialize_share_data
-from lightrag.utils import make_relation_chunk_key
+from lightrag.utils import VectorStorageConsistencyError, make_relation_chunk_key
 
 pytestmark = pytest.mark.offline
 
@@ -1555,12 +1555,18 @@ class TestRelationEditGrowsBeforeItShrinks:
         ]
 
     @pytest.mark.asyncio
-    async def test_a_failed_shrink_keeps_the_edit_and_the_wider_row(
+    async def test_a_failed_shrink_keeps_the_edit_and_reports_the_wider_row(
         self, deferred, monkeypatch
     ):
         # The accepted residue of the staging: the edge is durable, the row
         # still names a chunk it no longer cites. Under-deletion, repairable
-        # offline -- and deliberately NOT reported as a failed edit.
+        # offline -- but NOT silent. `VectorStorageConsistencyError` is the type
+        # this codebase already uses for "a step after a durable graph update
+        # failed" (its docstring names a chunk-tracking retirement, and the
+        # rename branch of `_edit_entity_impl` raises it for the same shape), and
+        # the route maps it to a 500. Logging alone would answer 200 for a row
+        # only an operator can fix: a retry re-reads the unchanged source_id and
+        # skips the tracking block, so nothing else will ever reconcile it.
         await self._seed_two_chunk_relation(deferred)
         calls = {"n": 0}
         original = deferred.relation_chunks.upsert
@@ -1573,9 +1579,19 @@ class TestRelationEditGrowsBeforeItShrinks:
 
         monkeypatch.setattr(deferred.relation_chunks, "upsert", _upsert)
 
-        result = await self._edit(deferred)
+        with pytest.raises(VectorStorageConsistencyError) as excinfo:
+            await self._edit(deferred)
 
-        assert result["graph_data"]["source_id"] == "chunk-1"
+        # The message has to say the edit landed, and name both the row and the
+        # only tool that can reconcile it -- that is the whole point of raising
+        # this type rather than a bare failure.
+        message = str(excinfo.value)
+        assert RELATION_KEY in message
+        assert "durable" in message
+        assert "lightrag-repair-chunk-tracking" in message
+
+        # The edit is durable despite the raise, and the residue is the wider
+        # row -- under-deletion, never the over-deleting mirror.
         assert deferred.persisted_graph()[ENTITY][OTHER]["source_id"] == "chunk-1"
         assert deferred.relation_chunks.disk[RELATION_KEY]["chunk_ids"] == [
             "chunk-1",


### PR DESCRIPTION
## Summary

Follow-up to #3878. A review of that merged change found three places where the
new commit-ordering contract does not match what the code actually guarantees.
All three are closed here, plus the contract statements that were falsified.

## Motivation

#3878 split `_persist_graph_updates` into two ordered phases — tracking rows,
then the objects those rows describe — to keep the forbidden state out of reach:
**a graph object durable while the tracking row carrying its attribution is
not**. With the row missing, `_purge_kg_contributions` degrades to the truncated
graph `source_id`, concludes "no remaining sources" and deletes an object other
documents still reference.

The direction is right, but ordering the *flushes* is not the same as ordering
the *writes*, and one of the three call sites is not a pure "add" at all.

## What's changed

### F1 — a declined graph commit was swallowed

`NetworkXStorage.index_done_callback` returns `False` **without raising** when a
peer committed since this process last read the graph: it reloads from disk and
DISCARDS the in-memory mutation. `_persist_graph_updates` dropped that return
value, and `acreate_entity` / `acreate_relation` / `aedit_relation` commit the
graph only through that helper (the deletion paths use `_commit_graph_or_raise`).
So a discarded write returned HTTP 200 — `get_entity_info` answering
`graph_data: None` — while the tracking row phase 1 had just made durable stayed
on disk describing an object that does not exist. That also falsified #3878's own
new claim that "the losing writer declines, so the caller gets a loud 500".

Phase 2 now checks the graph's return value and raises through a shared
`_declined_commit_error`, so both commit sites word it identically. Only an
explicit `False` counts; backends returning `None` are unaffected.

### F2 — `aedit_relation` committed a shrunken row ahead of the graph

Its tracking delta can both add and remove evidence IDs, and the two have
**opposite** safe orderings:

| | crash leaves on disk |
| --- | --- |
| tracking-first + shrinking edit | row `[c1]`, edge `c1<SEP>c2` |
| graph-first + growing edit | row `[c1]`, edge `c1<SEP>c2` |

The same over-deleting state. Flipping the direction would only move *which*
edit steps on it — a mirror swap, which AGENTS.md rules out. The update is
therefore staged as **grow-then-shrink** around the graph write: superset row,
graph write, final row. The durable row is then never a strict subset of the
durable graph evidence, and the only residue is a row still naming IDs the edit
removed — under-deletion, the accepted direction.

A failure in the shrink step raises `VectorStorageConsistencyError`, keeping its
error log, with a message that states the edit landed and names both the row key
and `lightrag-repair-chunk-tracking`; the route maps it to a 500 through its
generic handler, as on the merge path. The accepted *state* does not make it a
silent one — AGENTS.md separates the two: a residue may heal at leisure, a
failure may not go unreported. And this is the one residue here a retry cannot
heal, since the next edit reads an unchanged `source_id` and skips the tracking
block, so the operator is the only recovery path.

*(Initially this was log-only, on the grounds that reporting a durable edit as
failed would misdescribe the graph. That premise is exactly why
`VectorStorageConsistencyError` exists — its docstring already names a
chunk-tracking retirement as one of its two cases, and the rename branch of
`_edit_entity_impl` already raises it for this same shape — so it argues for the
typed error rather than against it. Corrected after review; see
[#3889 (comment)](https://github.com/HKUDS/LightRAG/pull/3889#discussion_r3964302442).)*

### F3 — the creation paths ordered only their flushes

By the time `_persist_graph_updates` is reached, `upsert_node` / `upsert_edge`
has already run: durable on the spot on Neo4j / PostgreSQL, and on NetworkX
sitting in the process-wide in-memory graph where the **next flush by any
co-tenant** publishes it. Both reach the forbidden state with no concurrency and
without ever crashing inside the helper.

The tracking row is now written **and committed before the graph mutation is
issued at all**, in `acreate_entity` and `acreate_relation`. The helper's two
phases are demoted to the second line of defence, and its docstring says so.
VDB writes stay strictly after the graph write, per the existing contract.

### Behaviour change worth calling out

Phase 2 now gathers with `return_exceptions=True`: a raising flush no longer
strands its siblings as never-awaited tasks. When more than one fails, the
declined-commit error is re-raised **ahead of** a vector flush failure — a stale
vector store is the rebuildable window accepted elsewhere in this module, a
discarded graph write is not, and it must not be masked.

### Contract statements corrected

`NetworkXStorage`'s *Non-pipeline write paths* and the *Concurrent admin writes*
section of `docs/ProgramingWithCore.md` said the forbidden state is unreachable
"because of the commit order". After this change that is true, but for a
different reason, and the wording now names the real one: the row precedes the
mutation, not merely the flush. Also fixes three `Relation Delete:` log prefixes
left inside `aedit_relation`.

## Known limitation / follow-up

`aedit_entity`'s non-rename path commits the graph first and flushes tracking
afterwards, so a **growing** edit that crashes in between leaves exactly the
state F2 describes: row `[c1]`, node `c1<SEP>c2`. It is out of scope here (it
predates #3878 and is not one of the reported findings) and wants the same
grow-then-shrink staging in a separate change.

It cannot be lifted across verbatim, which is why it is deferred rather than
bundled: that tracking block is **shared** with the rename branch, whose
ordering is deliberately the opposite (#3609) and which additionally carries
`tracking_keys_to_retire`, the `_finish_deferring_cancellation` region and typed
`VectorStorageConsistencyError` failures.

Tracked in #3890. Because AGENTS.md makes an undocumented residue a defect and a
documented one a decision, the residue is now written down in the repository
rather than only here: a bullet in `docs/ProgramingWithCore.md` → *Concurrent
admin writes*, a paragraph in the `NetworkXStorage` non-pipeline write-path
docstring, and an inline `KNOWN GAP` note at the branch itself. The bullet above
it is also scoped to the creation paths, which is all its justification actually
covers.

## Tests

`tests/pipeline/test_graph_deletion_tracking_ordering.py`, +9 cases:

- `TestDeclinedCommitFailsTheCreateAndEditPaths` — create entity / create
  relation / edit relation all raise on a declined commit; a backend returning
  `None` still succeeds; a declined commit outranks a failing vector flush.
- `TestCreationWritesTheRowBeforeTheGraphCall` — an immediate-write graph double
  (Neo4j/PG shaped) plus a failing tracking commit: the node/edge must not be in
  the store.
- `TestRelationEditGrowsBeforeItShrinks` — a failed graph commit leaves the wider
  row on disk; a successful edit ends with the narrowed row; a purely growing
  edit keeps the original order; a failed shrink raises
  `VectorStorageConsistencyError` while keeping the edit durable and the row
  wider, with the message naming the row and the repair tool.
- The two existing creation fix proofs now also assert that a **later** co-tenant
  flush finds nothing to publish.

**8 of these fail behaviourally on the pre-fix code** (verified by reverting
`lightrag/utils_graph.py` alone: 9 failures including the two strengthened ones);
the rest are stability/residue pins. The shrink-failure case was additionally
verified against the log-only behaviour it replaced (DID NOT RAISE).

Suites run: `tests/pipeline`, `tests/kg/networkx_impl` — **909 passed**.
`tests/api/routes` has 19 pre-existing failures in `test_query_stream_routes.py`,
identical with and without these changes; `tests/extraction` needs the
`offline-llm` extra to collect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBBsrz9z5DsKbEE837R4QM
