### PR TITLE
fix(graph): surface a declined graph commit through _persist_graph_updates

### DIFF
--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -289,6 +289,29 @@ async def _persist_graph_updates(
     tracking rows the retry would then believe it still owed. Every other
     exception still propagates: those mean the flush did not happen.
 
+    An explicit ``False`` is the third answer, and it is the opposite of a
+    ``CommitBookkeepingError``: the commit was **DECLINED**, so the in-memory
+    mutation was discarded rather than persisted (see
+    ``NetworkXStorage.index_done_callback``'s first block, and rule 5 of
+    #3854). This helper used to drop the return value, which made a decline
+    reaching ``aedit_relation`` / ``acreate_entity`` / ``acreate_relation``
+    silent: the graph mutation gone, the caller told it succeeded. It now
+    raises, matching :func:`_commit_graph_or_raise`, which every other admin
+    graph path already routes its commit through.
+
+    **Accepted residue — the sibling flushes still land.** All flushes are
+    awaited to completion before the decline is raised, so a declined graph
+    commit leaves this operation's vector and chunk-tracking rows durable with
+    no graph object behind them. Raising early to cancel the siblings would be
+    worse, not better: ``commit_in_storage_io`` defers cancellation, so a
+    cancelled flush may have written anyway, and which ones did would depend
+    on scheduling. Per *Consistency without transactions* in ``AGENTS.md``
+    this is the acceptable direction — the rows are keyed by deterministic ids
+    (entity name / relation pair hashes), so the caller's retry rewrites them,
+    a rebuild rewrites them, and in the meantime a query may surface a row
+    whose graph object is missing. Reporting a discarded mutation as a success
+    is the direction that is never acceptable.
+
     Args:
         entities_vdb: Entity vector database storage (optional)
         relationships_vdb: Relationship vector database storage (optional)
@@ -310,9 +333,10 @@ async def _persist_graph_updates(
     if relation_chunks_storage is not None:
         storages.append(relation_chunks_storage)
 
-    async def _flush(storage_inst) -> None:
+    async def _flush(storage_inst) -> str | None:
+        """Flush one store. Returns its namespace if it DECLINED, else None."""
         try:
-            await cast(StorageNameSpace, storage_inst).index_done_callback()
+            committed = await cast(StorageNameSpace, storage_inst).index_done_callback()
         except CommitBookkeepingError as e:
             log_without_raising(
                 logger.error,
@@ -321,10 +345,31 @@ async def _persist_graph_updates(
                 "durable; cross-process visibility is deferred to the next "
                 "commit.",
             )
+            return None
+        # Only an explicit False counts. The base signature is ``-> None``, so
+        # backends that simply return nothing are unaffected -- same test as
+        # _commit_graph_or_raise.
+        if committed is False:
+            return str(getattr(storage_inst, "namespace", storage_inst))
+        return None
 
     # Persist all storage instances in parallel
     if storages:
-        await asyncio.gather(*[_flush(storage_inst) for storage_inst in storages])
+        declined = [
+            namespace
+            for namespace in await asyncio.gather(
+                *[_flush(storage_inst) for storage_inst in storages]
+            )
+            if namespace is not None
+        ]
+        if declined:
+            # Raised only after every flush has run: see the accepted residue
+            # in the docstring for why the siblings are not cancelled.
+            raise RuntimeError(
+                "Graph persistence was skipped because another process updated "
+                f"the storage, so the in-memory mutation was discarded: "
+                f"{', '.join(sorted(declined))}"
+            )
 
 
 async def _finish_deferring_cancellation(coro, description: str) -> None:

--- a/tests/pipeline/test_persist_graph_updates_decline.py
+++ b/tests/pipeline/test_persist_graph_updates_decline.py
@@ -1,0 +1,150 @@
+"""A DECLINED graph commit must reach the caller through _persist_graph_updates.
+
+Rule 5 of #3854 says a decline has to surface as a failure, because declining
+DISCARDS the in-memory mutation. Two of the three commit paths already did that
+(``_commit_graph_or_raise`` for the admin paths that route through it,
+``LightRAG._flush_storages``'s ``_flush_one`` for the pipeline).
+``_persist_graph_updates`` -- the path ``aedit_relation`` / ``acreate_entity`` /
+``acreate_relation`` use -- dropped the return value, so the decline was silent:
+the graph mutation gone, the vector and tracking rows of the same operation
+durable, and the caller told it succeeded.
+"""
+
+from typing import Any
+
+import pytest
+
+from lightrag import utils_graph
+from lightrag.exceptions import CommitBookkeepingError
+
+pytestmark = pytest.mark.offline
+
+
+class _Store:
+    """Minimal storage double: records the flush, answers however it is told."""
+
+    def __init__(self, namespace: str, answer: Any = None):
+        self.namespace = namespace
+        self._answer = answer
+        self.flushes = 0
+
+    async def index_done_callback(self):
+        self.flushes += 1
+        if isinstance(self._answer, BaseException):
+            raise self._answer
+        return self._answer
+
+
+@pytest.mark.asyncio
+async def test_a_declined_graph_commit_raises():
+    """The defect this file exists for: False must not be swallowed."""
+    graph = _Store("chunk_entity_relation", answer=False)
+
+    with pytest.raises(RuntimeError, match="in-memory mutation was discarded"):
+        await utils_graph._persist_graph_updates(chunk_entity_relation_graph=graph)
+
+    assert graph.flushes == 1
+
+
+@pytest.mark.asyncio
+async def test_the_error_names_the_store_that_declined():
+    """An operator reading the 500 has to know which store refused."""
+    graph = _Store("chunk_entity_relation", answer=False)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await utils_graph._persist_graph_updates(
+            entities_vdb=_Store("entities"),
+            chunk_entity_relation_graph=graph,
+        )
+
+    assert "chunk_entity_relation" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_a_backend_returning_none_still_succeeds():
+    """Only an explicit False counts.
+
+    ``StorageNameSpace.index_done_callback`` is declared ``-> None``, so every
+    backend that simply returns nothing -- which is all of them except
+    NetworkX / Nano / FAISS -- must be unaffected. Testing ``is False`` rather
+    than falsiness is the whole reason this holds.
+    """
+    stores = [_Store(f"ns{i}") for i in range(3)]
+
+    await utils_graph._persist_graph_updates(
+        entities_vdb=stores[0],
+        chunk_entity_relation_graph=stores[1],
+        entity_chunks_storage=stores[2],
+    )
+
+    assert [s.flushes for s in stores] == [1, 1, 1]
+
+
+@pytest.mark.asyncio
+async def test_a_true_answer_is_not_a_decline():
+    """Nano and FAISS return True from a successful commit."""
+    await utils_graph._persist_graph_updates(
+        entities_vdb=_Store("entities", answer=True),
+        chunk_entity_relation_graph=_Store("chunk_entity_relation", answer=True),
+    )
+
+
+@pytest.mark.asyncio
+async def test_every_sibling_still_flushes_before_the_raise():
+    """Pins the accepted residue, so it stays a decision.
+
+    The siblings are deliberately NOT cancelled: commit_in_storage_io defers
+    cancellation, so a cancelled flush may have written anyway and which ones
+    did would depend on scheduling. Awaiting them all first makes the outcome
+    deterministic -- their rows are durable, the graph object is not, and the
+    caller's retry rewrites both under the same deterministic ids.
+    """
+    siblings = [_Store("entities"), _Store("relationships"), _Store("entity_chunks")]
+    graph = _Store("chunk_entity_relation", answer=False)
+
+    with pytest.raises(RuntimeError):
+        await utils_graph._persist_graph_updates(
+            entities_vdb=siblings[0],
+            relationships_vdb=siblings[1],
+            chunk_entity_relation_graph=graph,
+            entity_chunks_storage=siblings[2],
+        )
+
+    assert [s.flushes for s in siblings] == [1, 1, 1]
+
+
+@pytest.mark.asyncio
+async def test_a_publication_failure_is_still_swallowed():
+    """CommitBookkeepingError is the OPPOSITE answer and must not start raising.
+
+    It says the write DID land and only its cross-process publication failed.
+    Folding it into the decline path would report a durable mutation as one
+    that did not happen -- the direction AGENTS.md forbids outright.
+    """
+    graph = _Store(
+        "chunk_entity_relation", answer=CommitBookkeepingError("publish failed")
+    )
+    sibling = _Store("entities")
+
+    await utils_graph._persist_graph_updates(
+        entities_vdb=sibling,
+        chunk_entity_relation_graph=graph,
+    )
+
+    assert graph.flushes == 1
+    assert sibling.flushes == 1
+
+
+@pytest.mark.asyncio
+async def test_a_publication_failure_alongside_a_decline_still_raises():
+    """One store's durable-but-unpublished write does not excuse another's decline."""
+    with pytest.raises(RuntimeError, match="in-memory mutation was discarded"):
+        await utils_graph._persist_graph_updates(
+            entities_vdb=_Store("entities", answer=CommitBookkeepingError("boom")),
+            chunk_entity_relation_graph=_Store("chunk_entity_relation", answer=False),
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_storages_is_still_a_no_op():
+    await utils_graph._persist_graph_updates()


### PR DESCRIPTION
## Description

Rule 5 of #3854 requires a **DECLINED** commit to reach its caller as a failure: declining DISCARDS the in-memory mutation, so acknowledging it reports work that no longer exists.

Two of the three commit paths did that. The third did not:

| Commit path | Checks `False`? | Covers |
|---|---|---|
| `LightRAG._flush_storages` → `_flush_one` | ✅ raises `IndexFlushError` | pipeline writes |
| `utils_graph._commit_graph_or_raise` | ✅ raises `RuntimeError` | `adelete_by_entity`, `_edit_entity_impl`, `_merge_entities_impl` |
| `utils_graph._persist_graph_updates` | ❌ **return value discarded** | `aedit_relation`, `acreate_entity`, `acreate_relation` |

This is the quietest form of the defect the fence exists to prevent. `NetworkXStorage.index_done_callback` declines when the file on disk has moved past the snapshot it holds; the decline branch calls `_reload_locked`, which **destroys the pending mutation**, and returns `False`. The helper swallowed it, the caller logged `Entity Create: 'X' successfully created` and returned **200** — while the same operation's `entities_vdb` / `relationships_vdb` / chunk-tracking upserts had already been flushed by the same `asyncio.gather`.

The observable outcome: a vector row and a tracking row with **no graph object behind them**, reported as a success.

It needs no peer to reach, either. The failed-save recovery arm makes `index_done_callback` return `False` in single-process mode too — through `storage_updated` on `main`, through `_recovery_reload_pending` once #3874 lands.

## Related Issues

Third call site of rule 5 in #3854. Split out of #3874, whose class docstring previously asserted "Both callers do that" and now names this helper as the known gap; that PR corrects the text, this one closes the gap.

## Changes Made

**`lightrag/utils_graph.py`**

- `_flush` returns the store's namespace when `index_done_callback` answered an explicit `False`, and `None` otherwise.
- `_persist_graph_updates` collects those and raises `RuntimeError` naming the declining store(s), matching `_commit_graph_or_raise`'s message and semantics.
- **Only an explicit `False` counts.** `StorageNameSpace.index_done_callback` is declared `-> None`, so every backend that simply returns nothing — all of them except NetworkX / Nano / FAISS — is unaffected. `True` (Nano and FAISS on success) is not a decline either.
- `CommitBookkeepingError` handling is untouched: it is the *opposite* answer, and folding it in would report a durable write as one that did not happen.
- Docstring records the reasoning and the accepted residue below.

**`tests/pipeline/test_persist_graph_updates_decline.py`** — 8 cases.

## What could break, and why it does not

- **Other graph backends.** Neo4j, Memgraph, PostgreSQL and friends return `None`; the test is `is False`, so nothing changes for them. Pinned by a test.
- **`CommitBookkeepingError` is still swallowed.** Pinned by a test, including the case where one store raises it while another declines — the decline still wins.
- **Admin endpoints change from 200 to 500 in the racing case.** That is the point, and it is the same direction #3854 already accepted for the paths using `_commit_graph_or_raise`: "the fence makes a stale writer decline more often … where it previously lost the write silently. That is the correct direction."

## Accepted residue

Per *Consistency without transactions* in `AGENTS.md`, written down rather than left implicit, and pinned by `test_every_sibling_still_flushes_before_the_raise`:

**All flushes are awaited to completion before the decline is raised**, so a declined graph commit leaves that operation's vector and chunk-tracking rows durable with no graph object behind them.

Raising early to cancel the siblings would be worse, not better: `commit_in_storage_io` defers cancellation, so a cancelled flush may have written anyway, and *which* ones did would depend on scheduling. Awaiting them all makes the outcome deterministic.

The residue heals and is harmless in direction: the rows are keyed by deterministic ids (entity name / relation pair hashes), so the caller's retry rewrites them and a rebuild rewrites them; in the meantime a query may surface a row whose graph object is missing. Reporting a discarded mutation as a success is the direction that never heals.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (if necessary) — `_persist_graph_updates` docstring; no file under `docs/` describes this helper
- [x] Unit tests added (if applicable)

## Additional Notes

**Tests.** 8 cases in `tests/pipeline/test_persist_graph_updates_decline.py`:

*The fix* — a declined graph commit raises; the error names the store that declined; a decline alongside another store's `CommitBookkeepingError` still raises.

*The no-regression half* — a backend returning `None` still succeeds; `True` is not a decline; a publication failure is still swallowed; no storages is still a no-op.

*The residue* — every sibling still flushed before the raise.

Verified against a mutation: with the `committed is False` branch removed, 4 of the 8 go red and the other 4 stay green (they pin the half that must not change). Restored afterwards.

**Test runs:** `tests/pipeline`, `tests/api` — **96 failed, 1916 passed, 14 skipped**. An unmodified checkout of `main` gives **96 failed, 1908 passed** on the same selection; the delta is exactly the 8 new tests. Every one of the 96 is `ModuleNotFoundError: No module named 'ollama'`, an optional binding that is not installable in this sandbox. CI covers those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfwqnMzXtJmpoP5yaBQq7P

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfwqnMzXtJmpoP5yaBQq7P)_