### PR TITLE
fix(query): drop empty entity chunk groups

### DIFF
--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -6275,6 +6275,12 @@ async def _find_related_text_unit_from_entities(
         entity_info for entity_info in entities_with_chunks if entity_info["chunks"]
     ]
 
+    # Defensive only: unreachable on this path. Deduplication drops a chunk
+    # solely because an earlier-positioned entity already claimed it, so the
+    # first entity keeps every chunk it carries and at least one group always
+    # survives. The relation path's equivalent guard IS reachable, because it
+    # additionally excludes the chunks already delivered by the entity path,
+    # which can empty every relation group.
     if not entities_with_chunks:
         logger.info(
             f"Find no entity-related chunks from {len(node_datas)} entities after deduplication"

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -6269,6 +6269,18 @@ async def _find_related_text_unit_from_entities(
         # Update entity's chunks to deduplicated chunks
         entity_info["chunks"] = deduplicated_chunks
 
+    # Drop entities emptied by deduplication so they do not inflate the
+    # per-group chunk budget used by the selection strategies.
+    entities_with_chunks = [
+        entity_info for entity_info in entities_with_chunks if entity_info["chunks"]
+    ]
+
+    if not entities_with_chunks:
+        logger.info(
+            f"Find no entity-related chunks from {len(node_datas)} entities after deduplication"
+        )
+        return []
+
     # Step 3: Sort chunks for each entity by occurrence count (higher count = higher priority)
     total_entity_chunks = 0
     for entity_info in entities_with_chunks:

--- a/tests/test_operate_entity_chunk_selection.py
+++ b/tests/test_operate_entity_chunk_selection.py
@@ -1,0 +1,45 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lightrag.base import QueryParam
+from lightrag.constants import GRAPH_FIELD_SEP
+from lightrag.operate import _find_related_text_unit_from_entities
+
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.mark.asyncio
+async def test_entity_chunk_selection_drops_groups_emptied_by_deduplication():
+    chunk_ids = [f"chunk-{index}" for index in range(20)]
+    source_id = GRAPH_FIELD_SEP.join(chunk_ids)
+    node_datas = [
+        {"entity_name": f"entity-{index}", "source_id": source_id} for index in range(5)
+    ]
+
+    text_chunks_db = AsyncMock()
+    text_chunks_db.global_config = {
+        "kg_chunk_pick_method": "WEIGHT",
+        "related_chunk_number": 2,
+    }
+    text_chunks_db.get_by_ids.return_value = [
+        {"content": f"content-{chunk_id}"} for chunk_id in chunk_ids[:2]
+    ]
+
+    with patch(
+        "lightrag.operate.pick_by_weighted_polling",
+        return_value=chunk_ids[:2],
+    ) as weighted_picker:
+        result = await _find_related_text_unit_from_entities(
+            node_datas,
+            QueryParam(),
+            text_chunks_db,
+            AsyncMock(),
+        )
+
+    groups, max_related_chunks = weighted_picker.call_args.args[:2]
+    assert len(groups) == 1
+    assert groups[0]["sorted_chunks"] == chunk_ids
+    assert max_related_chunks == 2
+    assert [chunk["chunk_id"] for chunk in result] == chunk_ids[:2]

--- a/tests/test_operate_entity_chunk_selection.py
+++ b/tests/test_operate_entity_chunk_selection.py
@@ -1,45 +1,144 @@
+"""Budget parity between the entity and relation chunk-selection paths.
+
+Both paths deduplicate each group's chunk list, both can empty a group that
+way, and both size their chunk budget from the surviving group count. The
+entity path used to keep the emptied groups, so phantom groups inflated the
+WEIGHT and VECTOR budgets and over-delivered beyond ``related_chunk_number``.
+"""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from lightrag.base import QueryParam
 from lightrag.constants import GRAPH_FIELD_SEP
-from lightrag.operate import _find_related_text_unit_from_entities
+from lightrag.operate import (
+    _find_related_text_unit_from_entities,
+    _find_related_text_unit_from_relations,
+)
 
 
 pytestmark = pytest.mark.offline
 
+CHUNK_IDS = [f"chunk-{index}" for index in range(20)]
+SOURCE_ID = GRAPH_FIELD_SEP.join(CHUNK_IDS)
+RELATED_CHUNK_NUMBER = 2
+DUPLICATE_GROUPS = 5
 
-@pytest.mark.asyncio
-async def test_entity_chunk_selection_drops_groups_emptied_by_deduplication():
-    chunk_ids = [f"chunk-{index}" for index in range(20)]
-    source_id = GRAPH_FIELD_SEP.join(chunk_ids)
-    node_datas = [
-        {"entity_name": f"entity-{index}", "source_id": source_id} for index in range(5)
-    ]
 
+def _text_chunks_db(pick_method: str) -> AsyncMock:
     text_chunks_db = AsyncMock()
     text_chunks_db.global_config = {
-        "kg_chunk_pick_method": "WEIGHT",
-        "related_chunk_number": 2,
+        "kg_chunk_pick_method": pick_method,
+        "related_chunk_number": RELATED_CHUNK_NUMBER,
     }
-    text_chunks_db.get_by_ids.return_value = [
-        {"content": f"content-{chunk_id}"} for chunk_id in chunk_ids[:2]
+    text_chunks_db.get_by_ids.side_effect = lambda chunk_ids: [
+        {"content": f"content-{chunk_id}"} for chunk_id in chunk_ids
+    ]
+    return text_chunks_db
+
+
+def _duplicate_entities() -> list[dict]:
+    """Entities that all carry the same chunks, so one group survives dedup."""
+    return [
+        {"entity_name": f"entity-{index}", "source_id": SOURCE_ID}
+        for index in range(DUPLICATE_GROUPS)
     ]
 
+
+def _duplicate_relations() -> list[dict]:
+    """The relation-path twin of :func:`_duplicate_entities`."""
+    return [
+        {"src_tgt": (f"src-{index}", f"tgt-{index}"), "source_id": SOURCE_ID}
+        for index in range(DUPLICATE_GROUPS)
+    ]
+
+
+async def _select_from_entities(text_chunks_db: AsyncMock, **kwargs) -> list[dict]:
+    return await _find_related_text_unit_from_entities(
+        _duplicate_entities(),
+        QueryParam(),
+        text_chunks_db,
+        AsyncMock(),
+        **kwargs,
+    )
+
+
+async def _select_from_relations(text_chunks_db: AsyncMock, **kwargs) -> list[dict]:
+    return await _find_related_text_unit_from_relations(
+        _duplicate_relations(),
+        QueryParam(),
+        text_chunks_db,
+        entity_chunks=[],
+        **kwargs,
+    )
+
+
+def _vector_call_args(picker: AsyncMock) -> tuple[int, int]:
+    """Return the (budget, group count) a path handed to the vector picker."""
+    return (
+        picker.call_args.kwargs["num_of_chunks"],
+        len(picker.call_args.kwargs["entity_info"]),
+    )
+
+
+async def test_weighted_polling_sees_only_surviving_entity_groups():
     with patch(
         "lightrag.operate.pick_by_weighted_polling",
-        return_value=chunk_ids[:2],
+        return_value=CHUNK_IDS[:RELATED_CHUNK_NUMBER],
     ) as weighted_picker:
-        result = await _find_related_text_unit_from_entities(
-            node_datas,
-            QueryParam(),
-            text_chunks_db,
-            AsyncMock(),
-        )
+        result = await _select_from_entities(_text_chunks_db("WEIGHT"))
 
     groups, max_related_chunks = weighted_picker.call_args.args[:2]
     assert len(groups) == 1
-    assert groups[0]["sorted_chunks"] == chunk_ids
-    assert max_related_chunks == 2
-    assert [chunk["chunk_id"] for chunk in result] == chunk_ids[:2]
+    assert groups[0]["sorted_chunks"] == CHUNK_IDS
+    assert max_related_chunks == RELATED_CHUNK_NUMBER
+    assert [chunk["chunk_id"] for chunk in result] == CHUNK_IDS[:RELATED_CHUNK_NUMBER]
+
+
+async def test_entity_path_honours_the_configured_weight_budget():
+    """The user-visible symptom: phantom groups used to deliver 8, not 2."""
+    result = await _select_from_entities(_text_chunks_db("WEIGHT"))
+
+    assert [chunk["chunk_id"] for chunk in result] == CHUNK_IDS[:RELATED_CHUNK_NUMBER]
+
+
+async def test_vector_budget_counts_only_surviving_entity_groups():
+    text_chunks_db = _text_chunks_db("VECTOR")
+    text_chunks_db.embedding_func = AsyncMock()
+
+    with patch(
+        "lightrag.operate.pick_by_vector_similarity",
+        new=AsyncMock(return_value=[]),
+    ) as vector_picker:
+        await _select_from_entities(
+            text_chunks_db, query="question", chunks_vdb=AsyncMock()
+        )
+
+    # int(2 * 1 / 2) over the single surviving group, not int(2 * 5 / 2).
+    assert _vector_call_args(vector_picker) == (1, 1)
+
+
+async def test_both_paths_deliver_the_same_weight_budget():
+    """The asymmetry is what makes this easy to reintroduce, so pin it."""
+    entity_result = await _select_from_entities(_text_chunks_db("WEIGHT"))
+    relation_result = await _select_from_relations(_text_chunks_db("WEIGHT"))
+
+    assert [chunk["chunk_id"] for chunk in entity_result] == [
+        chunk["chunk_id"] for chunk in relation_result
+    ]
+
+
+async def test_both_paths_hand_the_same_budget_to_the_vector_picker():
+    budgets = []
+    for select in (_select_from_entities, _select_from_relations):
+        text_chunks_db = _text_chunks_db("VECTOR")
+        text_chunks_db.embedding_func = AsyncMock()
+        with patch(
+            "lightrag.operate.pick_by_vector_similarity",
+            new=AsyncMock(return_value=[]),
+        ) as vector_picker:
+            await select(text_chunks_db, query="question", chunks_vdb=AsyncMock())
+        budgets.append(_vector_call_args(vector_picker))
+
+    assert budgets[0] == budgets[1]


### PR DESCRIPTION
## Summary

Drop entity groups emptied by chunk deduplication before calculating the per-group retrieval budget.

## Motivation

The entity retrieval path retained empty groups after deduplication, unlike the relation path. Those phantom groups inflated both WEIGHT and VECTOR chunk budgets and could over-deliver context beyond `related_chunk_number`.

On five duplicate entities carrying the same 20 chunks with `related_chunk_number=2`, the entity path delivered 8 chunks where the relation path delivered 2, and handed the vector picker a budget of 5 instead of 1 — identical logical input, 4-5x the budget, purely because the divisor counted groups that no longer carried anything.

Fixes #3898.

## What changed

- filter entity groups that have no chunks after deduplication, before the group count is read by either selection strategy
- return early when no entity chunks survive, and mark that guard as defensive only. It is unreachable on the entity path: deduplication drops a chunk solely because an earlier-positioned entity already claimed it, so the first group keeps everything it carries and always survives. The relation path's equivalent guard *is* reachable, because it additionally excludes the chunks the entity path already delivered.
- add offline regression tests over five duplicate entity groups collapsing to one real group, covering the arguments handed to the weighted picker, the chunk ids actually delivered under WEIGHT (2, not 8), the `num_of_chunks` handed to the vector picker (1, not 5), and a pair of tests asserting the entity and relation paths agree on both budgets for equivalent input.
- pin the interaction with #3887 at `related_chunk_number=1`, the only input where the two fixes can disagree. Collapsing the duplicates to one group makes the ungated `int(1 * 1 / 2)` truncate to 0, which downgrades a valid VECTOR configuration to WEIGHT; #3887's `_vector_chunk_quota` floor is what answers it. The zero predates this branch — a single entity at `related_chunk_number=1` hits it on the base commit too — but the phantom groups used to inflate the divisor past it, so dropping them is what exposes the input.

## What's broken and how it works

Nothing leaves the candidate pool — only the budget divisor changes. Empty groups contributed no chunk ids to begin with, so filtering them alters the quota and nothing else. `chunk_occurrence_count` is deliberately left untouched, so `chunk_tracking[...]["frequency"]` still reflects every entity a chunk appeared in, not just the surviving ones. Filtering preserves the relative order of the survivors, so they move up into the positions the linear-gradient allocation intended for them — the same thing the relation path already does.

One downstream effect is intended rather than incidental: the entity path now delivers fewer chunks, which shrinks the `entity_chunks` exclusion set passed to the relation path, so the relation side may pick up a few more. That re-balancing is the point of making both paths honour the same knob.

## Verification

- `./scripts/test.sh tests/test_operate_entity_chunk_selection.py` — 6 passed; all six fail against the base commit `d964d92`
- `./scripts/test.sh tests/test_operate_entity_chunk_selection.py tests/test_weighted_polling_nonpositive_max.py tests/utils tests/test_operate_vector_context.py` — 353 passed
- `main` is merged into this branch, so #3887's `_vector_chunk_quota()` now owns both call sites; the filter still sits ahead of the quota call
- `./scripts/test.sh tests/test_operate_entity_chunk_selection.py tests/test_kg_vector_chunk_quota.py tests/test_docstring_budget.py tests/test_weighted_polling_nonpositive_max.py tests/utils tests/test_operate_vector_context.py tests/test_operate_truncation_order.py` — 403 passed
- the `related_chunk_number=1` test tells all three states apart: `(2, 5)` on the base commit, `(0, 1)` on this branch before `main` was merged, `(1, 1)` only with both fixes present. Dropping the filter fails the `related_chunk_number=2` VECTOR assertion with `(5, 5) == (1, 1)`.
- `ruff check lightrag/operate.py tests/test_operate_entity_chunk_selection.py`
- `git diff --check`

