### PR TITLE
fix(delete): report an incomplete LLM cache deletion instead of an unqualified success

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -4477,8 +4477,18 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         doc_llm_cache_ids: list[str],
         error_message: str | None = None,
         failed: bool,
+        cache_gap: tuple[int, int] | None = None,
     ) -> dict[str, Any]:
         """Persist deletion retry metadata and return the updated status record.
+
+        ``cache_gap`` is ``(chunks_without_refs, chunks_examined)`` from the
+        cache-id collection step. It is persisted as
+        ``deletion_llm_cache_gap`` whenever chunks without references were
+        seen, for the same reason the cache ids are: once the purge has
+        removed the chunk rows, a retry can no longer examine them, and the
+        notice that a requested cache deletion is incomplete would otherwise
+        be lost with the attempt that observed it. An unprovided or all-clear
+        gap leaves the stored value alone.
 
         Re-reads the record first, and writes only the fields it changes. The
         caller's ``doc_status_data`` is a snapshot taken before deletion began,
@@ -4526,6 +4536,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         updated_metadata = dict(metadata)
         if retry_cache_ids:
             updated_metadata["deletion_llm_cache_ids"] = retry_cache_ids
+        if cache_gap is not None and cache_gap[0] > 0:
+            updated_metadata["deletion_llm_cache_gap"] = {
+                "chunks_without_refs": cache_gap[0],
+                "chunks_examined": cache_gap[1],
+            }
         updated_metadata["last_deletion_attempt_at"] = datetime.now(
             timezone.utc
         ).isoformat()
@@ -5858,6 +5873,7 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         # be reported as incomplete instead of as an unqualified success.
         chunks_examined_for_cache = 0
         chunks_without_cache_refs = 0
+        persisted_cache_gap: tuple[int, int] | None = None
         incomplete_cache_notice: str | None = None
         deletion_stage = "initializing"
         doc_status_data: dict[str, Any] | None = None
@@ -6008,6 +6024,28 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     )
                 )
             )
+            # A prior attempt that still saw the chunk rows may have recorded
+            # how many carried no cache reference; see
+            # ``_update_delete_retry_state``. Malformed values are ignored —
+            # this is diagnostics, never a reason to refuse the deletion.
+            raw_cache_gap = metadata.get("deletion_llm_cache_gap")
+            if isinstance(raw_cache_gap, dict):
+                gap_without = raw_cache_gap.get("chunks_without_refs")
+                gap_examined = raw_cache_gap.get("chunks_examined")
+                if (
+                    isinstance(gap_without, int)
+                    and isinstance(gap_examined, int)
+                    and not isinstance(gap_without, bool)
+                    and not isinstance(gap_examined, bool)
+                    and 0 < gap_without <= gap_examined
+                ):
+                    persisted_cache_gap = (gap_without, gap_examined)
+                else:
+                    logger.warning(
+                        "Ignoring malformed deletion_llm_cache_gap on document %s: %r",
+                        doc_id,
+                        raw_cache_gap,
+                    )
             # Order-preserving dedup so chunk_ids stays a list and satisfies the
             # storage delete contract (``delete(ids: list[str])``); a set view is
             # built below for membership/intersection checks. Staged chunks of
@@ -6176,7 +6214,18 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                             f"Failed to collect LLM cache ids for document {doc_id}: {cache_collect_error}"
                         ) from cache_collect_error
 
-                if doc_llm_cache_ids:
+                # A retry that runs after the purge already removed the chunk
+                # rows examines nothing, so it inherits the gap the attempt
+                # that still saw the rows recorded. A live count always wins.
+                if chunks_examined_for_cache == 0 and persisted_cache_gap:
+                    chunks_without_cache_refs, chunks_examined_for_cache = (
+                        persisted_cache_gap
+                    )
+
+                # Persist before anything is deleted: the cache ids because a
+                # retry needs them for cleanup, the gap because a retry can no
+                # longer measure it once the chunk rows are gone.
+                if doc_llm_cache_ids or chunks_without_cache_refs:
                     try:
                         doc_status_data = await self._update_delete_retry_state(
                             doc_id,
@@ -6184,10 +6233,14 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                             deletion_stage=deletion_stage,
                             doc_llm_cache_ids=doc_llm_cache_ids,
                             failed=False,
+                            cache_gap=(
+                                chunks_without_cache_refs,
+                                chunks_examined_for_cache,
+                            ),
                         )
                     except Exception as status_write_error:
                         logger.error(
-                            "Failed to persist LLM cache IDs for document %s to retry state: %s",
+                            "Failed to persist LLM cache retry state for document %s: %s",
                             doc_id,
                             status_write_error,
                         )
@@ -6199,9 +6252,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                             else "deletion not yet started"
                         )
                         raise Exception(
-                            f"Failed to persist LLM cache IDs for document {doc_id} "
+                            f"Failed to persist LLM cache retry state for document {doc_id} "
                             f"({attempt_context}): {status_write_error}"
                         ) from status_write_error
+                if doc_llm_cache_ids:
                     logger.info(
                         "Collected %d LLM cache entries for document %s",
                         len(doc_llm_cache_ids),
@@ -6382,6 +6436,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         doc_llm_cache_ids=doc_llm_cache_ids,
                         error_message=error_message,
                         failed=True,
+                        cache_gap=(
+                            chunks_without_cache_refs,
+                            chunks_examined_for_cache,
+                        ),
                     )
             except Exception as status_update_error:
                 logger.error(
@@ -6415,6 +6473,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         doc_llm_cache_ids=doc_llm_cache_ids,
                         error_message=error_message,
                         failed=True,
+                        cache_gap=(
+                            chunks_without_cache_refs,
+                            chunks_examined_for_cache,
+                        ),
                     )
             except Exception as status_update_error:
                 logger.error(

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -5819,7 +5819,11 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         Args:
             doc_id (str): The unique identifier of the document to be deleted.
             delete_llm_cache (bool): Whether to delete cached LLM extraction results
-                associated with the document. Defaults to False.
+                associated with the document. Defaults to False. Cache rows are
+                found through each chunk's ``llm_cache_list``; when a chunk of a
+                document whose extraction ran carries no such reference, the
+                deletion still succeeds but the returned ``message`` reports the
+                cache deletion as incomplete (issue #3833).
 
         Returns:
             DeletionResult: An object containing the outcome of the deletion process.
@@ -5849,6 +5853,12 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         in_final_delete_stage = False
         original_exception = None
         doc_llm_cache_ids: list[str] = []
+        # Chunk rows that exist but carry no ``llm_cache_list`` reference,
+        # counted during cache-id collection so a requested cache deletion can
+        # be reported as incomplete instead of as an unqualified success.
+        chunks_examined_for_cache = 0
+        chunks_without_cache_refs = 0
+        incomplete_cache_notice: str | None = None
         deletion_stage = "initializing"
         doc_status_data: dict[str, Any] | None = None
         file_path: str | None = None
@@ -6141,17 +6151,21 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         for chunk_data in chunk_data_list:
                             if not chunk_data or not isinstance(chunk_data, dict):
                                 continue
+                            chunks_examined_for_cache += 1
                             cache_ids = chunk_data.get("llm_cache_list", [])
                             if not isinstance(cache_ids, list):
+                                chunks_without_cache_refs += 1
                                 continue
+                            chunk_has_cache_ref = False
                             for cache_id in cache_ids:
-                                if (
-                                    isinstance(cache_id, str)
-                                    and cache_id
-                                    and cache_id not in seen_cache_ids
-                                ):
+                                if not (isinstance(cache_id, str) and cache_id):
+                                    continue
+                                chunk_has_cache_ref = True
+                                if cache_id not in seen_cache_ids:
                                     doc_llm_cache_ids.append(cache_id)
                                     seen_cache_ids.add(cache_id)
+                            if not chunk_has_cache_ref:
+                                chunks_without_cache_refs += 1
                     except Exception as cache_collect_error:
                         logger.error(
                             "Failed to collect LLM cache ids for document %s: %s",
@@ -6195,6 +6209,36 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     )
                 else:
                     logger.info("No LLM cache entries found for document %s", doc_id)
+
+                # Cache rows written during extraction are reachable for
+                # cleanup only through the owning chunk's ``llm_cache_list``.
+                # A chunk row without one on a document whose extraction ran
+                # means its rows — if the extraction cache was enabled at
+                # ingest — were never attached (a cancelled sibling, a hard
+                # kill, or a suppressed ``update_chunk_cache_list`` failure;
+                # issue #3833) and cannot be found from here. They self-heal
+                # only on a successful re-ingest of the same content, which
+                # deleting the document forecloses. Accepted residue: the rows
+                # stay behind, and a requested cache deletion says so instead
+                # of reporting an unqualified success. Documents ingested with
+                # ``process_options='!'`` never ran extraction, so their
+                # reference-less chunks are expected and not reported.
+                if (
+                    delete_llm_cache
+                    and chunks_without_cache_refs
+                    and metadata.get("skip_kg") is not True
+                ):
+                    incomplete_cache_notice = (
+                        f"{chunks_without_cache_refs} of {chunks_examined_for_cache} "
+                        "chunks carried no llm_cache_list references, so any "
+                        "extraction cache rows written for them could not be "
+                        "located and were not deleted"
+                    )
+                    logger.warning(
+                        "LLM cache deletion for document %s is incomplete: %s",
+                        doc_id,
+                        incomplete_cache_notice,
+                    )
 
             # 4. Purge every KG contribution of this document, then its chunks.
             #
@@ -6276,6 +6320,19 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                         pipeline_status["latest_message"] = log_message
                         append_pipeline_history(pipeline_status, log_message)
                     raise Exception(log_message) from cache_delete_error
+
+            if incomplete_cache_notice:
+                # Qualify the success: the document is gone, but part of what
+                # ``delete_llm_cache`` promised to remove could not be found.
+                # Reported on the result AND in the pipeline history, the two
+                # places a caller reads without opening the server log.
+                log_message = (
+                    f"{log_message}; LLM cache deletion is incomplete: "
+                    f"{incomplete_cache_notice}"
+                )
+                async with pipeline_status_lock:
+                    pipeline_status["latest_message"] = log_message
+                    append_pipeline_history(pipeline_status, log_message)
 
             # 10. (The recovery anchor rows were deleted by the purge above —
             # LAST within that operation, and only once its journal recorded

--- a/tests/pipeline/test_delete_llm_cache_incomplete_notice.py
+++ b/tests/pipeline/test_delete_llm_cache_incomplete_notice.py
@@ -1,0 +1,259 @@
+"""``delete_llm_cache=True`` must not report an unqualified success when part of
+the cache is unreachable (issue #3833).
+
+LLM cache rows written during extraction are found for cleanup only through
+the owning chunk's ``llm_cache_list``. A row whose key was never attached — a
+sibling chunk raised and the collector was discarded, a hard kill, or a
+suppressed ``update_chunk_cache_list`` failure — is invisible to
+``adelete_by_doc_id``: the chunks go, the rows stay, and the deletion used to
+come back as ``status="success"`` with a message saying nothing about it.
+
+The deletion still succeeds (the residue is documented and self-healing only on
+re-ingest), but the result message and the pipeline history now say that the
+cache deletion was incomplete, and how many chunks had nothing to follow. The
+notice is limited to documents whose extraction actually ran: a
+``process_options='!'`` document never wrote cache rows, so its reference-less
+chunks are expected.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import numpy as np
+import pytest
+
+from lightrag import LightRAG
+from lightrag.base import DocStatus
+from lightrag.kg.shared_storage import get_namespace_data
+from lightrag.utils import EmbeddingFunc, Tokenizer, compute_mdhash_id
+
+pytestmark = pytest.mark.offline
+
+
+class _SimpleTokenizerImpl:
+    def encode(self, content: str) -> list[int]:
+        return [ord(ch) for ch in content]
+
+    def decode(self, tokens: list[int]) -> str:
+        return "".join(chr(t) for t in tokens)
+
+
+async def _dummy_embedding(texts: list[str]) -> np.ndarray:
+    return np.ones((len(texts), 8), dtype=float)
+
+
+async def _dummy_llm(*args, **kwargs) -> str:
+    return "ok"
+
+
+def _two_chunk_chunking(
+    tokenizer,
+    content: str,
+    split_by_character,
+    split_by_character_only: bool,
+    chunk_overlap_token_size: int,
+    chunk_token_size: int,
+) -> list[dict]:
+    return [
+        {"tokens": 1, "content": f"{content}::chunk{i}", "chunk_order_index": i}
+        for i in range(2)
+    ]
+
+
+def _wire_fake_extraction(rag: LightRAG) -> None:
+    """One ALICE--ACME relation per chunk; writes no LLM cache rows itself."""
+
+    async def fake_extract(chunks, *args, **kwargs):
+        results = []
+        for chunk_id in chunks:
+            nodes = {
+                name: [
+                    {
+                        "entity_name": name,
+                        "entity_type": "person",
+                        "description": f"{name} description",
+                        "source_id": chunk_id,
+                        "file_path": "d.txt",
+                        "timestamp": 1,
+                    }
+                ]
+                for name in ("ALICE", "ACME")
+            }
+            edges = {
+                ("ACME", "ALICE"): [
+                    {
+                        "src_id": "ACME",
+                        "tgt_id": "ALICE",
+                        "description": "works at",
+                        "keywords": "employment",
+                        "weight": 1.0,
+                        "source_id": chunk_id,
+                        "file_path": "d.txt",
+                        "timestamp": 1,
+                    }
+                ]
+            }
+            results.append((nodes, edges))
+        return results
+
+    rag._process_extract_entities = fake_extract
+
+
+async def _build_rag(tmp_path) -> LightRAG:
+    rag = LightRAG(
+        working_dir=str(tmp_path / "wd"),
+        workspace=f"cache-notice-{uuid4().hex[:8]}",
+        llm_model_func=_dummy_llm,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        ),
+        tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
+        chunking_func=_two_chunk_chunking,
+        max_parallel_insert=1,
+    )
+    await rag.initialize_storages()
+    _wire_fake_extraction(rag)
+    return rag
+
+
+async def _ingest(rag: LightRAG, process_options: str | None = None) -> str:
+    doc_id = compute_mdhash_id("d.txt", prefix="doc-")
+    kwargs = {"process_options": process_options} if process_options else {}
+    await rag.apipeline_enqueue_documents(
+        "alice works at acme", ids=[doc_id], file_paths=["d.txt"], **kwargs
+    )
+    await rag.apipeline_process_enqueue_documents()
+    row = await rag.doc_status.get_by_id(doc_id)
+    status = row.get("status")
+    status_text = status.value if isinstance(status, DocStatus) else str(status)
+    assert status_text == DocStatus.PROCESSED.value, row
+    return doc_id
+
+
+async def _chunk_ids(rag: LightRAG, doc_id: str) -> list[str]:
+    row = await rag.doc_status.get_by_id(doc_id)
+    chunk_ids = list(row.get("chunks_list") or [])
+    assert len(chunk_ids) == 2, chunk_ids
+    return chunk_ids
+
+
+async def _attach_cache_rows(rag: LightRAG, chunk_ids: list[str]) -> list[str]:
+    """Write one extraction cache row per chunk and attach it via ``llm_cache_list``.
+
+    Mirrors what ``use_llm_func_with_cache`` + ``update_chunk_cache_list`` leave
+    behind after a successful extraction. The fake extraction above writes
+    neither, so the fixture stands in for it.
+    """
+    cache_ids: list[str] = []
+    for chunk_id in chunk_ids:
+        cache_id = f"default:extract:{uuid4().hex}"
+        await rag.llm_response_cache.upsert(
+            {
+                cache_id: {
+                    "return": "extracted",
+                    "cache_type": "extract",
+                    "chunk_id": chunk_id,
+                }
+            }
+        )
+        row = await rag.text_chunks.get_by_id(chunk_id)
+        assert row is not None
+        row["llm_cache_list"] = [cache_id]
+        await rag.text_chunks.upsert({chunk_id: row})
+        cache_ids.append(cache_id)
+    return cache_ids
+
+
+async def _history(rag: LightRAG) -> list[str]:
+    pipeline_status = await get_namespace_data(
+        "pipeline_status", workspace=rag.workspace
+    )
+    return list(pipeline_status.get("history_messages", []))
+
+
+@pytest.mark.asyncio
+async def test_unreachable_cache_rows_qualify_the_success(tmp_path):
+    """One chunk has no cache reference: delete succeeds, but says it is incomplete."""
+    rag = await _build_rag(tmp_path)
+    try:
+        doc_id = await _ingest(rag)
+        chunk_ids = await _chunk_ids(rag, doc_id)
+        # Attach a row to the first chunk only; the second chunk's rows (if any)
+        # are the stranded case from the issue — nothing points at them.
+        (attached_cache_id,) = await _attach_cache_rows(rag, chunk_ids[:1])
+
+        result = await rag.adelete_by_doc_id(doc_id, delete_llm_cache=True)
+
+        assert result.status == "success", result.message
+        assert result.status_code == 200
+        assert "LLM cache deletion is incomplete" in result.message
+        assert "1 of 2 chunks carried no llm_cache_list references" in result.message
+        # What could be found was still deleted, and the document is gone.
+        assert await rag.llm_response_cache.get_by_id(attached_cache_id) is None
+        assert await rag.doc_status.get_by_id(doc_id) is None
+        assert await rag.full_docs.get_by_id(doc_id) is None
+        # The pipeline history — what the WebUI shows — carries the same notice.
+        assert any("LLM cache deletion is incomplete" in m for m in await _history(rag))
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_every_chunk_referenced_reports_a_plain_success(tmp_path):
+    """No false alarm when every chunk's cache rows were reachable and deleted."""
+    rag = await _build_rag(tmp_path)
+    try:
+        doc_id = await _ingest(rag)
+        chunk_ids = await _chunk_ids(rag, doc_id)
+        cache_ids = await _attach_cache_rows(rag, chunk_ids)
+
+        result = await rag.adelete_by_doc_id(doc_id, delete_llm_cache=True)
+
+        assert result.status == "success", result.message
+        assert (
+            result.message
+            == f"Successfully deleted {len(cache_ids)} LLM cache entries for document {doc_id}"
+        )
+        assert "incomplete" not in result.message
+        for cache_id in cache_ids:
+            assert await rag.llm_response_cache.get_by_id(cache_id) is None
+        assert not any("incomplete" in m for m in await _history(rag))
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_no_notice_when_cache_deletion_was_not_requested(tmp_path):
+    """``delete_llm_cache=False`` promised nothing about the cache, so nothing to qualify."""
+    rag = await _build_rag(tmp_path)
+    try:
+        doc_id = await _ingest(rag)
+        await _chunk_ids(rag, doc_id)  # both chunks carry no reference
+
+        result = await rag.adelete_by_doc_id(doc_id, delete_llm_cache=False)
+
+        assert result.status == "success", result.message
+        assert result.message == f"Document {doc_id} successfully deleted"
+        assert not any("incomplete" in m for m in await _history(rag))
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_no_notice_for_a_document_whose_extraction_never_ran(tmp_path):
+    """``process_options='!'`` skips extraction: reference-less chunks are expected."""
+    rag = await _build_rag(tmp_path)
+    try:
+        doc_id = await _ingest(rag, process_options="!")
+        row = await rag.doc_status.get_by_id(doc_id)
+        assert row["metadata"]["skip_kg"] is True
+        await _chunk_ids(rag, doc_id)
+
+        result = await rag.adelete_by_doc_id(doc_id, delete_llm_cache=True)
+
+        assert result.status == "success", result.message
+        assert "incomplete" not in result.message
+        assert not any("incomplete" in m for m in await _history(rag))
+    finally:
+        await rag.finalize_storages()

