### PR TITLE
fix: validate custom chunk token limits before journaling

### DIFF
--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -171,6 +171,7 @@ from lightrag.exceptions import (
     ADMIN_WRITE_PIPELINE_BUSY_PREFIX,
     AdminWriteGateRefusedError,
     AdminWriteHoldExceededError,
+    ChunkTokenLimitExceededError,
     IndexFlushError,
     KGPurgeOperationConflictError,
     PipelineNotInitializedError,
@@ -2410,6 +2411,10 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
         marked ``FAILED`` with the journal (and any staged data) retained —
         the same call can be retried by the SDK caller, and ``/documents/scan``
         can roll the operation back. Partial work is never blind-flushed.
+
+        Caller boundaries are preserved: chunks exceeding ``chunk_token_size``
+        or a positive embedding token limit are rejected before any journal or
+        storage mutation, rather than split or truncated.
         """
         # Owner token for the busy reservation, generated before any await so the
         # finally always holds it and can release the slot by owner (even if the
@@ -2456,6 +2461,31 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
             if not chunk_entries:
                 logger.warning("No non-empty custom chunks to insert.")
                 return
+
+            chunk_token_limit = self.chunk_token_size
+            if (
+                self.embedding_token_limit is not None
+                and self.embedding_token_limit > 0
+            ):
+                chunk_token_limit = min(chunk_token_limit, self.embedding_token_limit)
+
+            # Validate the entire input before reserving busy or writing a journal.
+            # Encoding stays off the event loop, bounded by the shared chunking
+            # executor; reuse these counts when constructing the staged payloads.
+            def _validate_chunk_token_sizes() -> dict[str, int]:
+                counts = {}
+                for chunk_id, content, _ in chunk_entries:
+                    count = len(self.tokenizer.encode(content))
+                    if count > chunk_token_limit:
+                        raise ChunkTokenLimitExceededError(
+                            count, chunk_token_limit, chunk_preview=content
+                        )
+                    counts[chunk_id] = count
+                return counts
+
+            chunk_token_counts = await run_in_chunking_executor(
+                _validate_chunk_token_sizes
+            )
             operation_id = make_custom_chunk_operation_id(
                 doc_key, [cid for cid, _, _ in chunk_entries]
             )
@@ -2759,28 +2789,16 @@ class LightRAG(_RoleLLMMixin, _StorageMigrationMixin, _PipelineMixin):
                     # concurrently with these upserts can observe a
                     # not-yet-persisted chunk and silently drop the cache
                     # reference.
-                    # Off the loop: this shares ``self.tokenizer`` with the
-                    # chunking executor, and this entry point is gated by
-                    # neither max_parallel_insert nor the pipeline busy flag, so
-                    # nothing else keeps it from encoding concurrently with a
-                    # document being chunked.
-                    def _build_inserting_chunks() -> dict[str, Any]:
-                        return {
-                            chunk_id: {
-                                "content": content,
-                                "full_doc_id": doc_key,
-                                "tokens": len(self.tokenizer.encode(content)),
-                                "chunk_order_index": index,
-                                "file_path": file_path,
-                            }
-                            for index, (chunk_id, content, _) in enumerate(
-                                chunk_entries
-                            )
+                    inserting_chunks: dict[str, Any] = {
+                        chunk_id: {
+                            "content": content,
+                            "full_doc_id": doc_key,
+                            "tokens": chunk_token_counts[chunk_id],
+                            "chunk_order_index": index,
+                            "file_path": file_path,
                         }
-
-                    inserting_chunks: dict[str, Any] = await run_in_chunking_executor(
-                        _build_inserting_chunks
-                    )
+                        for index, (chunk_id, content, _) in enumerate(chunk_entries)
+                    }
                     stage1_writes = [
                         self.chunks_vdb.upsert(inserting_chunks),
                         self.text_chunks.upsert(inserting_chunks),

--- a/tests/pipeline/test_custom_chunk_patch.py
+++ b/tests/pipeline/test_custom_chunk_patch.py
@@ -16,6 +16,7 @@ monkeypatched to a deterministic fake (one entity per staged chunk), covering:
 
 from __future__ import annotations
 
+from threading import get_ident
 from uuid import uuid4
 
 import numpy as np
@@ -25,6 +26,7 @@ import lightrag.lightrag as lightrag_module
 import lightrag.operate as operate_module
 from lightrag import LightRAG
 from lightrag.base import DocStatus
+from lightrag.exceptions import ChunkTokenLimitExceededError
 from lightrag.utils import (
     EmbeddingFunc,
     LLM_TRUNCATION_METADATA_KEY,
@@ -60,8 +62,9 @@ async def _build_rag(tmp_path, **overrides) -> LightRAG:
         working_dir=str(tmp_path / "wd"),
         workspace=f"ccpatch-{uuid4().hex[:8]}",
         llm_model_func=_dummy_llm,
-        embedding_func=EmbeddingFunc(
-            embedding_dim=8, max_token_size=8192, func=_dummy_embedding
+        embedding_func=overrides.pop(
+            "embedding_func",
+            EmbeddingFunc(embedding_dim=8, max_token_size=8192, func=_dummy_embedding),
         ),
         tokenizer=Tokenizer("mock-tokenizer", _SimpleTokenizerImpl()),
         max_parallel_insert=1,
@@ -69,6 +72,105 @@ async def _build_rag(tmp_path, **overrides) -> LightRAG:
     )
     await rag.initialize_storages()
     return rag
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["create", "patch"])
+@pytest.mark.parametrize("embedding_limit", [None, 0, 8, 8192])
+async def test_oversized_custom_chunk_rejected_before_journal(
+    tmp_path, monkeypatch, mode, embedding_limit
+):
+    rag = await _build_rag(
+        tmp_path,
+        chunk_token_size=16 if embedding_limit == 8 else 8,
+        chunk_overlap_token_size=0,
+        embedding_func=EmbeddingFunc(
+            embedding_dim=8, max_token_size=embedding_limit, func=_dummy_embedding
+        ),
+    )
+    try:
+        _fake_extraction(rag, monkeypatch)
+        if mode == "patch":
+            await rag.ainsert_custom_chunks("base", ["alice"], doc_id="doc-1")
+        before = await rag.doc_status.get_by_id("doc-1")
+        full_doc_before = await rag.full_docs.get_by_id("doc-1")
+
+        async def unexpected_extraction(*args, **kwargs):
+            pytest.fail("over-limit input reached extraction")
+
+        monkeypatch.setattr(rag, "_process_extract_entities", unexpected_extraction)
+        with pytest.raises(ChunkTokenLimitExceededError) as exc:
+            await rag.ainsert_custom_chunks(
+                "changed", ["bob", "123456789"], doc_id="doc-1"
+            )
+
+        assert exc.value.chunk_tokens == 9
+        assert exc.value.chunk_token_limit == 8
+        assert await rag.doc_status.get_by_id("doc-1") == before
+        assert await rag.full_docs.get_by_id("doc-1") == full_doc_before
+        for text in ("bob", "123456789"):
+            assert await rag.text_chunks.get_by_id(_chunk_id("doc-1", text)) is None
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_exact_limit_custom_chunk_keeps_caller_boundaries(tmp_path, monkeypatch):
+    rag = await _build_rag(tmp_path, chunk_token_size=8, chunk_overlap_token_size=0)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        original_encode = rag.tokenizer.encode
+        encoded = []
+        loop_thread = get_ident()
+
+        def recording_encode(content):
+            encoded.append((content, get_ident()))
+            return original_encode(content)
+
+        monkeypatch.setattr(rag.tokenizer, "encode", recording_encode)
+        await rag.ainsert_custom_chunks(
+            "base", ["alice xx", "", "alice xx", "bob"], doc_id="doc-1"
+        )
+
+        row = await rag.doc_status.get_by_id("doc-1")
+        assert _status_text(row) == DocStatus.PROCESSED.value
+        assert row["chunks_list"] == [
+            _chunk_id("doc-1", "alice xx"),
+            _chunk_id("doc-1", "bob"),
+        ]
+        chunk = await rag.text_chunks.get_by_id(_chunk_id("doc-1", "alice xx"))
+        assert chunk["content"] == "alice xx"
+        assert chunk["tokens"] == 8
+        custom_encodes = [
+            (text, thread) for text, thread in encoded if text in ("alice xx", "bob")
+        ]
+        assert [text for text, _ in custom_encodes] == ["alice xx", "bob"]
+        assert all(thread != loop_thread for _, thread in custom_encodes)
+    finally:
+        await rag.finalize_storages()
+
+
+@pytest.mark.asyncio
+async def test_token_rejection_preserves_existing_recovery_journal(
+    tmp_path, monkeypatch
+):
+    rag = await _build_rag(tmp_path, chunk_token_size=16, chunk_overlap_token_size=0)
+    try:
+        _fake_extraction(rag, monkeypatch)
+        await _fail_one_merge_then_restore(monkeypatch)
+        with pytest.raises(RuntimeError, match="merge boom"):
+            await rag.ainsert_custom_chunks("base", ["alice xxx"], doc_id="doc-1")
+        before = await rag.doc_status.get_by_id("doc-1")
+        assert _journal(before) is not None
+
+        # Configuration can become stricter between a failed call and its retry.
+        rag.chunk_token_size = 8
+        with pytest.raises(ChunkTokenLimitExceededError):
+            await rag.ainsert_custom_chunks("base", ["alice xxx"], doc_id="doc-1")
+
+        assert await rag.doc_status.get_by_id("doc-1") == before
+    finally:
+        await rag.finalize_storages()
 
 
 def _fake_extraction(rag, monkeypatch):

--- a/tests/pipeline/test_document_file_path_normalization.py
+++ b/tests/pipeline/test_document_file_path_normalization.py
@@ -96,6 +96,8 @@ def _patch_custom_chunk_saga(monkeypatch, rag):
 
     rag.doc_status = CaptureKV()
     rag.llm_response_cache = CaptureKV()
+    # These bare instances bypass the constructor's resolved chunker defaults.
+    rag.chunk_token_size = 1200
     monkeypatch.setattr(
         lightrag_module,
         "get_storage_keyed_lock",
@@ -780,6 +782,7 @@ async def test_custom_chunks_release_survives_cancel_at_lock_exit(monkeypatch):
     lock = _CancelOnFirstExitLock()
 
     rag = LightRAG.__new__(LightRAG)
+    rag.chunk_token_size = 1200
     rag.full_docs = CaptureKV()
     rag.text_chunks = CaptureKV()
     rag.chunks_vdb = CaptureKV()


### PR DESCRIPTION
## Summary

Addresses the independently separable ingress-validation item 2a of #3873. The rest of that issue, including date context, provenance, segmentation storage and pipeline reprocessing, is deliberately out of scope.

Reject caller-supplied chunks that exceed the configured chunk size or a positive embedding limit before reserving pipeline busy, writing a recovery journal, or mutating storage. Preserve caller boundaries instead of splitting or truncating them, reuse the token counts in staged metadata, and keep encoding in the bounded chunking executor.

Tests cover create/patch rejection, missing or disabled embedding limits, exact-limit boundaries, deduplication, off-loop single-pass encoding and preservation of an existing failed-operation journal. Bare-instance saga fixtures now supply the chunk size normally resolved by the constructor.

## Validation

- Four initial regression cases failed on unchanged production code.
- Directly affected custom-chunk and saga modules: 44 passed.
- Full pipeline subset: 920 passed; five failures remain on this Windows host. All five also fail with the edited method restored from upstream HEAD: four require unavailable symlink privileges, one expects an unescaped POSIX sidecar path. No unrelated tests or production behavior were modified to hide these failures.
- Ruff and required changed-file pre-commit hooks passed.
- Offline storage/dummy-provider tests only; no live embedding or LLM service was exercised. Missing spaCy language-model notices concern other test areas.

The journal format, rollback fences, SDK roll-forward behavior, scan roll-back behavior and purge/reprocessing gate remain unchanged.

AI-assisted contribution, submitted as a draft for maintainer review.
