### PR TITLE
Settle aedit_relation's tracking shrink inside a cancellation-deferring region

### DIFF
--- a/docs/ProgramingWithCore.md
+++ b/docs/ProgramingWithCore.md
@@ -1667,25 +1667,32 @@ What that can leave behind, and why it is tolerated:
   because a retry cannot heal it — the second edit sees an unchanged `source_id`
   and skips the tracking update — so the operator is the only recovery path, and
   a 200 would guarantee they never learn to take it.
-  **Residue, not yet closed:** that last step can still be *skipped* rather than
-  fail, and then nothing is reported. It sits outside any
-  cancellation-deferring region and after the `_persist_graph_updates` call that
-  flushes the graph and the relation vector store together, so a cancellation
-  delivered during that commit, or a failure of the vector flush inside it,
-  exits the edit with the row still holding the superset and no line naming it.
-  The state stays the accepted direction, but the operator is not told to run
-  the repair — which is the part that cannot heal itself. Tracked in issue
-  #3895; `aedit_entity`'s non-rename path (below) does not share it.
+  Both ways that last step could be *skipped* rather than fail are closed
+  (issue #3895): it runs *inside* a cancellation-deferring region alongside the
+  graph commit, so a cancellation deferred through that commit cannot walk past
+  it, and *before* the relation's vector work, so no vector failure can strand
+  it. The reverse exposure is the acceptable one — a shrink failure skips the
+  vector write, leaving records a re-issued edit rewrites and
+  `lightrag-rebuild-vdb` restores, and the message names both. A declined graph
+  commit still outranks a vector failure, because the commit is confirmed on its
+  own before any vector call is made.
+  **One residue stays open, deliberately, the same one the entity path carries
+  below:** a cancellation — or an ordinary error, an acknowledgement lost after
+  the fact carries the same ambiguity — delivered inside `upsert_edge`'s own
+  await tears the edit down before the shrink, so the edge may be narrowed while
+  the row keeps the superset. It cannot be deferred (the exception originates in
+  that coroutine) and must not be settled blind (narrowing a row whose write the
+  backend never accepted is the over-deleting mirror), so the row stays wide and
+  the failure is *logged* with the row key and the repair tool.
 - `aedit_entity`'s non-rename path stages its row the same way, for the same
   reason: a **growing** edit there used to commit the node before flushing the
   row that attributes it, leaving `rows ⊂ graph` — reachable from `POST
   /graph/entity/edit`, whose `updated_data` accepts `source_id`. The superset
   row is now durable before `upsert_node` is called at all, and the removals are
-  applied after the graph commit. Its shrink goes further than the relation
+  applied after the graph commit. Its shrink is staged exactly like the relation
   one's: it runs *inside* the cancellation-deferring region and *before* the
-  vector flush, so neither a cancellation nor a vector failure can skip it —
-  the two ways the relation path still can. It either completes or raises with
-  the row key and the repair tool named.
+  vector write, so neither a cancellation nor a vector failure can skip it. It
+  either completes or raises with the row key and the repair tool named.
   **One residue there stays open, deliberately:** a cancellation delivered
   *inside* `upsert_node`'s own await — after an immediate-write backend accepted
   the row, before control returns — tears the edit down before the shrink, so

--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -1901,10 +1901,12 @@ async def aedit_relation(
             # verify the VDB payload BEFORE any mutation below: if truncation
             # fails (a deterministic, non-retryable content-shape problem),
             # nothing has been touched yet. The actual VDB delete/upsert I/O
-            # calls happen strictly after the graph write below, so a
-            # transient VDB I/O failure (unlike a truncation failure) still
-            # leaves the normal recoverable (graph-updated, VDB-stale)
-            # window -- the new relation content is never lost.
+            # calls happen strictly after the graph write AND after the
+            # tracking row it justifies is settled, so a transient VDB I/O
+            # failure (unlike a truncation failure) still leaves the normal
+            # recoverable (graph-updated, VDB-stale) window -- the new relation
+            # content is never lost, and no vector failure can come between the
+            # graph write and the shrink that answers it.
             new_edge_data = {**edge_data, **updated_data}
             description = new_edge_data.get("description", "")
             keywords = new_edge_data.get("keywords", "")
@@ -2058,84 +2060,186 @@ async def aedit_relation(
                     )
 
             # 4. Update relation information in the graph
-            await chunk_entity_relation_graph.upsert_edge(
-                source_entity, target_entity, new_edge_data
-            )
-
-            # Delete the old relation record from the vector database.
-            # Delete both permutations to handle relationships created
-            # before normalization.
-            rel_ids_to_delete = [
-                compute_mdhash_id(source_entity + target_entity, prefix="rel-"),
-                compute_mdhash_id(target_entity + source_entity, prefix="rel-"),
-            ]
-            await relationships_vdb.delete(rel_ids_to_delete)
-            logger.debug(
-                f"Relation Edit: delete vdb for `{source_entity}`~`{target_entity}`"
-            )
-
-            # Update vector database
-            await relationships_vdb.upsert(relation_data)
-
-            # 5. Save changes
-            await _persist_graph_updates(
-                relationships_vdb=relationships_vdb,
-                chunk_entity_relation_graph=chunk_entity_relation_graph,
-                context=f"Relation Edit: `{source_entity}`~`{target_entity}`",
-            )
-
-            # 6. Shrink phase: the graph write that justifies dropping these IDs
-            #    is durable now, so the row may finally lose them.
-            #
-            #    A failure here raises `VectorStorageConsistencyError`, the type
-            #    this codebase already uses for "a step AFTER a durable graph
-            #    update failed" -- its docstring names a chunk-tracking
-            #    retirement as one of its two cases, and the rename branch of
-            #    `_edit_entity_impl` raises it for exactly this shape. The edit
-            #    IS durable, so the message says so; what must not happen is
-            #    answering 200 and letting the caller believe the row matches.
-            #    Logging alone would be a swallowed failure (AGENTS.md,
-            #    *Consistency without transactions*): the residue may heal at
-            #    leisure, the failure may not go unreported. It is also the one
-            #    residue in this function a retry CANNOT heal -- the second edit
-            #    sees an unchanged source_id and skips the tracking block
-            #    entirely -- so the operator is the only recovery path, and a
-            #    silent 200 guarantees they never learn to take it. The residue
-            #    itself stays the accepted direction (a row naming IDs the
-            #    relation no longer cites); reordering to avoid it would produce
-            #    the over-deleting mirror instead.
-            if pending_tracking_shrink is not None:
-                try:
-                    await relation_chunks_storage.upsert(
-                        {
-                            tracking_storage_key: {
-                                "chunk_ids": pending_tracking_shrink,
-                                "count": len(pending_tracking_shrink),
-                            }
-                        }
-                    )
-                    await _persist_graph_updates(
-                        relation_chunks_storage=relation_chunks_storage,
-                    )
-                except Exception as e:
+            try:
+                await chunk_entity_relation_graph.upsert_edge(
+                    source_entity, target_entity, new_edge_data
+                )
+            except BaseException as e:
+                # Accepted residue, and the one place in this staging that
+                # cannot be closed -- the same one `_edit_entity_impl` documents
+                # around its `upsert_node`. A cancellation delivered INSIDE this
+                # await, after an immediate-write backend accepted the edge and
+                # before control returns, tears the edit down before the shrink
+                # can run, leaving the edge narrowed with the row still at the
+                # staged superset.
+                #
+                # It cannot be deferred away: the `CancelledError` originates in
+                # this coroutine, so `_finish_deferring_cancellation` has
+                # nothing to defer. It must not be settled blind either --
+                # whether the backend accepted the mutation is unknowable from
+                # here, and narrowing the row when it did NOT would leave the
+                # row a strict SUBSET of the graph, over-deletion, which
+                # AGENTS.md ranks as losing data. So the row stays wide on
+                # purpose and the diagnostic is what is owed.
+                #
+                # Owed for an ordinary exception too: an acknowledgement lost
+                # after the backend applied the write carries the same
+                # ambiguity, and the error the caller gets says only that the
+                # graph write failed. The line fires only for a SHRINKING edit,
+                # so it is not noise, and it is hedged because whether the write
+                # landed is precisely what is unknown.
+                if pending_tracking_shrink is not None:
                     logger.error(
-                        f"Relation Edit: `{source_entity}`~`{target_entity}` is "
-                        f"durable, but pruning its chunk tracking row "
-                        f"`{tracking_storage_key}` down to "
-                        f"{pending_tracking_shrink} failed: {e}"
+                        f"Relation Edit: `{source_entity}`~`{target_entity}`'s "
+                        f"graph write did not complete ({type(e).__name__}: {e}). "
+                        "If the backend applied it anyway -- an immediate-write "
+                        "backend may have, and an acknowledgement can be lost "
+                        "after the fact -- then its chunk tracking row "
+                        f"`{tracking_storage_key}` is now wider than the "
+                        "relation's evidence: it still names the IDs this edit "
+                        "removed, and no retry will prune them, because the next "
+                        "edit reads the narrowed source_id and skips the "
+                        "staging. Run lightrag-repair-chunk-tracking to "
+                        "reconcile it."
                     )
-                    raise VectorStorageConsistencyError(
-                        f"Pruning the chunk tracking row `{tracking_storage_key}` "
-                        f"failed after editing relation `{source_entity}`~"
-                        f"`{target_entity}`: {e}. The edit itself is durable -- the "
-                        "graph and vector records carry the new values -- but the "
-                        "row still names chunk IDs the edit removed, so it is wider "
-                        "than the relation's evidence. No data is lost (a purge "
-                        "reading the wider row is more conservative, not less), and "
-                        "re-issuing the edit cannot repair it: the second run sees "
-                        "an unchanged source_id and skips the tracking update. Run "
-                        "lightrag-repair-chunk-tracking to reconcile the row."
-                    ) from e
+                raise
+
+            async def _commit_graph_and_settle_tracking() -> None:
+                # 5. Commit the graph on its own, and confirm it, before the row
+                #    that describes it is allowed to narrow.
+                #
+                #    This used to be one `_persist_graph_updates` call flushing
+                #    the graph and `relationships_vdb` together, with the shrink
+                #    after it -- so a failure of the vector half exited the edit
+                #    before the shrink ran, leaving the row on the staged
+                #    superset with nothing reported about it (issue #3895).
+                #    Committing the graph alone here keeps the #3889 ranking
+                #    without needing the combined call: a declined commit raises
+                #    at this line, before the vector flush is attempted at all,
+                #    so it still outranks any vector failure -- and the wording
+                #    is the same, both sites raise `_declined_commit_error`.
+                await _commit_graph_or_raise(
+                    chunk_entity_relation_graph,
+                    f"Relation Edit: `{source_entity}`~`{target_entity}`",
+                )
+
+                # 6. Shrink phase: the graph write that justifies dropping these
+                #    IDs is durable now, so the row may finally lose them.
+                #
+                #    Inside the region, and before the vector work, for the two
+                #    reasons #3892 moved the entity one. A cancellation
+                #    delivered during the commit above is deferred to the END of
+                #    this coroutine -- `commit_in_storage_io` finishes the write
+                #    and its commit hook first -- and `CancelledError` is a
+                #    `BaseException`, so a shrink placed outside would simply
+                #    never run and no `except Exception` out there could notice.
+                #
+                #    A failure here raises `VectorStorageConsistencyError`, the
+                #    type this codebase already uses for "a step AFTER a durable
+                #    graph update failed" -- its docstring names a chunk-tracking
+                #    retirement as one of its two cases, and the rename branch of
+                #    `_edit_entity_impl` raises it for exactly this shape. The
+                #    edit IS durable, so the message says so; what must not
+                #    happen is answering 200 and letting the caller believe the
+                #    row matches. Logging alone would be a swallowed failure
+                #    (AGENTS.md, *Consistency without transactions*): the residue
+                #    may heal at leisure, the failure may not go unreported. It
+                #    is also the one residue in this function a retry CANNOT
+                #    heal -- the second edit sees an unchanged source_id and
+                #    skips the tracking block entirely -- so the operator is the
+                #    only recovery path, and a silent 200 guarantees they never
+                #    learn to take it. When a cancel is already pending,
+                #    `_finish_deferring_cancellation` logs it instead: that is
+                #    the one place the failure can still be seen. The residue
+                #    itself stays the accepted direction (a row naming IDs the
+                #    relation no longer cites); reordering to avoid it would
+                #    produce the over-deleting mirror instead.
+                if pending_tracking_shrink is not None:
+                    try:
+                        await relation_chunks_storage.upsert(
+                            {
+                                tracking_storage_key: {
+                                    "chunk_ids": pending_tracking_shrink,
+                                    "count": len(pending_tracking_shrink),
+                                }
+                            }
+                        )
+                        await _persist_graph_updates(
+                            relation_chunks_storage=relation_chunks_storage,
+                        )
+                    except Exception as e:
+                        logger.error(
+                            f"Relation Edit: `{source_entity}`~`{target_entity}` is "
+                            f"durable, but pruning its chunk tracking row "
+                            f"`{tracking_storage_key}` down to "
+                            f"{pending_tracking_shrink} failed: {e}"
+                        )
+                        raise VectorStorageConsistencyError(
+                            f"Pruning the chunk tracking row `{tracking_storage_key}` "
+                            f"failed after editing relation `{source_entity}`~"
+                            f"`{target_entity}`: {e}. The edit itself is durable -- "
+                            "the graph carries the new values -- but the row still "
+                            "names chunk IDs the edit removed, so it is wider than "
+                            "the relation's evidence. No data is lost (a purge "
+                            "reading the wider row is more conservative, not less), "
+                            "and re-issuing the edit cannot repair it: the second "
+                            "run sees an unchanged source_id and skips the tracking "
+                            "update. Run lightrag-repair-chunk-tracking to reconcile "
+                            "the row. The vector records were not written either, so "
+                            "re-issue the edit or run lightrag-rebuild-vdb for those."
+                        ) from e
+
+            # One cancellation-deferring region, as in `_edit_entity_impl`: it
+            # starts before the commit, because that await is itself where a
+            # deferred cancellation reappears, and it ENDS after the tracking is
+            # settled, because the narrowing the durable edge now owes its row
+            # has to survive a cancel.
+            await _finish_deferring_cancellation(
+                _commit_graph_and_settle_tracking(),
+                f"Relation Edit: `{source_entity}`~`{target_entity}` graph commit "
+                "and tracking shrink",
+            )
+
+            # 7. The relation's vector record is written only once the graph
+            #    state it mirrors is durable AND the tracking is settled. It
+            #    used to sit between the edge mutation and the commit, which
+            #    made it one more thing that could strand the pending shrink: on
+            #    an immediate-write backend `upsert_edge` is already durable
+            #    when this runs, so a delete or upsert failure left the edge
+            #    narrowed with the row still holding the superset -- and nothing
+            #    heals that, because the next edit reads the narrowed source_id
+            #    and skips the staging. The reverse exposure is the acceptable
+            #    one: vector records a re-issued edit rewrites and
+            #    `lightrag-rebuild-vdb` restores.
+            try:
+                # Delete the old relation record from the vector database.
+                # Delete both permutations to handle relationships created
+                # before normalization.
+                rel_ids_to_delete = [
+                    compute_mdhash_id(source_entity + target_entity, prefix="rel-"),
+                    compute_mdhash_id(target_entity + source_entity, prefix="rel-"),
+                ]
+                await relationships_vdb.delete(rel_ids_to_delete)
+                logger.debug(
+                    f"Relation Edit: delete vdb for `{source_entity}`~`{target_entity}`"
+                )
+                await relationships_vdb.upsert(relation_data)
+            except Exception as e:
+                raise VectorStorageConsistencyError(
+                    f"Vector storage write failed for relation `{source_entity}`~"
+                    f"`{target_entity}` during relation edit: {e}. The knowledge "
+                    "graph was already updated, so it may now be inconsistent with "
+                    "the vector storage. No data is lost (the graph is the "
+                    "authoritative source). Stop the LightRAG server and run the "
+                    "offline rebuild tool (lightrag-rebuild-vdb) to restore "
+                    "consistency."
+                ) from e
+
+            # Vector store last: its residue is the rebuildable window this
+            # codebase accepts elsewhere, and it is strictly AFTER the tracking
+            # is settled inside the region above, so a raising vector callback
+            # can no longer strand the staged shrink.
+            await _persist_graph_updates(relationships_vdb=relationships_vdb)
 
             logger.info(
                 f"Relation Edit: `{source_entity}`~`{target_entity}` successfully updated"

--- a/tests/extraction/test_vdb_content_truncation_coverage.py
+++ b/tests/extraction/test_vdb_content_truncation_coverage.py
@@ -740,10 +740,12 @@ async def test_edit_relation_truncation_failure_leaves_edge_and_vdb_untouched():
 
 async def test_edit_relation_vdb_delete_failure_still_leaves_graph_updated():
     """A *transient* VDB I/O failure (unlike a TokenBudgetError) must not
-    prevent the graph write: the graph write happens before the VDB delete,
-    so a delete failure still leaves the new relation content saved in the
-    graph -- the recoverable (graph-updated, VDB-stale) window the offline
-    rebuild tool is for."""
+    prevent the graph write: the vector records are written after the graph
+    commit and after the chunk-tracking shrink that commit justifies (issue
+    #3895), so a delete failure still leaves the new relation content saved in
+    the graph -- the recoverable (graph-updated, VDB-stale) window the offline
+    rebuild tool is for. It surfaces as `VectorStorageConsistencyError`, the
+    type that says the graph update IS durable, matching the entity path."""
     graph = _MemGraph()
     for name in ("A", "B"):
         await graph.upsert_node(name, {"entity_id": name, "description": name})
@@ -764,7 +766,9 @@ async def test_edit_relation_vdb_delete_failure_still_leaves_graph_updated():
 
     relationships_vdb.delete = _boom
 
-    with pytest.raises(RuntimeError, match="transient VDB backend error"):
+    with pytest.raises(
+        VectorStorageConsistencyError, match="transient VDB backend error"
+    ):
         await aedit_relation(
             graph,
             entities_vdb,

--- a/tests/pipeline/test_graph_deletion_tracking_ordering.py
+++ b/tests/pipeline/test_graph_deletion_tracking_ordering.py
@@ -1598,6 +1598,198 @@ class TestRelationEditGrowsBeforeItShrinks:
             "chunk-2",
         ]
 
+    @pytest.mark.asyncio
+    async def test_a_failing_vector_flush_does_not_strand_the_shrink(self, deferred):
+        # Issue #3895. The shrink used to sit after a `_persist_graph_updates`
+        # call that flushed the graph and `relationships_vdb` TOGETHER, so the
+        # vector half raising exited the edit before the shrink ran -- the row
+        # kept the staged superset and nothing said so. Nothing heals that: the
+        # next edit reads the already-narrowed source_id and skips the staging.
+        # The vector store, by contrast, is the rebuildable window. So the
+        # shrink completes and the vector error is re-raised after it.
+        await self._seed_two_chunk_relation(deferred)
+        deferred.relationships_vdb.fail_flush = True
+
+        with pytest.raises(_Boom, match="vector flush failed"):
+            await self._edit(deferred)
+
+        assert deferred.relation_chunks.disk[RELATION_KEY]["chunk_ids"] == ["chunk-1"]
+        assert deferred.relation_chunks.disk[RELATION_KEY]["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_a_failing_vector_write_cannot_skip_the_shrink(self, deferred):
+        # The same hole one call earlier: the vector delete/upsert used to run
+        # between the edge mutation and the commit, and on an immediate-write
+        # backend `upsert_edge` is already durable by then -- so a vector
+        # failure there left the edge narrowed with the row at the superset.
+        # The write is now after the region, so it cannot come between the two.
+        await self._seed_two_chunk_relation(deferred)
+        deferred.relationships_vdb.fail = True
+
+        with pytest.raises(VectorStorageConsistencyError):
+            await self._edit(deferred)
+
+        assert deferred.persisted_graph()[ENTITY][OTHER]["source_id"] == "chunk-1"
+        assert deferred.relation_chunks.disk[RELATION_KEY]["chunk_ids"] == ["chunk-1"]
+
+    @pytest.mark.asyncio
+    async def test_a_failed_shrink_skips_the_vector_work_and_says_so(
+        self, deferred, monkeypatch
+    ):
+        # The shrink now precedes the vector work, so a failure there skips it.
+        # That is the acceptable exposure of the two -- vector records are
+        # rewritten by a re-issued edit and restored by lightrag-rebuild-vdb,
+        # while the row is reachable only by the offline repair -- but the
+        # caller has to be told about both, so the message names both.
+        await self._seed_two_chunk_relation(deferred)
+        calls = {"n": 0}
+        original = deferred.relation_chunks.upsert
+
+        async def _upsert(data):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise _Boom("shrink write failed")
+            return await original(data)
+
+        monkeypatch.setattr(deferred.relation_chunks, "upsert", _upsert)
+        flushes_before = deferred.relationships_vdb.flushes
+
+        with pytest.raises(VectorStorageConsistencyError) as excinfo:
+            await self._edit(deferred)
+
+        message = str(excinfo.value)
+        assert "lightrag-repair-chunk-tracking" in message
+        assert "lightrag-rebuild-vdb" in message
+        assert deferred.relationships_vdb.flushes == flushes_before
+
+    @pytest.mark.asyncio
+    async def test_a_declined_commit_outranks_a_failing_vector_flush(
+        self, deferred, monkeypatch
+    ):
+        # Splitting the combined flush must not lose the #3889 ranking: a graph
+        # that DISCARDED the mutation is the answer the caller needs, and a
+        # stale vector store -- the rebuildable window -- must not mask it.
+        await self._seed_two_chunk_relation(deferred)
+        deferred.relationships_vdb.fail_flush = True
+
+        async def _declined():
+            return False
+
+        monkeypatch.setattr(deferred.graph, "index_done_callback", _declined)
+
+        with pytest.raises(RuntimeError, match="discarded"):
+            await self._edit(deferred)
+
+        # The mutation was thrown away, so the row must keep the wider evidence.
+        assert deferred.relation_chunks.disk[RELATION_KEY]["chunk_ids"] == [
+            "chunk-1",
+            "chunk-2",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_cancel_past_the_commit_still_completes_the_shrink(
+        self, deferred, monkeypatch
+    ):
+        # The other half of issue #3895. `commit_in_storage_io` defers a
+        # cancellation through the graph commit and re-raises it at the END of
+        # the deferring region, and `CancelledError` is a `BaseException`, so
+        # the shrink -- which had no region at all -- simply never ran, and no
+        # `except Exception` out there could notice. The row would keep the
+        # staged superset with nothing able to heal it.
+        await self._seed_two_chunk_relation(deferred)
+        owner: dict = {}
+        original = deferred.graph.index_done_callback
+
+        async def _commit_then_cancel():
+            result = await original()
+            # Cancel the CALLER's task: the owed work runs in a task of its own,
+            # so cancelling from the inside would model a different scenario.
+            owner["task"].cancel()
+            return result
+
+        monkeypatch.setattr(deferred.graph, "index_done_callback", _commit_then_cancel)
+
+        owner["task"] = asyncio.ensure_future(self._edit(deferred))
+        with pytest.raises(asyncio.CancelledError):
+            await owner["task"]
+
+        # The edge is durably narrowed, so the row is owed the same narrowing.
+        assert deferred.persisted_graph()[ENTITY][OTHER]["source_id"] == "chunk-1"
+        assert deferred.relation_chunks.disk[RELATION_KEY]["chunk_ids"] == ["chunk-1"]
+
+    @pytest.mark.parametrize(
+        "teardown",
+        [
+            pytest.param(asyncio.CancelledError(), id="cancelled"),
+            # Same ambiguity, and the caller's own error says only that the
+            # graph write failed: an acknowledgement lost after an
+            # immediate-write backend applied the update.
+            pytest.param(_Boom("ack timed out"), id="ordinary-exception"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_a_failed_edge_write_leaves_a_diagnosed_wide_row(
+        self, deferred, monkeypatch, teardown
+    ):
+        # The one residue of this staging that cannot be closed, and the same
+        # one the entity path documents: a teardown inside `upsert_edge`'s own
+        # await aborts before the shrink, so the edge may be narrowed while the
+        # row still holds the superset. Deferring cannot help (the exception
+        # originates in that coroutine) and settling blind would risk the
+        # over-deleting mirror, so what is owed is the diagnostic.
+        graph = _ImmediateGraphStorage()
+        for name in (ENTITY, OTHER):
+            await graph.upsert_node(name, {"entity_id": name, "source_id": "chunk-1"})
+        await graph.upsert_edge(
+            ENTITY,
+            OTHER,
+            {
+                "description": "d",
+                "weight": 2.0,
+                "source_id": f"chunk-1{GRAPH_FIELD_SEP}chunk-2",
+            },
+        )
+        await deferred.relation_chunks.upsert(
+            {RELATION_KEY: {"chunk_ids": ["chunk-1", "chunk-2"], "count": 2}}
+        )
+        await deferred.relation_chunks.index_done_callback()
+        original = graph.upsert_edge
+
+        async def _write_then_fail(src, tgt, edge_data):
+            await original(src, tgt, edge_data)
+            raise teardown
+
+        monkeypatch.setattr(graph, "upsert_edge", _write_then_fail)
+        # `lightrag.utils.logger` sets propagate=False, so caplog sees nothing;
+        # collect from the logger this module actually calls.
+        errors: list[str] = []
+        monkeypatch.setattr(
+            utils_graph.logger, "error", lambda msg, *a, **k: errors.append(str(msg))
+        )
+
+        with pytest.raises(type(teardown)):
+            await utils_graph.aedit_relation(
+                graph,
+                deferred.entities_vdb,
+                deferred.relationships_vdb,
+                ENTITY,
+                OTHER,
+                dict(self.SHRINKING_EDIT),
+                relation_chunks_storage=deferred.relation_chunks,
+            )
+
+        # The write landed, the row stayed wide -- under-deletion, never the
+        # over-deleting mirror. Same outcome for either teardown.
+        assert graph.edges[(ENTITY, OTHER)]["source_id"] == "chunk-1"
+        assert deferred.relation_chunks.disk[RELATION_KEY]["chunk_ids"] == [
+            "chunk-1",
+            "chunk-2",
+        ]
+        # And it is not silent: the operator is told which row and which tool.
+        diagnostic = "\n".join(errors)
+        assert "lightrag-repair-chunk-tracking" in diagnostic
+        assert RELATION_KEY in diagnostic
+
 
 class _EntityEditMixin:
     """Shared helpers for the entity-edit staging cases."""


### PR DESCRIPTION
## Description

`aedit_relation`'s grow-then-shrink chunk-tracking staging kept the right *state*, but its final step could be **skipped entirely with nothing reported**. The shrink sat outside any cancellation-deferring region and after the `_persist_graph_updates` call that flushed the graph **and** `relationships_vdb` together, so two routes exited the edit before it ran:

1. a **cancellation** delivered during that commit — `commit_in_storage_io` defers it through the write and re-raises at the end, and `CancelledError` is a `BaseException`, so the `except Exception` around the shrink never saw it;
2. a **failure of the vector half** of that same call, which propagated before the shrink was reached.

Either way the edge was durably narrowed while the row still held the staged superset. The residue direction is the accepted one (`rows ⊃ graph`, under-deletion, no data lost), but it is the one residue in this function **no retry heals** — the next edit reads an unchanged `source_id` and skips the tracking block — so only `lightrag-repair-chunk-tracking` can reconcile it, and a silent success guarantees the operator never learns to run it. That is the *silent failure* AGENTS.md separates out from an accepted residue.

This applies the two moves #3892 made on the entity path, bringing the relation path to parity.

## Related Issues

Closes #3895. Follow-up to #3892 (entity path) and #3889 (the shrink's own failure reporting and the declined-commit ranking).

## Changes Made

`lightrag/utils_graph.py` — `aedit_relation`:

- The graph commit and the shrink now run together inside one `_finish_deferring_cancellation` region, so a deferred cancel cannot walk past the shrink. A shrink failure under a pending cancel is logged where `_finish_deferring_cancellation` documents it.
- The graph is committed on its own with `_commit_graph_or_raise` instead of the combined flush. This preserves the #3889 ranking without needing phase 2: a declined commit raises before any vector work is attempted, so it still outranks a vector failure, and the message wording is unchanged (both sites raise `_declined_commit_error`).
- The vector delete/upsert **and** its flush moved after that region, so neither can strand the shrink — on an immediate-write backend `upsert_edge` is already durable when they run, which made them the same hazard one call earlier. A failure there now raises `VectorStorageConsistencyError` (previously the raw backend error), matching the entity path; the shrink's own error additionally names `lightrag-rebuild-vdb`, since the vector records are no longer written when it fires.
- The one residue that cannot be closed — a teardown inside `upsert_edge`'s own await, where deferring has nothing to defer and settling blind would risk the over-deleting mirror — is now diagnosed with the row key and the repair tool, mirroring `_edit_entity_impl`.

`docs/ProgramingWithCore.md` → *Concurrent admin writes*: the open-residue paragraph on the `aedit_relation` bullet is retired and replaced with the deliberate residue that remains; the entity bullet's "goes further than the relation one's" wording is updated now that parity holds.

Tests:

- `tests/pipeline/test_graph_deletion_tracking_ordering.py` gains the relation counterparts of the entity cases: cancel past the commit still completes the shrink, a failing vector flush does not strand it, a failing vector write cannot skip it, a failed shrink skips the vector work and says so (naming both tools), a declined commit outranks a failing vector flush, and a failed edge write leaves a diagnosed wide row (cancelled + ordinary exception). Five of the six go red on the previous ordering; the declined-commit one is a stability pin for the split.
- `tests/extraction/test_vdb_content_truncation_coverage.py`: `test_edit_relation_vdb_delete_failure_still_leaves_graph_updated` now expects `VectorStorageConsistencyError` (still asserting the graph write landed).

## Checklist

- [x] Changes tested locally
- [ ] Code reviewed
- [x] Documentation updated (if necessary)
- [x] Unit tests added (if applicable)

## Additional Notes

Local runs (subset mirroring the changed modules):

- `tests/pipeline` — all green, including the 75 in `test_graph_deletion_tracking_ordering.py`.
- `tests/extraction` — green except 7 pre-existing failures in `test_entity_extraction_stability.py` (prompt/addon-params env), reproduced on a clean checkout of `main`; `test_keyword_extraction_drivers.py` cannot be collected in this sandbox (it tries to pip-install `ollama`).
- `tests/api` — 96 pre-existing failures (login/CORS/path-prefix/ollama config), likewise reproduced unchanged on `main` here.

`ruff check` and `ruff format --check` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AC7HAHAN8N6E2E6aq1vzN

---
_Generated by [Claude Code](https://claude.ai/code/session_013AC7HAHAN8N6E2E6aq1vzN)_