--- a/tests/pipeline/test_delete_llm_cache_incomplete_notice.py
+++ b/tests/pipeline/test_delete_llm_cache_incomplete_notice.py
@@ -14,6 +14,11 @@ cache deletion was incomplete, and how many chunks had nothing to follow. The
 notice is limited to documents whose extraction actually ran: a
 ``process_options='!'`` document never wrote cache rows, so its reference-less
 chunks are expected.
+
+The gap is measured while the chunk rows still exist. A purge that fails after
+removing them leaves a retry with nothing to count, so the count is persisted
+in the deletion retry metadata next to the cache ids and inherited by the
+retry, which must still qualify its success.
 """
 
 from __future__ import annotations
@@ -255,5 +260,66 @@ async def test_no_notice_for_a_document_whose_extraction_never_ran(tmp_path):
         assert result.status == "success", result.message
         assert "incomplete" not in result.message
         assert not any("incomplete" in m for m in await _history(rag))
+    finally:
+        await rag.finalize_storages()
+
+
+def _fail_once(monkeypatch, obj, attr: str, exc_message: str) -> None:
+    """Wrap an async method to raise on its first call only."""
+    calls = {"n": 0}
+    original = getattr(obj, attr)
+
+    async def wrapper(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError(exc_message)
+        return await original(*args, **kwargs)
+
+    monkeypatch.setattr(obj, attr, wrapper)
+
+
+@pytest.mark.asyncio
+async def test_notice_survives_a_retry_after_the_chunk_rows_are_gone(
+    tmp_path, monkeypatch
+):
+    """A retry that can no longer examine the chunks inherits the recorded gap.
+
+    Fail the purge at the relation-anchor delete, which runs AFTER the chunk
+    rows are removed. The retry's own count is then zero — ``get_by_ids``
+    returns nothing — so it must fall back to what the first attempt persisted
+    and still report the cache deletion as incomplete.
+    """
+    rag = await _build_rag(tmp_path)
+    try:
+        doc_id = await _ingest(rag)
+        chunk_ids = await _chunk_ids(rag, doc_id)
+        (attached_cache_id,) = await _attach_cache_rows(rag, chunk_ids[:1])
+
+        _fail_once(
+            monkeypatch, rag.full_relations, "delete", "relations anchor delete boom"
+        )
+        first = await rag.adelete_by_doc_id(doc_id, delete_llm_cache=True)
+        assert first.status == "fail", first.message
+        assert first.status_code == 500
+
+        # Nothing is left to re-examine: the purge removed the chunk rows...
+        assert all(row is None for row in await rag.text_chunks.get_by_ids(chunk_ids))
+        # ...but the gap was persisted next to the cache ids before it ran.
+        row = await rag.doc_status.get_by_id(doc_id)
+        assert row["metadata"]["deletion_llm_cache_gap"] == {
+            "chunks_without_refs": 1,
+            "chunks_examined": 2,
+        }
+        assert row["metadata"]["deletion_llm_cache_ids"] == [attached_cache_id]
+
+        monkeypatch.undo()
+        second = await rag.adelete_by_doc_id(doc_id, delete_llm_cache=True)
+
+        assert second.status == "success", second.message
+        assert "LLM cache deletion is incomplete" in second.message
+        assert "1 of 2 chunks carried no llm_cache_list references" in second.message
+        assert await rag.llm_response_cache.get_by_id(attached_cache_id) is None
+        assert await rag.doc_status.get_by_id(doc_id) is None
+        assert any("LLM cache deletion is incomplete" in m for m in await _history(rag))
     finally:
         await rag.finalize_storages()


### PR DESCRIPTION
## Description

`adelete_by_doc_id(delete_llm_cache=True)` can only find the extraction cache rows it is asked to remove through each chunk's `llm_cache_list`. A row whose key was never attached — a sibling chunk raised and the collector was discarded, a hard kill, or a suppressed `update_chunk_cache_list` failure — is invisible to the delete path: the chunks are deleted, the rows stay behind, and the call returns `status="success"` with a message that says nothing about it. Since a stranded row holds the chunk text verbatim plus the extracted entities, a user who set the flag for confidentiality has no way to learn that part of the document is still stored.

This PR is the "cheaper first step" proposed on #3833: make the silence audible. The operator-invoked GC described there is a separate, larger change and is not attempted here.

## Related Issues

Partially addresses #3833 (the "make the silence audible" step; the GC remains open).

## Changes Made

- `lightrag/lightrag.py` — `adelete_by_doc_id`:
  - While collecting cache ids, count the chunk rows that exist but carry no usable `llm_cache_list` reference (missing key, non-list, or no non-empty string ids). Rows absent from `text_chunks` are not counted; that is a different, already-handled residue.
  - When cache deletion was requested **and** the document's extraction ran, log a warning at collection time, then qualify the success: the returned `DeletionResult.message` and the pipeline history both state that the LLM cache deletion is incomplete and how many chunks had nothing to follow. `status` stays `"success"` — the document is gone, and the residue is the documented, self-healing-only-on-re-ingest one from the issue.
  - Documents ingested with `process_options='!'` (`metadata.skip_kg`) never ran extraction, so their reference-less chunks are expected and produce no notice.
  - Documented the accepted residue next to the code, and the qualified message in the `delete_llm_cache` argument docstring.
  - The gap is persisted as `deletion_llm_cache_gap` in the document's deletion retry metadata (via `_update_delete_retry_state`, next to `deletion_llm_cache_ids`) before the purge runs and on both failure paths. A retry that can no longer examine the chunk rows — the purge failed after removing them — inherits the recorded gap; a live count always wins, and a malformed stored value is logged and ignored.
- `tests/pipeline/test_delete_llm_cache_incomplete_notice.py` — four end-to-end tests over the real JSON/NetworkX storages, built on the `test_delete_fail_closed.py` fixtures:
  - one of two chunks has no reference → success, message and history carry the notice with `1 of 2 chunks`, the reachable row is still deleted;
  - every chunk referenced → the message is unchanged (`Successfully deleted N LLM cache entries …`), no notice anywhere;
  - `delete_llm_cache=False` → the plain `Document … successfully deleted` message, no notice;
  - skip-KG document with `delete_llm_cache=True` → no notice.
  - fault-injected retry: fail the relation-anchor delete (after the chunk rows are gone), confirm the gap and cache ids were persisted, retry, and require the retry's success to still carry the notice.

## Verification

- `python -m pytest tests/pipeline/test_delete_llm_cache_incomplete_notice.py` — 5 passed.
- Fix-proof check: the same file run against an unpatched `main` checkout fails the first test with exactly the reported symptom (`'LLM cache deletion is incomplete' not in 'Successfully deleted 1 LLM cache entries for document …'`); the three guard tests pass before and after, as intended. The retry test, run against the first commit of this PR (notice without persistence), fails at the persisted-metadata assertion (`KeyError: 'deletion_llm_cache_gap'`) and passes with the second commit.
- `python -m pytest tests/pipeline tests/api/routes/test_document_routes_docx_archive.py` — 914 passed, 2 failed. Both failures — `test_chunk_options_regex_scrub.py::test_audit_line_bounds_the_untrusted_pattern` and `test_strict_capability_gate.py::test_gaps_are_warned_with_their_operator_facing_consequence` — fail identically on an unpatched `main` checkout in this environment (a log-capture duplication under pip-resolved pytest 9.1.1 rather than the locked 9.0.3) and are unrelated to this change.
- `pre-commit run --files lightrag/lightrag.py tests/pipeline/test_delete_llm_cache_incomplete_notice.py` — all hooks passed.

## Checklist

- [x] Changes tested locally
- [x] Code reviewed
- [x] Documentation updated (docstring + in-code residue note; no user-facing docs describe the deletion message)
- [x] Unit tests added

## Additional Notes

- The notice cannot tell a stranded row from a chunk whose extraction ran with `enable_llm_cache_for_entity_extract=False` at ingest time — nothing durable records that flag — so the wording says the rows *could not be located* rather than asserting they exist. Suppressing it on the *current* value of the flag would be wrong in the other direction (the flag may have been toggled since ingest), so the notice is gated only on "extraction ran".
- The existing single-document endpoint only surfaces `DeletionResult.message` on failure; the pipeline history is what the WebUI shows, which is why the notice is appended there as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
