### PR TITLE
fix(merge): make join_unique deterministic so source_id limits keep the chunks they name

### DIFF
--- a/lightrag/utils_graph.py
+++ b/lightrag/utils_graph.py
@@ -3625,12 +3625,14 @@ def _merge_attributes(
         elif strategy == "keep_last":
             merged_data[key] = values[-1]
         elif strategy == "join_unique":
-            # Handle fields separated by GRAPH_FIELD_SEP
-            unique_items = set()
+            # Handle fields separated by GRAPH_FIELD_SEP.
+            # Deduplicate while preserving first-seen order: source_id ordering is
+            # meaningful downstream, where apply_source_ids_limit() truncates
+            # positionally (FIFO keeps the tail, IGNORE_NEW keeps the head).
+            unique_items = []
             for value in values:
-                items = str(value).split(GRAPH_FIELD_SEP)
-                unique_items.update(items)
-            merged_data[key] = GRAPH_FIELD_SEP.join(unique_items)
+                unique_items.extend(str(value).split(GRAPH_FIELD_SEP))
+            merged_data[key] = GRAPH_FIELD_SEP.join(dict.fromkeys(unique_items))
         elif strategy == "join_unique_comma":
             # Handle fields separated by comma, join unique items with comma
             unique_items = set()

--- a/tests/utils/test_merge_attributes_join_unique_order.py
+++ b/tests/utils/test_merge_attributes_join_unique_order.py
@@ -1,0 +1,112 @@
+"""Regression tests for ``join_unique`` ordering in ``_merge_attributes``.
+
+``_merge_attributes`` is the strategy dispatcher behind ``amerge_entities`` /
+``amerge_relations``. ``source_id`` and ``file_path`` are merged with the
+``join_unique`` strategy, which used to collect items into a ``set`` before
+joining them.
+
+Set iteration order for strings is not stable across processes (PYTHONHASHSEED
+randomization), and the order of ``source_id`` is load-bearing downstream:
+``apply_source_ids_limit`` truncates positionally, keeping the tail under
+``FIFO`` and the head under ``IGNORE_NEW``. A randomly ordered ``source_id``
+therefore made both limit strategies discard arbitrary chunks instead of the
+ones they name.
+
+The sibling branch in the same dispatcher, ``join_unique_comma``, already
+sorted its output, and the codebase uses ``dict.fromkeys`` for order-preserving
+dedup in ~18 other places -- including three in ``utils_graph`` itself.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+from lightrag.constants import GRAPH_FIELD_SEP
+from lightrag.utils import apply_source_ids_limit
+from lightrag.utils_graph import _merge_attributes
+
+
+def test_join_unique_preserves_first_seen_order():
+    # Scenario: two entities merged, each carrying its own chunk provenance.
+    first = {"source_id": GRAPH_FIELD_SEP.join(["chunk-01", "chunk-02"])}
+    second = {"source_id": GRAPH_FIELD_SEP.join(["chunk-03", "chunk-04"])}
+
+    merged = _merge_attributes([first, second], {"source_id": "join_unique"})
+
+    assert merged["source_id"].split(GRAPH_FIELD_SEP) == [
+        "chunk-01",
+        "chunk-02",
+        "chunk-03",
+        "chunk-04",
+    ]
+
+
+def test_join_unique_dedups_without_reordering():
+    # Scenario: overlapping provenance -- the duplicate keeps its first position.
+    first = {"source_id": GRAPH_FIELD_SEP.join(["chunk-01", "chunk-02"])}
+    second = {"source_id": GRAPH_FIELD_SEP.join(["chunk-02", "chunk-03"])}
+
+    merged = _merge_attributes([first, second], {"source_id": "join_unique"})
+
+    assert merged["source_id"].split(GRAPH_FIELD_SEP) == [
+        "chunk-01",
+        "chunk-02",
+        "chunk-03",
+    ]
+
+
+def test_join_unique_order_lets_fifo_keep_the_newest_chunks():
+    # Scenario: the merged entity exceeds max_source_ids_per_entity.
+    # FIFO keeps the tail, so it must keep the most recently merged chunks.
+    first = {"source_id": GRAPH_FIELD_SEP.join(["chunk-01", "chunk-02", "chunk-03"])}
+    second = {"source_id": GRAPH_FIELD_SEP.join(["chunk-04", "chunk-05", "chunk-06"])}
+
+    merged = _merge_attributes([first, second], {"source_id": "join_unique"})
+    kept = apply_source_ids_limit(merged["source_id"].split(GRAPH_FIELD_SEP), 3, "FIFO")
+
+    assert kept == ["chunk-04", "chunk-05", "chunk-06"]
+
+
+def test_join_unique_order_lets_ignore_new_keep_the_oldest_chunks():
+    # Scenario: the counterpart -- IGNORE_NEW keeps the head.
+    first = {"source_id": GRAPH_FIELD_SEP.join(["chunk-01", "chunk-02", "chunk-03"])}
+    second = {"source_id": GRAPH_FIELD_SEP.join(["chunk-04", "chunk-05", "chunk-06"])}
+
+    merged = _merge_attributes([first, second], {"source_id": "join_unique"})
+    kept = apply_source_ids_limit(
+        merged["source_id"].split(GRAPH_FIELD_SEP), 3, "IGNORE_NEW"
+    )
+
+    assert kept == ["chunk-01", "chunk-02", "chunk-03"]
+
+
+def test_join_unique_is_stable_across_processes():
+    """Same input, fresh interpreters: the merged order must not change.
+
+    An in-process assertion cannot catch this -- ``PYTHONHASHSEED`` is fixed
+    once per interpreter, so a set-based implementation looks deterministic
+    when tested inside a single process. Only separate processes expose it.
+    """
+    probe = textwrap.dedent(
+        """
+        from lightrag.constants import GRAPH_FIELD_SEP
+        from lightrag.utils_graph import _merge_attributes
+
+        first = {"source_id": GRAPH_FIELD_SEP.join(["chunk-01", "chunk-02", "chunk-03"])}
+        second = {"source_id": GRAPH_FIELD_SEP.join(["chunk-04", "chunk-05", "chunk-06"])}
+        merged = _merge_attributes([first, second], {"source_id": "join_unique"})
+        print(merged["source_id"].replace(GRAPH_FIELD_SEP, ","))
+        """
+    )
+
+    results = set()
+    for _ in range(5):
+        completed = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        results.add(completed.stdout.strip().splitlines()[-1])
+
+    assert results == {"chunk-01,chunk-02,chunk-03,chunk-04,chunk-05,chunk-06"}


### PR DESCRIPTION
## What's wrong

`_merge_attributes` (`lightrag/utils_graph.py`) is the strategy dispatcher behind
`amerge_entities` / `amerge_relations`. The `join_unique` branch built its result
from a `set`:

```python
elif strategy == "join_unique":
    unique_items = set()
    for value in values:
        items = str(value).split(GRAPH_FIELD_SEP)
        unique_items.update(items)
    merged_data[key] = GRAPH_FIELD_SEP.join(unique_items)   # <- arbitrary order
```

Set iteration order for strings is not stable across processes
(`PYTHONHASHSEED` randomization), so the same merge produced a different string
on every run. `join_unique` is the configured strategy for both `source_id` and
`file_path`, in the entity merge strategy and in the relation one alike.

## Why the order matters

Both fields are truncated **positionally** downstream, so their order decides
which entries survive the cap. Where they differ is whether anything else can
restore an order once this one is lost.

### `file_path` — affected unconditionally

`file_path` has no tracking side-channel: the graph string is the only store it
has. `_merge_nodes_then_upsert` rebuilds the list from that stored value and
caps it at `max_file_paths` by position (`_merge_edges_then_upsert` does the
same for relations, in `lightrag/operate.py`):

```python
if limit_method == SOURCE_IDS_LIMIT_METHOD_FIFO:
    file_paths_list = file_paths_list[-max_file_paths:]   # keep newest
else:
    file_paths_list = file_paths_list[:max_file_paths]    # keep oldest
```

After a merge that order was arbitrary, so which file paths survived the cap was
arbitrary too — and different in every process. Nothing heals it later.

### `source_id` — affected on the fallback path

`apply_source_ids_limit` (`lightrag/utils.py`) truncates the same way:

```python
if normalized_method == SOURCE_IDS_LIMIT_METHOD_FIFO:
    truncated = source_ids_list[-limit:]   # keep newest
else:  # IGNORE_NEW
    truncated = source_ids_list[:limit]    # keep oldest
```

Chunk tracking outranks the graph's `source_id`, so where a tracking row exists
it supplies the order and the graph string is rewritten from it on the next
ingest. The damage lands where no row exists — legacy graphs, or a merge whose
inputs had no usable row and which therefore writes no target row either
(`any_row_present` stays False). There `_merge_nodes_then_upsert` seeds
`already_source_ids` from the graph string and that string is the only
authority, so both limit strategies dropped arbitrary chunks instead of the ones
they are named after, losing provenance that retrieval and
`_purge_kg_contributions` rely on.

### A consistency gain

The same merge already builds its chunk tracking row with order-preserving
dedup, source entities first and then the target. Before this change the two
provenance views written by one function disagreed on order; now they agree.

## Reproduction

Merging `chunk-01..10` with `chunk-11..20` through the pre-fix branch, then
applying FIFO with `limit=10`. FIFO means "keep the newest", so the answer
should be `chunk-11..20` every time:

```
PYTHONHASHSEED=0  chunk-08,chunk-09,chunk-01,chunk-02,chunk-03,chunk-04,chunk-05,chunk-06,chunk-07,chunk-20
PYTHONHASHSEED=1  chunk-07,chunk-06,chunk-05,chunk-04,chunk-03,chunk-02,chunk-01,chunk-20,chunk-09,chunk-08
PYTHONHASHSEED=2  chunk-01,chunk-02,chunk-03,chunk-04,chunk-05,chunk-06,chunk-07,chunk-08,chunk-09,chunk-20
PYTHONHASHSEED=3  chunk-09,chunk-08,chunk-01,chunk-03,chunk-02,chunk-05,chunk-04,chunk-07,chunk-06,chunk-20
PYTHONHASHSEED=4  chunk-03,chunk-02,chunk-01,chunk-07,chunk-06,chunk-05,chunk-04,chunk-09,chunk-08,chunk-20
```

Five seeds, five different answers, and not one of them is what FIFO promises —
each keeps nine of the ten *oldest* chunks and exactly one of the newest. After
the fix every run returns `chunk-11..20`.

## Why not `sorted()`

The sibling branch immediately below, `join_unique_comma`, already sorts before
joining — so the dispatcher itself shows the author was aware order needed
pinning, and `join_unique` was the one branch left unsorted.

But sorting is the wrong fix *here*: it would impose lexical order on fields
whose order encodes insertion sequence, which is exactly what the positional
caps above read. Dedup preserving first-seen order is what these fields need,
and `dict.fromkeys` is the idiom this codebase already uses for it throughout,
including several times in `utils_graph.py` itself.

`join_unique_comma` is deliberately left alone: it feeds `keywords`, where
lexical order is harmless and changing it is out of scope here.

## Tests

New file `tests/utils/test_merge_attributes_join_unique_order.py`, alongside the
existing `test_merge_source_ids.py` / `test_compute_incremental_chunk_ids.py`
which cover the same provenance machinery:

- `test_join_unique_preserves_first_seen_order` — merged order follows input
  order; parametrized over `source_id` and `file_path`.
- `test_join_unique_dedups_without_reordering` — overlapping ids keep their
  first position.
- `test_join_unique_order_lets_fifo_keep_the_newest_chunks` — the end-to-end
  consequence.
- `test_join_unique_order_lets_ignore_new_keep_the_oldest_chunks` — the
  counterpart, so the fix cannot pass by reversing the list.
- `test_join_unique_order_is_identical_under_every_hash_seed` — runs the merge
  in three concurrent subprocesses under explicitly chosen seeds.

**Fixture size is part of the proof.** A `set` of six short, similar chunk IDs
reproduces insertion order outright under roughly a fifth of the possible hash
seeds. The first revision of this file used six, and against the buggy
implementation it passed under `PYTHONHASHSEED=0` and `=2` on CPython 3.12 — the
cross-process test included, because it inherited the caller's seed, so a CI
runner pinning `PYTHONHASHSEED=0` for reproducibility would have handed every
probe the same seed. The fixtures now carry twenty IDs, at which size no probed
seed reproduces insertion order in whole or in either ten-element half, and the
cross-process test passes its seeds explicitly (`0`, `1`, `2`) over an inherited
environment rather than relying on whatever it was launched with. Launching the
three probes concurrently also brings that test from 4.4s down to 1.5s.

## Verification

```
tests/utils/test_merge_attributes_join_unique_order.py      6 passed (1.67s)
tests/utils/ + tests/test_docstring_budget.py             379 passed
merge-related tests under tests/extraction/                38 passed
pre-commit ruff-format / ruff / trailing-whitespace / end-of-file-fixer   passed
```

Reverse-verified: with the one-branch source change restored to the `set`
implementation and the tests kept, all six fail under `PYTHONHASHSEED=0`, under
`=2`, and with the variable unset; with the fix applied they pass in all three
conditions.

## AI disclosure

This change was prepared with AI assistance. The defect was found by auditing
the merge-strategy branches against each other, then confirmed by executing the
real `_merge_attributes`, `apply_source_ids_limit` and the `max_file_paths` cap
across multiple interpreters; the call sites, seed probes and test results above
were all verified by running the code.

The test hardening described under *Tests* (fixture size, explicit seeds,
`file_path` coverage) and this description were added by a maintainer in a
follow-up commit, also with Claude Code.
