### PR TITLE
docs: add runtime configuration propagation contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,11 +89,12 @@ LightRAG writes to independent stores — graph, KV, vector, doc-status — with
 
 **Full contract: [docs/design/RuntimeConfigPropagationContract.md](docs/design/RuntimeConfigPropagationContract.md) — read it before touching `lightrag/addon_params.py`, `lightrag/llm_roles.py`, `lightrag/kg/shared_storage.py`, or runtime configuration hot-swap paths.**
 
-- Cross-worker propagation in multi-worker deployments is partitioned into two namespaces: `addon_params` (workspace-scoped) and `role_llm` + `max_async` (process-wide, `workspace=""`).
-- Publishing is explicit (`apublish_runtime_config()`, `aupdate_llm_role_config(..., publish=True)`) with monotonic versions ordered under keyed locks; workers never push implicitly.
-- Workers evaluate and apply updates at bounded execution boundaries (HTTP requests, document boundaries, and a 250ms debounced SDK check).
-- `get_global_concurrency_limit()` reads a worker-local cache refreshed by update flags to ensure zero live Manager IPC on slot acquisition.
-- Secrets (`_SECRET_MARKERS`) are scrubbed prior to publishing; credentials resolve locally. Worker apply failures roll back atomically without advancing `applied_version`.
+- Runtime configuration uses independent versioned namespaces: `runtime_addon_params` is scoped to `rag.workspace`, while `runtime_llm_config` uses `workspace=""` for process-wide role LLM configuration and `max_async`.
+- Publishing is explicit. Concurrent publishers serialize under the namespace lock, and workers apply only monotonically newer committed versions.
+- Update flags accelerate convergence, while bounded version audits recover missed notifications. Apply failures retain the complete previous configuration and retry without advancing the applied version.
+- `get_global_concurrency_limit()` and slot acquisition remain worker-local and IPC-free. Wrappers created while unlimited must observe a later limited configuration.
+- Entity prompt content is published with its SHA-256 identity; applying workers never treat the path hint as authoritative.
+- Secret-marked fields are rejected before any shared write. Propagation tests use a real Manager through `initialize_share_data(2)` and two real `LightRAG` instances.
 
 ### Relation weight contract
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,16 @@ LightRAG writes to independent stores — graph, KV, vector, doc-status — with
 - Chunk tracking (`entity_chunks` / `relation_chunks`) outranks graph `source_id`; code folding a `source_id` delta back into tracking must append genuine additions only.
 - Merge and rename apply *Consistency without transactions* above: [the failure model](docs/design/PurgeRecoveryContract.md#merge-and-rename-failure-model) lists their ordering invariants, accepted residues and already-rejected remedies. Read it before reordering `_merge_entities_impl` or the rename branch of `_edit_entity_impl`.
 
+### Runtime configuration propagation contract
+
+**Full contract: [docs/design/RuntimeConfigPropagationContract.md](docs/design/RuntimeConfigPropagationContract.md) — read it before touching `lightrag/addon_params.py`, `lightrag/llm_roles.py`, `lightrag/kg/shared_storage.py`, or runtime configuration hot-swap paths.**
+
+- Cross-worker propagation in multi-worker deployments is partitioned into two namespaces: `addon_params` (workspace-scoped) and `role_llm` + `max_async` (process-wide, `workspace=""`).
+- Publishing is explicit (`apublish_runtime_config()`, `aupdate_llm_role_config(..., publish=True)`) with monotonic versions ordered under keyed locks; workers never push implicitly.
+- Workers evaluate and apply updates at bounded execution boundaries (HTTP requests, document boundaries, and a 250ms debounced SDK check).
+- `get_global_concurrency_limit()` reads a worker-local cache refreshed by update flags to ensure zero live Manager IPC on slot acquisition.
+- Secrets (`_SECRET_MARKERS`) are scrubbed prior to publishing; credentials resolve locally. Worker apply failures roll back atomically without advancing `applied_version`.
+
 ### Relation weight contract
 
 **Full contract: [docs/ProgramingWithCore.md](docs/ProgramingWithCore.md#relation-weight-contract)** — keep it synchronized with the core API docstrings, REST graph documentation, and custom-KG examples whenever relation write behavior changes.

--- a/docs/design/RuntimeConfigPropagationContract.md
+++ b/docs/design/RuntimeConfigPropagationContract.md
@@ -1,0 +1,168 @@
+# Runtime Configuration Propagation Contract
+
+Read this before modifying `lightrag/addon_params.py`, `lightrag/llm_roles.py`, `lightrag/kg/shared_storage.py`, or any runtime configuration / role hot-swap paths. Summary referenced in `AGENTS.md`.
+
+---
+
+## 1. Motivation & Scope
+
+In multi-worker deployments (`lightrag-gunicorn --workers N`, where `preload_app = True`), the `LightRAG` orchestrator is constructed once in the master process and inherited across worker forks via copy-on-write memory. Process-local mutations to runtime configuration surfaces in worker $A$ remain completely invisible to peer workers $B_1 \dots B_{N-1}$.
+
+This contract governs cross-worker propagation of two runtime-mutable surfaces:
+
+1. **`addon_params`**: workspace-level settings including `language`, `entity_type_prompt_file`, `entity_types_guidance`, and `chunker`.
+2. **Role LLM configuration**: process-wide settings for LLM roles (`extract`, `keyword`, `query`, `vlm`), covering `binding`, `model`, `host`, `max_async`, `timeout`, and `model_kwargs`.
+
+### Out of Scope (Non-Goals)
+
+* Durable persistence across process restarts (environment variables remain boot authority; shared runtime state expires with the Manager process).
+* Cross-host / multi-node clustering (the multiprocessing Manager is single-host).
+* Runtime modification of `embedding_func` or `rerank_model_func`.
+* REST endpoints and WebUI toggles (phased for subsequent PRs; this contract governs the core propagation protocol and SDK methods).
+
+---
+
+## 2. Namespace Layout & Scoping
+
+To preserve workspace isolation without entangling process-wide LLM configuration with future multi-workspace models, runtime configuration is partitioned across two namespaces in `lightrag.kg.shared_storage`:
+
+| Configuration Surface | Namespace Key | Workspace Scope | Keyed Lock Name |
+| :--- | :--- | :--- | :--- |
+| **`addon_params`** | `runtime_config:addon_params` | `workspace=<workspace_id>` | `addon_params` |
+| **`role_llm` + `max_async`** | `runtime_config:role_llm` | `workspace=""` | `role_llm` |
+
+`runtime_config:role_llm` uses `workspace=""` just like `_CONCURRENCY_LEASE_NAMESPACE` and `_QUEUE_STATS_NAMESPACE` in `lightrag/kg/shared_storage.py`, consistent with its process-wide (non-workspace-scoped) status.
+
+### Shared State Schemas
+
+#### Addon Params Namespace (`workspace=<workspace_id>`)
+
+```python
+{
+    "version": int,               # Monotonically increasing version counter
+    "updated_by_pid": int,        # Publisher PID for observability/diagnostics
+    "updated_at": float,          # Epoch timestamp (time.time())
+    "payload": {
+        "language": str,
+        "entity_type_prompt_file": str | None,
+        "entity_type_prompt_hash": str | None,  # SHA-256 of file contents at publish
+        "entity_types_guidance": str | None,
+        "chunker": dict[str, Any],              # Normalized chunker configuration
+    }
+}
+```
+
+#### Role LLM Namespace (`workspace=""`)
+
+```python
+{
+    "version": int,               # Monotonically increasing version counter
+    "updated_by_pid": int,        # Publisher PID
+    "updated_at": float,          # Epoch timestamp
+    "roles": {
+        "<role_name>": {
+            "binding": str | None,
+            "model": str | None,
+            "host": str | None,
+            "max_async": int | None,
+            "timeout": int | None,
+            "model_kwargs": dict[str, Any] | None,
+            "metadata": dict[str, Any],         # Strictly sanitized (no credentials)
+        }
+    },
+    "global_concurrency_limits": dict[str, int],  # Group -> dynamic limit (e.g. "llm:extract": 8)
+}
+```
+
+---
+
+## 3. Publication Protocol
+
+Publishing is explicit, never an implicit side-effect of local in-place dictionary mutation. This prevents normal ingestion passes (such as `resolve_chunk_options()`) from firing continuous broadcast RPCs.
+
+### Public SDK Ingress Points
+
+* `await rag.apublish_runtime_config(workspace=None)`: Publishes local `addon_params` and role configurations.
+* `await rag.aupdate_llm_role_config(..., publish=True)`: Atomically applies a local role update and publishes to peers.
+
+### Publication Invariants
+
+* **Locking & Serialization**: Writers acquire `get_storage_keyed_lock(name, namespace=...)` for the target namespace. Concurrent publications from different workers are strictly serialized.
+* **Strict Monotonicity**: Inside the keyed lock, the writer reads the current shared version, increments it by 1, writes the new record, and invokes `set_all_update_flags(namespace, workspace=...)`.
+* **Secret Scrubbing (Zero Escape Hatch)**:
+  * Before writing to shared state, all role metadata is scrubbed against `_SECRET_MARKERS` (honoring `_SAFE_OPTION_KEYS`).
+  * Field values matching auth/tokens/passwords are stripped entirely.
+  * Workers resolve credentials locally via their own registered role builders and local environment variables.
+* **Prompt Profile Identity**: When publishing `entity_type_prompt_file`, the publisher computes and includes the SHA-256 hash of the content. The hash is the canonical identity; the file path serves as an operational hint.
+
+---
+
+## 4. Convergence & Application Invariants
+
+### Apply Boundaries (Bounded Staleness)
+
+Workers do not run background polling loops. Flag evaluation and state refresh occur strictly at predefined execution boundaries:
+
+* **HTTP Request Boundary**: Fast-path check executed via FastAPI request lifecycle dependency.
+* **Pipeline Document Boundary**: Evaluated at each document boundary within `apipeline_process_enqueue_documents`.
+* **Long-running SDK Boundary**: Evaluated inside `_ensure_addon_params_cache()` throttled by a 250 ms monotonic debounce window to minimize IPC overhead during compute-intensive loops.
+
+### Worker Local Caches & Fast Gate Reads
+
+* **Zero IPC on Concurrency Slots**: `get_global_concurrency_limit()` reads an in-process local dictionary cache. It must never perform a live Manager read in `_acquire_global_slot()`.
+* The local cache of concurrency limits is updated exclusively when the worker processes its update flag.
+
+### Atomic Per-Worker Application & Rollback
+
+* **Version Gate**: A worker inspects `shared["version"]`. If `shared["version"] <= worker.applied_version`, the update is ignored.
+* **Addon Params Application**: Applied via `_replace_addon_params(payload, mark_dirty=True)` followed by `_apply_chunk_size_overlay()`. If the file content on disk differs from the published hash, the worker re-reads the file, emits an actionable warning regarding the hash divergence, and converges rather than entering a permanent refuse-and-retry loop.
+* **Role LLM Application**:
+  * Applied as an all-or-nothing batch across all roles in the payload using `_apply_llm_role_config_update()`.
+  * Each role wrapper is reconstructed with the local role builder.
+  * If builder resolution fails for any role (e.g., missing local API credentials for a newly assigned binding), the worker rolls back all roles to their pre-update snapshots, does not advance `applied_version`, logs an explicit warning, and retries on the next boundary check.
+* **Retired Wrapper Lifecycle**: Replaced wrappers are scheduled for background queue drainage via `_schedule_retired_llm_queue_cleanup()`. Global concurrency leases are returned to shared storage upon drain or task completion; leases are never leaked.
+
+### Document Invariant
+
+Documents enqueued prior to a configuration publish maintain their frozen `chunk_options` and `process_options` snapshots in `full_docs`. Only documents enqueued subsequent to a local apply observe new chunker settings.
+
+---
+
+## 5. Single-Worker Mode Invariant (`workers == 1`)
+
+When `initialize_share_data(workers=1)` is used:
+
+* The Manager process is omitted.
+* Shared dictionary proxies, keyed holder tables, and IPC update flags are bypassed.
+* Calls to `rag.addon_params[...] = ...` and `update_llm_role_config()` function purely in-process with zero IPC overhead and zero regression in latency.
+
+---
+
+## 6. Observability Invariants
+
+* `/health` and `rag.get_llm_queue_status()` report `applied_addon_params_version` and `applied_role_llm_version` **per worker**, not a single worker's scalar view presented as global state. While a publish is in flight, the response identifies which version each worker is on, e.g. `{"applied_versions": {<pid>: <version>, ...}}` for each of `applied_addon_params_version` and `applied_role_llm_version`.
+* The aggregated queue status exposes this per-worker version mapping so an operator can instantly detect a diverging or un-converged worker during in-flight propagation.
+* Direct runtime assignment `rag.role_llm_configs = ...` is explicitly disallowed and must raise `AttributeError` or `TypeError` instead of failing as a silent no-op.
+
+---
+
+## 7. Consistency Without Transactions: Failure Model
+
+Because LightRAG distributes configuration across decoupled worker processes without distributed two-phase commit, intermediate states can exist. In alignment with `AGENTS.md` (Consistency without transactions), the table below records every accepted residue, its rationale, and its self-healing path.
+
+| Inconsistent State | Root Cause | Why It Is Accepted | Recovery Path |
+| :--- | :--- | :--- | :--- |
+| Worker config skew during propagation window | A publish completed, but peer workers have not reached an apply boundary. | Bounded staleness (≤ 250 ms or next request/doc). Prevents high-frequency polling IPC overhead. | Self-heals automatically at the next HTTP request, pipeline document boundary, or debounced SDK check. |
+| Worker stuck on previous version following apply failure | One worker lacks local environment credentials for a newly published binding or prompt file is unreadable. | Prevents complete process failure or unauthenticated calls. System fails safe by retaining working state. | Worker logs actionable error with PID. Operator provides local credentials or updates file; worker retries and converges on next boundary. |
+| Old LLM response cache entries orphaned | Model name or host changed, shifting cache key identity. | Partitioning is deliberate (binding/model/host are part of the cache key). No cross-talk or corruption can occur. | Orphaned keys remain inert. They are not forwarded to #3833 GC to ensure cache maintenance remains decoupled from propagation state. |
+| Retired role wrappers draining concurrently | Rapid successive publishes cause overlapping background wrapper drains. | In-flight requests must finish without data loss or severed connections. | Each retired queue drains gracefully bounded by `max_task_duration` (2 × timeout + 15s). Expired leases are cleaned by heartbeat sweepers. |
+| Unshared concurrency limit during transition | Concurrency group transitions between unlimited and limited states while old wrappers exist. | Wrappers rebuild upon role update, automatically re-resolving `use_global_limit`. | Rebuilding wrappers binds them to the new gate limit. In-flight tasks under retired wrappers finish under their original lease terms. |
+
+---
+
+## 8. Rejected Remedies
+
+* **Live Manager Read on Every Slot Acquisition**: Reading concurrency limits directly from `shared_storage` inside `_acquire_global_slot()` would introduce a synchronous Manager IPC round-trip onto the inner LLM invocation path, causing severe throughput loss.
+* **Auto-Publish on Addon Mutation**: Implicit broadcast on `ObservableAddonParams` mutation was rejected because ingestion passes (`resolve_chunk_options`) modify chunker options dynamically, which would flood the system with broadcast storms.
+* **Reporting Retired LLM Cache Spaces to #3833 GC**: Coupling retired key spaces to the maintenance garbage collector was rejected because cache GC must operate independently of real-time worker synchronization state.
+* **Permanent Worker Refusal on Prompt File Hash Mismatch**: Refusing to advance version permanently when a content hash mismatches would cause permanent divergence if files change out of sync on a single host. Re-reading and logging a clear diagnostic error prevents permanent silent split-brain.

--- a/docs/design/RuntimeConfigPropagationContract.md
+++ b/docs/design/RuntimeConfigPropagationContract.md
@@ -1,168 +1,387 @@
 # Runtime Configuration Propagation Contract
 
-Read this before modifying `lightrag/addon_params.py`, `lightrag/llm_roles.py`, `lightrag/kg/shared_storage.py`, or any runtime configuration / role hot-swap paths. Summary referenced in `AGENTS.md`.
+Read this before changing runtime publication or application of `addon_params`,
+role LLM configuration, role queue limits, the global concurrency gate, runtime
+configuration fields in `/health`, or the corresponding shared-storage
+namespaces. Summary in `AGENTS.md`.
 
----
+## Purpose and scope
 
-## 1. Motivation & Scope
+LightRAG permits useful configuration changes inside a running Python process,
+but a Gunicorn deployment has one `LightRAG` instance per worker. Updating one
+instance therefore does not update its peers. This contract defines how an
+explicit SDK publication converges those workers without persisting deployment
+configuration, copying secrets into shared memory, or adding a Manager call to
+every LLM invocation.
 
-In multi-worker deployments (`lightrag-gunicorn --workers N`, where `preload_app = True`), the `LightRAG` orchestrator is constructed once in the master process and inherited across worker forks via copy-on-write memory. Process-local mutations to runtime configuration surfaces in worker $A$ remain completely invisible to peer workers $B_1 \dots B_{N-1}$.
+This work lands in phases:
 
-This contract governs cross-worker propagation of two runtime-mutable surfaces:
+1. workspace-scoped `addon_params` publication and application;
+2. process-wide role LLM publication and batch application;
+3. dynamic `max_async` propagation into the global concurrency gate.
 
-1. **`addon_params`**: workspace-level settings including `language`, `entity_type_prompt_file`, `entity_types_guidance`, and `chunker`.
-2. **Role LLM configuration**: process-wide settings for LLM roles (`extract`, `keyword`, `query`, `vlm`), covering `binding`, `model`, `host`, `max_async`, `timeout`, and `model_kwargs`.
+The propagation layer and SDK publishing methods land before any HTTP control
+plane. REST authorization and WebUI permissions are separate work and are not
+licensed by this contract. Environment variables and constructor arguments
+remain the startup source of truth; runtime publications are intentionally lost
+on a full server restart.
 
-### Out of Scope (Non-Goals)
+## Terms
 
-* Durable persistence across process restarts (environment variables remain boot authority; shared runtime state expires with the Manager process).
-* Cross-host / multi-node clustering (the multiprocessing Manager is single-host).
-* Runtime modification of `embedding_func` or `rerank_model_func`.
-* REST endpoints and WebUI toggles (phased for subsequent PRs; this contract governs the core propagation protocol and SDK methods).
+- **Publisher**: the `LightRAG` instance that explicitly commits a new shared
+  configuration version.
+- **Desired version**: the highest committed version in a shared namespace.
+- **Applied version**: the highest version an individual instance has installed
+  successfully in full.
+- **Eligible boundary**: a point before new work captures or consumes runtime
+  configuration. Checks occur before an enqueue snapshot, at the start of each
+  document, at request/SDK operation entry, and before a role wrapper admits a
+  new LLM call.
+- **Residue**: an observable intermediate state left by a failure or crash in a
+  sequence that has no cross-object transaction.
 
----
+An operation already in progress is never rewritten underneath itself. A new
+version governs work admitted after that version has been applied locally.
 
-## 2. Namespace Layout & Scoping
+## Namespace topology
 
-To preserve workspace isolation without entangling process-wide LLM configuration with future multi-workspace models, runtime configuration is partitioned across two namespaces in `lightrag.kg.shared_storage`:
+There are two independent shared namespaces and two independent version
+counters. A change in one family must not wake or rebuild the other family.
 
-| Configuration Surface | Namespace Key | Workspace Scope | Keyed Lock Name |
-| :--- | :--- | :--- | :--- |
-| **`addon_params`** | `runtime_config:addon_params` | `workspace=<workspace_id>` | `addon_params` |
-| **`role_llm` + `max_async`** | `runtime_config:role_llm` | `workspace=""` | `role_llm` |
+| Family | Namespace | Workspace argument | Contents |
+| --- | --- | --- | --- |
+| Addon parameters | `runtime_addon_params` | `rag.workspace` | `language`, content-addressed entity prompt profile, `entity_types_guidance`, and `chunker` |
+| Role LLM configuration | `runtime_llm_config` | `""` | complete non-secret role configuration, including `max_async` |
 
-`runtime_config:role_llm` uses `workspace=""` just like `_CONCURRENCY_LEASE_NAMESPACE` and `_QUEUE_STATS_NAMESPACE` in `lightrag/kg/shared_storage.py`, consistent with its process-wide (non-workspace-scoped) status.
+`runtime_addon_params` is instance/workspace scoped. `runtime_llm_config` is
+process-wide, as are the existing `concurrency_leases` and `queue_stats`
+namespaces. The process-wide half does not depend on server-side multi-workspace
+ownership.
 
-### Shared State Schemas
+Each namespace uses flat Manager-dictionary entries:
 
-#### Addon Params Namespace (`workspace=<workspace_id>`)
+```text
+head_version                         -> non-negative integer
+payload:<version>                    -> complete immutable payload for version
+applied:<instance_id>                -> per-instance application report
+```
 
-```python
+`instance_id` is unique per `LightRAG` instance and is reported together with
+the PID. It cannot be only the PID: tests construct two real instances in one
+process, and future server layouts may do the same.
+
+Version `0` means that no runtime payload has been published since shared-data
+initialization. Each instance then uses its startup configuration. The first
+publication is version `1`. Timestamps and PIDs are diagnostic fields only and
+never participate in ordering.
+
+### Addon payload
+
+The addon payload is a full normalized snapshot, not a patch:
+
+```text
 {
-    "version": int,               # Monotonically increasing version counter
-    "updated_by_pid": int,        # Publisher PID for observability/diagnostics
-    "updated_at": float,          # Epoch timestamp (time.time())
-    "payload": {
-        "language": str,
-        "entity_type_prompt_file": str | None,
-        "entity_type_prompt_hash": str | None,  # SHA-256 of file contents at publish
-        "entity_types_guidance": str | None,
-        "chunker": dict[str, Any],              # Normalized chunker configuration
-    }
+  addon_params: {
+    language,
+    entity_types_guidance,
+    chunker
+  },
+  entity_type_prompt: null | {
+    sha256,
+    content_utf8,
+    path_hint
+  }
 }
 ```
 
-#### Role LLM Namespace (`workspace=""`)
+Only the fields governed by this contract are publishable. Unknown
+`addon_params` remain local and cause explicit publication to fail rather than
+being silently copied or discarded.
 
-```python
-{
-    "version": int,               # Monotonically increasing version counter
-    "updated_by_pid": int,        # Publisher PID
-    "updated_at": float,          # Epoch timestamp
-    "roles": {
-        "<role_name>": {
-            "binding": str | None,
-            "model": str | None,
-            "host": str | None,
-            "max_async": int | None,
-            "timeout": int | None,
-            "model_kwargs": dict[str, Any] | None,
-            "metadata": dict[str, Any],         # Strictly sanitized (no credentials)
-        }
-    },
-    "global_concurrency_limits": dict[str, int],  # Group -> dynamic limit (e.g. "llm:extract": 8)
-}
+`entity_type_prompt_file` is expanded by the publisher from one read of the
+file. The SHA-256 digest is computed from those exact bytes, and those same
+bytes are decoded and validated before publication. `content_utf8`, not the
+path, is authoritative. `path_hint` exists only for diagnostics and is never
+opened by applying workers. A later edit at the same path therefore cannot
+split workers between two prompt profiles. A malformed payload or digest
+mismatch is an application failure; an on-disk mismatch is impossible because
+workers do not re-read the hint.
+
+Workers validate the published content and install the resulting resolved
+profile as part of the same local batch as
+`_replace_addon_params(..., mark_dirty=True)`. The live mapping, derived
+language, chunker normalization, and entity-extraction prompt cache either all
+advance to the new version or all remain on the previous version.
+
+### Role LLM payload
+
+The role payload is also a complete snapshot. It contains every registered role
+and only these publishable fields:
+
+```text
+binding, model, host, max_async, timeout, model_kwargs
 ```
 
----
+Callables and credentials are not serializable runtime configuration.
+`model_func`, `api_key`, authentication options, and provider credential
+objects are never published. Each worker resolves the requested binding using
+its locally operator-provisioned credentials and registered production
+builder. A `publish=True` update that depends on a caller-supplied callable is
+rejected before the shared commit; the existing local-only update path remains
+available.
 
-## 3. Publication Protocol
+A role update may name one role, but the committed payload is a complete desired
+snapshot. Under the namespace lock, the publisher merges that change into the
+latest committed payload, not a potentially stale local copy. This prevents a
+concurrent update to a different role from being overwritten.
 
-Publishing is explicit, never an implicit side-effect of local in-place dictionary mutation. This prevents normal ingestion passes (such as `resolve_chunk_options()`) from firing continuous broadcast RPCs.
+## Secret exclusion
 
-### Public SDK Ingress Points
+Shared runtime namespaces are non-secret control data. Publication validates
+the complete candidate recursively before the first shared write:
 
-* `await rag.apublish_runtime_config(workspace=None)`: Publishes local `addon_params` and role configurations.
-* `await rag.aupdate_llm_role_config(..., publish=True)`: Atomically applies a local role update and publishes to peers.
+- keys matching `_RoleLLMMixin._SECRET_MARKERS` are rejected;
+- values must belong to the explicitly supported, serializable schema;
+- documented numeric token-count keys such as `chunk_token_size` and
+  `chunk_overlap_token_size` require explicit safe-key exceptions; there is no
+  generic exception for keys merely containing `token`;
+- validation failure leaves `head_version` and every payload entry unchanged.
 
-### Publication Invariants
+Secret-looking fields are rejected rather than scrubbed. Silent scrubbing could
+publish a configuration different from the one the caller requested. Tests
+walk every published key recursively with the production secret predicate,
+mirroring `test_get_llm_role_config_has_no_secret_escape_hatch`.
 
-* **Locking & Serialization**: Writers acquire `get_storage_keyed_lock(name, namespace=...)` for the target namespace. Concurrent publications from different workers are strictly serialized.
-* **Strict Monotonicity**: Inside the keyed lock, the writer reads the current shared version, increments it by 1, writes the new record, and invokes `set_all_update_flags(namespace, workspace=...)`.
-* **Secret Scrubbing (Zero Escape Hatch)**:
-  * Before writing to shared state, all role metadata is scrubbed against `_SECRET_MARKERS` (honoring `_SAFE_OPTION_KEYS`).
-  * Field values matching auth/tokens/passwords are stripped entirely.
-  * Workers resolve credentials locally via their own registered role builders and local environment variables.
-* **Prompt Profile Identity**: When publishing `entity_type_prompt_file`, the publisher computes and includes the SHA-256 hash of the content. The hash is the canonical identity; the file path serves as an operational hint.
+## Publication protocol
 
----
+Publication is serialized with `get_namespace_lock()` for the corresponding
+namespace and scope. The commit protocol is:
 
-## 4. Convergence & Application Invariants
+1. normalize and validate the complete candidate locally;
+2. acquire the namespace lock;
+3. read `head_version` and choose `next_version = head_version + 1`;
+4. for a role patch, merge it into the payload named by the locked head;
+5. write the complete candidate to `payload:<next_version>`;
+6. commit by assigning `head_version = next_version`;
+7. call `set_all_update_flags()` for that namespace before releasing the lock;
+8. return the committed version and allow the publisher to apply through the
+   same worker path as every peer.
 
-### Apply Boundaries (Bounded Staleness)
+The payload-first ordering is the governing invariant: a worker may never see a
+head version whose complete payload has not already been published. A payload
+whose version is above the head is inert staging residue.
 
-Workers do not run background polling loops. Flag evaluation and state refresh occur strictly at predefined execution boundaries:
+Two publishers cannot choose the same committed version because version
+selection happens under the namespace lock. Workers never apply a version less
+than or equal to their applied version. If versions are published faster than a
+worker checks, it may skip intermediate versions and apply the current head;
+it must never move backwards.
 
-* **HTTP Request Boundary**: Fast-path check executed via FastAPI request lifecycle dependency.
-* **Pipeline Document Boundary**: Evaluated at each document boundary within `apipeline_process_enqueue_documents`.
-* **Long-running SDK Boundary**: Evaluated inside `_ensure_addon_params_cache()` throttled by a 250 ms monotonic debounce window to minimize IPC overhead during compute-intensive loops.
+The shared assignment at step 6 is the commit point. Cancellation is deferred
+from the first shared write through notification. A failure before the commit
+reports no publication. A notification or cleanup failure after the commit must
+not be reported as though the publication did not happen: the committed
+version is returned or carried in an explicit commit-aware outcome, and the
+degraded notification is logged.
 
-### Worker Local Caches & Fast Gate Reads
+Old versioned payloads may be pruned only when doing so cannot make the current
+head unreadable. A reader that loses a superseded payload race keeps its current
+configuration, re-reads the head, and retries; it never substitutes a lower
+version.
 
-* **Zero IPC on Concurrency Slots**: `get_global_concurrency_limit()` reads an in-process local dictionary cache. It must never perform a live Manager read in `_acquire_global_slot()`.
-* The local cache of concurrency limits is updated exclusively when the worker processes its update flag.
+## Worker refresh and staleness
 
-### Atomic Per-Worker Application & Rollback
+Every multi-worker `LightRAG` instance registers its own update flag for both
+families it consumes and stores local applied versions. Checking is
+boundary-driven and locally debounced:
 
-* **Version Gate**: A worker inspects `shared["version"]`. If `shared["version"] <= worker.applied_version`, the update is ignored.
-* **Addon Params Application**: Applied via `_replace_addon_params(payload, mark_dirty=True)` followed by `_apply_chunk_size_overlay()`. If the file content on disk differs from the published hash, the worker re-reads the file, emits an actionable warning regarding the hash divergence, and converges rather than entering a permanent refuse-and-retry loop.
-* **Role LLM Application**:
-  * Applied as an all-or-nothing batch across all roles in the payload using `_apply_llm_role_config_update()`.
-  * Each role wrapper is reconstructed with the local role builder.
-  * If builder resolution fails for any role (e.g., missing local API credentials for a newly assigned binding), the worker rolls back all roles to their pre-update snapshots, does not advance `applied_version`, logs an explicit warning, and retries on the next boundary check.
-* **Retired Wrapper Lifecycle**: Replaced wrappers are scheduled for background queue drainage via `_schedule_retired_llm_queue_cleanup()`. Global concurrency leases are returned to shared storage upon drain or task completion; leases are never leaked.
+- an active instance reads its Manager-backed flags at most once every 250 ms;
+- a true flag triggers a `head_version` read and, when newer, a payload read;
+- regardless of the flag, an active instance audits `head_version` at least
+  once per second, recovering a notification failure;
+- an idle instance performs no polling and checks before its next eligible
+  operation.
 
-### Document Invariant
+The documented worst-case staleness window is therefore one second plus the
+time to the next eligible boundary. In the normal notified path it is 250 ms
+plus the time to that boundary. Local monotonic-clock checks happen freely, but
+the debounce permits no more than four flag-read cycles per second per active
+instance. The version audit, rather than the flag alone, is what makes a missed
+notification self-healing.
 
-Documents enqueued prior to a configuration publish maintain their frozen `chunk_options` and `process_options` snapshots in `full_docs`. Only documents enqueued subsequent to a local apply observe new chunker settings.
+Only the instance's own flag is cleared, and only after successful application
+or after confirming that the local applied version already equals the head.
+One worker must never call `clear_all_update_flags()` to acknowledge work for
+its peers. An apply failure leaves that worker's flag armed for retry.
 
----
+### Apply boundaries
 
-## 5. Single-Worker Mode Invariant (`workers == 1`)
+- `addon_params` refresh runs before an enqueue resolves and persists
+  `chunk_options`, before a query/SDK operation captures global configuration,
+  and before a pipeline worker starts the next document.
+- Role refresh runs before a role wrapper admits a new LLM call. Calls already
+  submitted retain their old wrapper and finish under the old configuration.
+- `/health` forces a refresh attempt before reporting this instance, without
+  claiming that a failed peer has converged.
 
-When `initialize_share_data(workers=1)` is used:
+Documents freeze `chunk_options` at enqueue. A document enqueued before a
+publication keeps that snapshot even if it is processed afterward; only
+subsequent enqueues receive the new chunker defaults. A document already being
+processed is not restarted. Other addon values become visible at the next
+document boundary.
 
-* The Manager process is omitted.
-* Shared dictionary proxies, keyed holder tables, and IPC update flags are bypassed.
-* Calls to `rag.addon_params[...] = ...` and `update_llm_role_config()` function purely in-process with zero IPC overhead and zero regression in latency.
+## Local atomic application and rollback
 
----
+Reading a new head does not make it applied. Each worker first validates and
+builds a complete local candidate without mutating live state.
 
-## 6. Observability Invariants
+For addon parameters, prompt content validation, normalization, replacement,
+chunk-size overlay, and derived-cache refresh form one batch. For role LLM
+configuration, every role in the payload is resolved and wrapped into a staged
+snapshot before any live role reference is swapped. If any binding is
+unresolvable, prompt profile is invalid, builder raises, or wrapper construction
+fails, the worker:
 
-* `/health` and `rag.get_llm_queue_status()` report `applied_addon_params_version` and `applied_role_llm_version` **per worker**, not a single worker's scalar view presented as global state. While a publish is in flight, the response identifies which version each worker is on, e.g. `{"applied_versions": {<pid>: <version>, ...}}` for each of `applied_addon_params_version` and `applied_role_llm_version`.
-* The aggregated queue status exposes this per-worker version mapping so an operator can instantly detect a diverging or un-converged worker during in-flight propagation.
-* Direct runtime assignment `rag.role_llm_configs = ...` is explicitly disallowed and must raise `AttributeError` or `TypeError` instead of failing as a silent no-op.
+1. retains its previous configuration in full;
+2. retains its previous applied version;
+3. logs the family, target version, failing role/field, and a sanitized
+   actionable error;
+4. reports the failed/retrying state for observability;
+5. leaves its update flag armed and retries at the next eligible check.
 
----
+The final live-state swap contains no `await`, so other coroutines in that
+event loop observe either the old complete snapshot or the new complete
+snapshot. Successful application updates the per-instance report only after
+the swap.
 
-## 7. Consistency Without Transactions: Failure Model
+Retired role wrappers drain through the existing cleanup path. Failure to clean
+up a retired wrapper does not roll back a successfully installed version: no
+new call can acquire that wrapper, the failure is logged, and finalization or a
+later cleanup attempt retires it.
 
-Because LightRAG distributes configuration across decoupled worker processes without distributed two-phase commit, intermediate states can exist. In alignment with `AGENTS.md` (Consistency without transactions), the table below records every accepted residue, its rationale, and its self-healing path.
+After initialization, assigning `rag.role_llm_configs = ...` directly must
+raise a clear error directing the caller to the supported update method. It
+must not remain a silent mutation of a dataclass field that leaves live wrappers
+unchanged. Constructor-time `role_llm_configs` behavior is unchanged.
 
-| Inconsistent State | Root Cause | Why It Is Accepted | Recovery Path |
-| :--- | :--- | :--- | :--- |
-| Worker config skew during propagation window | A publish completed, but peer workers have not reached an apply boundary. | Bounded staleness (≤ 250 ms or next request/doc). Prevents high-frequency polling IPC overhead. | Self-heals automatically at the next HTTP request, pipeline document boundary, or debounced SDK check. |
-| Worker stuck on previous version following apply failure | One worker lacks local environment credentials for a newly published binding or prompt file is unreadable. | Prevents complete process failure or unauthenticated calls. System fails safe by retaining working state. | Worker logs actionable error with PID. Operator provides local credentials or updates file; worker retries and converges on next boundary. |
-| Old LLM response cache entries orphaned | Model name or host changed, shifting cache key identity. | Partitioning is deliberate (binding/model/host are part of the cache key). No cross-talk or corruption can occur. | Orphaned keys remain inert. They are not forwarded to #3833 GC to ensure cache maintenance remains decoupled from propagation state. |
-| Retired role wrappers draining concurrently | Rapid successive publishes cause overlapping background wrapper drains. | In-flight requests must finish without data loss or severed connections. | Each retired queue drains gracefully bounded by `max_task_duration` (2 × timeout + 15s). Expired leases are cleaned by heartbeat sweepers. |
-| Unshared concurrency limit during transition | Concurrency group transitions between unlimited and limited states while old wrappers exist. | Wrappers rebuild upon role update, automatically re-resolving `use_global_limit`. | Rebuilding wrappers binds them to the new gate limit. In-flight tasks under retired wrappers finish under their original lease terms. |
+## Dynamic `max_async` and the global gate
 
----
+The shared role payload carries `max_async`, but the concurrency hot path never
+reads it from a Manager proxy. Applying a role version updates a worker-local
+cached limit and generation. `get_global_concurrency_limit()`,
+`is_global_concurrency_limited()`, and `_acquire_global_slot()` continue to read
+only worker-local memory.
 
-## 8. Rejected Remedies
+Role wrappers check the local generation before admission. A wrapper created
+while its group was unlimited must begin using the gate after an unlimited to
+limited transition; rebuilding the `LightRAG` instance is not required.
+Increases must raise observed cross-worker concurrency, while decreases stop
+new admissions above the new cap.
 
-* **Live Manager Read on Every Slot Acquisition**: Reading concurrency limits directly from `shared_storage` inside `_acquire_global_slot()` would introduce a synchronous Manager IPC round-trip onto the inner LLM invocation path, causing severe throughput loss.
-* **Auto-Publish on Addon Mutation**: Implicit broadcast on `ObservableAddonParams` mutation was rejected because ingestion passes (`resolve_chunk_options`) modify chunker options dynamically, which would flood the system with broadcast storms.
-* **Reporting Retired LLM Cache Spaces to #3833 GC**: Coupling retired key spaces to the maintenance garbage collector was rejected because cache GC must operate independently of real-time worker synchronization state.
-* **Permanent Worker Refusal on Prompt File Hash Mismatch**: Refusing to advance version permanently when a content hash mismatches would cause permanent divergence if files change out of sync on a single host. Re-reading and logging a clear diagnostic error prevents permanent silent split-brain.
+A lower limit does not cancel calls or leases already admitted. During the
+bounded convergence window, workers may temporarily enforce different limits,
+and existing holders may keep global usage above the new value. Once every
+worker applies, no new call is admitted above the new cap; ordinary completion
+and the existing lease reaper drain the excess.
+
+## Cache behavior
+
+Role model changes do not invalidate or delete LLM cache rows. The existing
+cache identity partitions different model configurations. Retired key spaces
+are not reported to the maintenance GC: doing so would make GC correctness
+depend on propagation and rollback state. Old rows remain ordinary unreachable
+cache data under their existing identities.
+
+## Observability
+
+Each namespace's `applied:<instance_id>` report contains, at minimum:
+
+```text
+instance_id, pid, applied_version, target_version, state, last_seen
+```
+
+`state` distinguishes `applied` from `retrying`; error details exposed through
+health are bounded and sanitized. Dead reports expire from the global view
+after the documented worker-report TTL. Expiry hides dead bookkeeping; it does
+not change the desired version.
+
+`/health` reports each family's desired version and the applied version/state
+of every live reporting instance. It never presents the serving worker's local
+version as cluster-wide truth. During convergence, the differing versions stay
+visible.
+
+`get_llm_queue_status()` includes the desired role version and the applied role
+version for each worker entry. `/health` returns that queue-status view without
+reinterpreting it, so both surfaces agree after convergence and expose the same
+partial state while a publication is in flight.
+
+## Single-worker and SDK compatibility
+
+When `workers == 1`, existing operations take no propagation path:
+
+- no Manager is created or accessed;
+- no runtime namespace, update flag, applied report, or polling task is added;
+- `rag.addon_params[...] = ...` remains the same direct observable-dict
+  operation;
+- local role update behavior remains unchanged unless the caller explicitly
+  uses the new publishing option;
+- explicit publishing applies locally without IPC.
+
+Tests assert both observable behavior and zero calls into the new shared
+namespace/flag helpers. The propagation feature may not tax the SDK or
+single-worker server for a capability that only multiple workers need.
+
+## Accepted residues and recovery
+
+| Residue | Why it is acceptable | Recovery |
+| --- | --- | --- |
+| `payload:N` exists while `head_version < N` | Payload-first publication can crash before commit; the staged value is inert. | The next publisher overwrites/reuses the uncommitted version under the lock, or shutdown clears the Manager. |
+| `head_version` advanced but some flags were not set | The committed payload is complete; notification is an accelerator, not truth. | The one-second version audit discovers the head and applies it. |
+| Some workers applied the head while another still reports an older version | This is the bounded convergence state the protocol makes observable. | The lagging worker applies at its next eligible check. |
+| One worker cannot apply a validly published payload | Keeping the old full snapshot is safer than a partial rebuild. Failure is loud and visible. | Its flag remains armed; it retries on every eligible check after the debounce. Operator fixes its local binding/file-independent validation problem if retries continue. |
+| The publisher's `addon_params` was changed locally but validation or publication failed before commit | Direct SDK mutation is intentionally local and predates propagation; claiming peers changed would be false. | The caller corrects the value and republishes, or restores the local mapping. |
+| A reader targeted a payload pruned after it read an older head | It has not modified live state and retains a complete older version. | It re-reads the current head and retries, skipping superseded versions. |
+| A dead instance leaves an update-flag handle or applied report | The handle carries no configuration and cannot make another worker move backward. | Reports expire by TTL; handles disappear when the Manager is finalized/restarted. |
+| A retired role wrapper fails cleanup after the new wrapper is installed | New calls use only the new wrapper; the old queue is no longer reachable for admission. | Existing cleanup/finalization retries or terminates it, with a warning. |
+| Global usage temporarily exceeds a newly lowered limit | Already-admitted work is not cancelled, and workers converge within the documented bound. | Completions and lease expiry drain usage; new admissions use the lower local cache after apply. |
+| An old document uses pre-publication `chunk_options` | This is the required enqueue-time reproducibility guarantee, not divergence. | No repair: only documents enqueued after publication use new defaults. |
+| Old LLM cache identities remain after a model change | Identity partitioning prevents reuse under the new configuration. | No propagation action and no GC report; normal cache lifecycle applies. |
+| A full server restart loses all runtime versions | Runtime state is intentionally not deployment configuration. | Every worker starts again from operator-managed environment and constructor values at version `0`. |
+
+No failure is swallowed. Logs and observability must distinguish an uncommitted
+attempt, a committed-but-partially-notified version, and a worker-local apply
+failure.
+
+## Test contract
+
+Every propagation test uses `initialize_share_data(2)` and two real `LightRAG`
+instances connected to that Manager. A plain dictionary, permissive proxy,
+stand-in client constructor, or fake object that accepts arbitrary arguments
+cannot prove ordering, serialization, rollback, or cross-instance application.
+
+The phased test matrix is:
+
+- shared-storage tests: concurrent publishers, monotonic ordering, flag
+  isolation, missed-notification audit, stale report handling, and the
+  `workers == 1` no-new-IPC path;
+- addon tests: publish/apply for every governed field, content-addressed prompt
+  identity, invalid-profile rollback, and `_replace_addon_params(...,
+  mark_dirty=True)` cache refresh;
+- chunker tests: documents enqueued before publication retain frozen
+  `chunk_options`, while later documents use the new defaults;
+- role tests: real production resolution, complete batch swap, builder-failure
+  rollback, direct-assignment rejection, secret exclusion, cache identity, and
+  queue/health version agreement;
+- gate tests: no Manager read on acquisition, increased and decreased achieved
+  concurrency, transient over-cap drain, and wrappers created before an
+  unlimited to limited transition.
+
+Fault injection is allowed only at an explicit production failure seam and may
+not replace the Manager, `LightRAG` instances, payload schema, or constructor
+signature being tested. Each regression test is first demonstrated failing
+against the broken behavior and then restored.
+
+English and Chinese user documentation change together with the implementation.
+In particular, the runtime-mutation sections of
+`docs/FileProcessingPipeline.md` and `docs/FileProcessingPipeline-zh.md` must
+explain server propagation while preserving the enqueue-time snapshot rule.


### PR DESCRIPTION
## Description

This pull request adds the design contract for propagating runtime configuration across LightRAG workers in multi-worker deployments (`lightrag-gunicorn --workers N`).

As agreed in #3847, this is a documentation-only PR that defines the architecture, shared-state schemas, ordering rules, rollback guarantees, staleness bounds, and failure-recovery model before implementation begins. It does not introduce runtime behavior, API endpoints, or WebUI controls.

## Related Issues

* Related to #3847

## Changes Made

* Added `docs/design/RuntimeConfigPropagationContract.md`:

  * **Scoping and namespaces:** Defines `runtime_addon_params` as workspace-scoped and `runtime_llm_config` as process-wide using `workspace=""`, with independent version counters.
  * **Publication and version ordering:** Defines explicit publication through `apublish_runtime_config()` and `aupdate_llm_role_config(..., publish=True)`, serialized under namespace locks with monotonically increasing versions.
  * **Bounded staleness:** Defines HTTP request, document-processing, SDK operation, and LLM-admission boundaries. Update flags are checked through a 250 ms debounce, while periodic version audits recover missed notifications.
  * **Atomic application and rollback:** Requires workers to install complete configuration snapshots or retain their previous configuration and retry without advancing their applied version.
  * **Zero-IPC concurrency gate:** Requires `get_global_concurrency_limit()` and slot acquisition to use worker-local cached state rather than live Manager reads. Existing wrappers must also observe unlimited-to-limited transitions.
  * **Secret exclusion:** Requires secret-marked fields matching `_SECRET_MARKERS` to be rejected before anything is written to shared storage. Credentials remain local to each worker.
  * **Prompt-profile identity:** Makes the published prompt content and its SHA-256 hash authoritative. The file path is retained only as a diagnostic hint and is not reopened by applying workers.
  * **Document consistency:** Preserves frozen `chunk_options` for documents enqueued before a publication. Only later enqueues use the new chunker defaults.
  * **Observability:** Defines desired and applied version reporting per `LightRAG` instance, including its PID, through `/health` and `get_llm_queue_status()`.
  * **Failure recovery:** Records accepted intermediate states, why they are safe, and how each one recovers under the repository’s consistency-without-transactions rules.
  * **Testing contract:** Requires propagation tests to use `initialize_share_data(2)` with two real `LightRAG` instances rather than permissive fake proxies or constructors.
  * **Documentation consistency:** Requires the English and Chinese runtime-mutation documentation to be updated together during implementation.

* Updated `AGENTS.md`:

  * Added a reference to the new contract and summarized its main invariants under Core Architecture.

## Checklist

* [x] Changes validated locally with `git diff --check`
* [x] Changes reviewed
* [x] Documentation added and updated
* [x] Unit tests not applicable to this documentation-only PR

## Additional Notes

Implementation will follow in the three agreed phases:

1. **PR 1:** Shared namespace, update flags, monotonic versioning, and workspace-scoped `addon_params` application.
2. **PR 2:** Role LLM propagation, complete batch snapshot and rollback, and removal of the silent no-op on runtime `rag.role_llm_configs` assignment.
3. **PR 3:** Dynamic `max_async` gate propagation, including increased and decreased limits and wrappers transitioning from unlimited to limited.

@danielaskdd This is the contract-only PR discussed in #3847. I’d appreciate your review of the contract before I begin the first implementation phase.