### PR TITLE
fix: recognize repeated-letter alpha ordinals (aa, zz, aaa) in smart_heading

### DIFF
--- a/lightrag/parser/docx/numbering_resolver.py
+++ b/lightrag/parser/docx/numbering_resolver.py
@@ -36,8 +36,8 @@ class NumberingResolver:
     FORMAT_CONVERTERS = {
         "decimal": lambda n: str(n),
         # Word repeats a letter after each alphabet: a...z, aa...zz, aaa...
-        "lowerLetter": lambda n: chr(ord("a") + (n - 1) % 26) * ((n - 1) // 26 + 1),
-        "upperLetter": lambda n: chr(ord("A") + (n - 1) % 26) * ((n - 1) // 26 + 1),
+        "lowerLetter": lambda n: NumberingResolver._to_alpha(n),
+        "upperLetter": lambda n: NumberingResolver._to_alpha(n).upper(),
         "lowerRoman": lambda n: NumberingResolver._to_roman(n).lower(),
         "upperRoman": lambda n: NumberingResolver._to_roman(n),
         "chineseCounting": lambda n: NumberingResolver._to_chinese(n),
@@ -62,6 +62,8 @@ class NumberingResolver:
     #: table exists to make the event FINDABLE: a real document that gets there
     #: is the evidence needed to implement the right one.
     LIMITED_DOMAIN_FORMATS = {
+        "lowerLetter": 78,
+        "upperLetter": 78,
         "chineseCounting": 99,
         "chineseCountingThousand": 99,
         "japaneseCounting": 99,
@@ -375,6 +377,7 @@ class NumberingResolver:
         Returns:
             Rendered label string (e.g., "1.1", "a)", "第一章") or empty string
         """
+        self.last_label_format: str | None = None
         try:
             pPr = para_element.find(f"{{{NSMAP['w']}}}pPr")
             if pPr is None:
@@ -495,6 +498,8 @@ class NumberingResolver:
 
             # Format the label using lvlText template
             label = self._format_label(num_id, ilvl, levels)
+            if label:
+                self.last_label_format = levels[ilvl]["numFmt"]
 
             # Update tracking state for next paragraph
             self.last_numId = num_id
@@ -531,6 +536,17 @@ class NumberingResolver:
             return result
         except Exception:
             return ""
+
+    @staticmethod
+    def _to_alpha(n: int) -> str:
+        """Render Word's repeated letters within the classifier's 1-78 domain.
+
+        Check before multiplying: an untrusted DOCX startOverride can be a
+        32-bit integer, which must not allocate a label proportional to it.
+        """
+        if not 1 <= n <= 78:
+            return str(n)
+        return chr(ord("a") + (n - 1) % 26) * ((n - 1) // 26 + 1)
 
     @staticmethod
     def _to_roman(n: int) -> str:

--- a/lightrag/parser/docx/numbering_resolver.py
+++ b/lightrag/parser/docx/numbering_resolver.py
@@ -35,8 +35,9 @@ class NumberingResolver:
     # (not chineseCounting), which is why both are mapped here.
     FORMAT_CONVERTERS = {
         "decimal": lambda n: str(n),
-        "lowerLetter": lambda n: chr(ord("a") + (n - 1) % 26),
-        "upperLetter": lambda n: chr(ord("A") + (n - 1) % 26),
+        # Word repeats a letter after each alphabet: a...z, aa...zz, aaa...
+        "lowerLetter": lambda n: chr(ord("a") + (n - 1) % 26) * ((n - 1) // 26 + 1),
+        "upperLetter": lambda n: chr(ord("A") + (n - 1) % 26) * ((n - 1) // 26 + 1),
         "lowerRoman": lambda n: NumberingResolver._to_roman(n).lower(),
         "upperRoman": lambda n: NumberingResolver._to_roman(n),
         "chineseCounting": lambda n: NumberingResolver._to_chinese(n),

--- a/lightrag/parser/docx/parse_document.py
+++ b/lightrag/parser/docx/parse_document.py
@@ -649,6 +649,7 @@ class ParagraphRecord:
     # --- smart-heading features (populated only when smart is enabled) ------
     full_text_raw: str | None = None  # pre-policy label+text (keeps "\n")
     label: str = ""  # auto-numbering label, if any
+    numbering_format: str | None = None  # OOXML provenance; disambiguates ii/xx
     outline_level_raw: int | None = None  # pre-policy outline level
     style_id: str | None = None
     font_size_pt: float | None = None  # char-weighted dominant (0.5pt grid)
@@ -832,6 +833,7 @@ def _read_document_records(
                 phys = extract_paragraph_physical_features(element, style_attributes)
                 rec.full_text_raw = full_text_raw
                 rec.label = label or ""
+                rec.numbering_format = resolver.last_label_format
                 rec.outline_level_raw = outline_level_raw
                 rec.style_id = phys.style_id
                 rec.font_size_pt = phys.font_size_pt

--- a/lightrag/parser/docx/smart_heading/heading_flow.py
+++ b/lightrag/parser/docx/smart_heading/heading_flow.py
@@ -456,7 +456,9 @@ def gate_candidates(
         if _record_weight(records[i]) <= 0:
             numbering[i] = None
             continue
-        cls = classify_numbering(records[i].text)
+        cls = classify_numbering(
+            records[i].text, numbering_format=records[i].numbering_format
+        )
         if cls is not None:
             veto = numbering_veto(cls, records[i].text)
             if veto is not None:

--- a/lightrag/parser/docx/smart_heading/style_key.py
+++ b/lightrag/parser/docx/smart_heading/style_key.py
@@ -92,9 +92,12 @@ _P_CN_NUM = re.compile(rf"^\s*([{_CN_ORD}]+)[.、\s]")
 _P_CN_PARENT = re.compile(rf"^\s*([（(][{_CN_ORD}]+[）)]|[{_CN_ORD}]+[）)])")
 _P_ROMAN = re.compile(r"^\s*([IVX]{2,}|[ivx]{2,}|[Ⅰ-Ⅻⅰ-ⅻ])[.、]")
 _P_EN_NUM = re.compile(r"^\s*(\d+)(?:\s|[.、]|(?=[一-龥]))")
-_P_EN_ALPHA = re.compile(r"^\s*([A-Za-z])[.、]")
-_P_EN_DOUBLE_PAREN = re.compile(r"^\s*([（(](?:\d+|[a-zA-Z])[）)])")
-_P_EN_SINGLE_PAREN = re.compile(r"^\s*((?:\d+|[a-zA-Z]))[）)]")
+# Bounded repeated-letter group: Word list labels repeat the SAME letter
+# (a, z, aa, zz, aaa). Mixed runs like "CV" or "MD" are abbreviations and
+# must not classify as EnAlpha.
+_P_EN_ALPHA = re.compile(r"^\s*(([A-Za-z])\2{0,2})[.、]")
+_P_EN_DOUBLE_PAREN = re.compile(r"^\s*([（(](?:\d+|([A-Za-z])\2{0,2})[）)])")
+_P_EN_SINGLE_PAREN = re.compile(r"^\s*((?:\d+|([A-Za-z])\2{0,2}))[）)]")
 
 #: Try order: MultiLevelNum first, then the table order top-down.
 _MATCH_ORDER: tuple[tuple[str, re.Pattern], ...] = (
@@ -202,10 +205,23 @@ def _to_roman(num: int) -> str | None:
 
 
 def parse_alpha_ordinal(text: str) -> int | None:
+    """Parse a homogeneous ASCII-letter run like ``a``, ``z``, ``aa``, ``zz``.
+
+    Word repeated-letter labels run the letter through the alphabet and count
+    the run length as the round: ``a``/``z`` are 1/26, ``aa``/``zz`` are
+    27/52, ``aaa`` is 53. Mixed runs (``ab``) and runs longer than 3 letters
+    are not list labels and return None.
+    """
     text = text.strip()
-    if len(text) == 1 and text.isalpha() and text.isascii():
-        return ord(text.lower()) - ord("a") + 1
-    return None
+    if not (text.isalpha() and text.isascii()):
+        return None
+    if not 1 <= len(text) <= 3:
+        return None
+    lowered = text.lower()
+    if len(set(lowered)) != 1:
+        return None
+    letter_index = ord(lowered[0]) - ord("a") + 1
+    return letter_index + 26 * (len(lowered) - 1)
 
 
 #: Normalized unit ranks (smaller = shallower). Spec: 篇/部/编/卷 > 章 > 节;

--- a/lightrag/parser/docx/smart_heading/style_key.py
+++ b/lightrag/parser/docx/smart_heading/style_key.py
@@ -264,6 +264,7 @@ class NumberingClassification:
     ordinal: int | None = None  # parsed ordinal value, when parseable
     raw_level: int | None = None  # MultiLevelNum: dot count + 1
     top_ordinal: int | None = None  # MultiLevelNum: leading component value
+    automatic_alpha: bool = False  # explicit DOCX numFmt wins over Roman heuristics
 
     @property
     def priority(self) -> int:
@@ -334,7 +335,9 @@ def _parse_latin_ordinal(text: str) -> int | None:
     return parse_alpha_ordinal(text)
 
 
-def classify_numbering(text: str) -> NumberingClassification | None:
+def classify_numbering(
+    text: str, *, numbering_format: str | None = None
+) -> NumberingClassification | None:
     """Classify the leading numbering of a paragraph (first hit wins).
 
     Returns None when no pattern matches OR when the matched styleKey does
@@ -343,8 +346,11 @@ def classify_numbering(text: str) -> NumberingClassification | None:
     """
     if not text:
         return None
+    automatic_alpha = numbering_format in ("lowerLetter", "upperLetter")
     multi_level_shape = _P_MULTI_LEVEL_SHAPE.match(text) is not None
     for style_key, pattern in _MATCH_ORDER:
+        if automatic_alpha and style_key == ROMAN_NUM:
+            continue
         if multi_level_shape and style_key != MULTI_LEVEL_NUM:
             # A multi-level opener is claimed by MultiLevelNum exclusively;
             # if its full rule rejected the text, the paragraph is body.
@@ -375,6 +381,7 @@ def classify_numbering(text: str) -> NumberingClassification | None:
             ordinal=ordinal,
             raw_level=raw_level,
             top_ordinal=top_ordinal,
+            automatic_alpha=automatic_alpha,
         )
     return None
 
@@ -399,6 +406,7 @@ def reclassify_single_char_romans(
             item is not None
             and item.style_key == EN_ALPHA
             and item.label_text in _SINGLE_ROMAN_CHARS
+            and not item.automatic_alpha
         ):
             out.append(
                 replace(

--- a/tests/parser/docx/test_numbering_resolver.py
+++ b/tests/parser/docx/test_numbering_resolver.py
@@ -178,6 +178,36 @@ def _label(r: NumberingResolver, count: int) -> str:
     return r._format_label("100", 0, r.abstract_nums["10"])
 
 
+@pytest.mark.parametrize("num_fmt", ["lowerLetter", "upperLetter"])
+@pytest.mark.parametrize("lvl_text", ["%1.", "(%1)", "%1)"])
+def test_letter_labels_preserve_ordinals_after_first_alphabet(num_fmt, lvl_text):
+    from lightrag.parser.docx.smart_heading.style_key import classify_numbering
+
+    resolver = _fmt_resolver(num_fmt, lvl_text)
+    for count in range(1, 79):
+        label = resolver.get_label(_para(num_id="100", ilvl=0))
+        # Check alphabet boundaries and the next label. Roman-looking labels
+        # such as II retain the classifier's existing Roman precedence.
+        if count not in {1, 26, 27, 28, 52, 53, 78}:
+            continue
+        match = classify_numbering(f"{label} Heading")
+        assert match is not None
+        assert match.ordinal == count
+        if count in {1, 26, 27, 28, 52, 53, 78}:
+            letters = {
+                1: "a",
+                26: "z",
+                27: "aa",
+                28: "bb",
+                52: "zz",
+                53: "aaa",
+                78: "zzz",
+            }[count]
+            if num_fmt == "upperLetter":
+                letters = letters.upper()
+            assert label == lvl_text.replace("%1", letters)
+
+
 # The counting families all render 一/二/十/十一/… — [MS-DOCX] gives
 # japaneseCounting as 一,二,三 and chineseCounting / taiwaneseCounting as
 # 一 (1) / 十 (10). Chinese-locale Word writes 一二三 auto-numbering as

--- a/tests/parser/docx/test_numbering_resolver.py
+++ b/tests/parser/docx/test_numbering_resolver.py
@@ -186,11 +186,9 @@ def test_letter_labels_preserve_ordinals_after_first_alphabet(num_fmt, lvl_text)
     resolver = _fmt_resolver(num_fmt, lvl_text)
     for count in range(1, 79):
         label = resolver.get_label(_para(num_id="100", ilvl=0))
-        # Check alphabet boundaries and the next label. Roman-looking labels
-        # such as II retain the classifier's existing Roman precedence.
-        if count not in {1, 26, 27, 28, 52, 53, 78}:
-            continue
-        match = classify_numbering(f"{label} Heading")
+        match = classify_numbering(
+            f"{label} Heading", numbering_format=resolver.last_label_format
+        )
         assert match is not None
         assert match.ordinal == count
         if count in {1, 26, 27, 28, 52, 53, 78}:
@@ -206,6 +204,45 @@ def test_letter_labels_preserve_ordinals_after_first_alphabet(num_fmt, lvl_text)
             if num_fmt == "upperLetter":
                 letters = letters.upper()
             assert label == lvl_text.replace("%1", letters)
+
+
+@pytest.mark.parametrize("num_fmt", ["lowerLetter", "upperLetter"])
+@pytest.mark.parametrize("count", [-1, 0, 79, 2147483647])
+@pytest.mark.parametrize("override", [False, True])
+def test_large_letter_starts_fall_back_before_allocating(num_fmt, count, override):
+    resolver = _fmt_resolver(num_fmt, "%1.")
+    resolver._warnings = {}
+    if override:
+        resolver.start_overrides = {"100": {0: count}}
+    else:
+        resolver.abstract_nums["10"][0]["start"] = count
+    assert resolver.get_label(_para(num_id="100", ilvl=0)) == f"{count}."
+    assert resolver.out_of_range_formats == ({num_fmt} if count > 78 else set())
+    assert resolver._warnings == (
+        {"numbering_out_of_range_formats": 1} if count > 78 else {}
+    )
+
+
+def test_read_pass_retains_letter_provenance_and_clears_it_on_plain_text():
+    from docx import Document
+
+    from lightrag.parser.docx.parse_document import _read_document_records
+    from lightrag.parser.docx.smart_heading.features import StyleAttributes
+
+    doc = Document()
+    para = doc.add_paragraph("Heading")
+    para._p.get_or_add_pPr().append(
+        _para(num_id="100", ilvl=0).find(f"{{{W}}}pPr/{{{W}}}numPr")
+    )
+    doc.add_paragraph("II. Typed Roman heading")
+    resolver = _fmt_resolver("lowerLetter", "%1.")
+    resolver.abstract_nums["10"][0]["start"] = 35
+    records = _read_document_records(
+        doc, resolver, {}, None, {}, style_attributes=StyleAttributes()
+    )
+    assert records[0].text == "ii. Heading"
+    assert records[0].numbering_format == "lowerLetter"
+    assert records[1].numbering_format is None
 
 
 # The counting families all render 一/二/十/十一/… — [MS-DOCX] gives

--- a/tests/parser/docx/test_smart_heading_flow.py
+++ b/tests/parser/docx/test_smart_heading_flow.py
@@ -101,6 +101,26 @@ def test_outline_candidate_survives_smaller_font() -> None:
     assert d.rule_trail[0] == "outline"
 
 
+@pytest.mark.parametrize("fmt", ["lowerLetter", "upperLetter"])
+def test_automatic_alpha_keeps_roman_looking_ordinals(fmt):
+    labels = [("i", 9), ("ii", 35), ("vv", 48), ("xx", 50)]
+    records = _body() + [
+        _para(
+            f"{label.upper() if fmt == 'upperLetter' else label}. Heading",
+            outline_level=0,
+            numbering_format=fmt,
+        )
+        for label, _ in labels
+    ]
+    # A real, typed Roman companion must not promote the explicit alpha I.
+    records.append(_para("III. Roman heading", outline_level=0))
+    result = _gate(records)
+    classifications = [d.numbering for d in result.decisions]
+    assert [(c.style_key, c.ordinal) for c in classifications] == [
+        ("EnAlpha", ordinal) for _, ordinal in labels
+    ] + [("RomanNum", 3)]
+
+
 def test_outline_strong_body_demotion_is_rule_tagged() -> None:
     """Review C2: an outline paragraph the recognition-time strong-body check
     demotes must leave a rule-tagged demoted decision (not a silent drop), so

--- a/tests/parser/docx/test_smart_heading_style_key.py
+++ b/tests/parser/docx/test_smart_heading_style_key.py
@@ -21,6 +21,7 @@ from lightrag.parser.docx.smart_heading.style_key import (
     STYLE_KEY_PRIORITY,
     classify_numbering,
     compute_fs_base,
+    parse_alpha_ordinal,
     parse_cn_ordinal,
     parse_roman,
     reclassify_single_char_romans,
@@ -54,6 +55,7 @@ POSITIVE_CASES = [
     ("Section 3", EN_CHAPTER, "Section 3"),  # wins over EnClause
     ("Volume II Overview", EN_CHAPTER, "Volume II"),
     ("Part A", EN_CHAPTER, "Part A"),
+    ("Section aa", EN_CHAPTER, "Section aa"),
     # MultiLevelNum
     ("1.2 节", MULTI_LEVEL_NUM, "1.2"),
     ("§ 1.1.4 节", MULTI_LEVEL_NUM, "§ 1.1.4"),
@@ -102,15 +104,19 @@ POSITIVE_CASES = [
     ("A. 概念", EN_ALPHA, "A"),
     ("a. Intro", EN_ALPHA, "a"),
     ("B、内容", EN_ALPHA, "B"),
+    ("aa. Double", EN_ALPHA, "aa"),
+    ("zz. Double", EN_ALPHA, "zz"),
     # EnDoubleParen
     ("(1) 内容", EN_DOUBLE_PAREN, "(1)"),
     ("（a）内容", EN_DOUBLE_PAREN, "（a）"),
     ("(A) Text", EN_DOUBLE_PAREN, "(A)"),
     ("（12）内容", EN_DOUBLE_PAREN, "（12）"),
+    ("(bb) double", EN_DOUBLE_PAREN, "(bb)"),
     # EnSingleParen
     ("1) 内容", EN_SINGLE_PAREN, "1"),
     ("a) Intro", EN_SINGLE_PAREN, "a"),
     ("12）内容", EN_SINGLE_PAREN, "12"),
+    ("zz) double", EN_SINGLE_PAREN, "zz"),
 ]
 
 
@@ -217,6 +223,32 @@ def test_ordinals() -> None:
     assert classify_numbering("PART I").ordinal == 1
     assert parse_cn_ordinal("一百二十") == 120
     assert parse_roman("XXXIX") == 39
+
+
+def test_repeated_letter_alpha_ordinals() -> None:
+    """Word repeated-letter labels (aa, zz, aaa) parse to 27, 52, 53."""
+    assert classify_numbering("a. Intro").ordinal == 1
+    assert classify_numbering("z. Intro").ordinal == 26
+    assert classify_numbering("aa. Intro").ordinal == 27
+    assert classify_numbering("zz) Intro").ordinal == 52
+    assert classify_numbering("aaa. Intro").ordinal == 53
+    assert classify_numbering("(bb) Intro").ordinal == 28
+    assert classify_numbering("Section aa").ordinal == 27
+    assert classify_numbering("B. Beta").ordinal == 2
+    assert parse_alpha_ordinal("A") == 1
+    assert parse_alpha_ordinal("ZZ") == 52
+    assert parse_alpha_ordinal("AAA") == 53
+
+
+def test_non_word_letter_runs_return_no_ordinal() -> None:
+    """Mixed or over-long alpha runs are not Word list labels."""
+    assert parse_alpha_ordinal("ab") is None
+    assert parse_alpha_ordinal("aaaab") is None
+    assert parse_alpha_ordinal("a1") is None
+    # a mixed run must not classify as EnAlpha at all (words/abbreviations)
+    assert classify_numbering("ab. Intro") is None
+    assert classify_numbering("CV. 简历缩写") is None
+    assert classify_numbering("MD. 医生头像") is None
 
 
 def test_multilevel_raw_level_and_top() -> None:


### PR DESCRIPTION
## Summary

Fixes #3902: recognize Word-style repeated-letter alphabetic labels through item 78, including labels generated from DOCX numbering definitions.

- Parse homogeneous letter runs with ordinal `letter_index + 26 * (length - 1)`; reject mixed runs.
- Generate Word repeated-letter labels with a bounds check before string multiplication. Out-of-domain counters fall back to decimal instead of allocating an unbounded string.
- Carry explicit lowerLetter/upperLetter provenance into heading classification, so automatic ii/vv/xx remain alphabetic while typed Roman numerals retain existing behavior.
- Cover all 78 supported counters in both cases and supported punctuation forms, large start/startOverride values, and resolver-to-heading provenance.

## Validation

- DOCX parser suite: 871 passed, 45 skipped (optional spaCy language models unavailable).
- Focused regression suite: 317 passed, 1 skipped.
- No new Ruff findings versus the previous head; 46 existing findings remain in the six touched files.
- git diff --check passed.

The latest changes address the allocation-bound and Roman-looking automatic-label review findings. Upstream CI for this head is still pending.
