### PR TITLE
Stage aedit_entity's non-rename chunk-tracking row before the node mutation

### DIFF
--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1674,8 +1674,8 @@ What that can leave behind, and why it is tolerated:
   delivered during that commit, or a failure of the vector flush inside it,
   exits the edit with the row still holding the superset and no line naming it.
   The state stays the accepted direction, but the operator is not told to run
-  the repair — which is the part that cannot heal itself. Tracked separately;
-  `aedit_entity`'s non-rename path (below) does not share it.
+  the repair — which is the part that cannot heal itself. Tracked in issue
+  #3895; `aedit_entity`'s non-rename path (below) does not share it.
 - `aedit_entity`'s non-rename path stages its row the same way, for the same
   reason: a **growing** edit there used to commit the node before flushing the
   row that attributes it, leaving `rows ⊂ graph` — reachable from `POST

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1662,17 +1662,30 @@ What that can leave behind, and why it is tolerated:
   fails, the edit is already durable and the row keeps naming a chunk the
   relation no longer cites — under-deletion, the accepted direction, repaired by
   the [chunk-tracking repair](#repairing-chunk-tracking). The accepted *state*
-  does not make it a silent one: the failure raises
+  does not make it a silent one: a failure of that last step raises
   `VectorStorageConsistencyError` (a 500 naming the row and the repair tool),
   because a retry cannot heal it — the second edit sees an unchanged `source_id`
   and skips the tracking update — so the operator is the only recovery path, and
   a 200 would guarantee they never learn to take it.
+  **Residue, not yet closed:** that last step can still be *skipped* rather than
+  fail, and then nothing is reported. It sits outside any
+  cancellation-deferring region and after the `_persist_graph_updates` call that
+  flushes the graph and the relation vector store together, so a cancellation
+  delivered during that commit, or a failure of the vector flush inside it,
+  exits the edit with the row still holding the superset and no line naming it.
+  The state stays the accepted direction, but the operator is not told to run
+  the repair — which is the part that cannot heal itself. Tracked separately;
+  `aedit_entity`'s non-rename path (below) does not share it.
 - `aedit_entity`'s non-rename path stages its row the same way, for the same
   reason: a **growing** edit there used to commit the node before flushing the
   row that attributes it, leaving `rows ⊂ graph` — reachable from `POST
   /graph/entity/edit`, whose `updated_data` accepts `source_id`. The superset
   row is now durable before `upsert_node` is called at all, and the removals are
-  applied after the graph commit, with the same raise-on-failure contract. Its
+  applied after the graph commit. Its shrink goes further than the relation
+  one's: it runs *inside* the cancellation-deferring region and *before* the
+  vector flush, so neither a cancellation nor a vector failure can skip it —
+  the two ways the relation path still can. It either completes or raises with
+  the row key and the repair tool named. Its
   **rename** path needs no such staging and deliberately keeps its own ordering:
   it writes a fresh node whose `source_id` already equals the row it migrates,
   and it retires the old key only after the commit that removes the old node

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1685,7 +1685,19 @@ What that can leave behind, and why it is tolerated:
   one's: it runs *inside* the cancellation-deferring region and *before* the
   vector flush, so neither a cancellation nor a vector failure can skip it —
   the two ways the relation path still can. It either completes or raises with
-  the row key and the repair tool named. Its
+  the row key and the repair tool named.
+  **One residue there stays open, deliberately:** a cancellation delivered
+  *inside* `upsert_node`'s own await — after an immediate-write backend accepted
+  the row, before control returns — tears the edit down before the shrink, so
+  the node is narrowed while the row keeps the superset. It cannot be deferred
+  (the `CancelledError` originates in that coroutine, so there is nothing for
+  `_finish_deferring_cancellation` to defer, and issuing the call from inside
+  that region gives the identical residue), and it must not be settled blind:
+  whether the backend accepted the write is unknowable there, and narrowing the
+  row when it did not would leave `rows ⊂ graph` — over-deletion, which this
+  ranking treats as losing data, traded against a residue that merely retains a
+  chunk ID. So the row stays wide and the failure is *logged* with the row key
+  and the repair tool, which is the part that was actually owed. Its
   **rename** path needs no such staging and deliberately keeps its own ordering:
   it writes a fresh node whose `source_id` already equals the row it migrates,
   and it retires the old key only after the commit that removes the old node

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1697,7 +1697,10 @@ What that can leave behind, and why it is tolerated:
   row when it did not would leave `rows ⊂ graph` — over-deletion, which this
   ranking treats as losing data, traded against a residue that merely retains a
   chunk ID. So the row stays wide and the failure is *logged* with the row key
-  and the repair tool, which is the part that was actually owed. Its
+  and the repair tool, which is the part that was actually owed — for an
+  ordinary backend error as much as for a cancellation, since an
+  acknowledgement lost after the write was applied carries the same ambiguity
+  and the caller's error says only that the write failed. Its
   **rename** path needs no such staging and deliberately keeps its own ordering:
   it writes a fresh node whose `source_id` already equals the row it migrates,
   and it retires the old key only after the commit that removes the old node

--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1667,22 +1667,16 @@ What that can leave behind, and why it is tolerated:
   because a retry cannot heal it — the second edit sees an unchanged `source_id`
   and skips the tracking update — so the operator is the only recovery path, and
   a 200 would guarantee they never learn to take it.
-- **Accepted residue, not yet closed: `aedit_entity`'s non-rename path.** It
-  still commits the graph *before* flushing the tracking row, so a hard process
-  exit in that window leaves a **growing** edit — one that adds evidence IDs —
-  with the node on disk citing chunks its row does not yet name. That is the
-  `rows ⊂ graph` direction, the one this codebase does **not** accept: a later
-  purge of a document naming only the older chunks reads the row, concludes "no
-  remaining sources" and deletes an entity the added chunk still anchors. It is
-  reachable from `POST /graph/entity/edit`, whose `updated_data` accepts
-  `source_id`. It is a pre-existing gap rather than a new one — the rename
-  branch of the same function already stages its rows ahead of the commit (see
-  the [merge and rename failure model](design/PurgeRecoveryContract.md#merge-and-rename-failure-model))
-  — and closing it wants the same grow-then-shrink staging as `aedit_relation`,
-  applied without disturbing the rename branch's opposite, deliberate ordering
-  (issue #3609). Until then the recovery for an affected row is the
-  [chunk-tracking repair](#repairing-chunk-tracking), and a growing entity edit
-  should not be issued concurrently with, or shortly before, a document purge.
+- `aedit_entity`'s non-rename path stages its row the same way, for the same
+  reason: a **growing** edit there used to commit the node before flushing the
+  row that attributes it, leaving `rows ⊂ graph` — reachable from `POST
+  /graph/entity/edit`, whose `updated_data` accepts `source_id`. The superset
+  row is now durable before `upsert_node` is called at all, and the removals are
+  applied after the graph commit, with the same raise-on-failure contract. Its
+  **rename** path needs no such staging and deliberately keeps its own ordering:
+  it writes a fresh node whose `source_id` already equals the row it migrates,
+  and it retires the old key only after the commit that removes the old node
+  (see the [merge and rename failure model](design/PurgeRecoveryContract.md#merge-and-rename-failure-model)).
 - A graph backend that *declines* its commit (the NetworkX reload fence) raises
   out of the create, edit, merge and delete paths alike, so the caller sees a
   500 instead of a success for a write that was discarded.

--- a/lightrag/kg/networkx_impl.py
+++ b/lightrag/kg/networkx_impl.py
@@ -360,16 +360,12 @@ class NetworkXStorage(BaseGraphStorage):
         here: an uncommitted ``upsert_node`` still sits in the process-wide
         in-memory graph, where the next flush by any co-tenant publishes it.
 
-        **One path still reaches the forbidden state.**
-        ``utils_graph._edit_entity_impl``'s NON-rename branch commits the graph
-        before it flushes the tracking row, so a hard exit in that window
-        leaves a *growing* edit's node on disk citing chunks its row does not
-        name yet -- the state a later purge misreads as "no remaining
-        sources". Pre-existing (the rename branch of the same function already
-        stages its rows ahead of the commit); recovery is the chunk-tracking
-        rebuild tool; the fix is the grow-then-shrink staging
-        ``aedit_relation`` uses, applied without disturbing the rename
-        branch's opposite ordering (issue #3609).
+        The edit paths reach the same guarantee by a different route, because
+        their delta can also REMOVE ids and a narrowed row landing ahead of the
+        graph write is itself the over-deleting state: ``aedit_relation`` and
+        ``_edit_entity_impl``'s non-rename branch stage the row as
+        grow-then-shrink -- superset row, graph write, final row -- so the
+        durable row is never a strict subset of the durable evidence.
 
         **Requirement on new callers.** Any new caller of these mutators must
         make the tracking row durable BEFORE the mutation call, not merely

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1158,34 +1158,6 @@ async def _edit_entity_impl(
     entity_type = new_node_data.get("entity_type", "")
     entity_id = compute_mdhash_id(entity_name, prefix="ent-")
 
-    # The graph node was already updated above; a truncation failure here is
-    # the same "graph updated, VDB payload could not be completed" class of
-    # failure as an upsert failure.
-    try:
-        content = _truncate_vdb_content(
-            entity_name + "\n" + description,
-            entities_vdb.global_config,
-            f"entity:{entity_name}",
-        )
-        entity_data = {
-            entity_id: {
-                "content": content,
-                "entity_name": entity_name,
-                "source_id": source_id,
-                "description": description,
-                "entity_type": entity_type,
-            }
-        }
-        await entities_vdb.upsert(entity_data)
-    except Exception as e:
-        raise VectorStorageConsistencyError(
-            f"Vector storage upsert failed for entity `{entity_name}` during entity edit: "
-            f"{e}. The knowledge graph was already updated, so it may now be inconsistent "
-            "with the vector storage. No data is lost (the graph is the authoritative "
-            "source). Stop the LightRAG server and run the offline rebuild tool "
-            "(lightrag-rebuild-vdb) to restore consistency."
-        ) from e
-
     # Old keys whose rows may only be retired once the graph state that
     # replaced them is durable -- see the retirement block below.
     tracking_keys_to_retire: list[tuple[Any, str]] = []
@@ -1458,6 +1430,40 @@ async def _edit_entity_impl(
         _commit_graph_and_settle_tracking(),
         f"Entity Edit: `{original_entity_name}` graph and tracking cleanup",
     )
+    # The entity's vector record is written only once the graph state it mirrors
+    # is durable AND the tracking is settled. It used to sit between the
+    # mutation and that region, which made it one more thing that could strand
+    # the pending shrink: on an immediate-write backend `upsert_node` is already
+    # durable when this runs, so a truncation or upsert failure left the node
+    # narrowed with the row still holding the superset -- and nothing heals
+    # that, because the next edit reads the narrowed source_id and skips the
+    # staging. Writing it here instead removes the hazard rather than guarding
+    # it, and matches what the note below has always said about vector residue.
+    try:
+        content = _truncate_vdb_content(
+            entity_name + "\n" + description,
+            entities_vdb.global_config,
+            f"entity:{entity_name}",
+        )
+        entity_data = {
+            entity_id: {
+                "content": content,
+                "entity_name": entity_name,
+                "source_id": source_id,
+                "description": description,
+                "entity_type": entity_type,
+            }
+        }
+        await entities_vdb.upsert(entity_data)
+    except Exception as e:
+        raise VectorStorageConsistencyError(
+            f"Vector storage upsert failed for entity `{entity_name}` during entity edit: "
+            f"{e}. The knowledge graph was already updated, so it may now be inconsistent "
+            "with the vector storage. No data is lost (the graph is the authoritative "
+            "source). Stop the LightRAG server and run the offline rebuild tool "
+            "(lightrag-rebuild-vdb) to restore consistency."
+        ) from e
+
     # Vector stores last: their residue is the rebuildable window this codebase
     # accepts elsewhere, and bundling them earlier would let a vector failure
     # abort an edit whose graph state is already durable. It is also strictly

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -929,7 +929,9 @@ def _entity_chunk_tracking_update(
 
     existing_full_chunk_ids: list[str] = []
     if has_stored_row:
-        existing_full_chunk_ids = [cid for cid in stored_data.get("chunk_ids", []) if cid]
+        existing_full_chunk_ids = [
+            cid for cid in stored_data.get("chunk_ids", []) if cid
+        ]
     else:
         # Reseed from the graph's source_id only when no tracking row exists at
         # all; a present-but-empty row must not be repopulated from a possibly
@@ -1392,22 +1394,38 @@ async def _edit_entity_impl(
     # Vector stores last: their residue is the rebuildable window this codebase
     # accepts elsewhere, and bundling them earlier would let a vector failure
     # abort an edit whose graph state is already durable.
-    await _persist_graph_updates(
-        entities_vdb=entities_vdb,
-        relationships_vdb=relationships_vdb,
-    )
+    #
+    # A failure here is CAPTURED, not propagated yet, because the staged shrink
+    # below still has to be attempted. Letting it out here would strand the
+    # shrink, and the two residues are not equally recoverable: a stale vector
+    # store is rebuildable (`lightrag-rebuild-vdb`) and a re-issued edit rebuilds
+    # it anyway, while a row left holding the superset is repairable ONLY by the
+    # offline tool -- the next edit reads the already-narrowed source_id, so
+    # `_entity_chunk_tracking_update` returns None and the staging never runs
+    # again. Stranding the un-healable one to protect the self-healing one is
+    # backwards, so both are completed and the vector error is re-raised after.
+    vector_flush_error: BaseException | None = None
+    try:
+        await _persist_graph_updates(
+            entities_vdb=entities_vdb,
+            relationships_vdb=relationships_vdb,
+        )
+    except Exception as e:
+        logger.error(
+            f"Entity Edit: `{entity_name}` is durable, but flushing its vector "
+            f"records failed: {e}"
+        )
+        vector_flush_error = e
 
     # Shrink phase of the non-rename staging: the graph write that justifies
-    # dropping these ids is durable now, so the row may finally lose them. Run
-    # after the vector flush so a failure here cannot also strand that.
+    # dropping these ids is durable now, so the row may finally lose them.
     #
     # A failure raises `VectorStorageConsistencyError`, matching `aedit_relation`
     # and the rename retirement above: the edit IS durable, so the message says
     # so, but the row is left wider than the node's evidence and only an
-    # operator can reconcile it -- a repeated edit reads an unchanged source_id
-    # and skips the tracking staging entirely. The residue is the accepted
-    # direction (a row naming ids the entity no longer cites); reordering to
-    # avoid it would produce the over-deleting mirror instead.
+    # operator can reconcile it. The residue is the accepted direction (a row
+    # naming ids the entity no longer cites); reordering to avoid it would
+    # produce the over-deleting mirror instead.
     if pending_entity_shrink is not None:
         try:
             await entity_chunks_storage.upsert(
@@ -1427,17 +1445,33 @@ async def _edit_entity_impl(
                 f"tracking row `{entity_tracking_key}` down to "
                 f"{pending_entity_shrink} failed: {e}"
             )
+            # This outranks a vector flush failure, by the same ranking phase 2
+            # of `_persist_graph_updates` uses: the rebuildable window must not
+            # mask the residue nothing rebuilds. When both failed the operator
+            # needs both tools, so the message names both.
+            also_stale_vectors = (
+                " The vector records for this entity also failed to flush "
+                f"({vector_flush_error}), so they are stale as well; run "
+                "lightrag-rebuild-vdb for those."
+                if vector_flush_error is not None
+                else ""
+            )
             raise VectorStorageConsistencyError(
                 f"Pruning the chunk tracking row `{entity_tracking_key}` failed "
                 f"after editing entity `{entity_name}`: {e}. The edit itself is "
-                "durable -- the graph and vector records carry the new values -- "
-                "but the row still names chunk IDs the edit removed, so it is "
-                "wider than the entity's evidence. No data is lost (a purge "
-                "reading the wider row is more conservative, not less), and "
-                "re-issuing the edit cannot repair it: the second run sees an "
-                "unchanged source_id and skips the tracking staging. Run "
-                "lightrag-repair-chunk-tracking to reconcile the row."
+                "durable -- the graph carries the new values -- but the row still "
+                "names chunk IDs the edit removed, so it is wider than the "
+                "entity's evidence. No data is lost (a purge reading the wider "
+                "row is more conservative, not less), and re-issuing the edit "
+                "cannot repair it: the second run sees an unchanged source_id and "
+                "skips the tracking staging. Run lightrag-repair-chunk-tracking "
+                f"to reconcile the row.{also_stale_vectors}"
             ) from e
+
+    if vector_flush_error is not None:
+        # The shrink is settled; the vector failure is the caller's answer, with
+        # the same meaning it had before it was deferred past the shrink.
+        raise vector_flush_error
 
     logger.info(f"Entity Edit: `{entity_name}` successfully updated")
     return await get_entity_info(

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -941,9 +941,11 @@ def _entity_chunk_tracking_update(
     final_chunk_ids = compute_incremental_chunk_ids(
         existing_full_chunk_ids, old_chunk_ids, new_chunk_ids
     )
-    additions = [
-        cid for cid in final_chunk_ids if cid not in set(existing_full_chunk_ids)
-    ]
+    # Built once, not per element: a popular entity's row can hold thousands of
+    # chunk ids, and rebuilding the set inside the comprehension makes an
+    # ordinary source edit quadratic in that count.
+    existing_chunk_id_set = set(existing_full_chunk_ids)
+    additions = [cid for cid in final_chunk_ids if cid not in existing_chunk_id_set]
     superset_chunk_ids = existing_full_chunk_ids + additions
     return final_chunk_ids, superset_chunk_ids
 
@@ -1968,10 +1970,14 @@ async def aedit_relation(
                     # Grow phase: everything the row already held, plus the
                     # genuine additions. Identical to the final row whenever
                     # this edit removes nothing, which is the common case.
+                    # Set built once -- see the same note in
+                    # `_entity_chunk_tracking_update`: rebuilding it per element
+                    # makes the edit quadratic in the row's chunk count.
+                    existing_chunk_id_set = set(existing_full_chunk_ids)
                     additions = [
                         cid
                         for cid in updated_chunk_ids
-                        if cid not in set(existing_full_chunk_ids)
+                        if cid not in existing_chunk_id_set
                     ]
                     superset_chunk_ids = existing_full_chunk_ids + additions
                     if set(superset_chunk_ids) != set(updated_chunk_ids):

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -890,6 +890,62 @@ async def adelete_by_relation(
             )
 
 
+def _entity_chunk_tracking_update(
+    stored_data: Any,
+    node_data: dict[str, Any],
+    new_node_data: dict[str, Any],
+) -> tuple[list[str], list[str]] | None:
+    """Work out the chunk-tracking row an entity edit should leave behind.
+
+    Returns ``(final_chunk_ids, superset_chunk_ids)``, or ``None`` when this
+    edit has no reason to touch the row at all (the ``source_id`` is unchanged
+    and a row already exists).
+
+    ``superset_chunk_ids`` is the row plus this edit's genuine ADDITIONS and
+    nothing removed, which is what may be made durable ahead of the graph
+    mutation; ``final_chunk_ids`` is what the row must end up holding. They are
+    equal whenever the edit removes nothing, which is the common case.
+
+    The split exists because the two delta directions have opposite safe
+    orderings, exactly as in ``aedit_relation`` -- see the staging comments at
+    both call sites. This function is pure so both branches of
+    ``_edit_entity_impl`` derive the row from the same rules; only the ordering
+    of the writes differs between them.
+    """
+    from .utils import compute_incremental_chunk_ids, has_chunk_tracking_row
+
+    # Row presence by schema, never list truthiness -- see
+    # has_chunk_tracking_row for the authority model.
+    has_stored_row = has_chunk_tracking_row(stored_data)
+
+    old_source_id = node_data.get("source_id", "")
+    old_chunk_ids = [cid for cid in old_source_id.split(GRAPH_FIELD_SEP) if cid]
+
+    new_source_id = new_node_data.get("source_id", "")
+    new_chunk_ids = [cid for cid in new_source_id.split(GRAPH_FIELD_SEP) if cid]
+
+    if set(new_chunk_ids) == set(old_chunk_ids) and has_stored_row:
+        return None
+
+    existing_full_chunk_ids: list[str] = []
+    if has_stored_row:
+        existing_full_chunk_ids = [cid for cid in stored_data.get("chunk_ids", []) if cid]
+    else:
+        # Reseed from the graph's source_id only when no tracking row exists at
+        # all; a present-but-empty row must not be repopulated from a possibly
+        # stale source_id.
+        existing_full_chunk_ids = old_chunk_ids.copy()
+
+    final_chunk_ids = compute_incremental_chunk_ids(
+        existing_full_chunk_ids, old_chunk_ids, new_chunk_ids
+    )
+    additions = [
+        cid for cid in final_chunk_ids if cid not in set(existing_full_chunk_ids)
+    ]
+    superset_chunk_ids = existing_full_chunk_ids + additions
+    return final_chunk_ids, superset_chunk_ids
+
+
 async def _edit_entity_impl(
     chunk_entity_relation_graph,
     entities_vdb,
@@ -945,6 +1001,11 @@ async def _edit_entity_impl(
         del new_node_data[
             "entity_name"
         ]  # Node data should not contain entity_name field
+
+    # Set by the non-rename branch below when its tracking delta REMOVES ids, so
+    # the removal can be applied after the graph commit that justifies it.
+    pending_entity_shrink: list[str] | None = None
+    entity_tracking_key: str | None = None
 
     if is_renaming:
         logger.info(f"Entity Edit: renaming `{entity_name}` to `{new_entity_name}`")
@@ -1044,19 +1105,48 @@ async def _edit_entity_impl(
 
         entity_name = new_entity_name
     else:
-        # KNOWN GAP -- this mutation precedes the tracking row it needs, and the
-        # graph commit below (`_commit_rename_and_retire_tracking`) precedes the
-        # row's flush. A hard exit in between leaves a GROWING edit -- one whose
-        # `updated_data` adds evidence IDs, which `/graph/entity/edit` accepts --
-        # with the node durable citing chunks its row does not name yet: the
-        # `rows subset-of graph` direction a later purge misreads as "no
-        # remaining sources". Pre-existing, not introduced by the ordering work
-        # above; the rename branch already stages its rows ahead of the commit.
-        # The fix is the grow-then-shrink staging `aedit_relation` uses, which
-        # cannot simply be lifted here because this tracking block is shared
-        # with the rename branch, whose ordering is deliberately the opposite
-        # (issue #3609). Recovery meanwhile: lightrag-repair-chunk-tracking.
-        # Documented in docs/ProgramingWithCore.md -> Concurrent admin writes.
+        # Non-rename edit: stage the tracking row grow-then-shrink around this
+        # mutation (issue #3890). The row has to be durable BEFORE the mutation
+        # is issued, not merely before the flush -- on Neo4j or PostgreSQL
+        # `upsert_node` is durable the moment it returns, and on NetworkX the
+        # node is already in the process-wide in-memory graph, where the next
+        # flush by any co-tenant publishes it. Growing edits are the ones that
+        # need this: without it the node lands citing chunks its row does not
+        # name, the `rows subset-of graph` state a purge misreads as "no
+        # remaining sources".
+        #
+        # A single ordering cannot serve both delta directions -- committing a
+        # NARROWED row ahead of the graph is itself that same over-deleting
+        # state -- so the superset row goes first and the removals are applied
+        # after the graph commit, below. The rename branch above needs no such
+        # staging: it writes a fresh node whose `source_id` already matches the
+        # row it stages, and it flushes that row before the commit.
+        if entity_chunks_storage is not None:
+            tracking_update = _entity_chunk_tracking_update(
+                await entity_chunks_storage.get_by_id(entity_name),
+                node_data,
+                new_node_data,
+            )
+            if tracking_update is not None:
+                final_chunk_ids, superset_chunk_ids = tracking_update
+                await entity_chunks_storage.upsert(
+                    {
+                        entity_name: {
+                            "chunk_ids": superset_chunk_ids,
+                            "count": len(superset_chunk_ids),
+                        }
+                    }
+                )
+                await _persist_graph_updates(
+                    entity_chunks_storage=entity_chunks_storage,
+                )
+                if set(superset_chunk_ids) != set(final_chunk_ids):
+                    pending_entity_shrink = final_chunk_ids
+                    entity_tracking_key = entity_name
+                logger.info(
+                    f"Entity Edit: find {len(final_chunk_ids)} chunks related to `{entity_name}`"
+                )
+
         await chunk_entity_relation_graph.upsert_node(entity_name, new_node_data)
 
     description = new_node_data.get("description", "")
@@ -1097,69 +1187,59 @@ async def _edit_entity_impl(
     tracking_keys_to_retire: list[tuple[Any, str]] = []
 
     if entity_chunks_storage is not None or relation_chunks_storage is not None:
-        from .utils import (
-            make_relation_chunk_key,
-            compute_incremental_chunk_ids,
-            has_chunk_tracking_row,
-        )
+        from .utils import make_relation_chunk_key, has_chunk_tracking_row
 
-        if entity_chunks_storage is not None:
-            storage_key = original_entity_name if is_renaming else entity_name
-            stored_data = await entity_chunks_storage.get_by_id(storage_key)
-            # Row presence by schema, never list truthiness — see
-            # has_chunk_tracking_row for the authority model.
-            has_stored_row = has_chunk_tracking_row(stored_data)
-
-            old_source_id = node_data.get("source_id", "")
-            old_chunk_ids = [cid for cid in old_source_id.split(GRAPH_FIELD_SEP) if cid]
-
-            new_source_id = new_node_data.get("source_id", "")
-            new_chunk_ids = [cid for cid in new_source_id.split(GRAPH_FIELD_SEP) if cid]
-
-            source_id_changed = set(new_chunk_ids) != set(old_chunk_ids)
-
-            if source_id_changed or not has_stored_row or is_renaming:
-                existing_full_chunk_ids = []
-                if has_stored_row:
-                    existing_full_chunk_ids = [
-                        cid for cid in stored_data.get("chunk_ids", []) if cid
+        # Rename only. The non-rename edit stages its own row above, ahead of
+        # the graph mutation; reaching this point for it would put the row's
+        # write after the mutation again, which is the defect issue #3890 fixed.
+        if is_renaming and entity_chunks_storage is not None:
+            stored_data = await entity_chunks_storage.get_by_id(original_entity_name)
+            # A rename always migrates the row, even when the source_id is
+            # untouched and the helper would leave it alone: the row has to
+            # reappear under the new key. `final` is used directly -- a rename
+            # writes a FRESH node whose source_id already equals what this row
+            # will name, so there is no wider durable evidence to stay above and
+            # no reason to stage a superset.
+            tracking_update = _entity_chunk_tracking_update(
+                stored_data, node_data, new_node_data
+            )
+            if tracking_update is not None:
+                updated_chunk_ids = tracking_update[0]
+            else:
+                updated_chunk_ids = (
+                    [cid for cid in stored_data.get("chunk_ids", []) if cid]
+                    if has_chunk_tracking_row(stored_data)
+                    else [
+                        cid
+                        for cid in node_data.get("source_id", "").split(GRAPH_FIELD_SEP)
+                        if cid
                     ]
-
-                # Reseed from the graph's source_id only when no tracking row exists at
-                # all; a present-but-empty row must not be repopulated from a possibly
-                # stale source_id.
-                if not has_stored_row:
-                    existing_full_chunk_ids = old_chunk_ids.copy()
-
-                updated_chunk_ids = compute_incremental_chunk_ids(
-                    existing_full_chunk_ids, old_chunk_ids, new_chunk_ids
                 )
 
-                # On rename, write the new key BEFORE deleting the old one: on
-                # RPC-backed KV storages each call commits independently, so the
-                # reverse order opens a crash window in which the row exists under
-                # neither key — turning a curated row absent and re-arming the
-                # stale reseed. An orphaned old-key row is dead bookkeeping; a
-                # lost row is the bug.
-                await entity_chunks_storage.upsert(
-                    {
-                        entity_name: {
-                            "chunk_ids": updated_chunk_ids,
-                            "count": len(updated_chunk_ids),
-                        }
+            # On rename, write the new key BEFORE deleting the old one: on
+            # RPC-backed KV storages each call commits independently, so the
+            # reverse order opens a crash window in which the row exists under
+            # neither key — turning a curated row absent and re-arming the
+            # stale reseed. An orphaned old-key row is dead bookkeeping; a
+            # lost row is the bug.
+            await entity_chunks_storage.upsert(
+                {
+                    entity_name: {
+                        "chunk_ids": updated_chunk_ids,
+                        "count": len(updated_chunk_ids),
                     }
-                )
-                if is_renaming:
-                    # Retired below, after the graph commit that actually
-                    # removes the old node. Deleting it here would strip the
-                    # provenance of an entity still on disk.
-                    tracking_keys_to_retire.append(
-                        (entity_chunks_storage, original_entity_name)
-                    )
+                }
+            )
+            # Retired below, after the graph commit that actually removes the
+            # old node. Deleting it here would strip the provenance of an
+            # entity still on disk.
+            tracking_keys_to_retire.append(
+                (entity_chunks_storage, original_entity_name)
+            )
 
-                logger.info(
-                    f"Entity Edit: find {len(updated_chunk_ids)} chunks related to `{entity_name}`"
-                )
+            logger.info(
+                f"Entity Edit: find {len(updated_chunk_ids)} chunks related to `{entity_name}`"
+            )
 
         if is_renaming and relation_chunks_storage is not None and relations_to_update:
             for src, tgt, edge_data in relations_to_update:
@@ -1316,6 +1396,48 @@ async def _edit_entity_impl(
         entities_vdb=entities_vdb,
         relationships_vdb=relationships_vdb,
     )
+
+    # Shrink phase of the non-rename staging: the graph write that justifies
+    # dropping these ids is durable now, so the row may finally lose them. Run
+    # after the vector flush so a failure here cannot also strand that.
+    #
+    # A failure raises `VectorStorageConsistencyError`, matching `aedit_relation`
+    # and the rename retirement above: the edit IS durable, so the message says
+    # so, but the row is left wider than the node's evidence and only an
+    # operator can reconcile it -- a repeated edit reads an unchanged source_id
+    # and skips the tracking staging entirely. The residue is the accepted
+    # direction (a row naming ids the entity no longer cites); reordering to
+    # avoid it would produce the over-deleting mirror instead.
+    if pending_entity_shrink is not None:
+        try:
+            await entity_chunks_storage.upsert(
+                {
+                    entity_tracking_key: {
+                        "chunk_ids": pending_entity_shrink,
+                        "count": len(pending_entity_shrink),
+                    }
+                }
+            )
+            await _persist_graph_updates(
+                entity_chunks_storage=entity_chunks_storage,
+            )
+        except Exception as e:
+            logger.error(
+                f"Entity Edit: `{entity_name}` is durable, but pruning its chunk "
+                f"tracking row `{entity_tracking_key}` down to "
+                f"{pending_entity_shrink} failed: {e}"
+            )
+            raise VectorStorageConsistencyError(
+                f"Pruning the chunk tracking row `{entity_tracking_key}` failed "
+                f"after editing entity `{entity_name}`: {e}. The edit itself is "
+                "durable -- the graph and vector records carry the new values -- "
+                "but the row still names chunk IDs the edit removed, so it is "
+                "wider than the entity's evidence. No data is lost (a purge "
+                "reading the wider row is more conservative, not less), and "
+                "re-issuing the edit cannot repair it: the second run sees an "
+                "unchanged source_id and skips the tracking staging. Run "
+                "lightrag-repair-chunk-tracking to reconcile the row."
+            ) from e
 
     logger.info(f"Entity Edit: `{entity_name}` successfully updated")
     return await get_entity_info(

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1151,7 +1151,39 @@ async def _edit_entity_impl(
                     f"Entity Edit: find {len(final_chunk_ids)} chunks related to `{entity_name}`"
                 )
 
-        await chunk_entity_relation_graph.upsert_node(entity_name, new_node_data)
+        try:
+            await chunk_entity_relation_graph.upsert_node(entity_name, new_node_data)
+        except BaseException as e:
+            # Accepted residue, and the one place in this staging that cannot be
+            # closed. A cancellation delivered INSIDE this await -- after an
+            # immediate-write backend accepted the row, before control returns
+            # -- tears the edit down before the shrink can run, leaving the node
+            # narrowed with the row still at the staged superset.
+            #
+            # It cannot be deferred away: the CancelledError originates in this
+            # coroutine, so `_finish_deferring_cancellation` has nothing to
+            # defer, and issuing the call from inside that region changes
+            # nothing (measured -- the residue is identical either way).
+            #
+            # It must not be settled blind either. Whether the backend accepted
+            # the mutation is unknowable from here, and narrowing the row when
+            # it did NOT would leave the row a strict SUBSET of the graph --
+            # over-deletion, which AGENTS.md ranks as losing data, traded
+            # against a residue that merely retains a chunk id. So the row stays
+            # wide on purpose; only the diagnostic is owed, and only for a
+            # teardown that carries no normal error path of its own.
+            if pending_entity_shrink is not None and not isinstance(e, Exception):
+                logger.error(
+                    f"Entity Edit: `{entity_name}` was torn down by "
+                    f"{type(e).__name__} during its graph write. If the backend "
+                    f"accepted that write, its chunk tracking row "
+                    f"`{entity_tracking_key}` is now wider than the node's "
+                    f"evidence -- it still names the IDs this edit removed, and "
+                    "no retry will prune them (the next edit reads the narrowed "
+                    "source_id and skips the staging). Run "
+                    "lightrag-repair-chunk-tracking to reconcile it."
+                )
+            raise
 
     description = new_node_data.get("description", "")
     source_id = new_node_data.get("source_id", "")

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1210,15 +1210,15 @@ async def _edit_entity_impl(
             if tracking_update is not None:
                 updated_chunk_ids = tracking_update[0]
             else:
-                updated_chunk_ids = (
-                    [cid for cid in stored_data.get("chunk_ids", []) if cid]
-                    if has_chunk_tracking_row(stored_data)
-                    else [
-                        cid
-                        for cid in node_data.get("source_id", "").split(GRAPH_FIELD_SEP)
-                        if cid
-                    ]
-                )
+                # `None` means the helper saw an unchanged source_id AND a
+                # present row, so the row is already the authoritative list and
+                # migrating it verbatim is the whole job. There is deliberately
+                # no reseed-from-source_id arm here: an absent row cannot reach
+                # this branch, and reseeding one that could would be the stale
+                # reseed issue #3609 exists to prevent.
+                updated_chunk_ids = [
+                    cid for cid in stored_data.get("chunk_ids", []) if cid
+                ]
 
             # On rename, write the new key BEFORE deleting the old one: on
             # RPC-backed KV storages each call commits independently, so the
@@ -1379,10 +1379,19 @@ async def _edit_entity_impl(
         # Flushed inside the region: on a deferred KV backend the deletes above
         # only touch memory, so a cancellation delivered before this flush would
         # leave the retired rows on disk -- the orphan the region prevents.
-        await _persist_graph_updates(
-            entity_chunks_storage=entity_chunks_storage,
-            relation_chunks_storage=relation_chunks_storage,
-        )
+        #
+        # Rename-only, because retiring is the only thing that needs it. A
+        # non-rename edit touches neither storage here -- its superset row was
+        # flushed before the graph mutation and its shrink flushes its own row
+        # below -- so flushing them anyway only added a way to fail: this helper
+        # re-raises the first phase-1 error, so an unrelated
+        # `relation_chunks_storage` flush failure would skip the shrink and
+        # surface an error naming neither the row nor the repair tool.
+        if is_renaming:
+            await _persist_graph_updates(
+                entity_chunks_storage=entity_chunks_storage,
+                relation_chunks_storage=relation_chunks_storage,
+            )
 
         # Shrink phase of the non-rename staging (mutually exclusive with the
         # rename retirement above): the graph write that justifies dropping

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1170,18 +1170,27 @@ async def _edit_entity_impl(
             # it did NOT would leave the row a strict SUBSET of the graph --
             # over-deletion, which AGENTS.md ranks as losing data, traded
             # against a residue that merely retains a chunk id. So the row stays
-            # wide on purpose; only the diagnostic is owed, and only for a
-            # teardown that carries no normal error path of its own.
-            if pending_entity_shrink is not None and not isinstance(e, Exception):
+            # wide on purpose and the diagnostic is what is owed.
+            #
+            # It is owed for an ORDINARY exception too, not just a teardown. An
+            # RPC acknowledgement that times out after the backend applied the
+            # update carries exactly the same ambiguity, and the error the
+            # caller gets says "the graph write failed" -- not "your tracking
+            # row may now be wider than the node, and only the offline tool can
+            # prune it". The line only fires for a SHRINKING edit whose write
+            # failed, so it is not noise, and it is hedged because whether the
+            # write landed is precisely what is unknown.
+            if pending_entity_shrink is not None:
                 logger.error(
-                    f"Entity Edit: `{entity_name}` was torn down by "
-                    f"{type(e).__name__} during its graph write. If the backend "
-                    f"accepted that write, its chunk tracking row "
-                    f"`{entity_tracking_key}` is now wider than the node's "
-                    f"evidence -- it still names the IDs this edit removed, and "
-                    "no retry will prune them (the next edit reads the narrowed "
-                    "source_id and skips the staging). Run "
-                    "lightrag-repair-chunk-tracking to reconcile it."
+                    f"Entity Edit: `{entity_name}`'s graph write did not complete "
+                    f"({type(e).__name__}: {e}). If the backend applied it anyway "
+                    f"-- an immediate-write backend may have, and an "
+                    f"acknowledgement can be lost after the fact -- then its "
+                    f"chunk tracking row `{entity_tracking_key}` is now wider "
+                    "than the node's evidence: it still names the IDs this edit "
+                    "removed, and no retry will prune them, because the next "
+                    "edit reads the narrowed source_id and skips the staging. "
+                    "Run lightrag-repair-chunk-tracking to reconcile it."
                 )
             raise
 

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1340,7 +1340,7 @@ async def _edit_entity_impl(
                 "nothing has lost its provenance. Retry the rename."
             ) from e
 
-    async def _commit_rename_and_retire_tracking() -> None:
+    async def _commit_graph_and_settle_tracking() -> None:
         # `entity_name` has been rebound to the new name by now, so the removal
         # names the original explicitly.
         if is_renaming:
@@ -1382,96 +1382,83 @@ async def _edit_entity_impl(
             relation_chunks_storage=relation_chunks_storage,
         )
 
+        # Shrink phase of the non-rename staging (mutually exclusive with the
+        # rename retirement above): the graph write that justifies dropping
+        # these ids is durable now, so the row may finally lose them.
+        #
+        # Inside the region for the same reason the retirement is. A
+        # cancellation delivered during the commit is deferred to the END of
+        # this coroutine, so a shrink placed after the region would simply never
+        # run -- `CancelledError` is a `BaseException`, so no `except Exception`
+        # out there can catch it either. That leaves the un-healable residue: a
+        # row still holding the staged superset, which no retry reaches because
+        # the next edit reads the already-narrowed source_id and
+        # `_entity_chunk_tracking_update` returns None.
+        #
+        # A failure raises `VectorStorageConsistencyError`, matching the
+        # retirement above and `aedit_relation`: the edit IS durable, so the
+        # message says so, but the row is left wider than the node's evidence
+        # and only the offline tool can reconcile it. When a cancel is already
+        # pending, `_finish_deferring_cancellation` logs it instead -- that is
+        # the one place the failure can still be seen. The residue is the
+        # accepted direction (a row naming ids the entity no longer cites);
+        # reordering to avoid it would produce the over-deleting mirror.
+        if pending_entity_shrink is not None:
+            try:
+                await entity_chunks_storage.upsert(
+                    {
+                        entity_tracking_key: {
+                            "chunk_ids": pending_entity_shrink,
+                            "count": len(pending_entity_shrink),
+                        }
+                    }
+                )
+                await _persist_graph_updates(
+                    entity_chunks_storage=entity_chunks_storage,
+                )
+            except Exception as e:
+                logger.error(
+                    f"Entity Edit: `{entity_name}` is durable, but pruning its "
+                    f"chunk tracking row `{entity_tracking_key}` down to "
+                    f"{pending_entity_shrink} failed: {e}"
+                )
+                raise VectorStorageConsistencyError(
+                    f"Pruning the chunk tracking row `{entity_tracking_key}` "
+                    f"failed after editing entity `{entity_name}`: {e}. The edit "
+                    "itself is durable -- the graph carries the new values -- but "
+                    "the row still names chunk IDs the edit removed, so it is "
+                    "wider than the entity's evidence. No data is lost (a purge "
+                    "reading the wider row is more conservative, not less), and "
+                    "re-issuing the edit cannot repair it: the second run sees an "
+                    "unchanged source_id and skips the tracking staging. Run "
+                    "lightrag-repair-chunk-tracking to reconcile the row. The "
+                    "vector records were not flushed either, so re-issue the edit "
+                    "or run lightrag-rebuild-vdb for those."
+                ) from e
+
     # One cancellation-deferring region, as in adelete_by_entity: after the
     # commit the old node is gone for good, so its rows describe nothing and the
     # cleanup is owed; a cancellation delivered mid-cleanup would strand them.
     # The region starts before the commit because that await is itself where a
-    # deferred cancellation reappears.
+    # deferred cancellation reappears, and it ENDS after the tracking is
+    # settled -- retired on a rename, shrunk on a non-rename edit -- because
+    # everything it owes the graph state has to survive a cancel.
     await _finish_deferring_cancellation(
-        _commit_rename_and_retire_tracking(),
+        _commit_graph_and_settle_tracking(),
         f"Entity Edit: `{original_entity_name}` graph and tracking cleanup",
     )
     # Vector stores last: their residue is the rebuildable window this codebase
     # accepts elsewhere, and bundling them earlier would let a vector failure
-    # abort an edit whose graph state is already durable.
-    #
-    # A failure here is CAPTURED, not propagated yet, because the staged shrink
-    # below still has to be attempted. Letting it out here would strand the
-    # shrink, and the two residues are not equally recoverable: a stale vector
-    # store is rebuildable (`lightrag-rebuild-vdb`) and a re-issued edit rebuilds
-    # it anyway, while a row left holding the superset is repairable ONLY by the
-    # offline tool -- the next edit reads the already-narrowed source_id, so
-    # `_entity_chunk_tracking_update` returns None and the staging never runs
-    # again. Stranding the un-healable one to protect the self-healing one is
-    # backwards, so both are completed and the vector error is re-raised after.
-    vector_flush_error: BaseException | None = None
-    try:
-        await _persist_graph_updates(
-            entities_vdb=entities_vdb,
-            relationships_vdb=relationships_vdb,
-        )
-    except Exception as e:
-        logger.error(
-            f"Entity Edit: `{entity_name}` is durable, but flushing its vector "
-            f"records failed: {e}"
-        )
-        vector_flush_error = e
-
-    # Shrink phase of the non-rename staging: the graph write that justifies
-    # dropping these ids is durable now, so the row may finally lose them.
-    #
-    # A failure raises `VectorStorageConsistencyError`, matching `aedit_relation`
-    # and the rename retirement above: the edit IS durable, so the message says
-    # so, but the row is left wider than the node's evidence and only an
-    # operator can reconcile it. The residue is the accepted direction (a row
-    # naming ids the entity no longer cites); reordering to avoid it would
-    # produce the over-deleting mirror instead.
-    if pending_entity_shrink is not None:
-        try:
-            await entity_chunks_storage.upsert(
-                {
-                    entity_tracking_key: {
-                        "chunk_ids": pending_entity_shrink,
-                        "count": len(pending_entity_shrink),
-                    }
-                }
-            )
-            await _persist_graph_updates(
-                entity_chunks_storage=entity_chunks_storage,
-            )
-        except Exception as e:
-            logger.error(
-                f"Entity Edit: `{entity_name}` is durable, but pruning its chunk "
-                f"tracking row `{entity_tracking_key}` down to "
-                f"{pending_entity_shrink} failed: {e}"
-            )
-            # This outranks a vector flush failure, by the same ranking phase 2
-            # of `_persist_graph_updates` uses: the rebuildable window must not
-            # mask the residue nothing rebuilds. When both failed the operator
-            # needs both tools, so the message names both.
-            also_stale_vectors = (
-                " The vector records for this entity also failed to flush "
-                f"({vector_flush_error}), so they are stale as well; run "
-                "lightrag-rebuild-vdb for those."
-                if vector_flush_error is not None
-                else ""
-            )
-            raise VectorStorageConsistencyError(
-                f"Pruning the chunk tracking row `{entity_tracking_key}` failed "
-                f"after editing entity `{entity_name}`: {e}. The edit itself is "
-                "durable -- the graph carries the new values -- but the row still "
-                "names chunk IDs the edit removed, so it is wider than the "
-                "entity's evidence. No data is lost (a purge reading the wider "
-                "row is more conservative, not less), and re-issuing the edit "
-                "cannot repair it: the second run sees an unchanged source_id and "
-                "skips the tracking staging. Run lightrag-repair-chunk-tracking "
-                f"to reconcile the row.{also_stale_vectors}"
-            ) from e
-
-    if vector_flush_error is not None:
-        # The shrink is settled; the vector failure is the caller's answer, with
-        # the same meaning it had before it was deferred past the shrink.
-        raise vector_flush_error
+    # abort an edit whose graph state is already durable. It is also strictly
+    # AFTER the tracking is settled inside the region above, so a raising vector
+    # callback can no longer strand the staged shrink. The reverse exposure is
+    # the acceptable one: a shrink failure skips this flush, leaving vector
+    # records a re-issued edit rewrites and `lightrag-rebuild-vdb` restores,
+    # rather than a tracking row nothing but the offline tool can heal.
+    await _persist_graph_updates(
+        entities_vdb=entities_vdb,
+        relationships_vdb=relationships_vdb,
+    )
 
     logger.info(f"Entity Edit: `{entity_name}` successfully updated")
     return await get_entity_info(

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -1597,6 +1597,8 @@ class TestRelationEditGrowsBeforeItShrinks:
             "chunk-1",
             "chunk-2",
         ]
+
+
 class _EntityEditMixin:
     """Shared helpers for the entity-edit staging cases."""
 
@@ -1773,3 +1775,46 @@ class TestEntityEditGrowsBeforeItShrinks(_EntityEditMixin):
             "chunk-1",
             "chunk-2",
         ]
+
+    @pytest.mark.asyncio
+    async def test_a_failing_vector_flush_does_not_strand_the_shrink(self, deferred):
+        # The shrink sits after the vector flush, so a raising vector callback
+        # used to exit the edit with the row still holding the staged superset --
+        # and nothing heals that: the next edit reads the already-narrowed
+        # source_id and skips the staging entirely. The vector store, by
+        # contrast, is the rebuildable window. So the shrink is completed and
+        # the vector error is re-raised after it.
+        await self._seed_two_chunk_entity(deferred)
+        deferred.entities_vdb.fail_flush = True
+
+        with pytest.raises(_Boom, match="vector flush failed"):
+            await self._edit(deferred, self.SHRINKING_EDIT)
+
+        assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == ["chunk-1"]
+        assert deferred.entity_chunks.disk[ENTITY]["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_a_failed_shrink_outranks_a_failing_vector_flush(
+        self, deferred, monkeypatch
+    ):
+        # Both fail. The caller must hear about the residue nothing rebuilds,
+        # and the message has to name both recovery tools because both are owed.
+        await self._seed_two_chunk_entity(deferred)
+        deferred.entities_vdb.fail_flush = True
+        calls = {"n": 0}
+        original = deferred.entity_chunks.upsert
+
+        async def _upsert(data):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise _Boom("shrink write failed")
+            return await original(data)
+
+        monkeypatch.setattr(deferred.entity_chunks, "upsert", _upsert)
+
+        with pytest.raises(VectorStorageConsistencyError) as excinfo:
+            await self._edit(deferred, self.SHRINKING_EDIT)
+
+        message = str(excinfo.value)
+        assert "lightrag-repair-chunk-tracking" in message
+        assert "lightrag-rebuild-vdb" in message

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -1597,3 +1597,179 @@ class TestRelationEditGrowsBeforeItShrinks:
             "chunk-1",
             "chunk-2",
         ]
+class _EntityEditMixin:
+    """Shared helpers for the entity-edit staging cases."""
+
+    GROWING_EDIT = {"source_id": f"chunk-1{GRAPH_FIELD_SEP}chunk-7"}
+    SHRINKING_EDIT = {"source_id": "chunk-1"}
+
+    @staticmethod
+    async def _seed_two_chunk_entity(fixture):
+        node = await fixture.graph.get_node(ENTITY)
+        await fixture.graph.upsert_node(
+            ENTITY,
+            {**node, "source_id": f"chunk-1{GRAPH_FIELD_SEP}chunk-2"},
+        )
+        await fixture.graph.index_done_callback()
+        await fixture.entity_chunks.upsert(
+            {ENTITY: {"chunk_ids": ["chunk-1", "chunk-2"], "count": 2}}
+        )
+        await fixture.entity_chunks.index_done_callback()
+        fixture.commit_log.clear()
+
+    @staticmethod
+    async def _edit(fixture, updated_data):
+        return await utils_graph.aedit_entity(
+            fixture.graph,
+            fixture.entities_vdb,
+            fixture.relationships_vdb,
+            ENTITY,
+            dict(updated_data),
+            entity_chunks_storage=fixture.entity_chunks,
+            relation_chunks_storage=fixture.relation_chunks,
+        )
+
+
+class TestEntityEditWritesTheRowBeforeTheGraphCall(_EntityEditMixin):
+    """Fix proof: a non-rename entity edit must not mutate the node first.
+
+    `_edit_entity_impl`'s non-rename branch used to call `upsert_node` before
+    its tracking row existed, and flush that row only AFTER the graph commit. On
+    an immediate-write backend the node is durable the moment `upsert_node`
+    returns, so a growing edit whose row cannot be stored left the node citing
+    chunks nothing attributes -- `rows subset-of graph`, which a later purge
+    misreads as "no remaining sources".
+
+    Goes red on the pre-fix ordering: the node carries the widened source_id
+    even though the tracking write never landed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_growing_edit_leaves_the_node_alone_when_its_row_fails(
+        self, deferred
+    ):
+        # The graph double is passed in rather than swapped onto the fixture, so
+        # the fixture keeps owning the NetworkX instance it has to finalize.
+        graph = _ImmediateGraphStorage()
+        await graph.upsert_node(
+            ENTITY, {"entity_id": ENTITY, "description": "d", "source_id": "chunk-1"}
+        )
+        deferred.entity_chunks.fail_commit_times = 1
+
+        with pytest.raises(_Boom):
+            await utils_graph.aedit_entity(
+                graph,
+                deferred.entities_vdb,
+                deferred.relationships_vdb,
+                ENTITY,
+                dict(self.GROWING_EDIT),
+                entity_chunks_storage=deferred.entity_chunks,
+                relation_chunks_storage=deferred.relation_chunks,
+            )
+
+        # The node must still cite only what its durable row attributes.
+        assert graph.nodes[ENTITY]["source_id"] == "chunk-1"
+        assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == ["chunk-1"]
+
+
+class TestEntityEditGrowsBeforeItShrinks(_EntityEditMixin):
+    """Fix proof + residue pins for the non-rename grow-then-shrink staging.
+
+    The delta runs in both directions and they have opposite safe orderings, so
+    the row is staged as superset -> graph -> final, exactly as in
+    `aedit_relation`. The durable row is then never a strict subset of the
+    durable node evidence.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_growing_edit_commits_the_row_before_the_graph(
+        self, deferred, monkeypatch
+    ):
+        _log_graph_commit(deferred, monkeypatch, fail=False)
+
+        await self._edit(deferred, self.GROWING_EDIT)
+
+        assert deferred.commit_log.index("entity_chunks") < deferred.commit_log.index(
+            "graph"
+        )
+        assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == [
+            "chunk-1",
+            "chunk-7",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_failed_graph_commit_leaves_the_wider_row_on_disk(
+        self, deferred, monkeypatch
+    ):
+        _log_graph_commit(deferred, monkeypatch, fail=True)
+
+        with pytest.raises(_Boom):
+            await self._edit(deferred, self.GROWING_EDIT)
+
+        # Residue is the accepted direction: the row names a chunk the durable
+        # node does not cite yet, never the reverse.
+        assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == [
+            "chunk-1",
+            "chunk-7",
+        ]
+        assert deferred.persisted_graph().nodes[ENTITY]["source_id"] == "chunk-1"
+
+    @pytest.mark.asyncio
+    async def test_a_shrinking_edit_ends_with_the_narrowed_row(self, deferred):
+        await self._seed_two_chunk_entity(deferred)
+
+        await self._edit(deferred, self.SHRINKING_EDIT)
+
+        assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == ["chunk-1"]
+        assert deferred.entity_chunks.disk[ENTITY]["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_a_failed_graph_commit_during_a_shrink_keeps_the_wider_row(
+        self, deferred, monkeypatch
+    ):
+        # The shrink is withheld until the graph commit justifies it, so a
+        # failure here must not have narrowed the row already.
+        await self._seed_two_chunk_entity(deferred)
+        _log_graph_commit(deferred, monkeypatch, fail=True)
+
+        with pytest.raises(_Boom):
+            await self._edit(deferred, self.SHRINKING_EDIT)
+
+        assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == [
+            "chunk-1",
+            "chunk-2",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_failed_shrink_keeps_the_edit_and_reports_the_wider_row(
+        self, deferred, monkeypatch
+    ):
+        # Same contract as the relation path: the edit is durable, the residue is
+        # the wider row, and the failure is reported rather than swallowed --
+        # a retry reads an unchanged source_id and skips the staging, so only an
+        # operator can reconcile it.
+        await self._seed_two_chunk_entity(deferred)
+        calls = {"n": 0}
+        original = deferred.entity_chunks.upsert
+
+        async def _upsert(data):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise _Boom("shrink write failed")
+            return await original(data)
+
+        monkeypatch.setattr(deferred.entity_chunks, "upsert", _upsert)
+
+        with pytest.raises(VectorStorageConsistencyError) as excinfo:
+            await self._edit(deferred, self.SHRINKING_EDIT)
+
+        message = str(excinfo.value)
+        assert ENTITY in message
+        assert "durable" in message
+        assert "lightrag-repair-chunk-tracking" in message
+
+        assert deferred.persisted_graph().nodes[ENTITY]["source_id"] == "chunk-1"
+        assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == [
+            "chunk-1",
+            "chunk-2",
+        ]

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -1857,9 +1857,19 @@ class TestEntityEditGrowsBeforeItShrinks(_EntityEditMixin):
         assert deferred.persisted_graph().nodes[ENTITY]["source_id"] == "chunk-1"
         assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == ["chunk-1"]
 
+    @pytest.mark.parametrize(
+        "teardown",
+        [
+            pytest.param(asyncio.CancelledError(), id="cancelled"),
+            # Same ambiguity, and the caller's own error says only that the
+            # graph write failed: an acknowledgement lost after an
+            # immediate-write backend applied the update.
+            pytest.param(_Boom("ack timed out"), id="ordinary-exception"),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_a_cancel_inside_the_node_write_leaves_a_diagnosed_wide_row(
-        self, deferred, monkeypatch
+    async def test_a_failed_node_write_leaves_a_diagnosed_wide_row(
+        self, deferred, monkeypatch, teardown
     ):
         # The one residue of this staging that cannot be closed. A cancellation
         # delivered inside `upsert_node`'s own await -- after an immediate-write
@@ -1890,11 +1900,11 @@ class TestEntityEditGrowsBeforeItShrinks(_EntityEditMixin):
         await deferred.entity_chunks.index_done_callback()
         original = graph.upsert_node
 
-        async def _write_then_cancelled(node_id, node_data):
+        async def _write_then_fail(node_id, node_data):
             await original(node_id, node_data)
-            raise asyncio.CancelledError()
+            raise teardown
 
-        monkeypatch.setattr(graph, "upsert_node", _write_then_cancelled)
+        monkeypatch.setattr(graph, "upsert_node", _write_then_fail)
         # `lightrag.utils.logger` sets propagate=False, so caplog sees nothing;
         # collect from the logger this module actually calls.
         errors: list[str] = []
@@ -1902,7 +1912,7 @@ class TestEntityEditGrowsBeforeItShrinks(_EntityEditMixin):
             utils_graph.logger, "error", lambda msg, *a, **k: errors.append(str(msg))
         )
 
-        with pytest.raises(asyncio.CancelledError):
+        with pytest.raises(type(teardown)):
             await utils_graph.aedit_entity(
                 graph,
                 deferred.entities_vdb,
@@ -1914,7 +1924,7 @@ class TestEntityEditGrowsBeforeItShrinks(_EntityEditMixin):
             )
 
         # The write landed, the row stayed wide -- under-deletion, never the
-        # over-deleting mirror.
+        # over-deleting mirror. Same outcome for either teardown.
         assert graph.nodes[ENTITY]["source_id"] == "chunk-1"
         assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == [
             "chunk-1",

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -1858,6 +1858,25 @@ class TestEntityEditGrowsBeforeItShrinks(_EntityEditMixin):
         assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == ["chunk-1"]
 
     @pytest.mark.asyncio
+    async def test_a_failing_entity_vector_write_cannot_skip_the_shrink(self, deferred):
+        # The entity vector record used to be written BETWEEN the mutation and
+        # the region that settles tracking. On an immediate-write backend
+        # `upsert_node` is already durable by then, so a truncation or upsert
+        # failure there left the node narrowed with the row still at the
+        # superset -- and nothing heals it, because the next edit reads the
+        # narrowed source_id and skips the staging. The write is now after the
+        # region, so a failure cannot come between the two.
+        await self._seed_two_chunk_entity(deferred)
+        deferred.entities_vdb.fail = True
+
+        with pytest.raises(utils_graph.VectorStorageConsistencyError):
+            await self._edit(deferred, self.SHRINKING_EDIT)
+
+        # The edit is durable and the row is settled, despite the vector error.
+        assert deferred.persisted_graph().nodes[ENTITY]["source_id"] == "chunk-1"
+        assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == ["chunk-1"]
+
+    @pytest.mark.asyncio
     async def test_an_unrelated_relation_flush_failure_cannot_skip_the_shrink(
         self, deferred
     ):

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -1794,13 +1794,16 @@ class TestEntityEditGrowsBeforeItShrinks(_EntityEditMixin):
         assert deferred.entity_chunks.disk[ENTITY]["count"] == 1
 
     @pytest.mark.asyncio
-    async def test_a_failed_shrink_outranks_a_failing_vector_flush(
+    async def test_a_failed_shrink_skips_the_vector_flush_and_says_so(
         self, deferred, monkeypatch
     ):
-        # Both fail. The caller must hear about the residue nothing rebuilds,
-        # and the message has to name both recovery tools because both are owed.
+        # The shrink runs inside the cancellation-deferring region, so it now
+        # precedes the vector flush and a failure there skips it. That is the
+        # acceptable exposure of the two -- vector records are rewritten by a
+        # re-issued edit and restored by lightrag-rebuild-vdb, while the row is
+        # reachable only by the offline repair -- but the caller has to be told
+        # about both, so the message names both.
         await self._seed_two_chunk_entity(deferred)
-        deferred.entities_vdb.fail_flush = True
         calls = {"n": 0}
         original = deferred.entity_chunks.upsert
 
@@ -1811,6 +1814,7 @@ class TestEntityEditGrowsBeforeItShrinks(_EntityEditMixin):
             return await original(data)
 
         monkeypatch.setattr(deferred.entity_chunks, "upsert", _upsert)
+        flushes_before = deferred.entities_vdb.flushes
 
         with pytest.raises(VectorStorageConsistencyError) as excinfo:
             await self._edit(deferred, self.SHRINKING_EDIT)
@@ -1818,3 +1822,37 @@ class TestEntityEditGrowsBeforeItShrinks(_EntityEditMixin):
         message = str(excinfo.value)
         assert "lightrag-repair-chunk-tracking" in message
         assert "lightrag-rebuild-vdb" in message
+        assert deferred.entities_vdb.flushes == flushes_before
+
+    @pytest.mark.asyncio
+    async def test_a_cancel_past_the_commit_still_completes_the_shrink(
+        self, deferred, monkeypatch
+    ):
+        # The finding this staging was moved for. `commit_in_storage_io` defers a
+        # cancellation through the graph commit and re-raises it at the END of
+        # the deferring region, and `CancelledError` is a `BaseException`, so a
+        # shrink placed after that region would simply never run -- and no
+        # `except Exception` out there could notice. The row would keep the
+        # staged superset with nothing able to heal it: the next edit reads the
+        # already-narrowed source_id and skips the staging entirely.
+        await self._seed_two_chunk_entity(deferred)
+        owner: dict = {}
+        original = deferred.graph.index_done_callback
+
+        async def _commit_then_cancel():
+            result = await original()
+            # Cancel the CALLER's task, matching TestCancellationAfterTheCommit:
+            # the owed work runs in a task of its own, so cancelling from the
+            # inside would model a different scenario.
+            owner["task"].cancel()
+            return result
+
+        monkeypatch.setattr(deferred.graph, "index_done_callback", _commit_then_cancel)
+
+        owner["task"] = asyncio.ensure_future(self._edit(deferred, self.SHRINKING_EDIT))
+        with pytest.raises(asyncio.CancelledError):
+            await owner["task"]
+
+        # The node is durably narrowed, so the row is owed the same narrowing.
+        assert deferred.persisted_graph().nodes[ENTITY]["source_id"] == "chunk-1"
+        assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == ["chunk-1"]

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -1856,3 +1856,59 @@ class TestEntityEditGrowsBeforeItShrinks(_EntityEditMixin):
         # The node is durably narrowed, so the row is owed the same narrowing.
         assert deferred.persisted_graph().nodes[ENTITY]["source_id"] == "chunk-1"
         assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == ["chunk-1"]
+
+    @pytest.mark.asyncio
+    async def test_an_unrelated_relation_flush_failure_cannot_skip_the_shrink(
+        self, deferred
+    ):
+        # A non-rename entity edit writes nothing to relation_chunks, but the
+        # region's retirement flush used to flush it anyway -- and
+        # `_persist_graph_updates` re-raises the first phase-1 error, so that
+        # unrelated failure skipped the shrink and surfaced an error naming
+        # neither the row nor the repair tool. The flush is rename-only now.
+        await self._seed_two_chunk_entity(deferred)
+        deferred.relation_chunks.fail_commit_times = 1
+
+        await self._edit(deferred, self.SHRINKING_EDIT)
+
+        assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == ["chunk-1"]
+        assert deferred.entity_chunks.disk[ENTITY]["count"] == 1
+
+
+class TestEntityChunkTrackingUpdateHelper:
+    """`_entity_chunk_tracking_update`'s contract, which both branches rely on."""
+
+    NODE = {"source_id": f"chunk-1{GRAPH_FIELD_SEP}chunk-2"}
+
+    def test_none_is_returned_only_when_a_row_is_already_present(self):
+        # The rename branch reads `None` as "the stored row is authoritative",
+        # and migrates it verbatim with no reseed arm. That is only sound while
+        # `None` implies a present row, so pin it: an ABSENT row with an
+        # unchanged source_id must NOT return None.
+        absent = utils_graph._entity_chunk_tracking_update(None, self.NODE, self.NODE)
+
+        assert absent is not None
+        # Reseeded from the graph's source_id, exactly once, and identical in
+        # both slots because nothing was removed.
+        assert absent == (["chunk-1", "chunk-2"], ["chunk-1", "chunk-2"])
+
+    def test_a_present_row_with_an_unchanged_source_id_is_left_alone(self):
+        stored = {"chunk_ids": ["chunk-1", "chunk-2"], "count": 2}
+
+        assert (
+            utils_graph._entity_chunk_tracking_update(stored, self.NODE, self.NODE)
+            is None
+        )
+
+    def test_the_superset_keeps_the_row_and_adds_only_genuine_additions(self):
+        stored = {"chunk_ids": ["chunk-1", "chunk-2"], "count": 2}
+        new_node = {"source_id": f"chunk-2{GRAPH_FIELD_SEP}chunk-9"}
+
+        final, superset = utils_graph._entity_chunk_tracking_update(
+            stored, self.NODE, new_node
+        )
+
+        # chunk-9 is added, chunk-1 is dropped by the final row but retained by
+        # the superset -- that difference is what the staging is built on.
+        assert "chunk-9" in final and "chunk-1" not in final
+        assert superset == ["chunk-1", "chunk-2", "chunk-9"]

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -1858,6 +1858,74 @@ class TestEntityEditGrowsBeforeItShrinks(_EntityEditMixin):
         assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == ["chunk-1"]
 
     @pytest.mark.asyncio
+    async def test_a_cancel_inside_the_node_write_leaves_a_diagnosed_wide_row(
+        self, deferred, monkeypatch
+    ):
+        # The one residue of this staging that cannot be closed. A cancellation
+        # delivered inside `upsert_node`'s own await -- after an immediate-write
+        # backend accepted the row -- aborts before the shrink, so the node is
+        # narrowed while the row still holds the superset.
+        #
+        # Deferring cannot help: the CancelledError originates in this
+        # coroutine, so there is nothing for `_finish_deferring_cancellation` to
+        # defer, and issuing the call from inside that region gives the
+        # identical residue (measured before writing this test).
+        #
+        # Settling blind is worse: whether the backend accepted the write is
+        # unknowable, and narrowing the row when it did not would leave the row
+        # a strict SUBSET of the graph -- over-deletion. So the row stays wide,
+        # and what is owed is the diagnostic naming the repair tool.
+        graph = _ImmediateGraphStorage()
+        await graph.upsert_node(
+            ENTITY,
+            {
+                "entity_id": ENTITY,
+                "description": "d",
+                "source_id": f"chunk-1{GRAPH_FIELD_SEP}chunk-2",
+            },
+        )
+        await deferred.entity_chunks.upsert(
+            {ENTITY: {"chunk_ids": ["chunk-1", "chunk-2"], "count": 2}}
+        )
+        await deferred.entity_chunks.index_done_callback()
+        original = graph.upsert_node
+
+        async def _write_then_cancelled(node_id, node_data):
+            await original(node_id, node_data)
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(graph, "upsert_node", _write_then_cancelled)
+        # `lightrag.utils.logger` sets propagate=False, so caplog sees nothing;
+        # collect from the logger this module actually calls.
+        errors: list[str] = []
+        monkeypatch.setattr(
+            utils_graph.logger, "error", lambda msg, *a, **k: errors.append(str(msg))
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await utils_graph.aedit_entity(
+                graph,
+                deferred.entities_vdb,
+                deferred.relationships_vdb,
+                ENTITY,
+                dict(self.SHRINKING_EDIT),
+                entity_chunks_storage=deferred.entity_chunks,
+                relation_chunks_storage=deferred.relation_chunks,
+            )
+
+        # The write landed, the row stayed wide -- under-deletion, never the
+        # over-deleting mirror.
+        assert graph.nodes[ENTITY]["source_id"] == "chunk-1"
+        assert deferred.entity_chunks.disk[ENTITY]["chunk_ids"] == [
+            "chunk-1",
+            "chunk-2",
+        ]
+        # And it is not silent: the operator is told which row and which tool.
+        diagnostic = "\n".join(errors)
+        assert "lightrag-repair-chunk-tracking" in diagnostic
+        assert ENTITY in diagnostic
+
+    @pytest.mark.asyncio
     async def test_a_failing_entity_vector_write_cannot_skip_the_shrink(self, deferred):
         # The entity vector record used to be written BETWEEN the mutation and
         # the region that settles tracking. On an immediate-write backend


### PR DESCRIPTION
## Description

Closes the ordering gap #3889 recorded but deliberately left open.

`_edit_entity_impl`'s **non-rename** branch called `upsert_node` before its chunk-tracking row existed, and flushed that row only *after* the graph commit. So a **growing** edit — one whose `updated_data` adds evidence chunk IDs — could leave the node durable citing chunks nothing attributes.

That is `rows ⊂ graph`, the direction [PurgeRecoveryContract](https://github.com/HKUDS/LightRAG/blob/main/docs/design/PurgeRecoveryContract.md#merge-and-rename-failure-model) marks **Data is lost**: a later purge of a document naming only the older chunks reads the row, concludes "no remaining sources", and deletes an entity the added chunk still anchors. It is reachable from `POST /graph/entity/edit`, whose `updated_data` accepts `source_id`.

## Related Issues

- Closes #3890
- Follow-up to #3889, which fixed the same class on the creation paths and `aedit_relation`, and recorded this one as a documented residue rather than bundling it
- Depends on the raise-on-failure contract settled in #3889 ([review thread](https://github.com/HKUDS/LightRAG/pull/3889#discussion_r3964302442))
- Preserves the rename-branch ordering introduced for #3609
- Opens #3895 for the one finding kept out of scope (see *Out of scope*)

## Changes Made

### Why ordering the flush would have been neither sufficient nor safe

**Not sufficient.** By the time any flush runs, `upsert_node` has already executed: durable on the spot on Neo4j / PostgreSQL, and on NetworkX already in the process-wide in-memory graph where the *next flush by any co-tenant* publishes it. The row has to precede the **call**, not the flush — the F3 lesson from #3889.

**Not safe.** The delta also *removes* IDs, and a narrowed row committed ahead of the graph write is that same over-deleting state with the directions swapped — the mirror trade AGENTS.md rules out.

### The staging

The non-rename branch stages the row **grow-then-shrink**:

1. superset row (existing ∪ genuine additions) written **and committed** before `upsert_node` is issued,
2. the graph mutation,
3. the graph commit and then the removals, **both inside the cancellation-deferring region**,
4. the entity vector write and flush, strictly last.

The durable row is then never a strict subset of the durable node evidence, and the only residue is a row still naming IDs the edit dropped — under-deletion, the accepted direction.

A failure in step 3 raises `VectorStorageConsistencyError` naming the row key and `lightrag-repair-chunk-tracking`, matching the contract settled for the relation path in #3889: the edit is durable so the message says so, but a retry cannot heal the row — the next edit reads an unchanged `source_id` and skips the staging — which leaves the operator as the only recovery path.

### Nothing between the mutation and the shrink may skip it

The shrink is the one residue in this function that **no retry heals**: once the graph carries the new `source_id`, `_entity_chunk_tracking_update` returns `None` and the staging never runs again. Review found four ways to skip it, closed in turn:

| skipped by | closed by |
| --- | --- |
| the vector **flush** raising ([comment](https://github.com/HKUDS/LightRAG/pull/3892#discussion_r3964627992)) | the shrink now precedes that flush |
| a **cancellation** delivered to the caller ([comment](https://github.com/HKUDS/LightRAG/pull/3892#discussion_r3964749551)) | the shrink runs inside the cancellation-deferring region, since `CancelledError` is a `BaseException` and nothing after the region would run |
| an **unrelated tracking flush** in the region | that flush is rename-only now; a non-rename edit writes to neither storage there, and `_persist_graph_updates` re-raises the first phase-1 error |
| the vector **write** ([comment](https://github.com/HKUDS/LightRAG/pull/3892#discussion_r3965464708)) | moved after the region — the span `upsert_node → commit → shrink` now contains nothing fallible but the commit |

The fourth was the one that said the approach, not just its coverage, was wrong: three rounds of guarding one more occupant of that span each time, when the fix was to empty the span instead.

### The residue that stays open, and why

A cancellation or an ordinary backend error delivered *inside* `upsert_node`'s own await — after an immediate-write backend applied the row, before control returns ([comment](https://github.com/HKUDS/LightRAG/pull/3892#discussion_r3965589820)) — tears the edit down before the shrink.

- It **cannot be deferred away.** The exception originates in that coroutine, so `_finish_deferring_cancellation` has nothing to defer. Measured: issuing the call from inside the region gives the identical residue, so that change was reverted rather than shipped with a rationale that does not hold.
- It **must not be settled blind.** Whether the backend applied the write is unknowable there, and narrowing the row when it did not would leave `rows ⊂ graph` — over-deletion, ranked as losing data, traded against a residue that merely retains a chunk ID.

So the row stays wide and the **diagnostic** is what is owed: the failure is logged with the row key, why no retry prunes it, and the repair tool, then re-raised unchanged. That covers an ordinary backend error as much as a cancellation ([comment](https://github.com/HKUDS/LightRAG/pull/3892#discussion_r3965693336)) — a lost acknowledgement carries the same ambiguity, and the caller's own error says only that the write failed. Written down in `docs/ProgramingWithCore.md`, per AGENTS.md: an undocumented residue is a defect, a documented one is a decision.

### The rename branch keeps its own, opposite ordering

It needs no staging, and that is not an oversight: it writes a **fresh** node whose `source_id` already equals the row it migrates, and it must retire the old key only *after* the commit that removes the old node (#3609 — the reverse order opens a window where the row exists under neither key).

To keep both orderings without duplicating the rules, the row computation moves into `_entity_chunk_tracking_update`, a pure helper returning `(final_chunk_ids, superset_chunk_ids)`. Both branches derive the row from the same rules; only the ordering of the writes differs. The shared tracking block is explicitly rename-only, and the region's coroutine is renamed `_commit_graph_and_settle_tracking` since retiring is no longer all it does.

The rename branch's reseed-from-`source_id` fallback is removed: the helper returns `None` only when the `source_id` is unchanged **and** a row is present, so that arm was unreachable — and a hazard if the `None` condition were ever widened, since it would silently reseed a curated row from a possibly stale `source_id` (the defect #3609 exists to prevent). A contract test pins that `None` implies a present row.

The vector write moving after the region affects this branch too, in the same direction: a vector failure used to abort before `delete_node`, leaving the rename unlanded; now the rename completes and the record is stale, which is the accepted rebuildable window its message already describes. The rename ordering suites pass unchanged.

### Documentation

The three residue notes #3889 added are retired, since the residue they described is gone; `docs/ProgramingWithCore.md` and the `NetworkXStorage` docstring now describe the staging, why rename is exempt, and the one residue that stays open. One claim added mid-review was corrected: it said this shrink had "the same raise-on-failure contract" as `aedit_relation`'s, when it is in fact stronger.

## Out of scope

`aedit_relation`'s shrink can still be **skipped silently**: it sits outside any cancellation-deferring region and after the combined graph+vector flush. Its *state* guarantee is unaffected — a skipped shrink leaves the row **wider**, still the accepted direction — so what is missing is the report, not the invariant.

Closing it means introducing a cancellation-deferring region that function does not have, and splitting a flush whose declined-commit ranking #3889 deliberately placed *inside* phase 2 of `_persist_graph_updates`. That is a design change with its own tests, so it is tracked in **#3895** and recorded as an open residue on the `aedit_relation` bullet in `docs/ProgramingWithCore.md`.

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

### Tests

`tests/pipeline/test_graph_deletion_tracking_ordering.py`, +15 test functions (68 collected in the module, up from 52):

- **`TestEntityEditWritesTheRowBeforeTheGraphCall`** — an immediate-write graph double (Neo4j/PG shaped) plus a failing tracking commit: the node must still cite only what its durable row attributes.
- **`TestEntityEditGrowsBeforeItShrinks`** — commit order for a growing edit; the crash residue of a growing edit (wider row, narrower node, never the reverse); the narrowed end state of a shrinking edit; a failed graph commit mid-shrink leaving the row un-narrowed; a failed shrink raising with the row and tool named; a failing vector flush still leaving the row narrowed; a failed shrink skipping the vector flush and naming both recovery paths; a cancel past the graph commit still completing the shrink; an unrelated `relation_chunks` flush failure not skipping it; a failing entity vector **write** not skipping it; and the open residue — a failed node write (parametrised over a cancellation and an ordinary exception) leaving the row wide **and diagnosed**.
- **`TestEntityChunkTrackingUpdateHelper`** — the helper's contract: `None` only for a present row, an absent row reseeded once from `source_id`, and the superset keeping the row plus genuine additions only.

**11 of the 16 collected cases fail behaviourally on the code they fix** — 4 against `main`, 7 against intermediate commits on this branch, each verified by reverting `lightrag/utils_graph.py` alone. The rest pin the shrinking direction, which was already benign, and the helper contract, where dead-code removal cannot change behaviour.

### Suites run

- `tests/pipeline`, `tests/kg/networkx_impl`, `tests/utils` — **1267 passed** (includes the #3609 rename coverage, unchanged)
- `tests/tools`, `tests/kg/json_impl`, plus the rename/merge tracking-order suites — **312 passed**
- graph route suites — **51 passed**
- `pre-commit run --all-files` clean (this is what CI gates on; `ruff check .` alone missed a `ruff-format` reflow on the first push)

`tests/api/routes` has 19 pre-existing failures in `test_query_stream_routes.py`, identical on `main` with these changes stashed; `tests/extraction` and `tests/kg/mongo_impl` need optional extras to collect in this environment. CI's full run is the authority on the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBBsrz9z5DsKbEE837R4QM
